### PR TITLE
feat(bridge): per-asset load timeout (wafer-run #29 consumer)

### DIFF
--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -270,7 +270,7 @@ export async function loadAsset(assetId, manifestJson) {
                 _pendingAssetLoads.delete(correlationId);
                 resolve({ status: 'failed', error: 'load-asset timed out' });
             }
-        }, 120_000);
+        }, manifest.timeout_ms ?? 120_000);
     });
 
     clients[0].postMessage({


### PR DESCRIPTION
## Summary
Wires bridge.js to read `manifest.timeout_ms ?? 120_000` instead of hardcoding the 120s default. Producer side (`ExternalAsset.timeout_ms` field) shipped in [wafer-run/wafer-run#29](https://github.com/wafer-run/wafer-run/pull/29).

Lets blocks declaring assets with long download budgets (e.g. ffmpeg-core ~31MB on slow links) override the default. No behavior change for existing assets — `undefined ?? 120_000 = 120_000`.

## Test plan
- [x] `cargo build -p solobase-browser` clean.
- [ ] Future ffmpeg block with `timeout_ms: Some(300_000)` exercises the new path end-to-end.