### PR TITLE
feat(loader): SW auto-reload on controllerchange

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -20,8 +20,19 @@ async function boot() {
                 if (sw.state === 'activated') resolve();
             });
         }
+        // Auto-reload when a new SW takes control (subsequent updates).
+        // __solobaseReloading prevents a loop with the first-registration
+        // reload below (both fire window.location.reload()).
+        if (!window.__solobaseReloading) {
+            navigator.serviceWorker.addEventListener('controllerchange', () => {
+                if (window.__solobaseReloading) return;
+                window.__solobaseReloading = true;
+                window.location.reload();
+            });
+        }
         if (!navigator.serviceWorker.controller) {
             status.textContent = 'First-time setup complete. Loading __APP_NAME__...';
+            window.__solobaseReloading = true;
             window.location.reload();
             return;
         }


### PR DESCRIPTION
## Summary
- Adds a `serviceWorker.controllerchange` listener in `loader.js.tmpl`. When a new SW takes control after `skipWaiting()`, the page reloads automatically.
- A `window.__solobaseReloading` flag, set before any `window.location.reload()` site, prevents a reload loop between the first-registration reload and the new listener.
- Optional checklist item from `gizza-ai/NEXT.md` (Plan C — deploy track), moved to this repo because the loader lives in `solobase-browser`, not gizza-ai.

## Test plan
- [x] `cargo build -p solobase-browser` clean.
- [ ] Manual: push two consecutive deploys to a Pages-hosted gizza-ai; second deploy auto-reloads without manual refresh.