### PR TITLE
solobase-web: content-hash assets + host-agnostic SW update flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1013,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1066,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -2491,6 +2587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3135,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
@@ -4531,6 +4639,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solobase-web-bundle"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,6 +5628,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/solobase-core",
     "crates/solobase-native",
     "crates/solobase-web",
+    "crates/solobase-web-bundle",
 ]
 
 [workspace.package]

--- a/crates/solobase-web-bundle/Cargo.toml
+++ b/crates/solobase-web-bundle/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "solobase-web-bundle"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Post-processor for solobase-web/pkg: content-hashes assets and renders SW/HTML templates"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+sha2 = "0.10"
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/solobase-web-bundle/src/build_id.rs
+++ b/crates/solobase-web-bundle/src/build_id.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 /// Derives a build identifier for a `pkg/` directory.
 ///
@@ -31,7 +30,11 @@ fn git_short_sha(dir: &Path) -> Option<String> {
         return None;
     }
     let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
-    if s.is_empty() { None } else { Some(s) }
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
 }
 
 fn git_is_dirty(dir: &Path) -> bool {

--- a/crates/solobase-web-bundle/src/build_id.rs
+++ b/crates/solobase-web-bundle/src/build_id.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+use std::process::Command;
+
+/// Derives a build identifier for a `pkg/` directory.
+///
+/// Uses `git rev-parse --short=8 HEAD` when available; appends `-dirty` if
+/// the working tree has uncommitted changes. Falls back to a SHA-256-8 of
+/// the concatenated asset SHAs if `git` is unavailable or fails.
+pub fn build_id(repo_dir: &Path, asset_hashes: &[&str]) -> String {
+    if let Some(sha) = git_short_sha(repo_dir) {
+        let suffix = if git_is_dirty(repo_dir) { "-dirty" } else { "" };
+        return format!("{sha}{suffix}");
+    }
+    let joined: String = asset_hashes.join("");
+    crate::hash::short_hash(joined.as_bytes())
+}
+
+fn git_short_sha(dir: &Path) -> Option<String> {
+    // Only treat `dir` as a git repo root if it contains a `.git` entry
+    // directly. This prevents git from walking up to an outer repo when
+    // `dir` is a temp directory created by tests.
+    if !dir.join(".git").exists() {
+        return None;
+    }
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn git_is_dirty(dir: &Path) -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(dir)
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_when_not_a_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = build_id(tmp.path(), &["aaaa", "bbbb"]);
+        // SHA-256("aaaabbbb") first 8 hex chars
+        assert_eq!(id.len(), 8);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn fallback_is_deterministic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = build_id(tmp.path(), &["x", "y"]);
+        let b = build_id(tmp.path(), &["x", "y"]);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/solobase-web-bundle/src/hash.rs
+++ b/crates/solobase-web-bundle/src/hash.rs
@@ -1,0 +1,33 @@
+/// Returns the first 8 hex chars of the SHA-256 of `bytes`.
+pub fn short_hash(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    hex::encode(&digest[..4])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_hash_is_eight_chars() {
+        let h = short_hash(b"hello");
+        assert_eq!(h.len(), 8);
+    }
+
+    #[test]
+    fn short_hash_is_deterministic() {
+        assert_eq!(short_hash(b"abc"), short_hash(b"abc"));
+    }
+
+    #[test]
+    fn short_hash_differs_per_input() {
+        assert_ne!(short_hash(b"abc"), short_hash(b"abd"));
+    }
+
+    #[test]
+    fn short_hash_matches_known_value() {
+        // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        assert_eq!(short_hash(b"hello"), "2cf24dba");
+    }
+}

--- a/crates/solobase-web-bundle/src/lib.rs
+++ b/crates/solobase-web-bundle/src/lib.rs
@@ -17,10 +17,15 @@ const HASHED_ASSETS: &[(&str, &str)] = &[
 ];
 
 /// Cross-references inside hashed files that we rewrite after renaming.
-/// (source-logical, quote-char, target-logical)
-const REWRITES: &[(&str, char, &str)] = &[
-    ("solobase_web.js", '\'', "solobase_web_bg.wasm"),
-    ("sql-wasm-esm.js", '"', "sql-wasm.wasm"),
+/// (source-logical, quote-char, target-logical, replace-all)
+///
+/// `replace_all = true` — the UMD bundle embeds the path multiple times.
+/// `replace_all = false` — wasm-bindgen glue has exactly one reference.
+const REWRITES: &[(&str, char, &str, bool)] = &[
+    ("solobase_web.js", '\'', "solobase_web_bg.wasm", false),
+    // sql.js is a minified UMD bundle that contains several copies of the
+    // WASM filename (locateFile fallback + inline checks). Replace them all.
+    ("sql-wasm-esm.js", '"', "sql-wasm.wasm", true),
 ];
 
 pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool) -> Result<()> {
@@ -41,7 +46,7 @@ pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool) -> Result<()> {
     }
 
     // 2. Rewrite cross-references.
-    for (source_logical, quote, target_logical) in REWRITES {
+    for (source_logical, quote, target_logical, replace_all) in REWRITES {
         let source_path = renamed
             .get(*source_logical)
             .ok_or_else(|| anyhow::anyhow!("missing renamed source: {source_logical}"))?;
@@ -59,7 +64,11 @@ pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool) -> Result<()> {
             .into_owned();
         let old_literal = format!("{quote}{old_name}{quote}");
         let new_literal = format!("{quote}{new_name}{quote}");
-        rename::rewrite_literal(source_path, &old_literal, &new_literal)?;
+        if *replace_all {
+            rename::rewrite_all(source_path, &old_literal, &new_literal)?;
+        } else {
+            rename::rewrite_literal(source_path, &old_literal, &new_literal)?;
+        }
     }
 
     // 3. buildId.

--- a/crates/solobase-web-bundle/src/lib.rs
+++ b/crates/solobase-web-bundle/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod build_id;
+pub mod hash;
+pub mod manifest;
+pub mod rename;
+pub mod template;

--- a/crates/solobase-web-bundle/src/lib.rs
+++ b/crates/solobase-web-bundle/src/lib.rs
@@ -3,3 +3,129 @@ pub mod hash;
 pub mod manifest;
 pub mod rename;
 pub mod template;
+
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Input files we content-hash. Keys are logical names used by templates.
+const HASHED_ASSETS: &[(&str, &str)] = &[
+    ("solobase_web.js", "solobase_web.js"),
+    ("solobase_web_bg.wasm", "solobase_web_bg.wasm"),
+    ("sql-wasm-esm.js", "sql-wasm-esm.js"),
+    ("sql-wasm.wasm", "sql-wasm.wasm"),
+];
+
+/// Cross-references inside hashed files that we rewrite after renaming.
+/// (source-logical, quote-char, target-logical)
+const REWRITES: &[(&str, char, &str)] = &[
+    ("solobase_web.js", '\'', "solobase_web_bg.wasm"),
+    ("sql-wasm-esm.js", '"', "sql-wasm.wasm"),
+];
+
+pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool) -> Result<()> {
+    if dev {
+        return run_dev(pkg_dir);
+    }
+    let mut hashes: BTreeMap<String, String> = BTreeMap::new();
+    let mut renamed: BTreeMap<String, std::path::PathBuf> = BTreeMap::new();
+
+    // 1. Compute hashes and rename each asset.
+    for (logical, filename) in HASHED_ASSETS {
+        let src = pkg_dir.join(filename);
+        let bytes = std::fs::read(&src).with_context(|| format!("reading {}", src.display()))?;
+        let hash = hash::short_hash(&bytes);
+        let new_path = rename::rename_with_hash(&src, &hash)?;
+        hashes.insert((*logical).to_string(), hash);
+        renamed.insert((*logical).to_string(), new_path);
+    }
+
+    // 2. Rewrite cross-references.
+    for (source_logical, quote, target_logical) in REWRITES {
+        let source_path = renamed
+            .get(*source_logical)
+            .ok_or_else(|| anyhow::anyhow!("missing renamed source: {source_logical}"))?;
+        let old_name = HASHED_ASSETS
+            .iter()
+            .find(|(l, _)| *l == *target_logical)
+            .unwrap()
+            .1;
+        let new_name = renamed
+            .get(*target_logical)
+            .ok_or_else(|| anyhow::anyhow!("missing renamed target: {target_logical}"))?
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let old_literal = format!("{quote}{old_name}{quote}");
+        let new_literal = format!("{quote}{new_name}{quote}");
+        rename::rewrite_literal(source_path, &old_literal, &new_literal)?;
+    }
+
+    // 3. buildId.
+    let asset_hashes_ordered: Vec<&str> = HASHED_ASSETS
+        .iter()
+        .map(|(l, _)| hashes.get(*l).unwrap().as_str())
+        .collect();
+    let build_id = build_id::build_id(repo_dir, &asset_hashes_ordered);
+
+    // 4. Manifest.
+    let mut manifest_assets = BTreeMap::new();
+    for (logical, _) in HASHED_ASSETS {
+        let new_path = renamed.get(*logical).unwrap();
+        let url = format!("/{}", new_path.file_name().unwrap().to_string_lossy());
+        manifest_assets.insert((*logical).to_string(), url);
+    }
+    let manifest = manifest::AssetManifest {
+        build_id: build_id.clone(),
+        assets: manifest_assets.clone(),
+    };
+    manifest.write(&pkg_dir.join("asset-manifest.json"))?;
+
+    // 5. Render templates.
+    let mut vars: BTreeMap<String, String> = BTreeMap::new();
+    vars.insert("BUILD_ID".to_string(), build_id);
+    for (logical, url) in &manifest_assets {
+        vars.insert(template_key(logical), url.clone());
+    }
+    render_if_exists(pkg_dir, "sw.js.tmpl", "sw.js", &vars)?;
+    render_if_exists(pkg_dir, "index.html.tmpl", "index.html", &vars)?;
+
+    Ok(())
+}
+
+fn run_dev(pkg_dir: &Path) -> Result<()> {
+    let mut vars: BTreeMap<String, String> = BTreeMap::new();
+    vars.insert("BUILD_ID".to_string(), "dev".to_string());
+    for (logical, filename) in HASHED_ASSETS {
+        vars.insert(template_key(logical), format!("/{filename}"));
+    }
+    render_if_exists(pkg_dir, "sw.js.tmpl", "sw.js", &vars)?;
+    render_if_exists(pkg_dir, "index.html.tmpl", "index.html", &vars)?;
+    Ok(())
+}
+
+fn render_if_exists(
+    pkg_dir: &Path,
+    src_name: &str,
+    out_name: &str,
+    vars: &BTreeMap<String, String>,
+) -> Result<()> {
+    let src = pkg_dir.join(src_name);
+    if !src.exists() {
+        return Ok(());
+    }
+    template::render_to_file(&src, &pkg_dir.join(out_name), vars)?;
+    std::fs::remove_file(&src).ok();
+    Ok(())
+}
+
+fn template_key(logical: &str) -> String {
+    match logical {
+        "solobase_web.js" => "WASM_JS".into(),
+        "solobase_web_bg.wasm" => "WASM_BIN".into(),
+        "sql-wasm-esm.js" => "SQL_JS".into(),
+        "sql-wasm.wasm" => "SQL_WASM".into(),
+        other => panic!("unknown logical asset: {other}"),
+    }
+}

--- a/crates/solobase-web-bundle/src/lib.rs
+++ b/crates/solobase-web-bundle/src/lib.rs
@@ -4,9 +4,9 @@ pub mod manifest;
 pub mod rename;
 pub mod template;
 
+use std::{collections::BTreeMap, path::Path};
+
 use anyhow::{Context, Result};
-use std::collections::BTreeMap;
-use std::path::Path;
 
 /// Input files we content-hash. Keys are logical names used by templates.
 const HASHED_ASSETS: &[(&str, &str)] = &[

--- a/crates/solobase-web-bundle/src/main.rs
+++ b/crates/solobase-web-bundle/src/main.rs
@@ -1,6 +1,27 @@
 use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "solobase-web-bundle")]
+#[command(about = "Content-hash solobase-web/pkg assets and render SW/HTML templates")]
+struct Cli {
+    /// Path to the `pkg/` directory produced by wasm-pack.
+    pkg_dir: PathBuf,
+
+    /// Repo root (used to read `git rev-parse` for the build id). Defaults to `pkg_dir`'s parent.
+    #[arg(long)]
+    repo_dir: Option<PathBuf>,
+
+    /// Skip hashing; render templates with canonical filenames for fast local iteration.
+    #[arg(long)]
+    dev: bool,
+}
 
 fn main() -> Result<()> {
-    println!("solobase-web-bundle placeholder");
-    Ok(())
+    let cli = Cli::parse();
+    let repo = cli.repo_dir.clone()
+        .or_else(|| cli.pkg_dir.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| cli.pkg_dir.clone());
+    solobase_web_bundle::run(&cli.pkg_dir, &repo, cli.dev)
 }

--- a/crates/solobase-web-bundle/src/main.rs
+++ b/crates/solobase-web-bundle/src/main.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    println!("solobase-web-bundle placeholder");
+    Ok(())
+}

--- a/crates/solobase-web-bundle/src/main.rs
+++ b/crates/solobase-web-bundle/src/main.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::Parser;
-use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "solobase-web-bundle")]
@@ -20,7 +21,9 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let repo = cli.repo_dir.clone()
+    let repo = cli
+        .repo_dir
+        .clone()
         .or_else(|| cli.pkg_dir.parent().map(|p| p.to_path_buf()))
         .unwrap_or_else(|| cli.pkg_dir.clone());
     solobase_web_bundle::run(&cli.pkg_dir, &repo, cli.dev)

--- a/crates/solobase-web-bundle/src/manifest.rs
+++ b/crates/solobase-web-bundle/src/manifest.rs
@@ -1,7 +1,7 @@
+use std::{collections::BTreeMap, path::Path};
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AssetManifest {
@@ -13,8 +13,7 @@ pub struct AssetManifest {
 
 impl AssetManifest {
     pub fn write(&self, path: &Path) -> Result<()> {
-        let body = serde_json::to_string_pretty(self)
-            .context("serialising asset manifest")?;
+        let body = serde_json::to_string_pretty(self).context("serialising asset manifest")?;
         std::fs::write(path, body).context("writing asset-manifest.json")?;
         Ok(())
     }
@@ -30,7 +29,10 @@ mod tests {
         let path = tmp.path().join("asset-manifest.json");
         let mut assets = BTreeMap::new();
         assets.insert("solobase_web.js".into(), "/solobase_web-a1b2c3d4.js".into());
-        let m = AssetManifest { build_id: "a1b2c3d4".into(), assets };
+        let m = AssetManifest {
+            build_id: "a1b2c3d4".into(),
+            assets,
+        };
         m.write(&path).unwrap();
 
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -45,7 +47,10 @@ mod tests {
         let mut assets = BTreeMap::new();
         assets.insert("z.wasm".into(), "/z.wasm".into());
         assets.insert("a.js".into(), "/a.js".into());
-        let m = AssetManifest { build_id: "x".into(), assets };
+        let m = AssetManifest {
+            build_id: "x".into(),
+            assets,
+        };
         m.write(&path).unwrap();
         let body = std::fs::read_to_string(&path).unwrap();
         let a_pos = body.find("\"a.js\"").unwrap();

--- a/crates/solobase-web-bundle/src/manifest.rs
+++ b/crates/solobase-web-bundle/src/manifest.rs
@@ -1,0 +1,55 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssetManifest {
+    #[serde(rename = "buildId")]
+    pub build_id: String,
+    /// Logical asset name (as referenced from templates) → `/`-prefixed hashed URL.
+    pub assets: BTreeMap<String, String>,
+}
+
+impl AssetManifest {
+    pub fn write(&self, path: &Path) -> Result<()> {
+        let body = serde_json::to_string_pretty(self)
+            .context("serialising asset manifest")?;
+        std::fs::write(path, body).context("writing asset-manifest.json")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_expected_json_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("asset-manifest.json");
+        let mut assets = BTreeMap::new();
+        assets.insert("solobase_web.js".into(), "/solobase_web-a1b2c3d4.js".into());
+        let m = AssetManifest { build_id: "a1b2c3d4".into(), assets };
+        m.write(&path).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"buildId\": \"a1b2c3d4\""));
+        assert!(contents.contains("\"solobase_web.js\": \"/solobase_web-a1b2c3d4.js\""));
+    }
+
+    #[test]
+    fn ordering_is_stable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("m.json");
+        let mut assets = BTreeMap::new();
+        assets.insert("z.wasm".into(), "/z.wasm".into());
+        assets.insert("a.js".into(), "/a.js".into());
+        let m = AssetManifest { build_id: "x".into(), assets };
+        m.write(&path).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let a_pos = body.find("\"a.js\"").unwrap();
+        let z_pos = body.find("\"z.wasm\"").unwrap();
+        assert!(a_pos < z_pos);
+    }
+}

--- a/crates/solobase-web-bundle/src/rename.rs
+++ b/crates/solobase-web-bundle/src/rename.rs
@@ -34,6 +34,20 @@ pub fn rewrite_literal(path: &Path, from: &str, to: &str) -> Result<()> {
     Ok(())
 }
 
+/// Replace all occurrences of `from` with `to` in a UTF-8 file.
+/// Fails if `from` is not present at all.
+pub fn rewrite_all(path: &Path, from: &str, to: &str) -> Result<()> {
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let count = body.matches(from).count();
+    if count == 0 {
+        bail!("literal {:?} not found in {}", from, path.display());
+    }
+    let replaced = body.replace(from, to);
+    std::fs::write(path, replaced).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,5 +99,25 @@ mod tests {
         fs::write(&p, "foo foo").unwrap();
         let err = rewrite_literal(&p, "foo", "bar").unwrap_err();
         assert!(err.to_string().contains("expected exactly one"));
+    }
+
+    #[test]
+    fn rewrite_all_replaces_every_occurrence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.js");
+        // Simulate sql.js UMD bundle with multiple references to the wasm path.
+        fs::write(&p, r#""sql-wasm.wasm" || "sql-wasm.wasm" ? "sql-wasm.wasm" : B"#).unwrap();
+        rewrite_all(&p, "\"sql-wasm.wasm\"", "\"sql-wasm-abc123.wasm\"").unwrap();
+        let body = fs::read_to_string(&p).unwrap();
+        assert_eq!(body, r#""sql-wasm-abc123.wasm" || "sql-wasm-abc123.wasm" ? "sql-wasm-abc123.wasm" : B"#);
+    }
+
+    #[test]
+    fn rewrite_all_fails_when_literal_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.js");
+        fs::write(&p, "unrelated content").unwrap();
+        let err = rewrite_all(&p, "MISSING", "X").unwrap_err();
+        assert!(err.to_string().contains("not found"));
     }
 }

--- a/crates/solobase-web-bundle/src/rename.rs
+++ b/crates/solobase-web-bundle/src/rename.rs
@@ -1,14 +1,23 @@
-use anyhow::{anyhow, bail, Context, Result};
 use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
 
 /// Rename `path` to include `-<hash>` before its extension.
 /// Example: `foo.wasm` + `a1b2c3d4` → `foo-a1b2c3d4.wasm`.
 /// Returns the new path (absolute, same directory).
 pub fn rename_with_hash(path: &Path, hash: &str) -> Result<PathBuf> {
-    let dir = path.parent().ok_or_else(|| anyhow!("path has no parent: {}", path.display()))?;
-    let stem = path.file_stem().ok_or_else(|| anyhow!("no file stem: {}", path.display()))?
-        .to_string_lossy().into_owned();
-    let ext = path.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow!("path has no parent: {}", path.display()))?;
+    let stem = path
+        .file_stem()
+        .ok_or_else(|| anyhow!("no file stem: {}", path.display()))?
+        .to_string_lossy()
+        .into_owned();
+    let ext = path
+        .extension()
+        .map(|e| format!(".{}", e.to_string_lossy()))
+        .unwrap_or_default();
     let new_name = format!("{stem}-{hash}{ext}");
     let new_path = dir.join(&new_name);
     std::fs::rename(path, &new_path)
@@ -19,15 +28,19 @@ pub fn rename_with_hash(path: &Path, hash: &str) -> Result<PathBuf> {
 /// Replace one exact substring in a UTF-8 file. Fails if `from` is not
 /// present, or if it appears more than once.
 pub fn rewrite_literal(path: &Path, from: &str, to: &str) -> Result<()> {
-    let body = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let body =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let count = body.matches(from).count();
     if count == 0 {
         bail!("literal {:?} not found in {}", from, path.display());
     }
     if count > 1 {
-        bail!("literal {:?} appears {} times in {} — expected exactly one",
-              from, count, path.display());
+        bail!(
+            "literal {:?} appears {} times in {} — expected exactly one",
+            from,
+            count,
+            path.display()
+        );
     }
     let replaced = body.replace(from, to);
     std::fs::write(path, replaced).with_context(|| format!("writing {}", path.display()))?;
@@ -37,8 +50,8 @@ pub fn rewrite_literal(path: &Path, from: &str, to: &str) -> Result<()> {
 /// Replace all occurrences of `from` with `to` in a UTF-8 file.
 /// Fails if `from` is not present at all.
 pub fn rewrite_all(path: &Path, from: &str, to: &str) -> Result<()> {
-    let body = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let body =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let count = body.matches(from).count();
     if count == 0 {
         bail!("literal {:?} not found in {}", from, path.display());
@@ -50,8 +63,9 @@ pub fn rewrite_all(path: &Path, from: &str, to: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+
+    use super::*;
 
     #[test]
     fn rename_adds_hash_before_extension() {
@@ -78,7 +92,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let p = tmp.path().join("a.js");
         fs::write(&p, "x = 'solobase_web_bg.wasm';").unwrap();
-        rewrite_literal(&p, "'solobase_web_bg.wasm'", "'solobase_web_bg-abcd1234.wasm'").unwrap();
+        rewrite_literal(
+            &p,
+            "'solobase_web_bg.wasm'",
+            "'solobase_web_bg-abcd1234.wasm'",
+        )
+        .unwrap();
         let body = fs::read_to_string(&p).unwrap();
         assert_eq!(body, "x = 'solobase_web_bg-abcd1234.wasm';");
     }
@@ -106,10 +125,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let p = tmp.path().join("a.js");
         // Simulate sql.js UMD bundle with multiple references to the wasm path.
-        fs::write(&p, r#""sql-wasm.wasm" || "sql-wasm.wasm" ? "sql-wasm.wasm" : B"#).unwrap();
+        fs::write(
+            &p,
+            r#""sql-wasm.wasm" || "sql-wasm.wasm" ? "sql-wasm.wasm" : B"#,
+        )
+        .unwrap();
         rewrite_all(&p, "\"sql-wasm.wasm\"", "\"sql-wasm-abc123.wasm\"").unwrap();
         let body = fs::read_to_string(&p).unwrap();
-        assert_eq!(body, r#""sql-wasm-abc123.wasm" || "sql-wasm-abc123.wasm" ? "sql-wasm-abc123.wasm" : B"#);
+        assert_eq!(
+            body,
+            r#""sql-wasm-abc123.wasm" || "sql-wasm-abc123.wasm" ? "sql-wasm-abc123.wasm" : B"#
+        );
     }
 
     #[test]

--- a/crates/solobase-web-bundle/src/rename.rs
+++ b/crates/solobase-web-bundle/src/rename.rs
@@ -1,0 +1,89 @@
+use anyhow::{anyhow, bail, Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Rename `path` to include `-<hash>` before its extension.
+/// Example: `foo.wasm` + `a1b2c3d4` → `foo-a1b2c3d4.wasm`.
+/// Returns the new path (absolute, same directory).
+pub fn rename_with_hash(path: &Path, hash: &str) -> Result<PathBuf> {
+    let dir = path.parent().ok_or_else(|| anyhow!("path has no parent: {}", path.display()))?;
+    let stem = path.file_stem().ok_or_else(|| anyhow!("no file stem: {}", path.display()))?
+        .to_string_lossy().into_owned();
+    let ext = path.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    let new_name = format!("{stem}-{hash}{ext}");
+    let new_path = dir.join(&new_name);
+    std::fs::rename(path, &new_path)
+        .with_context(|| format!("rename {} -> {}", path.display(), new_path.display()))?;
+    Ok(new_path)
+}
+
+/// Replace one exact substring in a UTF-8 file. Fails if `from` is not
+/// present, or if it appears more than once.
+pub fn rewrite_literal(path: &Path, from: &str, to: &str) -> Result<()> {
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let count = body.matches(from).count();
+    if count == 0 {
+        bail!("literal {:?} not found in {}", from, path.display());
+    }
+    if count > 1 {
+        bail!("literal {:?} appears {} times in {} — expected exactly one",
+              from, count, path.display());
+    }
+    let replaced = body.replace(from, to);
+    std::fs::write(path, replaced).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn rename_adds_hash_before_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("foo.wasm");
+        fs::write(&p, b"x").unwrap();
+        let out = rename_with_hash(&p, "abcd1234").unwrap();
+        assert_eq!(out.file_name().unwrap(), "foo-abcd1234.wasm");
+        assert!(out.exists());
+        assert!(!p.exists());
+    }
+
+    #[test]
+    fn rename_handles_compound_stems() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("sql-wasm-esm.js");
+        fs::write(&p, b"x").unwrap();
+        let out = rename_with_hash(&p, "ffff0000").unwrap();
+        assert_eq!(out.file_name().unwrap(), "sql-wasm-esm-ffff0000.js");
+    }
+
+    #[test]
+    fn rewrite_replaces_single_literal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.js");
+        fs::write(&p, "x = 'solobase_web_bg.wasm';").unwrap();
+        rewrite_literal(&p, "'solobase_web_bg.wasm'", "'solobase_web_bg-abcd1234.wasm'").unwrap();
+        let body = fs::read_to_string(&p).unwrap();
+        assert_eq!(body, "x = 'solobase_web_bg-abcd1234.wasm';");
+    }
+
+    #[test]
+    fn rewrite_fails_when_literal_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.js");
+        fs::write(&p, "unrelated content").unwrap();
+        let err = rewrite_literal(&p, "MISSING", "X").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn rewrite_fails_on_multiple_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.js");
+        fs::write(&p, "foo foo").unwrap();
+        let err = rewrite_literal(&p, "foo", "bar").unwrap_err();
+        assert!(err.to_string().contains("expected exactly one"));
+    }
+}

--- a/crates/solobase-web-bundle/src/template.rs
+++ b/crates/solobase-web-bundle/src/template.rs
@@ -1,0 +1,106 @@
+use anyhow::{bail, Context, Result};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Render a template by substituting `__KEY__` tokens with values from `vars`.
+/// Fails if the rendered output still contains any `__…__` token, catching
+/// missed placeholders before they reach the browser.
+pub fn render_to_file(template_src: &Path, out: &Path, vars: &BTreeMap<String, String>) -> Result<()> {
+    let body = std::fs::read_to_string(template_src)
+        .with_context(|| format!("reading template {}", template_src.display()))?;
+    let mut rendered = body;
+    for (key, value) in vars {
+        let token = format!("__{}__", key);
+        rendered = rendered.replace(&token, value);
+    }
+    if let Some(stray) = find_unresolved_placeholder(&rendered) {
+        bail!("unresolved placeholder {:?} in {}", stray, template_src.display());
+    }
+    std::fs::write(out, rendered).with_context(|| format!("writing {}", out.display()))?;
+    Ok(())
+}
+
+fn find_unresolved_placeholder(body: &str) -> Option<String> {
+    // Look for __WORDCHARS__ — only flag tokens whose inner content is
+    // [A-Z0-9][A-Z0-9_]*[A-Z0-9] (or a single [A-Z0-9]) so we don't
+    // false-positive on arbitrary __ sequences in minified JS (e.g. __wbg__).
+    //
+    // Strategy: scan forward looking for `__`. When found, find the matching
+    // closing `__` by searching for the next occurrence of `__` that is
+    // preceded by a non-underscore. Then check that the inner span is entirely
+    // composed of [A-Z0-9_] with no lowercase letters.
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        if bytes[i] == b'_' && bytes[i + 1] == b'_' {
+            let inner_start = i + 2;
+            // Find the next `__` that can serve as a closing delimiter.
+            // We scan from inner_start looking for `__`.
+            let mut k = inner_start;
+            let mut found_close = None;
+            while k + 2 <= bytes.len() {
+                if bytes[k] == b'_' && bytes[k + 1] == b'_' && k > inner_start {
+                    found_close = Some(k);
+                    break;
+                }
+                k += 1;
+            }
+            if let Some(close) = found_close {
+                let inner = &bytes[inner_start..close];
+                // Accept only if inner is non-empty and every byte is
+                // [A-Z0-9_] with no lowercase letters (rejects wbg_init etc.)
+                let is_placeholder = !inner.is_empty()
+                    && inner.iter().all(|&b| b == b'_' || (b as char).is_ascii_uppercase() || (b as char).is_ascii_digit());
+                if is_placeholder {
+                    return Some(String::from_utf8_lossy(&bytes[i..close + 2]).into_owned());
+                }
+                // Skip past the opening __ we already examined.
+                i += 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(p: &Path, body: &str) { std::fs::write(p, body).unwrap(); }
+
+    #[test]
+    fn substitutes_known_placeholders() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("in.tmpl");
+        let out = tmp.path().join("out");
+        write(&src, "import x from '__WASM_JS__';\n// build: __BUILD_ID__\n");
+        let mut vars = BTreeMap::new();
+        vars.insert("WASM_JS".into(), "/solobase_web-abcd1234.js".into());
+        vars.insert("BUILD_ID".into(), "abcd1234".into());
+        render_to_file(&src, &out, &vars).unwrap();
+        let body = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(body, "import x from '/solobase_web-abcd1234.js';\n// build: abcd1234\n");
+    }
+
+    #[test]
+    fn fails_on_unresolved_placeholder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("in.tmpl");
+        let out = tmp.path().join("out");
+        write(&src, "x = __MISSING__;");
+        let err = render_to_file(&src, &out, &BTreeMap::new()).unwrap_err();
+        assert!(err.to_string().contains("__MISSING__"), "got: {err}");
+    }
+
+    #[test]
+    fn ignores_minified_double_underscores() {
+        // Minified JS sometimes has __wbg_foo__ (mixed case) — shouldn't trigger.
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("in.tmpl");
+        let out = tmp.path().join("out");
+        write(&src, "function __wbg_init__() {}");
+        render_to_file(&src, &out, &BTreeMap::new()).unwrap();
+    }
+}

--- a/crates/solobase-web-bundle/src/template.rs
+++ b/crates/solobase-web-bundle/src/template.rs
@@ -1,11 +1,15 @@
+use std::{collections::BTreeMap, path::Path};
+
 use anyhow::{bail, Context, Result};
-use std::collections::BTreeMap;
-use std::path::Path;
 
 /// Render a template by substituting `__KEY__` tokens with values from `vars`.
 /// Fails if the rendered output still contains any `__…__` token, catching
 /// missed placeholders before they reach the browser.
-pub fn render_to_file(template_src: &Path, out: &Path, vars: &BTreeMap<String, String>) -> Result<()> {
+pub fn render_to_file(
+    template_src: &Path,
+    out: &Path,
+    vars: &BTreeMap<String, String>,
+) -> Result<()> {
     let body = std::fs::read_to_string(template_src)
         .with_context(|| format!("reading template {}", template_src.display()))?;
     let mut rendered = body;
@@ -14,7 +18,11 @@ pub fn render_to_file(template_src: &Path, out: &Path, vars: &BTreeMap<String, S
         rendered = rendered.replace(&token, value);
     }
     if let Some(stray) = find_unresolved_placeholder(&rendered) {
-        bail!("unresolved placeholder {:?} in {}", stray, template_src.display());
+        bail!(
+            "unresolved placeholder {:?} in {}",
+            stray,
+            template_src.display()
+        );
     }
     std::fs::write(out, rendered).with_context(|| format!("writing {}", out.display()))?;
     Ok(())
@@ -50,7 +58,11 @@ fn find_unresolved_placeholder(body: &str) -> Option<String> {
                 // Accept only if inner is non-empty and every byte is
                 // [A-Z0-9_] with no lowercase letters (rejects wbg_init etc.)
                 let is_placeholder = !inner.is_empty()
-                    && inner.iter().all(|&b| b == b'_' || (b as char).is_ascii_uppercase() || (b as char).is_ascii_digit());
+                    && inner.iter().all(|&b| {
+                        b == b'_'
+                            || (b as char).is_ascii_uppercase()
+                            || (b as char).is_ascii_digit()
+                    });
                 if is_placeholder {
                     return Some(String::from_utf8_lossy(&bytes[i..close + 2]).into_owned());
                 }
@@ -68,20 +80,28 @@ fn find_unresolved_placeholder(body: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    fn write(p: &Path, body: &str) { std::fs::write(p, body).unwrap(); }
+    fn write(p: &Path, body: &str) {
+        std::fs::write(p, body).unwrap();
+    }
 
     #[test]
     fn substitutes_known_placeholders() {
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("in.tmpl");
         let out = tmp.path().join("out");
-        write(&src, "import x from '__WASM_JS__';\n// build: __BUILD_ID__\n");
+        write(
+            &src,
+            "import x from '__WASM_JS__';\n// build: __BUILD_ID__\n",
+        );
         let mut vars = BTreeMap::new();
         vars.insert("WASM_JS".into(), "/solobase_web-abcd1234.js".into());
         vars.insert("BUILD_ID".into(), "abcd1234".into());
         render_to_file(&src, &out, &vars).unwrap();
         let body = std::fs::read_to_string(&out).unwrap();
-        assert_eq!(body, "import x from '/solobase_web-abcd1234.js';\n// build: abcd1234\n");
+        assert_eq!(
+            body,
+            "import x from '/solobase_web-abcd1234.js';\n// build: abcd1234\n"
+        );
     }
 
     #[test]

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/index.html.tmpl
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/index.html.tmpl
@@ -1,0 +1,2 @@
+<!DOCTYPE html><html><head><meta http-equiv="Cache-Control" content="no-cache"></head>
+<body><script src="/loader.js"></script></body></html>

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/solobase_web.js
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/solobase_web.js
@@ -1,0 +1,5 @@
+// fake glue
+export async function init() {
+    const url = new URL('solobase_web_bg.wasm', import.meta.url);
+    return fetch(url);
+}

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/solobase_web_bg.wasm
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/solobase_web_bg.wasm
@@ -1,0 +1,1 @@
+deadbeef

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm-esm.js
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm-esm.js
@@ -1,1 +1,5 @@
-var x = "sql-wasm.wasm";
+// Simulates the shape of sql.js's minified UMD bundle, which embeds the
+// wasm filename at multiple call sites (locateFile fallback + inline
+// checks). The integration test must exercise the multi-occurrence path.
+var a = "sql-wasm.wasm";
+var b = locate("sql-wasm.wasm") || "sql-wasm.wasm";

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm-esm.js
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm-esm.js
@@ -1,0 +1,1 @@
+var x = "sql-wasm.wasm";

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm.wasm
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/sql-wasm.wasm
@@ -1,0 +1,1 @@
+deadbeef

--- a/crates/solobase-web-bundle/tests/fixtures/pkg-in/sw.js.tmpl
+++ b/crates/solobase-web-bundle/tests/fixtures/pkg-in/sw.js.tmpl
@@ -1,0 +1,2 @@
+// @generated build: __BUILD_ID__
+import init, { initialize, handle_request } from '__WASM_JS__';

--- a/crates/solobase-web-bundle/tests/integration.rs
+++ b/crates/solobase-web-bundle/tests/integration.rs
@@ -1,6 +1,6 @@
+use std::{fs, path::PathBuf};
+
 use solobase_web_bundle::run;
-use std::fs;
-use std::path::PathBuf;
 
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pkg-in")

--- a/crates/solobase-web-bundle/tests/integration.rs
+++ b/crates/solobase-web-bundle/tests/integration.rs
@@ -1,0 +1,79 @@
+use solobase_web_bundle::run;
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pkg-in")
+}
+
+#[test]
+fn end_to_end_renames_rewrites_and_templates() {
+    let tmp = tempfile::tempdir().unwrap();
+    copy_dir(&fixture_path(), tmp.path());
+
+    run(tmp.path(), tmp.path(), /* dev */ false).expect("bundler ok");
+
+    let manifest_body = fs::read_to_string(tmp.path().join("asset-manifest.json")).unwrap();
+    assert!(manifest_body.contains("\"buildId\""));
+    assert!(manifest_body.contains("\"solobase_web.js\""));
+    assert!(manifest_body.contains("\"solobase_web_bg.wasm\""));
+
+    let entries: Vec<String> = fs::read_dir(tmp.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().into_string().unwrap())
+        .collect();
+    assert!(
+        entries
+            .iter()
+            .any(|n| n.starts_with("solobase_web-") && n.ends_with(".js")),
+        "missing hashed JS in {:?}",
+        entries
+    );
+    assert!(entries
+        .iter()
+        .any(|n| n.starts_with("solobase_web_bg-") && n.ends_with(".wasm")));
+    assert!(!entries.iter().any(|n| n == "solobase_web.js"));
+    assert!(!entries.iter().any(|n| n == "solobase_web_bg.wasm"));
+
+    let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
+    assert!(sw.contains("from '/solobase_web-"), "sw.js = {sw}");
+    assert!(!sw.contains("__WASM_JS__"));
+    assert!(!sw.contains("__BUILD_ID__"));
+
+    let glue_name = entries
+        .iter()
+        .find(|n| n.starts_with("solobase_web-") && n.ends_with(".js"))
+        .unwrap();
+    let glue = fs::read_to_string(tmp.path().join(glue_name)).unwrap();
+    assert!(glue.contains("solobase_web_bg-"), "glue = {glue}");
+    assert!(!glue.contains("'solobase_web_bg.wasm'"));
+}
+
+#[test]
+fn deterministic_across_runs() {
+    let tmp1 = tempfile::tempdir().unwrap();
+    let tmp2 = tempfile::tempdir().unwrap();
+    copy_dir(&fixture_path(), tmp1.path());
+    copy_dir(&fixture_path(), tmp2.path());
+    solobase_web_bundle::run(tmp1.path(), tmp1.path(), false).unwrap();
+    solobase_web_bundle::run(tmp2.path(), tmp2.path(), false).unwrap();
+
+    let m1 = fs::read_to_string(tmp1.path().join("asset-manifest.json")).unwrap();
+    let m2 = fs::read_to_string(tmp2.path().join("asset-manifest.json")).unwrap();
+    let v1: serde_json::Value = serde_json::from_str(&m1).unwrap();
+    let v2: serde_json::Value = serde_json::from_str(&m2).unwrap();
+    assert_eq!(v1.get("assets"), v2.get("assets"));
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
+    for entry in fs::read_dir(src).unwrap() {
+        let e = entry.unwrap();
+        let to = dst.join(e.file_name());
+        if e.file_type().unwrap().is_dir() {
+            fs::create_dir_all(&to).unwrap();
+            copy_dir(&e.path(), &to);
+        } else {
+            fs::copy(e.path(), to).unwrap();
+        }
+    }
+}

--- a/crates/solobase-web/Makefile
+++ b/crates/solobase-web/Makefile
@@ -18,21 +18,21 @@ pkg/sql-wasm-esm.js: pkg/sql-wasm.js
 	@cat pkg/sql-wasm.js >> pkg/sql-wasm-esm.js
 	@printf '\n  return module.exports.default || module.exports;\n})();\nexport default _sqlJs;\n' >> pkg/sql-wasm-esm.js
 
-# Build for production
+# Build for production (content-hashes assets, renders templates)
 build: pkg/sql-wasm-esm.js
 	wasm-pack build --target web --release --out-dir pkg
-	cp js/sw.js pkg/
-	cp js/loader.js pkg/
-	cp js/ai-bridge.js pkg/
-	cp js/index.html pkg/
+	cp js/sw.js.tmpl pkg/
+	cp js/index.html.tmpl pkg/
+	cp js/loader.js js/ai-bridge.js js/manifest.json pkg/
+	cargo run -p solobase-web-bundle --release -- pkg/ --repo-dir $(CURDIR)/../..
 
-# Build for development
+# Build for development (no hashing; canonical filenames)
 dev: pkg/sql-wasm-esm.js
 	wasm-pack build --target web --dev --out-dir pkg
-	cp js/sw.js pkg/
-	cp js/loader.js pkg/
-	cp js/ai-bridge.js pkg/
-	cp js/index.html pkg/
+	cp js/sw.js.tmpl pkg/
+	cp js/index.html.tmpl pkg/
+	cp js/loader.js js/ai-bridge.js js/manifest.json pkg/
+	cargo run -p solobase-web-bundle --release -- pkg/ --repo-dir $(CURDIR)/../.. --dev
 
 # Serve locally for testing (localhost is exempt from HTTPS requirement for SW)
 serve: dev

--- a/crates/solobase-web/js/index.html.tmpl
+++ b/crates/solobase-web/js/index.html.tmpl
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache">
     <title>Solobase</title>
     <link rel="manifest" href="/manifest.json">
     <style>

--- a/crates/solobase-web/js/loader.js
+++ b/crates/solobase-web/js/loader.js
@@ -9,6 +9,7 @@ async function boot() {
         const registration = await navigator.serviceWorker.register('/sw.js', {
             type: 'module',
             scope: '/',
+            updateViaCache: 'none',
         });
         const sw = registration.installing || registration.waiting || registration.active;
         if (sw && sw.state !== 'activated') {

--- a/crates/solobase-web/js/sw.js.tmpl
+++ b/crates/solobase-web/js/sw.js.tmpl
@@ -1,5 +1,5 @@
-// sw.js — Service Worker that runs Solobase via WASM
-import init, { initialize, handle_request } from './solobase_web.js';
+// @generated build: __BUILD_ID__ — Service Worker that runs Solobase via WASM
+import init, { initialize, handle_request } from '__WASM_JS__';
 
 let initialized = false;
 let initPromise = null;
@@ -234,7 +234,9 @@ self.addEventListener('fetch', (event) => {
         url.pathname === '/manifest.json' ||
         url.pathname === '/index.html' ||
         url.pathname === '/' ||
-        url.pathname.startsWith('/pkg/') ||
+        url.pathname === '/asset-manifest.json' ||
+        url.pathname.startsWith('/solobase_web') ||
+        url.pathname.startsWith('/snippets/') ||
         url.pathname.startsWith('/sql-')) {
         return;
     }

--- a/crates/solobase-web/package-lock.json
+++ b/crates/solobase-web/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "solobase-web-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "solobase-web-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.40.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/crates/solobase-web/package.json
+++ b/crates/solobase-web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "solobase-web-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "e2e": "playwright test --config=tests/playwright.config.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0"
+  }
+}

--- a/crates/solobase-web/tests/e2e/sw-update.spec.ts
+++ b/crates/solobase-web/tests/e2e/sw-update.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PKG = join(__dirname, '../../pkg');
+
+function readManifestBuildId(): string {
+  const body = readFileSync(join(PKG, 'asset-manifest.json'), 'utf8');
+  return JSON.parse(body).buildId as string;
+}
+
+test('a new build causes the SW to update and fetch new hashed WASM', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+  const initialBuildId = readManifestBuildId();
+
+  const initialWasm = await new Promise<string>((resolve) => {
+    page.on('request', function listener(req) {
+      if (req.url().match(/solobase_web_bg-[a-f0-9]+\.wasm/)) {
+        page.off('request', listener);
+        resolve(req.url());
+      }
+    });
+    page.reload();
+  });
+
+  execSync(
+    `touch crates/solobase-web/src/lib.rs && cd crates/solobase-web && make build`,
+    { cwd: join(__dirname, '../../../..'), stdio: 'inherit' },
+  );
+
+  const newBuildId = readManifestBuildId();
+  expect(newBuildId).not.toBe(initialBuildId);
+
+  const newWasm = await new Promise<string>((resolve) => {
+    page.on('request', function listener(req) {
+      if (req.url().match(/solobase_web_bg-[a-f0-9]+\.wasm/) && req.url() !== initialWasm) {
+        page.off('request', listener);
+        resolve(req.url());
+      }
+    });
+    page.reload();
+  });
+
+  expect(newWasm).not.toBe(initialWasm);
+});
+
+test('a no-op rebuild does not trigger a SW update', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+  const buildId1 = readManifestBuildId();
+
+  execSync(
+    `cd crates/solobase-web && make build`,
+    { cwd: join(__dirname, '../../../..'), stdio: 'inherit' },
+  );
+
+  const buildId2 = readManifestBuildId();
+  expect(buildId2).toBe(buildId1);
+});

--- a/crates/solobase-web/tests/playwright.config.ts
+++ b/crates/solobase-web/tests/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.TEST_PORT ? parseInt(process.env.TEST_PORT) : 8080;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  timeout: 60_000,
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    serviceWorkers: 'allow',
+  },
+  projects: [
+    { name: 'desktop-chrome', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/packages/solobase-web/CHANGELOG.md
+++ b/packages/solobase-web/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.0
+
+### Breaking changes
+
+- `worker.ts` no longer calls `self.skipWaiting()` during `install`. Consumers who want the old behavior should post `{ type: 'skip-waiting' }` to the registration from the main thread after `register()` resolves, or (recommended) use the new `registerWithUpdates` helper.
+
+### New
+
+- `registerWithUpdates(scriptURL, opts?)` — registers the SW and returns a handle with `onUpdateReady` and `checkForUpdate` for wiring update UX.
+- `UpdateHandle` type re-exported from the package root.
+
+## 0.1.0
+
+- Initial release.

--- a/packages/solobase-web/README.md
+++ b/packages/solobase-web/README.md
@@ -1,0 +1,62 @@
+# solobase-web
+
+Solobase backend running in the browser via Service Worker + WASM.
+
+## Bundler integration
+
+The package ships wasm-pack output unmodified at `dist/wasm/`. The embedded glue uses `new URL('solobase_web_bg.wasm', import.meta.url)`, which Vite, Rollup, webpack 5, and esbuild all detect and bundle as a hashed asset automatically.
+
+### Vite / Rollup
+No config required in typical setups. The `.wasm` will be emitted to `dist/assets/` with a content hash.
+
+### webpack 5
+Make sure `experiments.asyncWebAssembly` is enabled in your webpack config; it handles the URL pattern out of the box.
+
+### esbuild
+Add a `.wasm` file loader:
+
+```js
+build({
+  loader: { '.wasm': 'file' },
+  // ...
+});
+```
+
+## Service Worker update lifecycle
+
+The exported `worker.ts` does **not** call `skipWaiting()` during install so consumers can control when an update takes effect. Three common patterns:
+
+### Silent (pick up on next navigation)
+
+```ts
+import { registerWithUpdates } from 'solobase-web';
+
+await registerWithUpdates('/sw.js');
+// Do nothing else. Next hard navigation uses the new SW.
+```
+
+### Auto-reload on update
+
+```ts
+import { registerWithUpdates } from 'solobase-web';
+
+const handle = await registerWithUpdates('/sw.js');
+handle.onUpdateReady(async (apply) => {
+  await apply();
+  location.reload();
+});
+```
+
+### Toast + opt-in reload
+
+```ts
+import { registerWithUpdates } from 'solobase-web';
+
+const handle = await registerWithUpdates('/sw.js');
+handle.onUpdateReady((apply) => {
+  showToast('New version available', async () => {
+    await apply();
+    location.reload();
+  });
+});
+```

--- a/packages/solobase-web/package-lock.json
+++ b/packages/solobase-web/package-lock.json
@@ -1,0 +1,1295 @@
+{
+  "name": "solobase-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "solobase-web",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/solobase-web/package.json
+++ b/packages/solobase-web/package.json
@@ -24,8 +24,15 @@
     "build": "npm run build:wasm && npm run build:ts"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "@types/node": "^25.6.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.4"
   },
-  "keywords": ["solobase", "wasm", "service-worker", "backend"],
+  "keywords": [
+    "solobase",
+    "wasm",
+    "service-worker",
+    "backend"
+  ],
   "license": "MIT"
 }

--- a/packages/solobase-web/package.json
+++ b/packages/solobase-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solobase-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Solobase backend running in the browser via Service Worker + WASM",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/solobase-web/src/index.ts
+++ b/packages/solobase-web/src/index.ts
@@ -24,7 +24,7 @@ export async function setupSolobase(config?: SolobaseConfig): Promise<void> {
 
   const registration = await navigator.serviceWorker.register(
     new URL('./worker.js', import.meta.url),
-    { scope, type: 'module' }
+    { scope, type: 'module', updateViaCache: 'none' }
   );
 
   // Wait for the SW to be active

--- a/packages/solobase-web/src/index.ts
+++ b/packages/solobase-web/src/index.ts
@@ -11,6 +11,9 @@ const DEFAULT_ROUTES = ['/b/', '/health', '/openapi.json', '/.well-known/agent.j
  * Register a Service Worker that runs the Solobase WASM backend.
  * All matching requests are intercepted and handled by the WASM runtime.
  */
+export { registerWithUpdates } from './update';
+export type { UpdateHandle } from './update';
+
 export async function setupSolobase(config?: SolobaseConfig): Promise<void> {
   if (!('serviceWorker' in navigator)) {
     throw new Error('Service Workers are not supported in this browser');

--- a/packages/solobase-web/src/update.test.ts
+++ b/packages/solobase-web/src/update.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerWithUpdates } from './update';
+
+type Listener = (event: any) => void;
+
+function makeFakeWorker() {
+  const listeners: Record<string, Listener[]> = {};
+  const postMessage = vi.fn();
+  return {
+    state: 'installing' as 'installing' | 'installed' | 'activating' | 'activated',
+    postMessage,
+    addEventListener(ev: string, cb: Listener) { (listeners[ev] ||= []).push(cb); },
+    removeEventListener(ev: string, cb: Listener) {
+      listeners[ev] = (listeners[ev] || []).filter(l => l !== cb);
+    },
+    _fire(ev: string, data: any = {}) { (listeners[ev] || []).forEach(l => l(data)); },
+  };
+}
+
+function makeRegistration(installing: any = null, waiting: any = null) {
+  const listeners: Record<string, Listener[]> = {};
+  return {
+    installing, waiting,
+    update: vi.fn().mockResolvedValue(undefined),
+    addEventListener(ev: string, cb: Listener) { (listeners[ev] ||= []).push(cb); },
+    _fire(ev: string, data: any = {}) { (listeners[ev] || []).forEach(l => l(data)); },
+  };
+}
+
+describe('registerWithUpdates', () => {
+  beforeEach(() => {
+    const waitingWorker = makeFakeWorker();
+    const registration = makeRegistration(null, waitingWorker);
+    const fakeNavigator = {
+      serviceWorker: {
+        register: vi.fn().mockResolvedValue(registration),
+        controller: { postMessage: vi.fn() } as any,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    };
+    Object.defineProperty(globalThis, 'navigator', {
+      value: fakeNavigator,
+      writable: true,
+      configurable: true,
+    });
+    (globalThis as any)._fakes = { waitingWorker, registration };
+  });
+
+  it('resolves to a handle exposing the registration', async () => {
+    const handle = await registerWithUpdates('/sw.js');
+    expect(handle.registration).toBe((globalThis as any)._fakes.registration);
+  });
+
+  it('does not fire updateReady on first install (no existing controller)', async () => {
+    navigator.serviceWorker.controller = null as any;
+    const handle = await registerWithUpdates('/sw.js');
+    const cb = vi.fn();
+    handle.onUpdateReady(cb);
+    const { registration } = (globalThis as any)._fakes;
+    const newWorker = makeFakeWorker();
+    registration.installing = newWorker;
+    registration._fire('updatefound');
+    newWorker.state = 'installed';
+    newWorker._fire('statechange');
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('fires updateReady when a new worker installs while an old one controls', async () => {
+    const handle = await registerWithUpdates('/sw.js');
+    const cb = vi.fn();
+    handle.onUpdateReady(cb);
+    const { registration } = (globalThis as any)._fakes;
+    const newWorker = makeFakeWorker();
+    registration.installing = newWorker;
+    registration._fire('updatefound');
+    newWorker.state = 'installed';
+    newWorker._fire('statechange');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('apply() posts skip-waiting to the waiting worker', async () => {
+    const handle = await registerWithUpdates('/sw.js');
+    const cb = vi.fn();
+    handle.onUpdateReady(cb);
+    const { registration } = (globalThis as any)._fakes;
+    const newWorker = makeFakeWorker();
+    registration.installing = newWorker;
+    registration._fire('updatefound');
+    newWorker.state = 'installed';
+    registration.waiting = newWorker;
+    newWorker._fire('statechange');
+    const apply = cb.mock.calls[0][0];
+    apply();
+    expect(newWorker.postMessage).toHaveBeenCalledWith({ type: 'skip-waiting' });
+  });
+
+  it('checkForUpdate() calls registration.update()', async () => {
+    const handle = await registerWithUpdates('/sw.js');
+    await handle.checkForUpdate();
+    expect((globalThis as any)._fakes.registration.update).toHaveBeenCalled();
+  });
+});

--- a/packages/solobase-web/src/update.ts
+++ b/packages/solobase-web/src/update.ts
@@ -1,0 +1,61 @@
+export interface UpdateHandle {
+  registration: ServiceWorkerRegistration;
+  /**
+   * Subscribe to updates. The callback receives an `apply` function that
+   * posts `skip-waiting` to the installed-but-waiting SW; call it when the
+   * consumer is ready to switch over (e.g., after user clicks a toast).
+   * Returns an unsubscribe function.
+   */
+  onUpdateReady(cb: (apply: () => Promise<void>) => void): () => void;
+  /** Force an update check. Wraps `registration.update()`. */
+  checkForUpdate(): Promise<void>;
+}
+
+export async function registerWithUpdates(
+  scriptURL: string,
+  opts?: { scope?: string; type?: WorkerType },
+): Promise<UpdateHandle> {
+  const registration = await navigator.serviceWorker.register(scriptURL, {
+    scope: opts?.scope ?? '/',
+    type: opts?.type ?? 'module',
+    updateViaCache: 'none',
+  });
+
+  const callbacks = new Set<(apply: () => Promise<void>) => void>();
+
+  registration.addEventListener('updatefound', () => {
+    const installing = registration.installing;
+    if (!installing) return;
+    installing.addEventListener('statechange', () => {
+      if (installing.state !== 'installed') return;
+      // Only treat as "update" when there's an existing controller.
+      if (!navigator.serviceWorker.controller) return;
+      const apply = () => applyUpdate(registration);
+      for (const cb of callbacks) cb(apply);
+    });
+  });
+
+  return {
+    registration,
+    onUpdateReady(cb) {
+      callbacks.add(cb);
+      return () => callbacks.delete(cb);
+    },
+    async checkForUpdate() {
+      await registration.update();
+    },
+  };
+}
+
+function applyUpdate(registration: ServiceWorkerRegistration): Promise<void> {
+  const waiting = registration.waiting ?? registration.installing;
+  if (!waiting) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const onChange = () => {
+      navigator.serviceWorker.removeEventListener('controllerchange', onChange);
+      resolve();
+    };
+    navigator.serviceWorker.addEventListener('controllerchange', onChange);
+    waiting.postMessage({ type: 'skip-waiting' });
+  });
+}

--- a/packages/solobase-web/src/worker.ts
+++ b/packages/solobase-web/src/worker.ts
@@ -42,7 +42,11 @@ declare const self: ServiceWorkerGlobalScope;
 
 if (typeof ServiceWorkerGlobalScope !== 'undefined') {
   self.addEventListener('install', (event) => {
-    event.waitUntil(initialize().then(() => self.skipWaiting()));
+    event.waitUntil(initialize());
+    // NOTE: no skipWaiting here. Consumers opt in by posting
+    // { type: 'skip-waiting' } from the main thread when they want to
+    // apply an update. The standalone pkg/ site uses its own sw.js
+    // which does call skipWaiting.
   });
 
   self.addEventListener('activate', (event) => {
@@ -50,6 +54,10 @@ if (typeof ServiceWorkerGlobalScope !== 'undefined') {
   });
 
   self.addEventListener('message', (event) => {
+    if (event.data?.type === 'skip-waiting') {
+      self.skipWaiting();
+      return;
+    }
     if (event.data?.type === 'solobase:config' && Array.isArray(event.data.routes)) {
       routes = event.data.routes;
     }

--- a/packages/solobase-web/test-fixtures/vite-app/index.html
+++ b/packages/solobase-web/test-fixtures/vite-app/index.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html><head><title>fixture</title></head>
+<body><script type="module" src="/src/main.ts"></script></body></html>

--- a/packages/solobase-web/test-fixtures/vite-app/package-lock.json
+++ b/packages/solobase-web/test-fixtures/vite-app/package-lock.json
@@ -1,0 +1,1001 @@
+{
+  "name": "vite-app-fixture",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vite-app-fixture",
+      "dependencies": {
+        "solobase-web": "file:../../"
+      },
+      "devDependencies": {
+        "vite": "^5.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/solobase-web": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/solobase-web/test-fixtures/vite-app/package.json
+++ b/packages/solobase-web/test-fixtures/vite-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vite-app-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "verify": "node verify.mjs"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "solobase-web": "file:../../"
+  }
+}

--- a/packages/solobase-web/test-fixtures/vite-app/src/main.ts
+++ b/packages/solobase-web/test-fixtures/vite-app/src/main.ts
@@ -1,0 +1,5 @@
+import { registerWithUpdates } from 'solobase-web';
+
+registerWithUpdates('/sw.js').then((handle) => {
+  console.log('registered', handle.registration);
+});

--- a/packages/solobase-web/test-fixtures/vite-app/src/sw.ts
+++ b/packages/solobase-web/test-fixtures/vite-app/src/sw.ts
@@ -1,0 +1,9 @@
+import { initialize, handleRequest } from 'solobase-web/worker';
+
+self.addEventListener('install', (event: any) => {
+  event.waitUntil(initialize());
+});
+
+self.addEventListener('fetch', (event: any) => {
+  event.respondWith(handleRequest(event.request));
+});

--- a/packages/solobase-web/test-fixtures/vite-app/verify.mjs
+++ b/packages/solobase-web/test-fixtures/vite-app/verify.mjs
@@ -1,0 +1,20 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dist = 'dist';
+const sw = readFileSync(join(dist, 'sw.js'), 'utf8');
+const assets = readdirSync(join(dist, 'assets'));
+const wasm = assets.find((n) => n.endsWith('.wasm'));
+if (!wasm) {
+  console.error('FAIL: no .wasm emitted in dist/assets');
+  process.exit(1);
+}
+if (!wasm.match(/[-_.][a-zA-Z0-9]{8,}\.wasm$/)) {
+  console.error(`FAIL: wasm filename not hashed: ${wasm}`);
+  process.exit(1);
+}
+if (!sw.includes(wasm)) {
+  console.error(`FAIL: sw.js does not reference the hashed wasm ${wasm}`);
+  process.exit(1);
+}
+console.log(`OK: ${wasm} referenced from sw.js`);

--- a/packages/solobase-web/test-fixtures/vite-app/vite.config.ts
+++ b/packages/solobase-web/test-fixtures/vite-app/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: './index.html',
+        sw: './src/sw.ts',
+      },
+      output: {
+        entryFileNames: (info) => info.name === 'sw' ? 'sw.js' : 'assets/[name]-[hash].js',
+      },
+      // sql-wasm-esm.js is a runtime-served asset (not bundled) referenced by an absolute
+      // path in the WASM bridge. Externalize it so Rollup doesn't try to resolve it.
+      external: ['/sql-wasm-esm.js'],
+    },
+  },
+});


### PR DESCRIPTION
Implements the asset-versioning design spec: content-hashes long-lived assets (`solobase_web_bg.wasm`, wasm-bindgen glue, sql.js), renders `sw.js` + `index.html` from templates with hashed paths baked in, and sets `updateViaCache: 'none'` so the SW update check works on any static host without server-side cache headers.

## Summary

- **New crate `crates/solobase-web-bundle/`** — Rust post-processor that runs after `wasm-pack build`. Hashes files, rewrites cross-references (wasm-bindgen glue + sql.js UMD), emits `asset-manifest.json`, renders `.tmpl` → final files. 18 unit + 2 integration tests, deterministic outputs.
- **Standalone site (`crates/solobase-web/`)** — `sw.js` and `index.html` converted to `.tmpl`. Cache-bypass list updated for hashed URLs. `loader.js` uses `updateViaCache: 'none'`. Makefile invokes the bundler after `wasm-pack`.
- **npm package (`packages/solobase-web/`)** — drops auto-`skipWaiting()` on install (now gated behind a `skip-waiting` postMessage). New `registerWithUpdates()` helper with `onUpdateReady`/`checkForUpdate` (5 vitest tests). Version bumped to 0.2.0 (breaking) with CHANGELOG entry.

## Test plan

- [x] Bundler unit tests (18 passing)
- [x] Bundler integration tests (2 passing, deterministic)
- [x] Package unit tests — `registerWithUpdates` (5 passing)
- [x] Local end-to-end: `make clean && make build` produces hashed `pkg/` with no placeholders
- [x] Vite consumer fixture: `packages/solobase-web/test-fixtures/vite-app/` — verifies consumer bundlers hash the WASM (`OK: solobase_web_bg-<hash>.wasm referenced from sw.js`)
- [ ] Playwright E2E scaffolded but not yet wired into CI — see follow-ups

## Deviations from the plan

- The plan assumed `"sql-wasm.wasm"` appeared once inside `sql-wasm-esm.js`; the real minified UMD has four occurrences. The bundler was extended with a new `rewrite_all` helper (kept strict `rewrite_literal` for wasm-bindgen glue, which has a contractual single reference). The integration fixture was expanded to multiple occurrences so the test actually exercises the multi-rewrite path.
- `packages/solobase-web/` has pre-existing TypeScript + build issues unrelated to this branch. Task 13 + 15 worked around them locally; fixing them is out of scope here.

## Docs

- Spec: `docs/superpowers/specs/2026-04-18-solobase-web-asset-versioning-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-solobase-web-asset-versioning.md`

## Known follow-ups (out of scope)

- Wire Playwright E2E into CI with a `webServer` config.
- Fix pre-existing vitest discovery picking up `dist/` in the npm package.
- Strengthen the "no-op rebuild" Playwright test to also compare asset-manifest URLs (not just `buildId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)