### PR TITLE
fix(blocks): adopt wafer_run::register_static_block! macro + use as _ anchors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,15 +2721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +2841,26 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6026,6 +6037,7 @@ dependencies = [
  "async-trait",
  "tracing",
  "wafer-block",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6079,6 +6091,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "wafer-block",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6148,6 +6161,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "wafer-block",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6157,6 +6171,7 @@ dependencies = [
  "async-trait",
  "tracing",
  "wafer-block",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6180,6 +6195,7 @@ dependencies = [
  "async-trait",
  "serde_json",
  "wafer-block",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6206,6 +6222,7 @@ dependencies = [
  "tracing",
  "wafer-block",
  "wafer-core",
+ "wafer-run",
 ]
 
 [[package]]
@@ -6243,7 +6260,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "getrandom 0.2.17",
- "inventory",
+ "linkme",
  "parking_lot",
  "reqwest",
  "serde",

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -449,10 +449,4 @@ async fn handle_delete_wrap_grant(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/admin",
-        factory: || ::std::sync::Arc::new(AdminBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/admin", AdminBlock);

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -679,10 +679,4 @@ pub async fn authenticate_api_key(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/auth",
-        factory: || ::std::sync::Arc::new(AuthBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/auth", AuthBlock);

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -400,10 +400,4 @@ impl<'a> std::io::Write for Base64Encoder<'a> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/email",
-        factory: || ::std::sync::Arc::new(EmailBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/email", EmailBlock);

--- a/crates/solobase-core/src/blocks/fastembed.rs
+++ b/crates/solobase-core/src/blocks/fastembed.rs
@@ -113,10 +113,4 @@ impl Block for FastembedBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/fastembed",
-        factory: || ::std::sync::Arc::new(FastembedBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/fastembed", FastembedBlock);

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -219,10 +219,4 @@ pub async fn handle_admin_cloud(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/files",
-        factory: || ::std::sync::Arc::new(FilesBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/files", FilesBlock);

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -629,10 +629,4 @@ impl Block for LegalPagesBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/legalpages",
-        factory: || ::std::sync::Arc::new(LegalPagesBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/legalpages", LegalPagesBlock);

--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -280,10 +280,4 @@ impl Block for MessagesBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/messages",
-        factory: || ::std::sync::Arc::new(MessagesBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/messages", MessagesBlock);

--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -24,8 +24,8 @@ pub mod vector;
 /// Return `BlockInfo` for every solobase block.
 ///
 /// Sources:
-/// - Auto-registered (zero-arg) blocks via the `inventory` crate — same
-///   instances Wafer::new() will register at runtime.
+/// - Auto-registered (zero-arg) blocks via `linkme` — same instances
+///   Wafer::new() will register at runtime.
 /// - LlmBlock — constructed with a throwaway ProviderLlmService since its
 ///   info() is declarative and doesn't depend on the real service. Can't
 ///   auto-register because its constructor takes Arc<ProviderLlmService>.
@@ -35,7 +35,8 @@ pub mod vector;
 #[cfg(not(target_arch = "wasm32"))]
 pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
     #[cfg_attr(not(feature = "llm"), allow(unused_mut))]
-    let mut infos: Vec<_> = wafer_run::inventory::iter::<wafer_run::StaticBlockRegistration>()
+    let mut infos: Vec<_> = wafer_run::STATIC_BLOCK_REGISTRATIONS
+        .iter()
         .map(|reg| (reg.factory)().info())
         .collect();
 
@@ -49,9 +50,9 @@ pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
     infos
 }
 
-/// wasm32 fallback: inventory doesn't exist on wasm32 (wafer-run gates
+/// wasm32 fallback: linkme is not supported on wasm32 (wafer-run gates
 /// `StaticBlockRegistration` behind `cfg(not(target_arch = "wasm32"))`), so
-/// enumerate blocks manually. Same content the inventory iteration would
+/// enumerate blocks manually. Same content the linkme iteration would
 /// produce on native, plus LlmBlock under `feature = "llm"`.
 #[cfg(target_arch = "wasm32")]
 pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
@@ -87,7 +88,7 @@ pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
 
 /// Register the LLM feature block with the WAFER runtime.
 ///
-/// LlmBlock cannot self-register via `inventory::submit!` because its
+/// LlmBlock cannot self-register via `register_static_block!` because its
 /// constructor takes `Arc<ProviderLlmService>`. Call this after the LLM
 /// service router is registered in `SolobaseBuilder::build()`.
 #[cfg(feature = "llm")]

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -330,10 +330,4 @@ impl Block for ProductsBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/products",
-        factory: || ::std::sync::Arc::new(ProductsBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/products", ProductsBlock);

--- a/crates/solobase-core/src/blocks/projects/mod.rs
+++ b/crates/solobase-core/src/blocks/projects/mod.rs
@@ -155,10 +155,4 @@ impl Block for ProjectsBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/projects",
-        factory: || ::std::sync::Arc::new(ProjectsBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/projects", ProjectsBlock);

--- a/crates/solobase-core/src/blocks/system.rs
+++ b/crates/solobase-core/src/blocks/system.rs
@@ -78,10 +78,4 @@ impl Block for SystemBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/system",
-        factory: || ::std::sync::Arc::new(SystemBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/system", SystemBlock);

--- a/crates/solobase-core/src/blocks/userportal.rs
+++ b/crates/solobase-core/src/blocks/userportal.rs
@@ -826,10 +826,4 @@ async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> OutputSt
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/userportal",
-        factory: || ::std::sync::Arc::new(UserPortalBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/userportal", UserPortalBlock);

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -93,10 +93,4 @@ impl Block for VectorBlock {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-::wafer_run::inventory::submit! {
-    ::wafer_run::StaticBlockRegistration {
-        name: "suppers-ai/vector",
-        factory: || ::std::sync::Arc::new(VectorBlock::new())
-            as ::std::sync::Arc<dyn ::wafer_run::Block>,
-    }
-}
+::wafer_run::register_static_block!("suppers-ai/vector", VectorBlock);

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -265,7 +265,7 @@ fn block_id_short_name(id: BlockId) -> &'static str {
 ///
 /// Checks feature flags and admin role. Dispatches via `ctx.call_block` — all
 /// solobase blocks are registered in the Wafer registry at boot (zero-arg
-/// blocks via `inventory::submit!`, LlmBlock via `register_llm()`).
+/// blocks via `register_static_block!`, LlmBlock via `register_llm()`).
 pub async fn route_to_block(
     ctx: &dyn Context,
     msg: Message,

--- a/crates/solobase-core/tests/autoreg_smoke.rs
+++ b/crates/solobase-core/tests/autoreg_smoke.rs
@@ -1,16 +1,16 @@
-//! Smoke test for inventory-based block auto-registration.
+//! Smoke test for linkme-based block auto-registration.
 //!
 //! Asserts that the 11 zero-arg suppers-ai/* blocks self-register at link
-//! time via #[inventory::submit!] (T4) and that LlmBlock — which has a
+//! time via register_static_block! and that LlmBlock — which has a
 //! non-zero-arg constructor — does NOT auto-register (it's manually
 //! registered by `solobase_core::blocks::register_llm()` from
 //! `solobase::SolobaseBuilder::build()`).
 
 // Force solobase_core's object files to be linked so that the
-// inventory::submit! static initialisers inside each block module are
-// included in the test binary.  Without this import the linker would
+// register_static_block! distributed-slice entries inside each block module
+// are included in the test binary.  Without this import the linker would
 // strip the crate's code entirely (no other symbols referenced) and
-// inventory::iter would return an empty set.
+// STATIC_BLOCK_REGISTRATIONS would be empty.
 use solobase_core as _;
 use wafer_run::Wafer;
 
@@ -39,7 +39,7 @@ fn all_zero_arg_blocks_auto_register() {
     for name in always_on {
         assert!(
             w.has_block(name),
-            "expected block {name} to be auto-registered via inventory"
+            "expected block {name} to be auto-registered via register_static_block!"
         );
     }
 

--- a/crates/solobase-core/tests/lockfile_e2e.rs
+++ b/crates/solobase-core/tests/lockfile_e2e.rs
@@ -66,8 +66,8 @@ source = "registry+https://example.test/registry"
     //    dirs::home_dir() → tmp.path(), then construct Wafer via the
     //    builder's explicit lockfile path (avoids WAFER_LOCKFILE global).
     //
-    //    disable_inventory() prevents the solobase inventory blocks from
-    //    being registered — we want a clean runtime for this assertion.
+    //    disable_inventory() prevents the solobase register_static_block! blocks
+    //    from being registered — we want a clean runtime for this assertion.
     // -----------------------------------------------------------------------
     let prior_home = std::env::var("HOME").ok();
     std::env::set_var("HOME", tmp.path());

--- a/crates/solobase-native/src/serve.rs
+++ b/crates/solobase-native/src/serve.rs
@@ -9,11 +9,10 @@
 
 use std::sync::Arc;
 
-use wafer_run::Wafer;
-
 // Force linker inclusion of wafer-block-http-listener so its
 // register_static_block! entry lands in STATIC_BLOCK_REGISTRATIONS.
 use wafer_block_http_listener as _;
+use wafer_run::Wafer;
 
 /// Register the `wafer-run/http-listener` block on `wafer` and configure
 /// it to bind `listen_addr` and dispatch through `flow_id`. Must be called

--- a/crates/solobase-native/src/serve.rs
+++ b/crates/solobase-native/src/serve.rs
@@ -11,6 +11,10 @@ use std::sync::Arc;
 
 use wafer_run::Wafer;
 
+// Force linker inclusion of wafer-block-http-listener so its
+// register_static_block! entry lands in STATIC_BLOCK_REGISTRATIONS.
+use wafer_block_http_listener as _;
+
 /// Register the `wafer-run/http-listener` block on `wafer` and configure
 /// it to bind `listen_addr` and dispatch through `flow_id`. Must be called
 /// before `wafer.start()`.
@@ -19,7 +23,10 @@ use wafer_run::Wafer;
 /// for solobase-server, but downstream consumers of this library pick their
 /// own flow name).
 pub fn register_http_listener(wafer: &mut Wafer, listen_addr: &str, flow_id: &str) {
-    wafer_block_http_listener::register(wafer).expect("register http-listener block");
+    // wafer-run/http-listener self-registers via register_static_block! in
+    // wafer-block-http-listener. The `use wafer_block_http_listener as _`
+    // above ensures the linker includes its .o file. We only need to set
+    // the block config here.
     wafer.add_block_config(
         "wafer-run/http-listener",
         serde_json::json!({ "flow": flow_id, "listen": listen_addr }),

--- a/crates/solobase/src/builder.rs
+++ b/crates/solobase/src/builder.rs
@@ -11,13 +11,6 @@ use solobase_core::{
     features::{BlockSettings, FeatureConfig},
     ExtraRoute, RouteAccess,
 };
-use wafer_core::interfaces::{
-    config::service::ConfigService, crypto::service::CryptoService,
-    database::service::DatabaseService, llm::service::LlmService, logger::service::LoggerService,
-    network::service::NetworkService, storage::service::StorageService,
-};
-use wafer_run::{block::Block, RuntimeError, Wafer};
-
 // Force linker inclusion of wafer-block-* crates so their linkme
 // distributed-slice entries land in the binary. Without these `use as _`
 // anchors the linker excludes the crate's .o file entirely and the
@@ -28,6 +21,12 @@ use wafer_block_readonly_guard as _;
 use wafer_block_router as _;
 use wafer_block_security_headers as _;
 use wafer_block_web as _;
+use wafer_core::interfaces::{
+    config::service::ConfigService, crypto::service::CryptoService,
+    database::service::DatabaseService, llm::service::LlmService, logger::service::LoggerService,
+    network::service::NetworkService, storage::service::StorageService,
+};
+use wafer_run::{block::Block, RuntimeError, Wafer};
 
 pub struct SolobaseBuilder {
     database: Option<Arc<dyn DatabaseService>>,

--- a/crates/solobase/src/builder.rs
+++ b/crates/solobase/src/builder.rs
@@ -18,6 +18,17 @@ use wafer_core::interfaces::{
 };
 use wafer_run::{block::Block, RuntimeError, Wafer};
 
+// Force linker inclusion of wafer-block-* crates so their linkme
+// distributed-slice entries land in the binary. Without these `use as _`
+// anchors the linker excludes the crate's .o file entirely and the
+// register_static_block! entries never appear in STATIC_BLOCK_REGISTRATIONS.
+use wafer_block_cors as _;
+use wafer_block_inspector as _;
+use wafer_block_readonly_guard as _;
+use wafer_block_router as _;
+use wafer_block_security_headers as _;
+use wafer_block_web as _;
+
 pub struct SolobaseBuilder {
     database: Option<Arc<dyn DatabaseService>>,
     storage: Option<Arc<dyn StorageService>>,
@@ -253,32 +264,24 @@ impl SolobaseBuilder {
         #[cfg(feature = "native-embedding")]
         register_vector_block(&mut wafer, self.sqlite_db_path.as_deref())?;
 
-        // 5. Register ALL middleware blocks.
-        //
-        // Auth + IAM used to live in the standalone `wafer-block-auth-validator`
-        // and `wafer-block-iam-guard` crates. They are now absorbed into the
-        // `suppers-ai/auth` feature block in `solobase-core` (auto-registered
-        // via `inventory::submit!` in step 3's `Wafer::new()`) and reached
-        // through `wafer_core::interfaces::auth::AuthService`.
-        wafer_block_cors::register(&mut wafer)?;
-        wafer_block_inspector::register(&mut wafer)?;
+        // 5. All middleware blocks (cors, inspector, readonly-guard, router,
+        // security-headers, web) self-register via register_static_block! in
+        // their respective wafer-block-* crates. The `use wafer_block_xxx as _`
+        // anchors at the top of this file ensure the linker includes those crate
+        // .o files so the linkme distributed-slice entries land in the binary.
         wafer.add_block_config(
             "wafer-run/inspector",
             serde_json::json!({ "allow_anonymous": false }),
         );
-        wafer_block_readonly_guard::register(&mut wafer)?;
-        wafer_block_router::register(&mut wafer)?;
-        wafer_block_security_headers::register(&mut wafer)?;
-        wafer_block_web::register(&mut wafer)?;
 
         // 5b. Apply platform-specific block configs
         for (name, config) in self.block_configs {
             wafer.add_block_config(&name, config);
         }
 
-        // 6. Register LlmBlock — it can't self-register via inventory::submit! because
-        //    its constructor takes Arc<ProviderLlmService>. All other solobase blocks
-        //    (including EmailBlock) self-register via inventory::submit! in Wafer::new().
+        // 6. Register LlmBlock — it can't self-register via register_static_block!
+        //    because its constructor takes Arc<ProviderLlmService>. All other solobase
+        //    blocks self-register via register_static_block! at link time.
         #[cfg(feature = "llm")]
         solobase_core::blocks::register_llm(&mut wafer, provider_llm_svc.clone())?;
 


### PR DESCRIPTION
Consumer migration for wafer-run#25 (inventory → linkme switch). Bundles the in-flight #28's removal of \`wafer_block_*::register()\` calls.

## What this does

1. **Replace 12 \`inventory::submit!\` stanzas** in \`solobase-core/src/blocks/\` with \`wafer_run::register_static_block!(name, Type)\` calls. The macro wraps wafer-run's new linkme-based collection.

2. **Drop the 7 \`wafer_block_*::register(&mut wafer)?\` calls** in \`builder.rs\` and \`serve.rs\` (deleted in wafer-run#23). Each crate is now anchored via \`use wafer_block_xxx as _;\` — without an anchor, the linker excludes the \`.o\` file entirely (linkme's caveat: it survives WITHIN-object DCE, not cross-crate inclusion).

3. **Update \`all_block_infos()\`** to iterate \`wafer_run::STATIC_BLOCK_REGISTRATIONS\` instead of \`inventory::iter\`.

4. **Update stale comments** in \`routing.rs\`, \`blocks/mod.rs\`, \`autoreg_smoke.rs\`, and \`lockfile_e2e.rs\`.

## Why both bundled

The two changes are tightly coupled. Without the \`use as _\` anchors, the wafer-block-* crates would not be linked in and the new linkme entries would never appear in the binary. Without the new macro, the inventory entries don't survive linker DCE. Either change alone is broken; both together work.

Closes #28 (the original consumer cleanup PR — its scope is bundled here).

## Test plan

- [x] \`cargo build --workspace --exclude solobase-web\` green
- [x] \`cargo test --workspace --exclude solobase-web\` green (572 tests passing)
- [x] \`autoreg_smoke\` test: 11 suppers-ai/* blocks register via register_static_block!
- [ ] All CI checks green (Format & Lint / Tests / WASM Build / E2E / Security Audit / TypeScript SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)