### PR TITLE
refactor(solobase-cli): drop dead --release flag

### DIFF
--- a/crates/solobase-cli/src/main.rs
+++ b/crates/solobase-cli/src/main.rs
@@ -21,13 +21,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Build the consumer app. Release profile by default.
+    /// Build the consumer app. Release profile unless --dev is given.
     Build {
-        /// Use the release profile (default). Mutually exclusive with --dev.
-        #[arg(long, default_value_t = false)]
-        release: bool,
         /// Use the dev profile (skips wasm-opt + content-hashing).
-        #[arg(long, default_value_t = false, conflicts_with = "release")]
+        /// Equivalent to the `dev` subcommand.
+        #[arg(long, default_value_t = false)]
         dev: bool,
     },
     /// Alias for `build --dev`.
@@ -45,7 +43,7 @@ fn run() -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let (cfg, repo_root) = config::find_and_load(&cwd)?;
     match cli.command {
-        Commands::Build { release: _, dev } => {
+        Commands::Build { dev } => {
             let profile = if dev {
                 build::BuildProfile::Dev
             } else {


### PR DESCRIPTION
Follow-up from PR #17's code review (finding scored 75 — just below the 80 auto-flag threshold but worth folding in).

The `Build` subcommand declared a `--release` flag but bound it to `_` in the match arm — `Release` is already the default when `--dev` is absent, so the flag was purely decorative, and would silently mismatch user intent if a third profile were ever added. Drop it; `--dev` alone captures the only meaningful toggle. Help text updated to 'Release profile unless --dev is given.'

## Test plan
- [x] `cargo test -p solobase-cli` — 31 pass (14 lib + 14 bin + 3 integration)
- [x] `cargo clippy -p solobase-cli -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)