### PR TITLE
fix(webllm bridge): interrupt MLCEngine on cancel + drop leaked stream entry

### DIFF
--- a/crates/solobase-browser/assets/webllm-engine.js
+++ b/crates/solobase-browser/assets/webllm-engine.js
@@ -77,6 +77,12 @@ async function handleChatStream(msg) {
 function handleCancel(msg) {
     const ac = _activeStreams.get(msg.id);
     if (ac) ac.abort();
+    // WebLLM's chat.completions iterator doesn't accept an AbortSignal, but
+    // `interruptGenerate()` sets an internal flag the token loop checks —
+    // this is the only way to actually stop GPU work mid-generation.
+    if (_engine && typeof _engine.interruptGenerate === 'function') {
+        _engine.interruptGenerate();
+    }
 }
 
 navigator.serviceWorker.addEventListener('message', (event) => {

--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -409,7 +409,13 @@ export async function llmNextChunk(id) {
 export async function llmCancelStream(id) {
     const stream = _activeLlmStreams.get(id);
     if (stream) {
+        // Terminate any pending awaiter with an error frame (no-op if the
+        // Rust side has already broken out of its loop).
         stream.closeErr('cancelled');
+        // Remove the entry now rather than waiting for the (possibly never
+        // called) next llmNextChunk to notice the terminal frame — the Rust
+        // side breaks its loop immediately after calling cancel_stream.
+        _activeLlmStreams.delete(id);
     }
     await _postToWindowClient({ type: 'llm-stream-cancel', id });
 }


### PR DESCRIPTION
Two small follow-ups to the WebLLM bridge landed in PR #15. Both were flagged during code review at score 72 (below the 80 merge threshold) but are real.

## Changes

### 1. Actually stop GPU work on cancel (`webllm-engine.js`)
\`handleCancel\` previously only called \`AbortController.abort()\`. The chunk loop in \`handleChatStream\` checks \`ac.signal.aborted\` between yields, but WebLLM's \`chat.completions.create\` iterator doesn't accept a signal — the GPU kept generating tokens until the current one completed before the loop body noticed. Call \`engine.interruptGenerate()\` alongside the abort; that sets WebLLM's internal flag the token-generation loop polls, halting GPU work promptly.

### 2. Fix `_activeLlmStreams` leak (\`bridge.js\`)
\`llmCancelStream\` used to push an error frame via \`closeErr\` and rely on the next \`llmNextChunk(id)\` call to notice the terminal frame + delete the Map entry. But the Rust side breaks its poll loop immediately after \`bridge::cancel_stream\`, so \`llmNextChunk\` is never called again — one Map entry leaked per cancelled stream. Delete the entry eagerly in \`llmCancelStream\` itself.

## Test plan

- [x] \`cargo check -p solobase-browser --target wasm32-unknown-unknown\` clean
- [x] \`cargo test -p solobase-browser --lib llm\` — 16 pass (no tests touch bridge JS directly; browser smoke covers the chain)
- [ ] Manual browser smoke: start a chat, cancel mid-stream, confirm GPU stops + Map entry count doesn't grow

🤖 Generated with [Claude Code](https://claude.ai/code)