### PR TITLE
chore(deps): bump wafer-run to pick up wasm32 lockfile fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5860,6 +5860,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "futures",
@@ -5879,6 +5880,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5891,6 +5893,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5901,6 +5904,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5920,6 +5924,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5929,6 +5934,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5944,6 +5950,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5955,6 +5962,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5965,6 +5973,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "serde",
@@ -5976,6 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5985,6 +5995,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -5999,6 +6010,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6016,6 +6028,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6025,6 +6038,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6035,6 +6049,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6049,6 +6064,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6059,6 +6075,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6075,6 +6092,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6086,6 +6104,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6102,6 +6121,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "serde",
  "serde_json",
@@ -6111,6 +6131,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6139,6 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#151830ecdb91d58281636bdc32382ad0e549c7ce"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
## Summary

Repins all 20 `wafer-*` git deps to `151830ec` (wafer-run main HEAD) to pick up [wafer-run/wafer-run#27](https://github.com/wafer-run/wafer-run/pull/27), which gates `LockfileSource::Auto` on `#[cfg(not(target_arch = "wasm32"))]`. That fixes the boot error on `demo.solobase.dev`:

```
{"error":"internal_error","message":"lockfile error: @ cache at wafer.lock: io: operation not supported on this platform. hint: run 'wafer install' to populate the cache"}
```

## Bonus: portable Cargo.lock

This commit also restores `source = "git+..."` lines for every `wafer-*` entry. They were missing on Cargo.lock since 3d757c0, which was committed under a local `[patch]` override (`.cargo/config.toml` pointing at `../wafer-run/`) — that silently strips the source URL. The lockfile is now portable again for builds that don't have the local path override active (i.e. CI, fresh clones, deploys).

## Test plan
- [x] `cargo check --workspace --exclude solobase-web` (native) — clean
- [x] `cd crates/solobase-web && wasm-pack build --target web --release` — clean
- [ ] Redeploy demo.solobase.dev and confirm the lockfile error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)