### PR TITLE
fix(blocks): mark optional empty-default ConfigVars as .optional()

### DIFF
--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -557,7 +557,8 @@ impl Block for LegalPagesBlock {
                     .name("Back Button URL")
                     .input_type(InputType::Url),
                 ConfigVar::new("SUPPERS_AI__LEGALPAGES__FOOTER", "Custom footer text (HTML allowed)", "")
-                    .name("Footer Text"),
+                    .name("Footer Text")
+                    .optional(),
             ])
             .admin_url("/b/legalpages/admin")
             .can_disable(true)

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -427,7 +427,8 @@ impl Block for LlmBlock {
                 "Default model to use (empty = provider default)",
                 "",
             )
-            .name("Default Model"),
+            .name("Default Model")
+            .optional(),
         ])
         .can_disable(true)
         .default_enabled(true)


### PR DESCRIPTION
## Summary
- `SUPPERS_AI__LEGALPAGES__FOOTER` and `SUPPERS_AI__LLM__DEFAULT_MODEL` have empty defaults and graceful in-block fallbacks, but were missing `.optional()` so `collect_missing_config` flagged them as required-but-missing and refused to start the runtime when nothing supplied a value.
- Every other empty-default-but-truly-optional var in the repo (auth's OAuth secrets, allowed email domains, redirect URI, etc.) already chains `.optional()`. These two were just missed.
- Surfaced by wafer-site CI on https://github.com/wafer-run/site/pull/3.

## Test plan
- [x] `cargo check -p solobase-core`
- [ ] Re-run wafer-site PR #3 CI after merge → Playwright job should boot the runtime cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)