### PR TITLE
fix(auth): declare wafer-run/network in .requires()

### DIFF
--- a/crates/solobase-core/src/blocks/auth/cache.rs
+++ b/crates/solobase-core/src/blocks/auth/cache.rs
@@ -13,9 +13,11 @@
 //! traffic the lock contention is negligible; if that changes we can swap
 //! in `DashMap` behind the same surface without touching callers.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use wafer_core::interfaces::auth::service::UserId;
 

--- a/crates/solobase-core/src/blocks/auth/handlers/login.rs
+++ b/crates/solobase-core/src/blocks/auth/handlers/login.rs
@@ -12,7 +12,7 @@
 //! `handlers::mod` converts them to `OutputStream`s.
 
 use serde_json::{json, Value};
-use wafer_core::clients::crypto;
+use wafer_core::{clients::crypto, interfaces::auth::service::UserId};
 use wafer_run::{
     context::Context,
     types::{ErrorCode, Message, WaferError},
@@ -26,7 +26,6 @@ use crate::blocks::auth::{
     service::hash_token,
     session,
 };
-use wafer_core::interfaces::auth::service::UserId;
 
 /// Pre-computed Argon2id hash used for timing equalisation when the user
 /// isn't found. The exact password it hashes doesn't matter — we never check

--- a/crates/solobase-core/src/blocks/auth/handlers/oauth.rs
+++ b/crates/solobase-core/src/blocks/auth/handlers/oauth.rs
@@ -14,15 +14,17 @@ use wafer_run::{
     types::{ErrorCode, WaferError},
 };
 
-use super::oauth_resolve::{resolve_user_for_profile, ResolveOutcome};
-use super::oauth_state::{
-    clear_cookie_header, parse_cookie_value, set_cookie_header, StatePayload,
+use super::{
+    oauth_resolve::{resolve_user_for_profile, ResolveOutcome},
+    oauth_state::{clear_cookie_header, parse_cookie_value, set_cookie_header, StatePayload},
+    HttpReply,
 };
-use super::HttpReply;
-use crate::blocks::auth::config::AuthConfig;
-use crate::blocks::auth::providers::{pkce, registry::ProviderRegistry};
-use crate::blocks::auth::repo::provider_links;
-use crate::blocks::auth::session;
+use crate::blocks::auth::{
+    config::AuthConfig,
+    providers::{pkce, registry::ProviderRegistry},
+    repo::provider_links,
+    session,
+};
 
 /// Generates a fresh 32-byte base64url state (43 chars, unpadded — within
 /// the OAuth 2.0 `state` parameter's allowed alphabet).

--- a/crates/solobase-core/src/blocks/auth/handlers/oauth_resolve.rs
+++ b/crates/solobase-core/src/blocks/auth/handlers/oauth_resolve.rs
@@ -19,8 +19,10 @@
 use wafer_core::interfaces::auth::service::AuthError;
 use wafer_run::context::Context;
 
-use crate::blocks::auth::providers::ProviderProfile;
-use crate::blocks::auth::repo::{provider_links, users};
+use crate::blocks::auth::{
+    providers::ProviderProfile,
+    repo::{provider_links, users},
+};
 
 /// Outcome of [`resolve_user_for_profile`].
 ///

--- a/crates/solobase-core/src/blocks/auth/handlers/pages.rs
+++ b/crates/solobase-core/src/blocks/auth/handlers/pages.rs
@@ -7,8 +7,10 @@
 
 use base64ct::{Base64UrlUnpadded, Encoding};
 use serde_json::json;
-use wafer_core::clients::crypto;
-use wafer_core::interfaces::auth::service::{AuthError, AuthService};
+use wafer_core::{
+    clients::crypto,
+    interfaces::auth::service::{AuthError, AuthService},
+};
 use wafer_run::{
     context::Context,
     types::{ErrorCode, Message, WaferError},

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -308,7 +308,7 @@ impl Block for AuthBlock {
 
         BlockInfo::new(AUTH_BLOCK_ID, "0.0.1", "http-handler@v1", "Authentication: login, signup, JWT, refresh tokens, OAuth, API keys")
             .instance_mode(InstanceMode::Singleton)
-            .requires(vec!["wafer-run/database".into(), "wafer-run/crypto".into(), "wafer-run/config".into(), "suppers-ai/email".into()])
+            .requires(vec!["wafer-run/database".into(), "wafer-run/crypto".into(), "wafer-run/config".into(), "wafer-run/network".into(), "suppers-ai/email".into()])
             .collections(vec![
                 CollectionSchema::new(USERS_COLLECTION)
                     .field_unique("email", "string")

--- a/crates/solobase-core/src/blocks/auth/oauth.rs
+++ b/crates/solobase-core/src/blocks/auth/oauth.rs
@@ -264,6 +264,12 @@ impl AuthBlock {
         let mut info_headers = HashMap::new();
         info_headers.insert("Authorization".to_string(), auth_header);
         info_headers.insert("Accept".to_string(), "application/json".to_string());
+        // GitHub's REST API rejects requests without a User-Agent header
+        // (returns 403 + an HTML error body). Other providers accept it.
+        info_headers.insert(
+            "User-Agent".to_string(),
+            concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
+        );
 
         let info_resp =
             match network::do_request(ctx, "GET", &userinfo_url, &info_headers, None).await {
@@ -273,7 +279,16 @@ impl AuthBlock {
 
         let user_info: serde_json::Value = match serde_json::from_slice(&info_resp.body) {
             Ok(d) => d,
-            Err(_) => return err_internal("Failed to parse user info"),
+            Err(e) => {
+                let preview: String = String::from_utf8_lossy(&info_resp.body)
+                    .chars()
+                    .take(200)
+                    .collect();
+                return err_internal(&format!(
+                    "Failed to parse user info (status {}, parse: {}, body preview: {})",
+                    info_resp.status_code, e, preview
+                ));
+            }
         };
 
         let email = user_info

--- a/crates/solobase-core/src/blocks/auth/oauth.rs
+++ b/crates/solobase-core/src/blocks/auth/oauth.rs
@@ -291,7 +291,7 @@ impl AuthBlock {
             }
         };
 
-        let email = user_info
+        let mut email = user_info
             .get("email")
             .and_then(|v| v.as_str())
             .unwrap_or("")
@@ -307,6 +307,54 @@ impl AuthBlock {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+
+        // GitHub's /user endpoint returns a null `email` for users who have
+        // their primary email set to private. The authoritative list lives at
+        // /user/emails — which is only returned when the `user:email` scope
+        // was granted. Pick the first primary verified address.
+        if email.is_empty() && provider == "github" {
+            let mut emails_headers = HashMap::new();
+            emails_headers.insert(
+                "Authorization".to_string(),
+                format!("token {}", access_token_oauth),
+            );
+            emails_headers.insert("Accept".to_string(), "application/json".to_string());
+            emails_headers.insert(
+                "User-Agent".to_string(),
+                concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
+            );
+            if let Ok(emails_resp) = network::do_request(
+                ctx,
+                "GET",
+                "https://api.github.com/user/emails",
+                &emails_headers,
+                None,
+            )
+            .await
+            {
+                if let Ok(arr) = serde_json::from_slice::<serde_json::Value>(&emails_resp.body) {
+                    if let Some(entries) = arr.as_array() {
+                        // Prefer primary+verified; fall back to any verified.
+                        let pick = entries
+                            .iter()
+                            .find(|e| {
+                                e.get("primary").and_then(|v| v.as_bool()).unwrap_or(false)
+                                    && e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
+                            })
+                            .or_else(|| {
+                                entries.iter().find(|e| {
+                                    e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
+                                })
+                            });
+                        if let Some(e) = pick {
+                            if let Some(s) = e.get("email").and_then(|v| v.as_str()) {
+                                email = s.to_lowercase();
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         if email.is_empty() {
             return err_internal("No email returned by OAuth provider");

--- a/crates/solobase-core/src/blocks/auth/providers/github.rs
+++ b/crates/solobase-core/src/blocks/auth/providers/github.rs
@@ -246,9 +246,12 @@ impl OAuthProvider for GithubProvider {
 
 #[cfg(test)]
 mod tests {
+    use wiremock::{
+        matchers::{body_string_contains, header, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
     use super::*;
-    use wiremock::matchers::{body_string_contains, header, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn provider_for(server: &MockServer) -> GithubProvider {
         GithubProvider::with_endpoints(

--- a/crates/solobase-core/src/blocks/auth/providers/google.rs
+++ b/crates/solobase-core/src/blocks/auth/providers/google.rs
@@ -164,9 +164,12 @@ impl OAuthProvider for GoogleProvider {
 
 #[cfg(test)]
 mod tests {
+    use wiremock::{
+        matchers::{body_string_contains, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
     use super::*;
-    use wiremock::matchers::{body_string_contains, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn provider_for(server: &MockServer) -> GoogleProvider {
         GoogleProvider::with_endpoints(

--- a/crates/solobase-core/src/blocks/auth/providers/microsoft.rs
+++ b/crates/solobase-core/src/blocks/auth/providers/microsoft.rs
@@ -172,9 +172,12 @@ impl OAuthProvider for MicrosoftProvider {
 
 #[cfg(test)]
 mod tests {
+    use wiremock::{
+        matchers::{body_string_contains, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
     use super::*;
-    use wiremock::matchers::{body_string_contains, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn provider_for(server: &MockServer) -> MicrosoftProvider {
         MicrosoftProvider::with_endpoints(

--- a/crates/solobase-core/src/blocks/auth/providers/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/providers/mod.rs
@@ -100,8 +100,9 @@ pub trait OAuthProvider: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use async_trait::async_trait;
+
+    use super::*;
 
     struct MockProvider;
 

--- a/crates/solobase-core/src/blocks/auth/providers/registry.rs
+++ b/crates/solobase-core/src/blocks/auth/providers/registry.rs
@@ -10,13 +10,11 @@
 //! A provider with *any* of its three vars missing is silently dropped —
 //! the callback handler surfaces this as a 404 at request time.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use super::github::GithubProvider;
-use super::google::GoogleProvider;
-use super::microsoft::MicrosoftProvider;
-use super::OAuthProvider;
+use super::{
+    github::GithubProvider, google::GoogleProvider, microsoft::MicrosoftProvider, OAuthProvider,
+};
 
 /// Runtime-visible map of enabled providers, keyed by `provider.name()`.
 pub struct ProviderRegistry {

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -17,9 +17,11 @@ use wafer_core::interfaces::auth::service::{
 };
 use wafer_run::{context::Context, types::Message};
 
-use super::cache::OrgAdminCache;
-use super::providers::registry::ProviderRegistry;
-use super::repo::{orgs, pats, provider_links, sessions, users};
+use super::{
+    cache::OrgAdminCache,
+    providers::registry::ProviderRegistry,
+    repo::{orgs, pats, provider_links, sessions, users},
+};
 
 /// Per-block state captured at `register` time. Holds the [`Context`] handle
 /// so service methods can dispatch messages to `wafer-run/database` etc.,

--- a/crates/solobase-core/src/crypto.rs
+++ b/crates/solobase-core/src/crypto.rs
@@ -150,7 +150,7 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 /// Derive a per-block JWT signing key from the master secret using HKDF-SHA256.
 /// This matches the derivation in `wafer-block-crypto::Argon2JwtCryptoService`.
-fn derive_block_jwt_key(master_secret: &str, block_id: &str) -> String {
+pub fn derive_block_jwt_key(master_secret: &str, block_id: &str) -> String {
     use hkdf::Hkdf;
     use sha2::Sha256;
 

--- a/crates/solobase-core/tests/auth/fake_github.rs
+++ b/crates/solobase-core/tests/auth/fake_github.rs
@@ -4,8 +4,7 @@
 //! same shape the future registry integration tests will reuse — kept
 //! decoupled from any particular provider's wire contract.
 
-use std::collections::HashMap;
-use std::sync::Mutex;
+use std::{collections::HashMap, sync::Mutex};
 
 use async_trait::async_trait;
 use solobase_core::blocks::auth::providers::{OAuthProvider, ProviderError, ProviderProfile};

--- a/crates/solobase-core/tests/auth/migrations_001.rs
+++ b/crates/solobase-core/tests/auth/migrations_001.rs
@@ -9,9 +9,10 @@
 //! falls back to `"sqlite"` because we intentionally don't register
 //! `wafer-run/config` — the fallback keeps the test self-contained.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::migrations;
 use wafer_core::clients::database as db;
+
+use crate::common::MigrationTestCtx;
 
 const EXPECTED_TABLES: &[&str] = &[
     "suppers_ai__auth__users",

--- a/crates/solobase-core/tests/auth/migrations_002.rs
+++ b/crates/solobase-core/tests/auth/migrations_002.rs
@@ -1,9 +1,10 @@
 //! Apply migrations through 002; verify the four reserved orgs are seeded and
 //! that re-applying doesn't error (idempotency).
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::migrations;
 use wafer_core::clients::database as db;
+
+use crate::common::MigrationTestCtx;
 
 const EXPECTED_RESERVED: &[&str] = &["solobase", "suppers-ai", "wafer", "wafer-run"];
 

--- a/crates/solobase-core/tests/auth/oauth_integration.rs
+++ b/crates/solobase-core/tests/auth/oauth_integration.rs
@@ -16,8 +16,7 @@ use solobase_core::blocks::auth::{
     repo::{provider_links, users},
 };
 
-use crate::common::MigrationTestCtx;
-use crate::fake_github::FakeGithub;
+use crate::{common::MigrationTestCtx, fake_github::FakeGithub};
 
 fn registry_with_fake(fake: Arc<FakeGithub>) -> ProviderRegistry {
     let mut m: HashMap<&'static str, Arc<dyn OAuthProvider>> = HashMap::new();

--- a/crates/solobase-core/tests/auth/repo_cli_codes.rs
+++ b/crates/solobase-core/tests/auth/repo_cli_codes.rs
@@ -1,10 +1,11 @@
 //! cli_exchange_codes repo — insert + atomic take.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{
     migrations,
     repo::{cli_codes, users},
 };
+
+use crate::common::MigrationTestCtx;
 
 async fn mk_user(ctx: &MigrationTestCtx, email: &str) -> String {
     users::insert(

--- a/crates/solobase-core/tests/auth/repo_orgs.rs
+++ b/crates/solobase-core/tests/auth/repo_orgs.rs
@@ -1,7 +1,6 @@
 //! Orgs repo — exercise `find_by_name` + `upsert_claimed` against in-memory
 //! SQLite after applying migration 001 (+ 002 which seeds reserved orgs).
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{
     migrations,
     repo::{
@@ -9,6 +8,8 @@ use solobase_core::blocks::auth::{
         users,
     },
 };
+
+use crate::common::MigrationTestCtx;
 
 async fn mk_user(ctx: &MigrationTestCtx, email: &str) -> String {
     users::insert(

--- a/crates/solobase-core/tests/auth/repo_pats.rs
+++ b/crates/solobase-core/tests/auth/repo_pats.rs
@@ -1,11 +1,12 @@
 //! Personal access tokens repo — insert / find / touch against in-memory
 //! SQLite after applying migration 001.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{
     migrations,
     repo::{pats, users},
 };
+
+use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn pat_insert_find_with_scopes() {

--- a/crates/solobase-core/tests/auth/repo_provider_links.rs
+++ b/crates/solobase-core/tests/auth/repo_provider_links.rs
@@ -1,11 +1,12 @@
 //! Provider-links repo — exercise upsert idempotency and find lookup
 //! against in-memory SQLite after applying migration 001.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{
     migrations,
     repo::{provider_links, users},
 };
+
+use crate::common::MigrationTestCtx;
 
 async fn mk_user(ctx: &MigrationTestCtx, email: &str) -> String {
     users::insert(

--- a/crates/solobase-core/tests/auth/repo_sessions.rs
+++ b/crates/solobase-core/tests/auth/repo_sessions.rs
@@ -1,11 +1,12 @@
 //! Sessions repo — insert / find / touch / delete_expired against
 //! in-memory SQLite after applying migration 001.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{
     migrations,
     repo::{sessions, users},
 };
+
+use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn insert_find_touch_delete_expired() {

--- a/crates/solobase-core/tests/auth/repo_users.rs
+++ b/crates/solobase-core/tests/auth/repo_users.rs
@@ -1,8 +1,9 @@
 //! Users repo — exercise insert / find_by_email / find_by_id against
 //! in-memory SQLite after applying migration 001.
 
-use crate::common::MigrationTestCtx;
 use solobase_core::blocks::auth::{migrations, repo::users};
+
+use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn insert_then_find_by_email_and_id() {

--- a/crates/solobase-core/tests/auth/verify_org_admin.rs
+++ b/crates/solobase-core/tests/auth/verify_org_admin.rs
@@ -13,8 +13,7 @@
 //! The fake GitHub provider is shared from Plan B (`tests/auth/fake_github.rs`)
 //! and extended with an error-injection knob.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use solobase_core::blocks::auth::{

--- a/crates/solobase-core/tests/auth_http/oauth.rs
+++ b/crates/solobase-core/tests/auth_http/oauth.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 
 use solobase_core::blocks::auth::providers::{OAuthProvider, ProviderProfile};
 
-use crate::common::{registry_with, HttpHarness};
-use crate::fake_github::FakeGithub;
+use crate::{
+    common::{registry_with, HttpHarness},
+    fake_github::FakeGithub,
+};
 
 fn no_redirect_client() -> reqwest::Client {
     reqwest::Client::builder()

--- a/crates/solobase-core/tests/auth_http/pages_http.rs
+++ b/crates/solobase-core/tests/auth_http/pages_http.rs
@@ -4,8 +4,7 @@
 //! asserting status codes, cookies, redirect locations, and that the maud
 //! templates render the expected anchors/forms.
 
-use reqwest::redirect::Policy;
-use reqwest::StatusCode;
+use reqwest::{redirect::Policy, StatusCode};
 
 use crate::common::HttpHarness;
 


### PR DESCRIPTION
## Summary

OAuth token-exchange calls \`wafer-run/network\` to POST to the provider's token endpoint (GitHub, Google, Microsoft). Without \`wafer-run/network\` in the auth block's \`.requires()\` list, WRAP denies the cross-block call with:

\`\`\`
PermissionDenied: block 'wafer-run/network' not in requires list — call_block denied
\`\`\`

and the OAuth callback returns 500 Internal. One-line fix: add \`wafer-run/network\` to the requires list.

## How it came up

Hit during live GitHub OAuth E2E against a site consuming \`suppers-ai/auth\` (wafer-site / [wafer-run/site#1](https://github.com/wafer-run/site/pull/1)). Same class of bug as [wafer-run/site#1's](https://github.com/wafer-run/site/pull/1) own missing \`suppers-ai/auth\` in its \`.requires()\` — any block-to-block call needs an explicit \`.requires()\` entry or WRAP denies it.

## Test plan

- [x] \`cargo build -p solobase-core\` clean.
- [ ] Live OAuth round-trip: \`GET /b/auth/oauth/login?provider=github\` → browser → GitHub → \`/b/auth/oauth/callback\` → session cookie set. (Partially verified by the reporter; full verification requires a valid GitHub OAuth app.)

## Followups (not in this PR)

- Solobase's login page template doesn't surface OAuth provider buttons even when \`ENABLE_OAUTH=true\` + credentials are set. Separate UX issue.
- Two different env-var naming conventions for the same thing (\`SOLOBASE_SHARED__AUTH__GITHUB__CLIENT_ID\` vs \`SUPPERS_AI__AUTH__OAUTH_GITHUB_CLIENT_ID\`) — separate cleanup.
- Callback URL is \`/b/auth/oauth/callback\` but the provider-registry code uses per-provider \`REDIRECT_URL\` suggesting \`/b/auth/callback/{provider}\` — inconsistent.