### PR TITLE
ci: solobase-web Playwright smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,74 @@ jobs:
       - name: Build WASM
         run: cd crates/solobase-web && wasm-pack build --target web --release
 
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout wafer-run
+        run: git clone --depth 1 https://github.com/wafer-run/wafer-run.git "$GITHUB_WORKSPACE/../wafer-run"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: e2e
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build solobase-web (framework assets + hashed pkg/)
+        run: cd crates/solobase-web && make build
+
+      - name: Install Playwright
+        working-directory: crates/solobase-web
+        run: |
+          npm install
+          npx playwright install chromium --with-deps
+
+      - name: Serve pkg/ in background
+        working-directory: crates/solobase-web
+        run: |
+          python3 -m http.server 8080 -d pkg &
+          echo $! > /tmp/http-pid
+          # Wait for server to accept connections
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/sw.js > /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run Playwright tests
+        working-directory: crates/solobase-web
+        run: npx playwright test --config=tests/playwright.config.ts tests/e2e/smoke.spec.ts
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f /tmp/http-pid ]; then
+            kill "$(cat /tmp/http-pid)" 2>/dev/null || true
+          fi
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: crates/solobase-web/playwright-report/
+          retention-days: 7
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/crates/solobase-web/tests/e2e/smoke.spec.ts
+++ b/crates/solobase-web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Lightweight smoke test that doesn't rebuild mid-test. Catches regressions
+ * like the `/manifest.json` bypass bug and the `/sql-wasm-esm.js` import
+ * path bug (both of which silently prevented SW registration).
+ */
+test('service worker registers and controls the page', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => navigator.serviceWorker.controller !== null,
+    null,
+    { timeout: 20_000 },
+  );
+  const controllerURL = await page.evaluate(
+    () => navigator.serviceWorker.controller?.scriptURL ?? null,
+  );
+  expect(controllerURL).toMatch(/\/sw\.js$/);
+});
+
+test('solobase-web admin UI at /b/system/ renders after SW activation', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => navigator.serviceWorker.controller !== null,
+    null,
+    { timeout: 20_000 },
+  );
+  // Navigate to the admin UI that solobase-web ships. Past the SW boundary,
+  // the UI block renders HTML served from WAFER. Any title/heading works —
+  // this smoke just confirms the runtime responds.
+  await page.goto('/b/system/');
+  const bodyText = await page.locator('body').textContent();
+  expect(bodyText ?? '').not.toBe('');
+});


### PR DESCRIPTION
## Summary

Adds an E2E CI job that builds solobase-web, serves \`pkg/\` on port 8080, and runs a new lightweight smoke test (\`crates/solobase-web/tests/e2e/smoke.spec.ts\`).

Two tests:
1. Service Worker registers and controls the page (catches SW registration failures).
2. \`/b/system/\` (solobase-web's admin UI) renders after SW activation (catches runtime / block-routing regressions).

## Why

Recent sub-project 1 PRs (#9, #10, #11) shipped two bugs that silently prevented SW registration — \`/manifest.json\` bypass and \`/sql-wasm-esm.js\` import path. Neither was caught by existing CI (wasm builds succeeded but nothing exercised the page in a browser). The existing \`sw-update.spec.ts\` is too heavy for CI because it rebuilds mid-test; this smoke test is lightweight (no rebuild) and runs fast.

## Test plan

- [x] Smoke test passes locally against a fresh \`make build\`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)