### PR TITLE
ui: phase 2 — shell + ⌘K adoption across 10 block files

### DIFF
--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -3,7 +3,8 @@ use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use wafer_sql_utils::{query, upsert, value::sea_values_to_json, Backend};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::BLOCK_SETTINGS_COLLECTION as BLOCK_SETTINGS,
     ui::{self, components, icons, SiteConfig, UserInfo},
@@ -203,6 +204,11 @@ pub async fn blocks_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/blocks",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Blocks"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -4,10 +4,9 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use wafer_sql_utils::{query, upsert, value::sea_values_to_json, Backend};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::BLOCK_SETTINGS_COLLECTION as BLOCK_SETTINGS,
-    ui::{self, components, icons, SiteConfig, UserInfo},
+    ui::{self, components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn blocks_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -4,13 +4,12 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{aggregate, query, value::sea_values_to_json, Backend};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::{AUDIT_LOGS_COLLECTION as AUDIT_LOGS, REQUEST_LOGS_COLLECTION as REQUEST_LOGS},
         auth::USERS_COLLECTION as USERS,
     },
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -3,7 +3,8 @@ use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, S
 use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{aggregate, query, value::sea_values_to_json, Backend};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::{AUDIT_LOGS_COLLECTION as AUDIT_LOGS, REQUEST_LOGS_COLLECTION as REQUEST_LOGS},
@@ -309,6 +310,11 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Dashboard"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -2,7 +2,8 @@ use maud::{html, PreEscaped};
 use wafer_core::clients::config;
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::helpers::{err_bad_request, ok_json},
     ui::{components, icons, SiteConfig, UserInfo},
@@ -102,6 +103,11 @@ function submitEmailSettings(e) {
         &site_config,
         "/b/admin/email",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Email"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -3,10 +3,9 @@ use wafer_core::clients::config;
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::helpers::{err_bad_request, ok_json},
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 const EMAIL_SETTINGS_KEYS: &[(&str, &str, &str, &str, bool)] = &[

--- a/crates/solobase-core/src/blocks/admin/pages/logs.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/logs.rs
@@ -2,7 +2,8 @@ use maud::{html, Markup};
 use wafer_core::clients::database::{self as db, Filter, FilterOp, SortField};
 use wafer_run::{context::Context, types::*, OutputStream};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::{AUDIT_LOGS_COLLECTION as AUDIT_LOGS, REQUEST_LOGS_COLLECTION as REQUEST_LOGS},
@@ -61,6 +62,11 @@ pub async fn logs_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/logs",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Logs"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/logs.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/logs.rs
@@ -3,13 +3,12 @@ use wafer_core::clients::database::{self as db, Filter, FilterOp, SortField};
 use wafer_run::{context::Context, types::*, OutputStream};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::{AUDIT_LOGS_COLLECTION as AUDIT_LOGS, REQUEST_LOGS_COLLECTION as REQUEST_LOGS},
         helpers::RecordExt,
     },
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn logs_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/mod.rs
@@ -27,8 +27,7 @@ pub use variables::*;
 use wafer_run::{types::*, OutputStream};
 
 use crate::ui::{
-    self,
-    nav_groups,
+    self, nav_groups,
     shell::{Crumb, Topbar},
     SiteConfig, UserInfo,
 };

--- a/crates/solobase-core/src/blocks/admin/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/mod.rs
@@ -26,77 +26,29 @@ pub use users::*;
 pub use variables::*;
 use wafer_run::{types::*, OutputStream};
 
-use crate::ui::{self, NavItem, SiteConfig, UserInfo};
+use crate::ui::{
+    self,
+    nav_groups,
+    shell::{Crumb, Topbar},
+    SiteConfig, UserInfo,
+};
 
-/// Admin nav items for the sidebar.
-pub(crate) fn admin_nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Dashboard".into(),
-            href: "/b/admin/".into(),
-            icon: "layout-dashboard",
-        },
-        NavItem {
-            label: "Users".into(),
-            href: "/b/admin/users".into(),
-            icon: "users",
-        },
-        NavItem {
-            label: "Config".into(),
-            href: "/b/admin/variables".into(),
-            icon: "settings",
-        },
-        NavItem {
-            label: "Network".into(),
-            href: "/b/admin/network".into(),
-            icon: "network",
-        },
-        NavItem {
-            label: "Storage".into(),
-            href: "/b/admin/storage".into(),
-            icon: "hard-drive",
-        },
-        NavItem {
-            label: "Permissions".into(),
-            href: "/b/admin/permissions".into(),
-            icon: "shield",
-        },
-        NavItem {
-            label: "Logs".into(),
-            href: "/b/admin/logs".into(),
-            icon: "file-text",
-        },
-        NavItem {
-            label: "Email".into(),
-            href: "/b/admin/email".into(),
-            icon: "globe",
-        },
-        NavItem {
-            label: "Blocks".into(),
-            href: "/b/admin/blocks".into(),
-            icon: "package",
-        },
-    ]
-}
-
-/// Wrap content in the admin shell (sidebar + layout), or return fragment for htmx.
+/// Wrap content in the admin shell. The caller passes a `Topbar` describing
+/// the page's breadcrumbs + optional primary action.
 pub(crate) fn admin_page(
     title: &str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    topbar: Topbar<'_>,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
-        title,
-        config,
-        &admin_nav(),
-        user,
-        path,
-        content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+    let groups = nav_groups::admin(path);
+    ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
+}
+
+/// Convenience: a single top-level breadcrumb with no link.
+pub(crate) fn crumb(label: &'static str) -> Vec<Crumb<'static>> {
+    vec![Crumb { label, href: None }]
 }

--- a/crates/solobase-core/src/blocks/admin/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn admin_page(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::admin(path);
+    let groups = nav_groups::admin();
     ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -4,13 +4,12 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{query, value::sea_values_to_json, Backend};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         NETWORK_REQUEST_LOGS_COLLECTION as NETWORK_REQUEST_LOGS,
         NETWORK_RULES_COLLECTION as NETWORK_RULES, REQUEST_LOGS_COLLECTION as REQUEST_LOGS,
     },
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn network_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -3,7 +3,8 @@ use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, S
 use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{query, value::sea_values_to_json, Backend};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         NETWORK_REQUEST_LOGS_COLLECTION as NETWORK_REQUEST_LOGS,
@@ -76,6 +77,11 @@ pub async fn network_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/network",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Network"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -2,7 +2,8 @@ use maud::{html, Markup};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, OutputStream};
 
-use super::{admin_page, network::network_rules_tab, storage::storage_rules_tab};
+use super::{admin_page, crumb, network::network_rules_tab, storage::storage_rules_tab};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         NETWORK_RULES_COLLECTION as NETWORK_RULES, STORAGE_RULES_COLLECTION as STORAGE_RULES,
@@ -80,6 +81,11 @@ pub async fn permissions_page(ctx: &dyn Context, msg: &Message) -> OutputStream 
         &config,
         "/b/admin/permissions",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Permissions"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -3,13 +3,12 @@ use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, OutputStream};
 
 use super::{admin_page, crumb, network::network_rules_tab, storage::storage_rules_tab};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         NETWORK_RULES_COLLECTION as NETWORK_RULES, STORAGE_RULES_COLLECTION as STORAGE_RULES,
         WRAP_GRANTS_COLLECTION as WRAP_GRANTS,
     },
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn grants_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/storage.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/storage.rs
@@ -4,13 +4,12 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{query, value::sea_values_to_json, Backend};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         STORAGE_ACCESS_LOGS_COLLECTION as STORAGE_ACCESS_LOGS,
         STORAGE_RULES_COLLECTION as STORAGE_RULES,
     },
-    ui::{components, icons, SiteConfig, UserInfo},
+    ui::{components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn storage_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/storage.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/storage.rs
@@ -3,7 +3,8 @@ use wafer_core::clients::database::{self as db, ListOptions, SortField};
 use wafer_run::{context::Context, types::*, OutputStream};
 use wafer_sql_utils::{query, value::sea_values_to_json, Backend};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::admin::{
         STORAGE_ACCESS_LOGS_COLLECTION as STORAGE_ACCESS_LOGS,
@@ -67,6 +68,11 @@ pub async fn storage_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/storage",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Storage"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -1,8 +1,8 @@
-use maud::{html, Markup};
+use maud::{html, Markup, PreEscaped};
 use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, SortField};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::admin_page;
+use super::{admin_page, crumb};
 use crate::{
     blocks::{
         admin::{ROLES_COLLECTION, USER_ROLES_COLLECTION},
@@ -12,7 +12,13 @@ use crate::{
             ResponseBuilder,
         },
     },
-    ui::{self, components, icons, SiteConfig, UserInfo},
+    ui::{
+        self,
+        components::{self, button, BtnVariant, CtrlSize},
+        icons,
+        shell::Topbar,
+        SiteConfig, UserInfo,
+    },
 };
 
 pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -67,6 +73,18 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/users",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Users"),
+            primary_action: Some(button(
+                BtnVariant::Primary,
+                CtrlSize::Md,
+                "+ Invite user",
+                PreEscaped(
+                    r##"hx-get="/b/admin/users/new" hx-target="#content""##.to_string(),
+                ),
+            )),
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -79,9 +79,7 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 BtnVariant::Primary,
                 CtrlSize::Md,
                 "+ Invite user",
-                PreEscaped(
-                    r##"hx-get="/b/admin/users/new" hx-target="#content""##.to_string(),
-                ),
+                PreEscaped(r##"hx-get="/b/admin/users/new" hx-target="#content""##.to_string()),
             )),
             show_palette: true,
         },

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -2,7 +2,8 @@ use maud::{html, Markup};
 use wafer_core::clients::database::{self as db, ListOptions};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::admin_page;
+use super::{admin_page, crumb};
+use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::VARIABLES_COLLECTION as VARIABLES,
@@ -92,6 +93,11 @@ pub async fn variables_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/admin/variables",
         user.as_ref(),
+        Topbar {
+            crumbs: crumb("Variables"),
+            primary_action: None,
+            show_palette: true,
+        },
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -3,13 +3,12 @@ use wafer_core::clients::database::{self as db, ListOptions};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use super::{admin_page, crumb};
-use crate::ui::shell::Topbar;
 use crate::{
     blocks::{
         admin::VARIABLES_COLLECTION as VARIABLES,
         helpers::{self, err_bad_request, err_internal, err_not_found, parse_form_body, RecordExt},
     },
-    ui::{self, components, icons, SiteConfig, UserInfo},
+    ui::{self, components, icons, shell::Topbar, SiteConfig, UserInfo},
 };
 
 pub async fn variables_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/auth/login.rs
+++ b/crates/solobase-core/src/blocks/auth/login.rs
@@ -860,35 +860,37 @@ impl AuthBlock {
         let markup = ui::layout::page(
             "Reset Password",
             &config,
-            auth_split(brand_panel(&config), html! {
-                div .login-container {
-                    div .login-logo {
-                        @if !logo_url.is_empty() {
-                            img .logo-image src=(logo_url) alt="Solobase";
+            auth_split(
+                brand_panel(&config),
+                html! {
+                    div .login-container {
+                        div .login-logo {
+                            @if !logo_url.is_empty() {
+                                img .logo-image src=(logo_url) alt="Solobase";
+                            }
+                            p .login-subtitle { "Reset your password" }
                         }
-                        p .login-subtitle { "Reset your password" }
+
+                        div #error .login-error style="display:none" {}
+                        div #success style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:.75rem;margin-bottom:1rem;font-size:.813rem;color:#059669;display:none" {}
+
+                        form #form .login-form onsubmit="return handleReset(event)" {
+                            input type="hidden" #reset-token name="token" value=(token);
+
+                            div .form-group {
+                                label .form-label for="password" { "New Password" }
+                                input .form-input type="password" #password required minlength="8" placeholder="Min 8 characters";
+                            }
+                            div .form-group {
+                                label .form-label for="confirm" { "Confirm Password" }
+                                input .form-input type="password" #confirm required minlength="8" placeholder="Repeat password";
+                            }
+
+                            button .login-button type="submit" #btn { "Reset Password" }
+                        }
                     }
 
-                    div #error .login-error style="display:none" {}
-                    div #success style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:.75rem;margin-bottom:1rem;font-size:.813rem;color:#059669;display:none" {}
-
-                    form #form .login-form onsubmit="return handleReset(event)" {
-                        input type="hidden" #reset-token name="token" value=(token);
-
-                        div .form-group {
-                            label .form-label for="password" { "New Password" }
-                            input .form-input type="password" #password required minlength="8" placeholder="Min 8 characters";
-                        }
-                        div .form-group {
-                            label .form-label for="confirm" { "Confirm Password" }
-                            input .form-input type="password" #confirm required minlength="8" placeholder="Repeat password";
-                        }
-
-                        button .login-button type="submit" #btn { "Reset Password" }
-                    }
-                }
-
-                script { (PreEscaped(r#"
+                    script { (PreEscaped(r#"
 var $=function(id){return document.getElementById(id)};
 async function handleReset(e){
   e.preventDefault();
@@ -910,7 +912,8 @@ async function handleReset(e){
   return false;
 }
 "#)) }
-            }),
+                },
+            ),
         );
 
         ui::html_response(markup)
@@ -1030,25 +1033,28 @@ fn html_respond(title: &str, message: &str, success: bool, logo_url: &str) -> Ou
     let markup = ui::layout::page(
         title,
         &config,
-        auth_split(brand_panel(&config), html! {
-            div .login-container {
-                div .login-logo {
-                    @if !logo_url.is_empty() {
-                        img .logo-image src=(logo_url) alt="Solobase";
+        auth_split(
+            brand_panel(&config),
+            html! {
+                div .login-container {
+                    div .login-logo {
+                        @if !logo_url.is_empty() {
+                            img .logo-image src=(logo_url) alt="Solobase";
+                        }
+                    }
+                    div style="text-align:center" {
+                        div style={"width:48px;height:48px;background:" (color) "15;border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto 1rem;font-size:1.5rem;color:" (color)} {
+                            @if success { "✓" } @else { "✗" }
+                        }
+                        h2 style="font-size:1.25rem;font-weight:700;margin:0 0 .5rem" { (title) }
+                        p .login-subtitle style="line-height:1.6;margin:0 0 1.5rem" { (message) }
+                        a .login-button href="/b/auth/login" style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
+                            "Go to Sign In"
+                        }
                     }
                 }
-                div style="text-align:center" {
-                    div style={"width:48px;height:48px;background:" (color) "15;border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto 1rem;font-size:1.5rem;color:" (color)} {
-                        @if success { "✓" } @else { "✗" }
-                    }
-                    h2 style="font-size:1.25rem;font-weight:700;margin:0 0 .5rem" { (title) }
-                    p .login-subtitle style="line-height:1.6;margin:0 0 1.5rem" { (message) }
-                    a .login-button href="/b/auth/login" style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
-                        "Go to Sign In"
-                    }
-                }
-            }
-        }),
+            },
+        ),
     );
     ui::html_response(markup)
 }

--- a/crates/solobase-core/src/blocks/auth/login.rs
+++ b/crates/solobase-core/src/blocks/auth/login.rs
@@ -4,7 +4,7 @@ use maud::{html, PreEscaped};
 use wafer_core::clients::{config, crypto, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{helpers::*, AuthBlock, USERS_COLLECTION};
+use super::{brand_panel, helpers::*, AuthBlock, USERS_COLLECTION};
 use crate::{
     blocks::{
         errors::{error_response, ErrorCode},
@@ -14,6 +14,7 @@ use crate::{
         },
     },
     ui,
+    ui::templates::auth_split,
 };
 
 impl AuthBlock {
@@ -856,10 +857,10 @@ impl AuthBlock {
             embedded_scripts: Vec::new(),
         };
 
-        let markup = ui::layout::centered_page(
+        let markup = ui::layout::page(
             "Reset Password",
             &config,
-            html! {
+            auth_split(brand_panel(&config), html! {
                 div .login-container {
                     div .login-logo {
                         @if !logo_url.is_empty() {
@@ -909,7 +910,7 @@ async function handleReset(e){
   return false;
 }
 "#)) }
-            },
+            }),
         );
 
         ui::html_response(markup)
@@ -1026,10 +1027,10 @@ fn html_respond(title: &str, message: &str, success: bool, logo_url: &str) -> Ou
         favicon_url: String::new(),
         embedded_scripts: Vec::new(),
     };
-    let markup = ui::layout::centered_page(
+    let markup = ui::layout::page(
         title,
         &config,
-        html! {
+        auth_split(brand_panel(&config), html! {
             div .login-container {
                 div .login-logo {
                     @if !logo_url.is_empty() {
@@ -1047,7 +1048,7 @@ fn html_respond(title: &str, message: &str, success: bool, logo_url: &str) -> Ou
                     }
                 }
             }
-        },
+        }),
     );
     ui::html_response(markup)
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -681,8 +681,9 @@ pub async fn authenticate_api_key(
 #[cfg(not(target_arch = "wasm32"))]
 ::wafer_run::register_static_block!("suppers-ai/auth", AuthBlock);
 
-use crate::ui::{templates::BrandPanel, SiteConfig};
 use maud::html;
+
+use crate::ui::{templates::BrandPanel, SiteConfig};
 
 /// Shared brand panel used by login / signup / reset / OAuth pages.
 pub(crate) fn brand_panel(config: &SiteConfig) -> BrandPanel<'_> {

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -680,3 +680,19 @@ pub async fn authenticate_api_key(
 
 #[cfg(not(target_arch = "wasm32"))]
 ::wafer_run::register_static_block!("suppers-ai/auth", AuthBlock);
+
+use crate::ui::{templates::BrandPanel, SiteConfig};
+use maud::html;
+
+/// Shared brand panel used by login / signup / reset / OAuth pages.
+pub(crate) fn brand_panel(config: &SiteConfig) -> BrandPanel<'_> {
+    BrandPanel {
+        logo_html: if !config.logo_url.is_empty() {
+            Some(html! { img src=(config.logo_url) alt=(config.app_name); })
+        } else {
+            None
+        },
+        headline: &config.app_name,
+        tagline: Some("Sign in to continue."),
+    }
+}

--- a/crates/solobase-core/src/blocks/auth/pages.rs
+++ b/crates/solobase-core/src/blocks/auth/pages.rs
@@ -10,8 +10,8 @@ use wafer_core::clients::{config, database as db, database::ListOptions};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
-    blocks::helpers::{err_bad_request, ok_json, RecordExt},
-    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    blocks::{auth::brand_panel, helpers::{err_bad_request, ok_json, RecordExt}},
+    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, templates::auth_split, SiteConfig, UserInfo},
 };
 
 /// Read all key-value pairs from the variables table.
@@ -190,10 +190,10 @@ pub async fn login_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         format!("?redirect={redirect}")
     };
 
-    let markup = ui::layout::centered_page(
+    let markup = ui::layout::page(
         "Sign In",
         &config,
-        html! {
+        auth_split(brand_panel(&config), html! {
             div .login-container {
                 div .login-logo {
                     @if !logo_url.is_empty() {
@@ -240,7 +240,7 @@ pub async fn login_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
             script { (PreEscaped(pw_toggle_js())) }
             script { (PreEscaped(login_script())) }
-        },
+        }),
     );
 
     ui::html_response(markup)
@@ -274,10 +274,10 @@ pub async fn signup_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         format!("?redirect={redirect}")
     };
 
-    let markup = ui::layout::centered_page(
+    let markup = ui::layout::page(
         "Sign Up",
         &config,
-        html! {
+        auth_split(brand_panel(&config), html! {
             div .login-container {
                 div .login-logo {
                     @if !logo_url.is_empty() {
@@ -346,7 +346,7 @@ async function handleSignup(ev){
   return false;
 }
 "#)) }
-        },
+        }),
     );
 
     ui::html_response(markup)
@@ -362,10 +362,10 @@ pub async fn change_password_page(ctx: &dyn Context, _msg: &Message) -> OutputSt
     let app_name = &config.app_name;
     let logo_url = &config.logo_url;
 
-    let markup = ui::layout::centered_page(
+    let markup = ui::layout::page(
         "Change Password",
         &config,
-        html! {
+        auth_split(brand_panel(&config), html! {
             div .login-container {
                 div .login-logo {
                     @if !logo_url.is_empty() {
@@ -431,7 +431,7 @@ async function handleChange(ev){
   return false;
 }
 "#)) }
-        },
+        }),
     );
 
     ui::html_response(markup)

--- a/crates/solobase-core/src/blocks/auth/pages.rs
+++ b/crates/solobase-core/src/blocks/auth/pages.rs
@@ -590,7 +590,7 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         script { (PreEscaped(SETTINGS_JS)) }
     };
 
-    let groups = nav_groups::admin("/b/auth/admin/settings");
+    let groups = nav_groups::admin();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: "Auth Settings",

--- a/crates/solobase-core/src/blocks/auth/pages.rs
+++ b/crates/solobase-core/src/blocks/auth/pages.rs
@@ -10,8 +10,16 @@ use wafer_core::clients::{config, database as db, database::ListOptions};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
-    blocks::{auth::brand_panel, helpers::{err_bad_request, ok_json, RecordExt}},
-    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, templates::auth_split, SiteConfig, UserInfo},
+    blocks::{
+        auth::brand_panel,
+        helpers::{err_bad_request, ok_json, RecordExt},
+    },
+    ui::{
+        self, components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        templates::auth_split,
+        SiteConfig, UserInfo,
+    },
 };
 
 /// Read all key-value pairs from the variables table.
@@ -193,54 +201,57 @@ pub async fn login_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let markup = ui::layout::page(
         "Sign In",
         &config,
-        auth_split(brand_panel(&config), html! {
-            div .login-container {
-                div .login-logo {
-                    @if !logo_url.is_empty() {
-                        img .logo-image src=(logo_url) alt=(app_name);
-                    } @else {
-                        span .login-app-name { (app_name) }
-                    }
-                    p .login-subtitle { "Sign in to " (app_name) }
-                }
-
-                div #error .login-error style="display:none" {}
-                div #info style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:.75rem;margin-bottom:1.5rem;font-size:.813rem;color:#059669;display:none" {}
-
-                form #form .login-form onsubmit="return handleLogin(event)" {
-                    input type="hidden" #redirect value=(redirect);
-                    input type="hidden" #post_login value=(post_login);
-
-                    div .form-group {
-                        label .form-label for="email" { "Email" }
-                        input .form-input type="email" #email placeholder="you@example.com" required;
+        auth_split(
+            brand_panel(&config),
+            html! {
+                div .login-container {
+                    div .login-logo {
+                        @if !logo_url.is_empty() {
+                            img .logo-image src=(logo_url) alt=(app_name);
+                        } @else {
+                            span .login-app-name { (app_name) }
+                        }
+                        p .login-subtitle { "Sign in to " (app_name) }
                     }
 
-                    div .form-group {
-                        label .form-label for="password" { "Password" }
-                        (pw_field("password", "Enter your password", None))
+                    div #error .login-error style="display:none" {}
+                    div #info style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:.75rem;margin-bottom:1.5rem;font-size:.813rem;color:#059669;display:none" {}
+
+                    form #form .login-form onsubmit="return handleLogin(event)" {
+                        input type="hidden" #redirect value=(redirect);
+                        input type="hidden" #post_login value=(post_login);
+
+                        div .form-group {
+                            label .form-label for="email" { "Email" }
+                            input .form-input type="email" #email placeholder="you@example.com" required;
+                        }
+
+                        div .form-group {
+                            label .form-label for="password" { "Password" }
+                            (pw_field("password", "Enter your password", None))
+                        }
+
+                        div style="text-align:right;margin-bottom:1rem" {
+                            button type="button" class="btn btn-ghost btn-sm" onclick="handleForgot()" {
+                                "Forgot password?"
+                            }
+                        }
+
+                        button .login-button type="submit" #btn { "Sign In" }
                     }
 
-                    div style="text-align:right;margin-bottom:1rem" {
-                        button type="button" class="btn btn-ghost btn-sm" onclick="handleForgot()" {
-                            "Forgot password?"
+                    @if allow_signup {
+                        div .signup-link {
+                            "Don't have an account? "
+                            a href={"/b/auth/signup" (signup_redirect)} { "Sign up" }
                         }
                     }
-
-                    button .login-button type="submit" #btn { "Sign In" }
                 }
 
-                @if allow_signup {
-                    div .signup-link {
-                        "Don't have an account? "
-                        a href={"/b/auth/signup" (signup_redirect)} { "Sign up" }
-                    }
-                }
-            }
-
-            script { (PreEscaped(pw_toggle_js())) }
-            script { (PreEscaped(login_script())) }
-        }),
+                script { (PreEscaped(pw_toggle_js())) }
+                script { (PreEscaped(login_script())) }
+            },
+        ),
     );
 
     ui::html_response(markup)
@@ -277,52 +288,54 @@ pub async fn signup_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let markup = ui::layout::page(
         "Sign Up",
         &config,
-        auth_split(brand_panel(&config), html! {
-            div .login-container {
-                div .login-logo {
-                    @if !logo_url.is_empty() {
-                        img .logo-image src=(logo_url) alt=(app_name);
-                    } @else {
-                        span .login-app-name { (app_name) }
-                    }
-                    p .login-subtitle { "Create your " (app_name) " account" }
-                }
-
-                div #error .login-error style="display:none" {}
-
-                div #success style="text-align:center;display:none" {
-                    div style="width:48px;height:48px;background:#ecfdf5;border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto 1rem;font-size:1.5rem;color:#10b981" { "✓" }
-                    h2 style="font-size:1.25rem;font-weight:700;margin:0 0 .5rem" { "Check your email" }
-                    p #verify-msg style="font-size:.875rem;color:#64748b;line-height:1.6;margin:0 0 1.5rem" {}
-                    a .login-button href={"/b/auth/login" (redirect_qs)} style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
-                        "Back to Sign In"
-                    }
-                }
-
-                form #form .login-form onsubmit="return handleSignup(event)" {
-                    input type="hidden" #redirect value=(redirect);
-
-                    div .form-group {
-                        label .form-label for="email" { "Email" }
-                        input .form-input type="email" #email placeholder="you@example.com" required;
+        auth_split(
+            brand_panel(&config),
+            html! {
+                div .login-container {
+                    div .login-logo {
+                        @if !logo_url.is_empty() {
+                            img .logo-image src=(logo_url) alt=(app_name);
+                        } @else {
+                            span .login-app-name { (app_name) }
+                        }
+                        p .login-subtitle { "Create your " (app_name) " account" }
                     }
 
-                    div .form-group {
-                        label .form-label for="password" { "Password" }
-                        (pw_field("password", "Min 8 characters", Some("8")))
+                    div #error .login-error style="display:none" {}
+
+                    div #success style="text-align:center;display:none" {
+                        div style="width:48px;height:48px;background:#ecfdf5;border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto 1rem;font-size:1.5rem;color:#10b981" { "✓" }
+                        h2 style="font-size:1.25rem;font-weight:700;margin:0 0 .5rem" { "Check your email" }
+                        p #verify-msg style="font-size:.875rem;color:#64748b;line-height:1.6;margin:0 0 1.5rem" {}
+                        a .login-button href={"/b/auth/login" (redirect_qs)} style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
+                            "Back to Sign In"
+                        }
                     }
 
-                    button .login-button type="submit" #btn { "Create Account" }
+                    form #form .login-form onsubmit="return handleSignup(event)" {
+                        input type="hidden" #redirect value=(redirect);
+
+                        div .form-group {
+                            label .form-label for="email" { "Email" }
+                            input .form-input type="email" #email placeholder="you@example.com" required;
+                        }
+
+                        div .form-group {
+                            label .form-label for="password" { "Password" }
+                            (pw_field("password", "Min 8 characters", Some("8")))
+                        }
+
+                        button .login-button type="submit" #btn { "Create Account" }
+                    }
+
+                    div #signin-link .signup-link {
+                        "Already have an account? "
+                        a href={"/b/auth/login" (redirect_qs)} { "Sign in" }
+                    }
                 }
 
-                div #signin-link .signup-link {
-                    "Already have an account? "
-                    a href={"/b/auth/login" (redirect_qs)} { "Sign in" }
-                }
-            }
-
-            script { (PreEscaped(pw_toggle_js())) }
-            script { (PreEscaped(r#"
+                script { (PreEscaped(pw_toggle_js())) }
+                script { (PreEscaped(r#"
 var $=function(id){return document.getElementById(id)};
 function showErr(m){var e=$('error');e.textContent=m;e.style.display='flex'}
 async function handleSignup(ev){
@@ -346,7 +359,8 @@ async function handleSignup(ev){
   return false;
 }
 "#)) }
-        }),
+            },
+        ),
     );
 
     ui::html_response(markup)
@@ -365,54 +379,56 @@ pub async fn change_password_page(ctx: &dyn Context, _msg: &Message) -> OutputSt
     let markup = ui::layout::page(
         "Change Password",
         &config,
-        auth_split(brand_panel(&config), html! {
-            div .login-container {
-                div .login-logo {
-                    @if !logo_url.is_empty() {
-                        img .logo-image src=(logo_url) alt=(app_name);
-                    } @else {
-                        span .login-app-name { (app_name) }
+        auth_split(
+            brand_panel(&config),
+            html! {
+                div .login-container {
+                    div .login-logo {
+                        @if !logo_url.is_empty() {
+                            img .logo-image src=(logo_url) alt=(app_name);
+                        } @else {
+                            span .login-app-name { (app_name) }
+                        }
+                        p .login-subtitle { "Change your password" }
                     }
-                    p .login-subtitle { "Change your password" }
+
+                    div #error .login-error style="display:none" {}
+
+                    div #success style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:1rem;text-align:center;display:none" {
+                        p style="font-size:.875rem;color:#16a34a;margin:0 0 1rem;font-weight:500" {
+                            "Password changed successfully!"
+                        }
+                        button .login-button onclick="history.back()" style="width:auto;display:inline-block;padding:.625rem 1.25rem" {
+                            "Go Back"
+                        }
+                    }
+
+                    form #form .login-form onsubmit="return handleChange(event)" {
+                        div .form-group {
+                            label .form-label for="current" { "Current Password" }
+                            (pw_field("current", "Enter your current password", None))
+                        }
+
+                        div .form-group {
+                            label .form-label for="newpw" { "New Password" }
+                            (pw_field("newpw", "Min 8 characters", Some("8")))
+                        }
+
+                        div .form-group {
+                            label .form-label for="confirm" { "Confirm New Password" }
+                            (pw_field("confirm", "Repeat new password", Some("8")))
+                        }
+
+                        button .login-button type="submit" #btn { "Change Password" }
+                    }
+
+                    div style="text-align:center;margin-top:1rem" {
+                        a .btn .btn-ghost href="javascript:history.back()" { "Cancel" }
+                    }
                 }
 
-                div #error .login-error style="display:none" {}
-
-                div #success style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:1rem;text-align:center;display:none" {
-                    p style="font-size:.875rem;color:#16a34a;margin:0 0 1rem;font-weight:500" {
-                        "Password changed successfully!"
-                    }
-                    button .login-button onclick="history.back()" style="width:auto;display:inline-block;padding:.625rem 1.25rem" {
-                        "Go Back"
-                    }
-                }
-
-                form #form .login-form onsubmit="return handleChange(event)" {
-                    div .form-group {
-                        label .form-label for="current" { "Current Password" }
-                        (pw_field("current", "Enter your current password", None))
-                    }
-
-                    div .form-group {
-                        label .form-label for="newpw" { "New Password" }
-                        (pw_field("newpw", "Min 8 characters", Some("8")))
-                    }
-
-                    div .form-group {
-                        label .form-label for="confirm" { "Confirm New Password" }
-                        (pw_field("confirm", "Repeat new password", Some("8")))
-                    }
-
-                    button .login-button type="submit" #btn { "Change Password" }
-                }
-
-                div style="text-align:center;margin-top:1rem" {
-                    a .btn .btn-ghost href="javascript:history.back()" { "Cancel" }
-                }
-            }
-
-            script { (PreEscaped(pw_toggle_js())) }
-            script { (PreEscaped(r#"
+                script { (PreEscaped(pw_toggle_js())) }
+                script { (PreEscaped(r#"
 var $=function(id){return document.getElementById(id)};
 function showErr(m){var e=$('error');e.textContent=m;e.style.display='flex'}
 async function handleChange(ev){
@@ -431,7 +447,8 @@ async function handleChange(ev){
   return false;
 }
 "#)) }
-        }),
+            },
+        ),
     );
 
     ui::html_response(markup)
@@ -575,11 +592,23 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     let groups = nav_groups::admin("/b/auth/admin/settings");
     let topbar = Topbar {
-        crumbs: vec![Crumb { label: "Auth Settings", href: None }],
+        crumbs: vec![Crumb {
+            label: "Auth Settings",
+            href: None,
+        }],
         primary_action: None,
         show_palette: true,
     };
-    crate::ui::shelled_response(msg, "Auth Settings", &site_config, &groups, user.as_ref(), "/b/auth/admin/settings", topbar, content)
+    crate::ui::shelled_response(
+        msg,
+        "Auth Settings",
+        &site_config,
+        &groups,
+        user.as_ref(),
+        "/b/auth/admin/settings",
+        topbar,
+        content,
+    )
 }
 
 const SETTINGS_JS: &str = r#"

--- a/crates/solobase-core/src/blocks/auth/pages.rs
+++ b/crates/solobase-core/src/blocks/auth/pages.rs
@@ -11,7 +11,7 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
     blocks::helpers::{err_bad_request, ok_json, RecordExt},
-    ui::{self, components, icons, NavItem, SiteConfig, UserInfo},
+    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
 /// Read all key-value pairs from the variables table.
@@ -525,14 +525,6 @@ const SETTINGS_KEYS: &[(&str, &str, &str, &str, bool, &str)] = &[
     ),
 ];
 
-fn auth_admin_nav() -> Vec<NavItem> {
-    vec![NavItem {
-        label: "Settings".into(),
-        href: "/b/auth/admin/settings".into(),
-        icon: "settings",
-    }]
-}
-
 pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let site_config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
@@ -581,17 +573,13 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         script { (PreEscaped(SETTINGS_JS)) }
     };
 
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
-        "Auth Settings",
-        &site_config,
-        &auth_admin_nav(),
-        user.as_ref(),
-        "/b/auth/admin/settings",
-        content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+    let groups = nav_groups::admin("/b/auth/admin/settings");
+    let topbar = Topbar {
+        crumbs: vec![Crumb { label: "Auth Settings", href: None }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, "Auth Settings", &site_config, &groups, user.as_ref(), "/b/auth/admin/settings", topbar, content)
 }
 
 const SETTINGS_JS: &str = r#"

--- a/crates/solobase-core/src/blocks/files/pages.rs
+++ b/crates/solobase-core/src/blocks/files/pages.rs
@@ -10,53 +10,25 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use super::{BUCKETS_COLLECTION, OBJECTS_COLLECTION, QUOTAS_COLLECTION, SHARES_COLLECTION};
 use crate::{
     blocks::helpers::RecordExt,
-    ui::{self, components, icons, NavItem, SiteConfig, UserInfo},
+    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
-fn files_admin_nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Overview".into(),
-            href: "/b/storage/admin/".into(),
-            icon: "bar-chart",
-        },
-        NavItem {
-            label: "Buckets".into(),
-            href: "/b/storage/admin/buckets".into(),
-            icon: "folder",
-        },
-        NavItem {
-            label: "Shares".into(),
-            href: "/b/storage/admin/shares".into(),
-            icon: "globe",
-        },
-        NavItem {
-            label: "Quotas".into(),
-            href: "/b/storage/admin/quotas".into(),
-            icon: "bar-chart",
-        },
-    ]
-}
-
-fn files_page(
+fn files_page<'a>(
     title: &str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'a str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
-        title,
-        config,
-        &files_admin_nav(),
-        user,
-        path,
-        content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+    let groups = nav_groups::portal(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +120,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/storage/admin/",
         user.as_ref(),
+        "Overview",
         content,
         msg,
     )
@@ -206,6 +179,7 @@ pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/storage/admin/buckets",
         user.as_ref(),
+        "Buckets",
         content,
         msg,
     )
@@ -275,6 +249,7 @@ pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/storage/admin/shares",
         user.as_ref(),
+        "Shares",
         content,
         msg,
     )
@@ -337,6 +312,7 @@ pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/storage/admin/quotas",
         user.as_ref(),
+        "Quotas",
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/files/pages.rs
+++ b/crates/solobase-core/src/blocks/files/pages.rs
@@ -10,7 +10,11 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use super::{BUCKETS_COLLECTION, OBJECTS_COLLECTION, QUOTAS_COLLECTION, SHARES_COLLECTION};
 use crate::{
     blocks::helpers::RecordExt,
-    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 fn files_page<'a>(
@@ -24,7 +28,10 @@ fn files_page<'a>(
 ) -> OutputStream {
     let groups = nav_groups::portal(path);
     let topbar = Topbar {
-        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
         primary_action: None,
         show_palette: true,
     };

--- a/crates/solobase-core/src/blocks/files/pages.rs
+++ b/crates/solobase-core/src/blocks/files/pages.rs
@@ -26,7 +26,7 @@ fn files_page<'a>(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::portal(path);
+    let groups = nav_groups::portal();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -14,52 +14,28 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
     blocks::helpers::{self, json_map, ok_json, RecordExt},
-    ui::{self, components, icons, NavItem, SiteConfig, UserInfo},
+    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
 const COLLECTION: &str = super::COLLECTION;
 
-// ---------------------------------------------------------------------------
-// Navigation
-// ---------------------------------------------------------------------------
-
-fn nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Privacy Policy".into(),
-            href: "/b/legalpages/admin/privacy".into(),
-            icon: "shield",
-        },
-        NavItem {
-            label: "Terms of Service".into(),
-            href: "/b/legalpages/admin/terms".into(),
-            icon: "file-text",
-        },
-        NavItem {
-            label: "Settings".into(),
-            href: "/b/legalpages/admin/settings".into(),
-            icon: "settings",
-        },
-        NavItem {
-            label: "Endpoints".into(),
-            href: "/b/legalpages/admin/endpoints".into(),
-            icon: "globe",
-        },
-    ]
-}
-
-/// Wrap content in the legalpages admin shell (sidebar + layout).
-fn legalpages_page(
+/// Wrap content in the legalpages portal shell (sidebar + layout).
+fn legalpages_page<'a>(
     title: &str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'a str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(title, config, &nav(), user, path, content, is_fragment);
-    ui::html_response(markup)
+    let groups = nav_groups::portal(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -277,6 +253,7 @@ pub async fn editor_page(ctx: &dyn Context, msg: &Message, doc_type: &str) -> Ou
         &config,
         &format!("/b/legalpages/admin/{doc_type}"),
         user.as_ref(),
+        default_title,
         page_content,
         msg,
     )
@@ -581,6 +558,7 @@ pub async fn endpoints_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/legalpages/admin/endpoints",
         user.as_ref(),
+        "Endpoints",
         content,
         msg,
     )
@@ -892,6 +870,7 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &site_config,
         "/b/legalpages/admin/settings",
         user.as_ref(),
+        "Settings",
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -14,7 +14,11 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
     blocks::helpers::{self, json_map, ok_json, RecordExt},
-    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 const COLLECTION: &str = super::COLLECTION;
@@ -31,7 +35,10 @@ fn legalpages_page<'a>(
 ) -> OutputStream {
     let groups = nav_groups::portal(path);
     let topbar = Topbar {
-        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
         primary_action: None,
         show_palette: true,
     };

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -33,7 +33,7 @@ fn legalpages_page<'a>(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::portal(path);
+    let groups = nav_groups::portal();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -15,7 +15,11 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use super::SETTINGS_COLLECTION;
 use crate::{
     blocks::helpers::{err_internal, RecordExt},
-    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        self, components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
@@ -409,7 +413,15 @@ pub async fn thread_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    llm_page(display_title, &config, &path, user.as_ref(), display_title, content, msg)
+    llm_page(
+        display_title,
+        &config,
+        &path,
+        user.as_ref(),
+        display_title,
+        content,
+        msg,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -545,7 +557,15 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    llm_page("LLM Settings", &config, &path, user.as_ref(), "Settings", content, msg)
+    llm_page(
+        "LLM Settings",
+        &config,
+        &path,
+        user.as_ref(),
+        "Settings",
+        content,
+        msg,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -42,7 +42,7 @@ fn llm_page<'a>(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::admin(path);
+    let groups = nav_groups::admin();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -15,7 +15,7 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use super::SETTINGS_COLLECTION;
 use crate::{
     blocks::helpers::{err_internal, RecordExt},
-    ui::{self, components, icons, NavItem, SiteConfig, UserInfo},
+    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
 const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
@@ -29,32 +29,25 @@ const ENTRIES_COLLECTION: &str = "suppers_ai__messages__entries";
 // Navigation
 // ---------------------------------------------------------------------------
 
-fn nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Chat".into(),
-            href: "/b/llm/".into(),
-            icon: "message-circle",
-        },
-        NavItem {
-            label: "Settings".into(),
-            href: "/b/llm/settings".into(),
-            icon: "settings",
-        },
-    ]
-}
-
-fn llm_page(
-    title: &str,
+fn llm_page<'a>(
+    title: &'a str,
     config: &SiteConfig,
-    path: &str,
+    path: &'a str,
     user: Option<&UserInfo>,
+    crumb_label: &'a str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(title, config, &nav(), user, path, content, is_fragment);
-    ui::html_response(markup)
+    let groups = nav_groups::admin(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -210,7 +203,7 @@ pub async fn chat_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    llm_page("Chat", &config, &path, user.as_ref(), content, msg)
+    llm_page("Chat", &config, &path, user.as_ref(), "Chat", content, msg)
 }
 
 fn thread_list_items(threads: &[db::Record]) -> Markup {
@@ -416,7 +409,7 @@ pub async fn thread_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    llm_page(display_title, &config, &path, user.as_ref(), content, msg)
+    llm_page(display_title, &config, &path, user.as_ref(), display_title, content, msg)
 }
 
 // ---------------------------------------------------------------------------
@@ -552,7 +545,7 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    llm_page("LLM Settings", &config, &path, user.as_ref(), content, msg)
+    llm_page("LLM Settings", &config, &path, user.as_ref(), "Settings", content, msg)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -27,7 +27,11 @@ use super::{
 };
 use crate::{
     blocks::helpers::{self, err_internal},
-    ui::{self, components, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        self, components, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -48,7 +48,7 @@ fn llm_page(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::admin(path);
+    let groups = nav_groups::admin();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -27,56 +27,33 @@ use super::{
 };
 use crate::{
     blocks::helpers::{self, err_internal},
-    ui::{self, components, NavItem, SiteConfig, UserInfo},
+    ui::{self, components, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
 // ---------------------------------------------------------------------------
 // Navigation
 // ---------------------------------------------------------------------------
 
-/// Admin nav shared between the providers and models pages.
-///
-/// Mirrors the `pages::nav()` used by the chat / settings pages but with
-/// admin-oriented entries. The dispatcher already gates non-API routes on
-/// admin role, so we can link without extra checks.
-fn nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Chat".into(),
-            href: "/b/llm/".into(),
-            icon: "message-circle",
-        },
-        NavItem {
-            label: "Providers".into(),
-            href: "/b/llm/providers".into(),
-            icon: "server",
-        },
-        NavItem {
-            label: "Models".into(),
-            href: "/b/llm/models".into(),
-            icon: "cpu",
-        },
-        NavItem {
-            label: "Settings".into(),
-            href: "/b/llm/settings".into(),
-            icon: "settings",
-        },
-    ]
-}
-
-/// Wrap content in the standard block shell (full page for normal GETs,
-/// raw fragment for htmx boosts/partials).
+/// Wrap content in the admin shell for LLM admin pages (providers, models).
 fn llm_page(
-    title: &str,
+    title: &'static str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'static str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(title, config, &nav(), user, path, content, is_fragment);
-    ui::html_response(markup)
+    let groups = nav_groups::admin(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -142,6 +119,7 @@ pub(super) async fn providers_page(
         &site_config,
         &path,
         user.as_ref(),
+        "Providers",
         content,
         msg,
     )
@@ -416,6 +394,7 @@ pub(super) async fn models_page(
         &site_config,
         &path,
         user.as_ref(),
+        "Models",
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -27,7 +27,7 @@ fn messages_page<'a>(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::admin(path);
+    let groups = nav_groups::admin();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -11,7 +11,11 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use super::service::{self, ListContextsParams, ListEntriesParams};
 use crate::{
     blocks::helpers::{err_internal, RecordExt},
-    ui::{self, components, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        self, components, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 fn messages_page<'a>(
@@ -25,7 +29,10 @@ fn messages_page<'a>(
 ) -> OutputStream {
     let groups = nav_groups::admin(path);
     let topbar = Topbar {
-        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
         primary_action: None,
         show_palette: true,
     };
@@ -179,7 +186,15 @@ pub async fn context_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream
         }
     };
 
-    messages_page("Messages", &config, &path, user.as_ref(), "Contexts", content, msg)
+    messages_page(
+        "Messages",
+        &config,
+        &path,
+        user.as_ref(),
+        "Contexts",
+        content,
+        msg,
+    )
 }
 
 pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -284,5 +299,13 @@ pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStre
         }
     };
 
-    messages_page(display_title, &config, &path, user.as_ref(), display_title, content, msg)
+    messages_page(
+        display_title,
+        &config,
+        &path,
+        user.as_ref(),
+        display_title,
+        content,
+        msg,
+    )
 }

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -11,28 +11,25 @@ use wafer_run::{context::Context, types::*, OutputStream};
 use super::service::{self, ListContextsParams, ListEntriesParams};
 use crate::{
     blocks::helpers::{err_internal, RecordExt},
-    ui::{self, components, NavItem, SiteConfig, UserInfo},
+    ui::{self, components, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
-fn nav() -> Vec<NavItem> {
-    vec![NavItem {
-        label: "Contexts".into(),
-        href: "/b/messages/".into(),
-        icon: "message-square",
-    }]
-}
-
-fn messages_page(
+fn messages_page<'a>(
     title: &str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'a str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(title, config, &nav(), user, path, content, is_fragment);
-    ui::html_response(markup)
+    let groups = nav_groups::admin(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 pub fn entry_card(record: &db::Record) -> Markup {
@@ -182,7 +179,7 @@ pub async fn context_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream
         }
     };
 
-    messages_page("Messages", &config, &path, user.as_ref(), content, msg)
+    messages_page("Messages", &config, &path, user.as_ref(), "Contexts", content, msg)
 }
 
 pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -287,5 +284,5 @@ pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStre
         }
     };
 
-    messages_page(display_title, &config, &path, user.as_ref(), content, msg)
+    messages_page(display_title, &config, &path, user.as_ref(), display_title, content, msg)
 }

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -10,64 +10,25 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use super::{GROUPS_COLLECTION, PRICING_COLLECTION, PRODUCTS_COLLECTION, PURCHASES_COLLECTION};
 use crate::{
     blocks::helpers::{ok_json, RecordExt},
-    ui::{self, components, icons, NavItem, SiteConfig, UserInfo},
+    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
 };
 
-/// Admin nav items.
-fn products_admin_nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "Overview".into(),
-            href: "/b/products/admin/".into(),
-            icon: "bar-chart",
-        },
-        NavItem {
-            label: "Products".into(),
-            href: "/b/products/admin/manage".into(),
-            icon: "package",
-        },
-        NavItem {
-            label: "Groups".into(),
-            href: "/b/products/admin/groups".into(),
-            icon: "folder",
-        },
-        NavItem {
-            label: "Pricing".into(),
-            href: "/b/products/admin/pricing".into(),
-            icon: "dollar-sign",
-        },
-        NavItem {
-            label: "Purchases".into(),
-            href: "/b/products/admin/purchases".into(),
-            icon: "shopping-cart",
-        },
-        NavItem {
-            label: "Settings".into(),
-            href: "/b/products/admin/settings".into(),
-            icon: "settings",
-        },
-    ]
-}
-
-fn products_page(
-    _title: &str,
+fn products_page<'a>(
+    title: &str,
     config: &SiteConfig,
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'a str,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
-        _title,
-        config,
-        &products_admin_nav(),
-        user,
-        path,
-        content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+    let groups = nav_groups::portal(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +75,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/products/admin/",
         user.as_ref(),
+        "Products",
         content,
         msg,
     )
@@ -212,6 +174,7 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/products/admin/manage",
         user.as_ref(),
+        "Products",
         content,
         msg,
     )
@@ -269,6 +232,7 @@ pub async fn groups(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/products/admin/groups",
         user.as_ref(),
+        "Groups",
         content,
         msg,
     )
@@ -325,6 +289,7 @@ pub async fn pricing(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/products/admin/pricing",
         user.as_ref(),
+        "Pricing",
         content,
         msg,
     )
@@ -416,6 +381,7 @@ pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &config,
         "/b/products/admin/purchases",
         user.as_ref(),
+        "Purchases",
         content,
         msg,
     )
@@ -457,19 +423,6 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
     )
     .await;
 
-    let nav = vec![
-        NavItem {
-            label: "My Products".into(),
-            href: "/b/products/my-products".into(),
-            icon: "package",
-        },
-        NavItem {
-            label: "My Purchases".into(),
-            href: "/b/products/my-purchases".into(),
-            icon: "shopping-cart",
-        },
-    ];
-
     let content = html! {
         (components::page_header("My Products", None, None))
 
@@ -502,17 +455,15 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
+    products_page(
         "My Products",
         &config,
-        &nav,
-        user.as_ref(),
         "/b/products/my-products",
+        user.as_ref(),
+        "My Products",
         content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+        msg,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -543,19 +494,6 @@ pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         sort,
     )
     .await;
-
-    let nav = vec![
-        NavItem {
-            label: "My Products".into(),
-            href: "/b/products/my-products".into(),
-            icon: "package",
-        },
-        NavItem {
-            label: "My Purchases".into(),
-            href: "/b/products/my-purchases".into(),
-            icon: "shopping-cart",
-        },
-    ];
 
     let content = html! {
         (components::page_header("My Purchases", None, None))
@@ -591,17 +529,15 @@ pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(
+    products_page(
         "My Purchases",
         &config,
-        &nav,
-        user.as_ref(),
         "/b/products/my-purchases",
+        user.as_ref(),
+        "My Purchases",
         content,
-        is_fragment,
-    );
-    ui::html_response(markup)
+        msg,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -748,6 +684,7 @@ function submitSettings(e) {
         &site_config,
         "/b/products/admin/settings",
         user.as_ref(),
+        "Settings",
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -26,7 +26,7 @@ fn products_page<'a>(
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::portal(path);
+    let groups = nav_groups::portal();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -10,7 +10,11 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use super::{GROUPS_COLLECTION, PRICING_COLLECTION, PRODUCTS_COLLECTION, PURCHASES_COLLECTION};
 use crate::{
     blocks::helpers::{ok_json, RecordExt},
-    ui::{components, icons, nav_groups, shell::{Crumb, Topbar}, SiteConfig, UserInfo},
+    ui::{
+        components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        SiteConfig, UserInfo,
+    },
 };
 
 fn products_page<'a>(
@@ -24,7 +28,10 @@ fn products_page<'a>(
 ) -> OutputStream {
     let groups = nav_groups::portal(path);
     let topbar = Topbar {
-        crumbs: vec![Crumb { label: crumb_label, href: None }],
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
         primary_action: None,
         show_palette: true,
     };

--- a/crates/solobase-core/src/blocks/userportal.rs
+++ b/crates/solobase-core/src/blocks/userportal.rs
@@ -219,7 +219,7 @@ fn render_page(
     content: maud::Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::portal(path);
+    let groups = nav_groups::portal();
     let topbar = Topbar {
         crumbs: vec![Crumb {
             label: crumb_label,

--- a/crates/solobase-core/src/blocks/userportal.rs
+++ b/crates/solobase-core/src/blocks/userportal.rs
@@ -13,7 +13,7 @@ use wafer_run::{
 use super::helpers::{self, parse_form_body, stamp_updated, RecordExt};
 use crate::{
     blocks::helpers::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json},
-    ui::{self, components, icons, sidebar::nav_icon, NavItem, SiteConfig, UserInfo},
+    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, sidebar::nav_icon, SiteConfig, UserInfo},
 };
 
 const BUTTONS_COLLECTION: &str = "suppers_ai__userportal__buttons";
@@ -205,46 +205,25 @@ impl UserPortalBlock {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-fn portal_nav() -> Vec<NavItem> {
-    vec![NavItem {
-        label: "My Account".into(),
-        href: "/b/userportal/".into(),
-        icon: "user",
-    }]
-}
-
-fn admin_nav() -> Vec<NavItem> {
-    vec![
-        NavItem {
-            label: "My Account".into(),
-            href: "/b/userportal/".into(),
-            icon: "user",
-        },
-        NavItem {
-            label: "Manage Buttons".into(),
-            href: "/b/userportal/admin/buttons".into(),
-            icon: "package",
-        },
-        NavItem {
-            label: "Settings".into(),
-            href: "/b/userportal/admin/settings".into(),
-            icon: "settings",
-        },
-    ]
-}
-
 fn render_page(
     title: &str,
     config: &SiteConfig,
-    nav: &[NavItem],
     path: &str,
     user: Option<&UserInfo>,
+    crumb_label: &'static str,
     content: maud::Markup,
     msg: &Message,
 ) -> OutputStream {
-    let is_fragment = ui::is_htmx(msg);
-    let markup = ui::layout::block_shell(title, config, nav, user, path, content, is_fragment);
-    ui::html_response(markup)
+    let groups = nav_groups::portal(path);
+    let topbar = Topbar {
+        crumbs: vec![Crumb {
+            label: crumb_label,
+            href: None,
+        }],
+        primary_action: None,
+        show_palette: true,
+    };
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 async fn load_buttons(ctx: &dyn Context) -> Vec<wafer_core::clients::database::Record> {
@@ -376,9 +355,9 @@ async fn profile_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     render_page(
         "My Account",
         &site_config,
-        &portal_nav(),
         "/b/userportal/",
         user.as_ref(),
+        "My Account",
         content,
         msg,
     )
@@ -475,9 +454,9 @@ async fn admin_buttons_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     render_page(
         "Portal Buttons",
         &site_config,
-        &admin_nav(),
         "/b/userportal/admin/buttons",
         user.as_ref(),
+        "Portal Buttons",
         content,
         msg,
     )
@@ -800,9 +779,9 @@ function submitPortalSettings(e) {
     render_page(
         "Settings",
         &site_config,
-        &admin_nav(),
         "/b/userportal/admin/settings",
         user.as_ref(),
+        "Settings",
         content,
         msg,
     )

--- a/crates/solobase-core/src/blocks/userportal.rs
+++ b/crates/solobase-core/src/blocks/userportal.rs
@@ -13,7 +13,12 @@ use wafer_run::{
 use super::helpers::{self, parse_form_body, stamp_updated, RecordExt};
 use crate::{
     blocks::helpers::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json},
-    ui::{self, components, icons, nav_groups, shell::{Crumb, Topbar}, sidebar::nav_icon, SiteConfig, UserInfo},
+    ui::{
+        self, components, icons, nav_groups,
+        shell::{Crumb, Topbar},
+        sidebar::nav_icon,
+        SiteConfig, UserInfo,
+    },
 };
 
 const BUTTONS_COLLECTION: &str = "suppers_ai__userportal__buttons";

--- a/crates/solobase-core/src/flows/site_main.rs
+++ b/crates/solobase-core/src/flows/site_main.rs
@@ -28,8 +28,13 @@ pub const JSON: &str = r#"{
 /// Block SSR pages + API go through `suppers-ai/router`.
 /// Static assets are embedded and served by the system block via `/static/`.
 /// User's own site content is served by `wafer-run/web` as fallback.
+///
+/// `/` is routed explicitly to `suppers-ai/router` (not the `/**` fallback)
+/// so the root redirect handler in `routing::route_to_block` fires:
+/// anonymous → `/b/auth/login`, authenticated → `/b/auth/dashboard`.
 pub fn default_routes() -> serde_json::Value {
     serde_json::json!([
+        { "path": "/",                        "block": "suppers-ai/router" },
         { "path": "/b/**",                    "block": "suppers-ai/router" },
         { "path": "/health",                  "block": "suppers-ai/router" },
         { "path": "/openapi.json",            "block": "suppers-ai/router" },

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -268,6 +268,11 @@ pub async fn route_to_block(
 ) -> OutputStream {
     let path = msg.path().to_string();
 
+    // Root: redirect logged-in users to portal dashboard, anonymous to login.
+    if path == "/" {
+        return root_redirect(msg.user_id().is_empty());
+    }
+
     for route in ROUTES {
         let matches = path == route.prefix || path.starts_with(route.prefix);
         if !matches {
@@ -318,6 +323,19 @@ pub async fn route_to_block(
     }
 
     crate::ui::not_found_response(&msg)
+}
+
+/// Build a root redirect response. Extracted for unit testability.
+fn root_redirect(user_id_empty: bool) -> OutputStream {
+    let target = if user_id_empty {
+        "/b/auth/login"
+    } else {
+        "/b/auth/dashboard"
+    };
+    crate::blocks::helpers::ResponseBuilder::new()
+        .status(302)
+        .set_header("Location", target)
+        .body(Vec::new(), "text/plain")
 }
 
 // ---------------------------------------------------------------------------
@@ -425,6 +443,39 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn root_redirects_anonymous_to_login() {
+        let out = super::root_redirect(true);
+        let buf = out.collect_buffered().await.unwrap();
+        let status = buf
+            .meta
+            .iter()
+            .find(|e| e.key == "resp.status")
+            .map(|e| e.value.as_str())
+            .unwrap_or("");
+        let location = buf
+            .meta
+            .iter()
+            .find(|e| e.key == "resp.header.Location")
+            .map(|e| e.value.as_str())
+            .unwrap_or("");
+        assert_eq!(status, "302");
+        assert_eq!(location, "/b/auth/login");
+    }
+
+    #[tokio::test]
+    async fn root_redirects_authenticated_to_dashboard() {
+        let out = super::root_redirect(false);
+        let buf = out.collect_buffered().await.unwrap();
+        let location = buf
+            .meta
+            .iter()
+            .find(|e| e.key == "resp.header.Location")
+            .map(|e| e.value.as_str())
+            .unwrap_or("");
+        assert_eq!(location, "/b/auth/dashboard");
     }
 
     struct AllEnabled;

--- a/crates/solobase-core/src/ui/assets.rs
+++ b/crates/solobase-core/src/ui/assets.rs
@@ -71,6 +71,8 @@ document.body.addEventListener("showToast", function(e) {
 pub fn palette_js() -> &'static str {
     r#"
 (function () {
+  if (window.__cmdkInit) return;
+  window.__cmdkInit = true;
   const el = document.getElementById('cmdk');
   if (!el) return;
   const input = document.getElementById('cmdk-input');

--- a/crates/solobase-core/src/ui/assets.rs
+++ b/crates/solobase-core/src/ui/assets.rs
@@ -65,25 +65,6 @@ document.body.addEventListener("showToast", function(e) {
 "#
 }
 
-/// Small inline JS for sidebar toggle (mobile menu + collapse).
-pub fn sidebar_js() -> &'static str {
-    r#"
-function toggleMobileMenu() {
-    document.querySelector('.sidebar-container').classList.toggle('active');
-}
-function toggleSidebar() {
-    document.querySelector('.sidebar').classList.toggle('collapsed');
-    localStorage.setItem('sidebar-collapsed', document.querySelector('.sidebar').classList.contains('collapsed'));
-}
-(function() {
-    if (localStorage.getItem('sidebar-collapsed') === 'true') {
-        var s = document.querySelector('.sidebar');
-        if (s) s.classList.add('collapsed');
-    }
-})();
-"#
-}
-
 /// Vanilla JS for the command palette — open/close, fuzzy filter,
 /// keyboard navigation. Embedded as a string the same way `toast_js()`
 /// and `modal_js()` are.

--- a/crates/solobase-core/src/ui/layout.rs
+++ b/crates/solobase-core/src/ui/layout.rs
@@ -1,8 +1,13 @@
-//! Page layout components — full page wrapper, block shell with sidebar.
+//! Page layout components — full page wrapper and centered_page escape hatch.
+//!
+//! `block_shell()` was removed in Phase 2 of the UI cleanup; pages now build
+//! chrome via `ui::shelled_response()` which delegates to `ui::shell::shell()`
+//! + `ui::sidebar::sidebar_grouped()`. `centered_page()` is kept as the raw
+//! escape hatch for any future standalone (non-shelled, non-auth-split) page.
 
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 
-use super::{assets, icons, sidebar, NavItem, SiteConfig, UserInfo};
+use super::{assets, SiteConfig};
 
 /// Render a full HTML page with head (CSS + htmx) and body.
 pub fn page(title: &str, config: &SiteConfig, body: Markup) -> Markup {
@@ -32,57 +37,8 @@ pub fn page(title: &str, config: &SiteConfig, body: Markup) -> Markup {
     }
 }
 
-/// The standard block shell layout: sidebar + main content area.
-///
-/// If `is_fragment` is true, only the inner content is returned (for htmx partials).
-pub fn block_shell(
-    title: &str,
-    config: &SiteConfig,
-    nav_items: &[NavItem],
-    user: Option<&UserInfo>,
-    current_path: &str,
-    content: Markup,
-    is_fragment: bool,
-) -> Markup {
-    if is_fragment {
-        return content;
-    }
-
-    page(
-        title,
-        config,
-        html! {
-            // Mobile header
-            div .mobile-header {
-                button .menu-toggle onclick="toggleMobileMenu()" {
-                    (icons::menu())
-                }
-                span .mobile-title { (title) }
-            }
-
-            div .app-layout {
-                // Sidebar
-                div .sidebar-container {
-                    div .sidebar-overlay onclick="toggleMobileMenu()" {}
-                    div .sidebar-wrapper {
-                        (sidebar::sidebar(nav_items, user, current_path, &config.logo_url, &config.logo_icon_url))
-                    }
-                }
-
-                // Main content
-                div .main-content {
-                    div .content-wrapper #content {
-                        (content)
-                    }
-                }
-            }
-
-            script { (PreEscaped(assets::sidebar_js())) }
-        },
-    )
-}
-
-/// A simple centered page layout (used for login, signup, etc.)
+/// A simple centered page layout — escape hatch for standalone pages that
+/// don't use the shell or `auth_split` template.
 pub fn centered_page(title: &str, config: &SiteConfig, content: Markup) -> Markup {
     page(
         title,

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -228,6 +228,35 @@ pub fn not_found_response(msg: &wafer_run::types::Message) -> wafer_run::OutputS
     }
 }
 
+/// Return styled 500 for browser requests, JSON for API requests.
+pub fn server_error_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
+    let accept = msg.get_meta("http.header.accept");
+    if accept.contains("text/html") && !accept.contains("application/json") {
+        let config = SiteConfig {
+            app_name: "Solobase".to_string(),
+            logo_url: String::new(),
+            logo_icon_url: String::new(),
+            favicon_url: String::new(),
+            embedded_scripts: Vec::new(),
+        };
+        let body = templates::status_page(
+            "500",
+            "Something went wrong",
+            "An unexpected error occurred. Please try again.",
+            Some(("Go home".to_string(), "/".to_string())),
+        );
+        let markup = layout::page("Server error", &config, body);
+        crate::blocks::helpers::ResponseBuilder::new()
+            .status(500)
+            .body(
+                markup.into_string().into_bytes(),
+                "text/html; charset=utf-8",
+            )
+    } else {
+        crate::blocks::helpers::err_internal("internal server error")
+    }
+}
+
 /// Respond with HTML + an HX-Trigger header for toast notifications.
 pub fn html_response_with_toast(
     markup: maud::Markup,
@@ -313,5 +342,19 @@ mod tests {
         assert!(body.contains("status-page"), "body should contain status-page class");
         assert!(body.contains(">403<"), "body should contain 403 code");
         assert!(body.contains("Sign in"), "body should contain Sign in action");
+    }
+
+    #[tokio::test]
+    async fn server_error_response_uses_status_template() {
+        let mut msg = Message::new("http.request");
+        msg.set_meta("http.header.accept", "text/html");
+        let out = server_error_response(&msg);
+        let buf = out.collect_buffered().await.unwrap();
+        let body = String::from_utf8(buf.body).unwrap_or_default();
+        assert!(body.contains(">500<"), "body should contain 500 code");
+        assert!(
+            body.contains("Something went wrong"),
+            "body should contain 'Something went wrong' title"
+        );
     }
 }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -165,7 +165,13 @@ pub fn shelled_response(
         return html_response(body);
     }
     html_response(shelled_page(
-        title, config, groups, user, current_path, topbar, body,
+        title,
+        config,
+        groups,
+        user,
+        current_path,
+        topbar,
+        body,
     ))
 }
 
@@ -276,10 +282,11 @@ pub fn html_response_with_toast(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::ui::shell::{Crumb, Topbar};
     use maud::html;
     use wafer_run::types::Message;
+
+    use super::*;
+    use crate::ui::shell::{Crumb, Topbar};
 
     fn site_config() -> SiteConfig {
         SiteConfig {
@@ -326,9 +333,15 @@ mod tests {
         let out = not_found_response(&msg);
         let buf = out.collect_buffered().await.unwrap();
         let body = String::from_utf8(buf.body).unwrap_or_default();
-        assert!(body.contains("status-page"), "body should contain status-page class");
+        assert!(
+            body.contains("status-page"),
+            "body should contain status-page class"
+        );
         assert!(body.contains(">404<"), "body should contain 404 code");
-        assert!(body.contains("Go home"), "body should contain Go home action");
+        assert!(
+            body.contains("Go home"),
+            "body should contain Go home action"
+        );
     }
 
     #[tokio::test]
@@ -338,9 +351,15 @@ mod tests {
         let out = forbidden_response(&msg);
         let buf = out.collect_buffered().await.unwrap();
         let body = String::from_utf8(buf.body).unwrap_or_default();
-        assert!(body.contains("status-page"), "body should contain status-page class");
+        assert!(
+            body.contains("status-page"),
+            "body should contain status-page class"
+        );
         assert!(body.contains(">403<"), "body should contain 403 code");
-        assert!(body.contains("Sign in"), "body should contain Sign in action");
+        assert!(
+            body.contains("Sign in"),
+            "body should contain Sign in action"
+        );
     }
 
     #[tokio::test]

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -111,6 +111,65 @@ pub fn html_response(markup: maud::Markup) -> wafer_run::OutputStream {
     )
 }
 
+/// Render a full page wrapping `body` in `shell()` + `page()`. Caller
+/// passes the audience's `nav_groups` (admin or portal) and a `Topbar`.
+/// Mounts the ⌘K palette modal at the bottom of the page when
+/// `topbar.show_palette` is true.
+pub fn shelled_page(
+    title: &str,
+    config: &SiteConfig,
+    groups: &[NavGroup],
+    user: Option<&UserInfo>,
+    current_path: &str,
+    topbar: shell::Topbar<'_>,
+    body: maud::Markup,
+) -> maud::Markup {
+    use maud::{html, PreEscaped};
+    let palette_markup = if topbar.show_palette {
+        palette::palette(nav_groups::palette_entries(current_path))
+    } else {
+        html! {}
+    };
+    layout::page(
+        title,
+        config,
+        html! {
+            (shell::shell(
+                groups,
+                user,
+                current_path,
+                &config.logo_url,
+                &config.logo_icon_url,
+                topbar,
+                body,
+            ))
+            (palette_markup)
+            script { (PreEscaped(assets::palette_js())) }
+        },
+    )
+}
+
+/// Same as `shelled_page`, but returns an `OutputStream`. Returns the
+/// raw `body` (no chrome) when the request is an htmx partial — same
+/// fragment behavior as `block_shell(is_fragment: true)` had.
+pub fn shelled_response(
+    msg: &wafer_run::types::Message,
+    title: &str,
+    config: &SiteConfig,
+    groups: &[NavGroup],
+    user: Option<&UserInfo>,
+    current_path: &str,
+    topbar: shell::Topbar<'_>,
+    body: maud::Markup,
+) -> wafer_run::OutputStream {
+    if is_htmx(msg) {
+        return html_response(body);
+    }
+    html_response(shelled_page(
+        title, config, groups, user, current_path, topbar, body,
+    ))
+}
+
 /// Render a styled 404 page.
 pub fn not_found_page() -> maud::Markup {
     use maud::{html, DOCTYPE};
@@ -217,4 +276,49 @@ pub fn html_response_with_toast(
             markup.into_string().into_bytes(),
             "text/html; charset=utf-8",
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::shell::{Crumb, Topbar};
+    use maud::html;
+
+    fn site_config() -> SiteConfig {
+        SiteConfig {
+            app_name: "TestApp".to_string(),
+            logo_url: String::new(),
+            logo_icon_url: String::new(),
+            favicon_url: String::new(),
+            embedded_scripts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn shelled_page_full_render_includes_html_doctype_shell_and_body() {
+        let groups = nav_groups::admin("/b/admin/");
+        let topbar = Topbar {
+            crumbs: vec![Crumb {
+                label: "Dashboard",
+                href: None,
+            }],
+            primary_action: None,
+            show_palette: true,
+        };
+        let body = html! { p { "hello" } };
+        let markup = shelled_page(
+            "Dashboard",
+            &site_config(),
+            &groups,
+            None,
+            "/b/admin/",
+            topbar,
+            body,
+        );
+        let s = markup.into_string();
+        assert!(s.contains("<!DOCTYPE html>"));
+        assert!(s.contains(r#"class="shell""#));
+        assert!(s.contains(r#"id="cmdk""#)); // palette mounted
+        assert!(s.contains("hello"));
+    }
 }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -170,74 +170,28 @@ pub fn shelled_response(
     ))
 }
 
-/// Render a styled 404 page.
-pub fn not_found_page() -> maud::Markup {
-    use maud::{html, DOCTYPE};
-    html! {
-        (DOCTYPE)
-        html lang="en" {
-            head {
-                meta charset="utf-8";
-                meta name="viewport" content="width=device-width,initial-scale=1";
-                title { "Not Found" }
-                link rel="stylesheet" href=(assets::css_url());
-            }
-            body {
-                div .login-page {
-                    div .login-container style="text-align:center" {
-                        div style="font-size:4rem;font-weight:700;color:var(--text-muted);margin-bottom:0.5rem" { "404" }
-                        h1 style="font-size:1.25rem;font-weight:600;margin:0 0 0.5rem" { "Page not found" }
-                        p .login-subtitle style="margin-bottom:1.5rem" {
-                            "The page you're looking for doesn't exist."
-                        }
-                        a .login-button href="/" style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
-                            "Go Home"
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Render a styled 403 page.
-pub fn forbidden_page() -> maud::Markup {
-    use maud::{html, DOCTYPE};
-    html! {
-        (DOCTYPE)
-        html lang="en" {
-            head {
-                meta charset="utf-8";
-                meta name="viewport" content="width=device-width,initial-scale=1";
-                title { "Access Denied" }
-                link rel="stylesheet" href=(assets::css_url());
-            }
-            body {
-                div .login-page {
-                    div .login-container style="text-align:center" {
-                        div style="font-size:4rem;font-weight:700;color:var(--text-muted);margin-bottom:0.5rem" { "403" }
-                        h1 style="font-size:1.25rem;font-weight:600;margin:0 0 0.5rem" { "Access denied" }
-                        p .login-subtitle style="margin-bottom:1.5rem" {
-                            "You don't have permission to access this page. Please sign in with an admin account."
-                        }
-                        a .login-button href="/b/auth/login" style="display:inline-block;width:auto;padding:.625rem 1.25rem;text-decoration:none" {
-                            "Sign In"
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Return styled 403 for browser requests, JSON for API requests.
 pub fn forbidden_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
     if accept.contains("text/html") && !accept.contains("application/json") {
+        let config = SiteConfig {
+            app_name: "Solobase".to_string(),
+            logo_url: String::new(),
+            logo_icon_url: String::new(),
+            favicon_url: String::new(),
+            embedded_scripts: Vec::new(),
+        };
+        let body = templates::status_page(
+            "403",
+            "Forbidden",
+            "You don't have access to this page.",
+            Some(("Sign in".to_string(), "/b/auth/login".to_string())),
+        );
+        let markup = layout::page("Forbidden", &config, body);
         crate::blocks::helpers::ResponseBuilder::new()
             .status(403)
             .body(
-                forbidden_page().into_string().into_bytes(),
+                markup.into_string().into_bytes(),
                 "text/html; charset=utf-8",
             )
     } else {
@@ -249,10 +203,24 @@ pub fn forbidden_response(msg: &wafer_run::types::Message) -> wafer_run::OutputS
 pub fn not_found_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
     if accept.contains("text/html") && !accept.contains("application/json") {
+        let config = SiteConfig {
+            app_name: "Solobase".to_string(),
+            logo_url: String::new(),
+            logo_icon_url: String::new(),
+            favicon_url: String::new(),
+            embedded_scripts: Vec::new(),
+        };
+        let body = templates::status_page(
+            "404",
+            "Not found",
+            "We couldn't find that page.",
+            Some(("Go home".to_string(), "/".to_string())),
+        );
+        let markup = layout::page("Not found", &config, body);
         crate::blocks::helpers::ResponseBuilder::new()
             .status(404)
             .body(
-                not_found_page().into_string().into_bytes(),
+                markup.into_string().into_bytes(),
                 "text/html; charset=utf-8",
             )
     } else {
@@ -283,6 +251,7 @@ mod tests {
     use super::*;
     use crate::ui::shell::{Crumb, Topbar};
     use maud::html;
+    use wafer_run::types::Message;
 
     fn site_config() -> SiteConfig {
         SiteConfig {
@@ -320,5 +289,29 @@ mod tests {
         assert!(s.contains(r#"class="shell""#));
         assert!(s.contains(r#"id="cmdk""#)); // palette mounted
         assert!(s.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn not_found_response_uses_status_template() {
+        let mut msg = Message::new("http.request");
+        msg.set_meta("http.header.accept", "text/html");
+        let out = not_found_response(&msg);
+        let buf = out.collect_buffered().await.unwrap();
+        let body = String::from_utf8(buf.body).unwrap_or_default();
+        assert!(body.contains("status-page"), "body should contain status-page class");
+        assert!(body.contains(">404<"), "body should contain 404 code");
+        assert!(body.contains("Go home"), "body should contain Go home action");
+    }
+
+    #[tokio::test]
+    async fn forbidden_response_uses_status_template() {
+        let mut msg = Message::new("http.request");
+        msg.set_meta("http.header.accept", "text/html");
+        let out = forbidden_response(&msg);
+        let buf = out.collect_buffered().await.unwrap();
+        let body = String::from_utf8(buf.body).unwrap_or_default();
+        assert!(body.contains("status-page"), "body should contain status-page class");
+        assert!(body.contains(">403<"), "body should contain 403 code");
+        assert!(body.contains("Sign in"), "body should contain Sign in action");
     }
 }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -126,7 +126,7 @@ pub fn shelled_page(
 ) -> maud::Markup {
     use maud::{html, PreEscaped};
     let palette_markup = if topbar.show_palette {
-        palette::palette(nav_groups::palette_entries(current_path))
+        palette::palette(nav_groups::palette_entries_from_groups(groups))
     } else {
         html! {}
     };
@@ -175,30 +175,57 @@ pub fn shelled_response(
     ))
 }
 
+/// Minimal `SiteConfig` used by the status-page helpers. They render
+/// before context is available, so they can't load real config; fixed
+/// branding + no embedded scripts is the right shape.
+fn minimal_config() -> SiteConfig {
+    SiteConfig {
+        app_name: "Solobase".to_string(),
+        logo_url: String::new(),
+        logo_icon_url: String::new(),
+        favicon_url: String::new(),
+        embedded_scripts: Vec::new(),
+    }
+}
+
+/// Render the styled `status_page` body wrapped in `layout::page` and
+/// return it with the requested HTTP status. Used by 403/404/500 helpers.
+fn status_response(
+    status: u16,
+    page_title: &str,
+    code: &str,
+    title: &str,
+    body_text: &str,
+    primary_action: (&str, &str),
+) -> wafer_run::OutputStream {
+    let config = minimal_config();
+    let body = templates::status_page(
+        code,
+        title,
+        body_text,
+        Some((primary_action.0.to_string(), primary_action.1.to_string())),
+    );
+    let markup = layout::page(page_title, &config, body);
+    crate::blocks::helpers::ResponseBuilder::new()
+        .status(status)
+        .body(
+            markup.into_string().into_bytes(),
+            "text/html; charset=utf-8",
+        )
+}
+
 /// Return styled 403 for browser requests, JSON for API requests.
 pub fn forbidden_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
     if accept.contains("text/html") && !accept.contains("application/json") {
-        let config = SiteConfig {
-            app_name: "Solobase".to_string(),
-            logo_url: String::new(),
-            logo_icon_url: String::new(),
-            favicon_url: String::new(),
-            embedded_scripts: Vec::new(),
-        };
-        let body = templates::status_page(
+        status_response(
+            403,
+            "Forbidden",
             "403",
             "Forbidden",
             "You don't have access to this page.",
-            Some(("Sign in".to_string(), "/b/auth/login".to_string())),
-        );
-        let markup = layout::page("Forbidden", &config, body);
-        crate::blocks::helpers::ResponseBuilder::new()
-            .status(403)
-            .body(
-                markup.into_string().into_bytes(),
-                "text/html; charset=utf-8",
-            )
+            ("Sign in", "/b/auth/login"),
+        )
     } else {
         crate::blocks::helpers::err_forbidden("admin access required")
     }
@@ -208,26 +235,14 @@ pub fn forbidden_response(msg: &wafer_run::types::Message) -> wafer_run::OutputS
 pub fn not_found_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
     if accept.contains("text/html") && !accept.contains("application/json") {
-        let config = SiteConfig {
-            app_name: "Solobase".to_string(),
-            logo_url: String::new(),
-            logo_icon_url: String::new(),
-            favicon_url: String::new(),
-            embedded_scripts: Vec::new(),
-        };
-        let body = templates::status_page(
+        status_response(
+            404,
+            "Not found",
             "404",
             "Not found",
             "We couldn't find that page.",
-            Some(("Go home".to_string(), "/".to_string())),
-        );
-        let markup = layout::page("Not found", &config, body);
-        crate::blocks::helpers::ResponseBuilder::new()
-            .status(404)
-            .body(
-                markup.into_string().into_bytes(),
-                "text/html; charset=utf-8",
-            )
+            ("Go home", "/"),
+        )
     } else {
         crate::blocks::helpers::err_not_found("endpoint not found")
     }
@@ -237,26 +252,14 @@ pub fn not_found_response(msg: &wafer_run::types::Message) -> wafer_run::OutputS
 pub fn server_error_response(msg: &wafer_run::types::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
     if accept.contains("text/html") && !accept.contains("application/json") {
-        let config = SiteConfig {
-            app_name: "Solobase".to_string(),
-            logo_url: String::new(),
-            logo_icon_url: String::new(),
-            favicon_url: String::new(),
-            embedded_scripts: Vec::new(),
-        };
-        let body = templates::status_page(
+        status_response(
+            500,
+            "Server error",
             "500",
             "Something went wrong",
             "An unexpected error occurred. Please try again.",
-            Some(("Go home".to_string(), "/".to_string())),
-        );
-        let markup = layout::page("Server error", &config, body);
-        crate::blocks::helpers::ResponseBuilder::new()
-            .status(500)
-            .body(
-                markup.into_string().into_bytes(),
-                "text/html; charset=utf-8",
-            )
+            ("Go home", "/"),
+        )
     } else {
         crate::blocks::helpers::err_internal("internal server error")
     }
@@ -300,7 +303,7 @@ mod tests {
 
     #[test]
     fn shelled_page_full_render_includes_html_doctype_shell_and_body() {
-        let groups = nav_groups::admin("/b/admin/");
+        let groups = nav_groups::admin();
         let topbar = Topbar {
             crumbs: vec![Crumb {
                 label: "Dashboard",

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -150,8 +150,7 @@ pub fn shelled_page(
 }
 
 /// Same as `shelled_page`, but returns an `OutputStream`. Returns the
-/// raw `body` (no chrome) when the request is an htmx partial — same
-/// fragment behavior as `block_shell(is_fragment: true)` had.
+/// raw `body` (no chrome) when the request is an htmx partial.
 pub fn shelled_response(
     msg: &wafer_run::types::Message,
     title: &str,

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod assets;
 pub mod components;
 pub mod icons;
 pub mod layout;
+pub mod nav_groups;
 pub mod palette;
 pub mod shell;
 pub mod sidebar;

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -125,7 +125,10 @@ mod tests {
     #[test]
     fn admin_settings_points_at_email_tab_for_phase_3_route() {
         let groups = admin("/b/admin/settings/email");
-        let system = groups.iter().find(|g| g.label.as_deref() == Some("System")).unwrap();
+        let system = groups
+            .iter()
+            .find(|g| g.label.as_deref() == Some("System"))
+            .unwrap();
         let settings = system.items.iter().find(|i| i.label == "Settings").unwrap();
         assert_eq!(settings.href, "/b/admin/settings/email");
     }
@@ -147,7 +150,11 @@ mod tests {
         let hrefs: Vec<&str> = account.items.iter().map(|i| i.href.as_str()).collect();
         assert_eq!(
             hrefs,
-            vec!["/b/userportal/profile", "/b/auth/orgs", "/b/userportal/sessions"]
+            vec![
+                "/b/userportal/profile",
+                "/b/auth/orgs",
+                "/b/userportal/sessions"
+            ]
         );
     }
 

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -49,6 +49,28 @@ pub fn admin(_current_path: &str) -> Vec<NavGroup> {
     ]
 }
 
+/// Portal sidebar groups (end-user account + apps).
+pub fn portal(_current_path: &str) -> Vec<NavGroup> {
+    vec![
+        NavGroup {
+            label: Some("Account".to_string()),
+            items: vec![
+                item("Profile", "/b/userportal/profile", "user"),
+                item("Organizations", "/b/auth/orgs", "users"),
+                item("Sessions", "/b/userportal/sessions", "shield"),
+            ],
+        },
+        NavGroup {
+            label: Some("Apps".to_string()),
+            items: vec![
+                item("Products", "/b/products/", "package"),
+                item("Files", "/b/storage/", "folder"),
+                item("Legal", "/b/legalpages/admin/privacy", "file-text"),
+            ],
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +99,34 @@ mod tests {
         let system = groups.iter().find(|g| g.label.as_deref() == Some("System")).unwrap();
         let settings = system.items.iter().find(|i| i.label == "Settings").unwrap();
         assert_eq!(settings.href, "/b/admin/settings/email");
+    }
+
+    #[test]
+    fn portal_has_account_and_apps() {
+        let groups = portal("/b/userportal/profile");
+        let labels: Vec<&str> = groups
+            .iter()
+            .map(|g| g.label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["Account", "Apps"]);
+    }
+
+    #[test]
+    fn portal_account_includes_profile_orgs_sessions() {
+        let groups = portal("/b/userportal/profile");
+        let account = &groups[0];
+        let hrefs: Vec<&str> = account.items.iter().map(|i| i.href.as_str()).collect();
+        assert_eq!(
+            hrefs,
+            vec!["/b/userportal/profile", "/b/auth/orgs", "/b/userportal/sessions"]
+        );
+    }
+
+    #[test]
+    fn portal_apps_includes_products_files_legal() {
+        let groups = portal("/b/products/");
+        let apps = &groups[1];
+        let labels: Vec<&str> = apps.items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["Products", "Files", "Legal"]);
     }
 }

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -71,6 +71,35 @@ pub fn portal(_current_path: &str) -> Vec<NavGroup> {
     ]
 }
 
+/// Build palette entries for the audience matching `current_path`.
+/// Admin paths get admin nav; everything else gets portal nav.
+pub fn palette_entries(current_path: &str) -> Vec<crate::ui::palette::PaletteEntry> {
+    use crate::ui::palette::PaletteEntry;
+    let groups = if is_admin_path(current_path) {
+        admin(current_path)
+    } else {
+        portal(current_path)
+    };
+    groups
+        .into_iter()
+        .flat_map(|g| g.items.into_iter())
+        .map(|item| PaletteEntry {
+            keywords: format!("{} {}", item.label.to_lowercase(), item.href),
+            label: item.label,
+            kind_label: "Page".to_string(),
+            href: item.href,
+        })
+        .collect()
+}
+
+fn is_admin_path(path: &str) -> bool {
+    path.starts_with("/b/admin")
+        || path.starts_with("/b/inspector")
+        || path.starts_with("/b/messages")
+        || path.starts_with("/b/llm")
+        || path.starts_with("/b/files")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +157,31 @@ mod tests {
         let apps = &groups[1];
         let labels: Vec<&str> = apps.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(labels, vec!["Products", "Files", "Legal"]);
+    }
+
+    #[test]
+    fn palette_entries_for_admin_path_includes_admin_pages() {
+        let entries = palette_entries("/b/admin/users");
+        let labels: Vec<&str> = entries.iter().map(|e| e.label.as_str()).collect();
+        assert!(labels.contains(&"Dashboard"));
+        assert!(labels.contains(&"Users"));
+        assert!(labels.contains(&"Settings"));
+    }
+
+    #[test]
+    fn palette_entries_for_portal_path_includes_portal_pages() {
+        let entries = palette_entries("/b/userportal/profile");
+        let labels: Vec<&str> = entries.iter().map(|e| e.label.as_str()).collect();
+        assert!(labels.contains(&"Profile"));
+        assert!(labels.contains(&"Products"));
+    }
+
+    #[test]
+    fn palette_entry_keywords_lowercase_label_plus_href() {
+        let entries = palette_entries("/b/admin/");
+        let users = entries.iter().find(|e| e.label == "Users").unwrap();
+        assert!(users.keywords.contains("users"));
+        assert!(users.keywords.contains("/b/admin/users"));
+        assert_eq!(users.kind_label, "Page");
     }
 }

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -11,10 +11,8 @@ fn item(label: &str, href: &str, icon: &'static str) -> NavItem {
     }
 }
 
-/// Admin sidebar groups. The `_current_path` arg exists for symmetry
-/// with `portal()` and is forwarded to `sidebar_grouped` by the caller;
-/// active-item highlighting happens there.
-pub fn admin(_current_path: &str) -> Vec<NavGroup> {
+/// Admin sidebar groups.
+pub fn admin() -> Vec<NavGroup> {
     vec![
         NavGroup {
             label: Some("Workspace".to_string()),
@@ -50,7 +48,7 @@ pub fn admin(_current_path: &str) -> Vec<NavGroup> {
 }
 
 /// Portal sidebar groups (end-user account + apps).
-pub fn portal(_current_path: &str) -> Vec<NavGroup> {
+pub fn portal() -> Vec<NavGroup> {
     vec![
         NavGroup {
             label: Some("Account".to_string()),
@@ -71,33 +69,21 @@ pub fn portal(_current_path: &str) -> Vec<NavGroup> {
     ]
 }
 
-/// Build palette entries for the audience matching `current_path`.
-/// Admin paths get admin nav; everything else gets portal nav.
-pub fn palette_entries(current_path: &str) -> Vec<crate::ui::palette::PaletteEntry> {
+/// Flatten a slice of `NavGroup`s into palette entries. Same items the
+/// sidebar shows; ⌘K uses the same source of truth so the two can never
+/// drift out of sync.
+pub fn palette_entries_from_groups(groups: &[NavGroup]) -> Vec<crate::ui::palette::PaletteEntry> {
     use crate::ui::palette::PaletteEntry;
-    let groups = if is_admin_path(current_path) {
-        admin(current_path)
-    } else {
-        portal(current_path)
-    };
     groups
-        .into_iter()
-        .flat_map(|g| g.items.into_iter())
+        .iter()
+        .flat_map(|g| g.items.iter())
         .map(|item| PaletteEntry {
             keywords: format!("{} {}", item.label.to_lowercase(), item.href),
-            label: item.label,
+            label: item.label.clone(),
             kind_label: "Page".to_string(),
-            href: item.href,
+            href: item.href.clone(),
         })
         .collect()
-}
-
-fn is_admin_path(path: &str) -> bool {
-    path.starts_with("/b/admin")
-        || path.starts_with("/b/inspector")
-        || path.starts_with("/b/messages")
-        || path.starts_with("/b/llm")
-        || path.starts_with("/b/files")
 }
 
 #[cfg(test)]
@@ -106,7 +92,7 @@ mod tests {
 
     #[test]
     fn admin_has_four_labeled_groups_in_spec_order() {
-        let groups = admin("/b/admin/");
+        let groups = admin();
         let labels: Vec<&str> = groups
             .iter()
             .map(|g| g.label.as_deref().unwrap_or(""))
@@ -116,7 +102,7 @@ mod tests {
 
     #[test]
     fn admin_workspace_has_dashboard_and_users() {
-        let groups = admin("/b/admin/");
+        let groups = admin();
         let workspace = &groups[0];
         let labels: Vec<&str> = workspace.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(labels, vec!["Dashboard", "Users"]);
@@ -124,7 +110,7 @@ mod tests {
 
     #[test]
     fn admin_settings_points_at_email_tab_for_phase_3_route() {
-        let groups = admin("/b/admin/settings/email");
+        let groups = admin();
         let system = groups
             .iter()
             .find(|g| g.label.as_deref() == Some("System"))
@@ -135,7 +121,7 @@ mod tests {
 
     #[test]
     fn portal_has_account_and_apps() {
-        let groups = portal("/b/userportal/profile");
+        let groups = portal();
         let labels: Vec<&str> = groups
             .iter()
             .map(|g| g.label.as_deref().unwrap_or(""))
@@ -145,7 +131,7 @@ mod tests {
 
     #[test]
     fn portal_account_includes_profile_orgs_sessions() {
-        let groups = portal("/b/userportal/profile");
+        let groups = portal();
         let account = &groups[0];
         let hrefs: Vec<&str> = account.items.iter().map(|i| i.href.as_str()).collect();
         assert_eq!(
@@ -160,15 +146,15 @@ mod tests {
 
     #[test]
     fn portal_apps_includes_products_files_legal() {
-        let groups = portal("/b/products/");
+        let groups = portal();
         let apps = &groups[1];
         let labels: Vec<&str> = apps.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(labels, vec!["Products", "Files", "Legal"]);
     }
 
     #[test]
-    fn palette_entries_for_admin_path_includes_admin_pages() {
-        let entries = palette_entries("/b/admin/users");
+    fn palette_entries_for_admin_groups_includes_admin_pages() {
+        let entries = palette_entries_from_groups(&admin());
         let labels: Vec<&str> = entries.iter().map(|e| e.label.as_str()).collect();
         assert!(labels.contains(&"Dashboard"));
         assert!(labels.contains(&"Users"));
@@ -176,8 +162,8 @@ mod tests {
     }
 
     #[test]
-    fn palette_entries_for_portal_path_includes_portal_pages() {
-        let entries = palette_entries("/b/userportal/profile");
+    fn palette_entries_for_portal_groups_includes_portal_pages() {
+        let entries = palette_entries_from_groups(&portal());
         let labels: Vec<&str> = entries.iter().map(|e| e.label.as_str()).collect();
         assert!(labels.contains(&"Profile"));
         assert!(labels.contains(&"Products"));
@@ -185,7 +171,7 @@ mod tests {
 
     #[test]
     fn palette_entry_keywords_lowercase_label_plus_href() {
-        let entries = palette_entries("/b/admin/");
+        let entries = palette_entries_from_groups(&admin());
         let users = entries.iter().find(|e| e.label == "Users").unwrap();
         assert!(users.keywords.contains("users"));
         assert!(users.keywords.contains("/b/admin/users"));

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -1,0 +1,81 @@
+//! Canonical sidebar groups per audience. Single source of truth for
+//! both `sidebar_grouped()` callers and the ⌘K palette entries.
+
+use super::{sidebar::NavGroup, NavItem};
+
+fn item(label: &str, href: &str, icon: &'static str) -> NavItem {
+    NavItem {
+        label: label.to_string(),
+        href: href.to_string(),
+        icon,
+    }
+}
+
+/// Admin sidebar groups. The `_current_path` arg exists for symmetry
+/// with `portal()` and is forwarded to `sidebar_grouped` by the caller;
+/// active-item highlighting happens there.
+pub fn admin(_current_path: &str) -> Vec<NavGroup> {
+    vec![
+        NavGroup {
+            label: Some("Workspace".to_string()),
+            items: vec![
+                item("Dashboard", "/b/admin/", "layout-dashboard"),
+                item("Users", "/b/admin/users", "users"),
+            ],
+        },
+        NavGroup {
+            label: Some("Data".to_string()),
+            items: vec![
+                item("Blocks", "/b/admin/blocks", "package"),
+                item("Storage", "/b/admin/storage", "hard-drive"),
+                item("SQL", "/b/admin/sql", "server"),
+            ],
+        },
+        NavGroup {
+            label: Some("Communication".to_string()),
+            items: vec![
+                item("Messages", "/b/messages/", "file-text"),
+                item("LLM", "/b/llm/", "globe"),
+            ],
+        },
+        NavGroup {
+            label: Some("System".to_string()),
+            items: vec![
+                item("Logs", "/b/admin/logs", "file-text"),
+                item("Inspector", "/b/inspector", "shield"),
+                item("Settings", "/b/admin/settings/email", "settings"),
+            ],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_has_four_labeled_groups_in_spec_order() {
+        let groups = admin("/b/admin/");
+        let labels: Vec<&str> = groups
+            .iter()
+            .map(|g| g.label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["Workspace", "Data", "Communication", "System"]);
+    }
+
+    #[test]
+    fn admin_workspace_has_dashboard_and_users() {
+        let groups = admin("/b/admin/");
+        let workspace = &groups[0];
+        let labels: Vec<&str> = workspace.items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["Dashboard", "Users"]);
+    }
+
+    #[test]
+    fn admin_settings_points_at_email_tab_for_phase_3_route() {
+        let groups = admin("/b/admin/settings/email");
+        let system = groups.iter().find(|g| g.label.as_deref() == Some("System")).unwrap();
+        let settings = system.items.iter().find(|i| i.label == "Settings").unwrap();
+        assert_eq!(settings.href, "/b/admin/settings/email");
+    }
+}

--- a/crates/solobase-core/src/ui/shell.rs
+++ b/crates/solobase-core/src/ui/shell.rs
@@ -1,6 +1,5 @@
-//! New shell — replaces `layout::block_shell` body. Renders sidebar
-//! (left) + topbar (top of content) + body (the rest). Pages declare
-//! `Topbar` inputs; this module owns the chrome.
+//! Shell — renders sidebar (left) + topbar (top of content) + body (the rest).
+//! Pages declare `Topbar` inputs; this module owns the chrome.
 
 use maud::{html, Markup};
 
@@ -96,8 +95,8 @@ pub fn shell(
     }
 }
 
-/// Backward-compat helper used by the existing `layout::block_shell`.
-/// Wraps a flat `Vec<NavItem>` into one unlabeled `NavGroup`.
+/// Wraps a flat `Vec<NavItem>` into one unlabeled `NavGroup`. Used by tests
+/// and any caller that doesn't need group labels.
 pub fn one_group(items: Vec<NavItem>) -> Vec<NavGroup> {
     vec![NavGroup { label: None, items }]
 }

--- a/crates/solobase-core/src/ui/sidebar.rs
+++ b/crates/solobase-core/src/ui/sidebar.rs
@@ -1,114 +1,8 @@
-//! Sidebar component with navigation and user profile.
+//! Sidebar component — grouped navigation with brand, groups, and user profile.
 
-use maud::{html, Markup, PreEscaped};
+use maud::Markup;
 
-use super::{icons, NavItem, UserInfo};
-
-/// Render the sidebar with nav items and user section.
-pub fn sidebar(
-    nav_items: &[NavItem],
-    user: Option<&UserInfo>,
-    current_path: &str,
-    logo_url: &str,
-    logo_icon_url: &str,
-) -> Markup {
-    html! {
-        nav .sidebar {
-            // Logo header
-            div .sidebar-header {
-                a .sidebar-logo href="/b/admin/" {
-                    @if !logo_url.is_empty() {
-                        img .sidebar-logo-long src=(logo_url) alt="Home";
-                    }
-                    @if !logo_icon_url.is_empty() {
-                        img .sidebar-logo-icon src=(logo_icon_url) alt="Home";
-                    }
-                    @if logo_url.is_empty() && logo_icon_url.is_empty() {
-                        span .font-semibold style="font-size: 1.25rem;" { "Solobase" }
-                    }
-                }
-            }
-
-            // Navigation
-            div .sidebar-nav {
-                @for item in nav_items {
-                    div .nav-item {
-                        a
-                            .nav-link
-                            .(if item.href.ends_with('/') { if current_path == item.href { "active" } else { "" } } else if current_path.starts_with(&item.href) { "active" } else { "" })
-                            href=(item.href)
-                        {
-                            span .nav-icon {
-                                (nav_icon(item.icon))
-                            }
-                            span .nav-text { (item.label) }
-                        }
-                    }
-                }
-
-                // Collapse toggle
-                button .sidebar-toggle onclick="toggleSidebar()" title="Toggle sidebar" {
-                    (icons::chevron_left())
-                }
-            }
-
-            // User section
-            @if let Some(user) = user {
-                div .sidebar-user-container {
-                    button .sidebar-user id="user-menu-btn" onclick="toggleProfileMenu()" {
-                        div .user-avatar { (user.avatar_initial()) }
-                        div .user-info {
-                            div .user-email { (user.email) }
-                        }
-                    }
-
-                    // Profile menu (hidden by default)
-                    div .profile-menu #profile-menu style="display:none" {
-                        div .profile-menu-header {
-                            div .profile-menu-avatar { (user.avatar_initial()) }
-                            div .profile-menu-info {
-                                div .profile-menu-email { (user.email) }
-                                div .profile-menu-role {
-                                    (user.roles.join(", "))
-                                }
-                            }
-                        }
-                        div .profile-menu-divider {}
-                        a .profile-menu-item href="/b/userportal/" {
-                            (icons::user())
-                            span { "My Account" }
-                        }
-                        a .profile-menu-item href="/b/auth/change-password" {
-                            (icons::settings())
-                            span { "Change Password" }
-                        }
-                        div .profile-menu-divider {}
-                        form action="/b/auth/api/logout" method="post" {
-                            button .profile-menu-item .profile-menu-item-danger type="submit" {
-                                (icons::log_out())
-                                span { "Sign Out" }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        script { (PreEscaped(r#"
-function toggleProfileMenu() {
-    var m = document.getElementById('profile-menu');
-    m.style.display = m.style.display === 'none' ? 'block' : 'none';
-}
-document.addEventListener('click', function(e) {
-    var m = document.getElementById('profile-menu');
-    var b = document.getElementById('user-menu-btn');
-    if (m && b && !b.contains(e.target) && !m.contains(e.target)) {
-        m.style.display = 'none';
-    }
-});
-"#)) }
-    }
-}
+use super::icons;
 
 /// Map icon name strings to icon functions.
 pub fn nav_icon(name: &str) -> Markup {
@@ -188,17 +82,57 @@ pub fn sidebar_grouped(
                 }
             }
             @if let Some(u) = user {
-                div .sidebar__user {
-                    (crate::ui::components::avatar(&u.email, crate::ui::components::CtrlSize::Sm))
-                    div .sidebar__user-text {
-                        div .sidebar__user-email { (u.email) }
-                        div .sidebar__user-role {
-                            @if u.is_admin() { "Admin" } @else { "User" }
+                div .sidebar__user-container {
+                    button .sidebar__user id="user-menu-btn" type="button" onclick="toggleProfileMenu()" {
+                        (crate::ui::components::avatar(&u.email, crate::ui::components::CtrlSize::Sm))
+                        div .sidebar__user-text {
+                            div .sidebar__user-email { (u.email) }
+                            div .sidebar__user-role {
+                                @if u.is_admin() { "Admin" } @else { "User" }
+                            }
+                        }
+                    }
+                    div .profile-menu #profile-menu style="display:none" {
+                        div .profile-menu-header {
+                            div .profile-menu-avatar { (u.avatar_initial()) }
+                            div .profile-menu-info {
+                                div .profile-menu-email { (u.email) }
+                                div .profile-menu-role { (u.roles.join(", ")) }
+                            }
+                        }
+                        div .profile-menu-divider {}
+                        a .profile-menu-item href="/b/userportal/" {
+                            (icons::user())
+                            span { "My Account" }
+                        }
+                        a .profile-menu-item href="/b/auth/change-password" {
+                            (icons::settings())
+                            span { "Change Password" }
+                        }
+                        div .profile-menu-divider {}
+                        form action="/b/auth/api/logout" method="post" {
+                            button .profile-menu-item .profile-menu-item-danger type="submit" {
+                                (icons::log_out())
+                                span { "Sign Out" }
+                            }
                         }
                     }
                 }
             }
         }
+        script { (maud::PreEscaped(r#"
+function toggleProfileMenu() {
+    var m = document.getElementById('profile-menu');
+    if (m) m.style.display = m.style.display === 'none' ? 'block' : 'none';
+}
+document.addEventListener('click', function(e) {
+    var m = document.getElementById('profile-menu');
+    var b = document.getElementById('user-menu-btn');
+    if (m && b && !b.contains(e.target) && !m.contains(e.target)) {
+        m.style.display = 'none';
+    }
+});
+"#)) }
     }
 }
 


### PR DESCRIPTION
## Summary

Migrates all `block_shell()` and `centered_page()` call sites in `solobase-core` to the Phase 1 shell engine. Every shelled page declares its sidebar groups, breadcrumbs, and primary action via the new `shelled_response()` helper. Auth flows move to `auth_split`. Status pages (404 / 403 / 500) render the `status_page` template. New `/` redirect handler. Old `block_shell`, `sidebar()`, and `sidebar_js()` deleted — fully replaced.

## What landed

- **Foundations** — `solobase-core/src/ui/nav_groups.rs` with `admin()` / `portal()` / `palette_entries()`. Single source of truth for sidebar AND ⌘K palette entries.
- **`shelled_response()`** — page + shell + palette wrapper that handles htmx fragments transparently.
- **10 block-file migrations** — admin, userportal, llm, messages, files, products, legalpages, auth (shelled page) — all use grouped sidebars + breadcrumbs.
- **Auth flows → `auth_split`** — login, signup, reset, change-password, OAuth complete (5 sites), with a shared `brand_panel(&SiteConfig)` helper in `auth/mod.rs`.
- **Status pages** — `not_found_response`, `forbidden_response`, new `server_error_response` render the `status_page` template.
- **Root `/` handler** — anonymous → `/b/auth/login`, authenticated → `/b/auth/dashboard`. Required adding `/` to the `site_main` routes so the dispatcher fires (was hitting `wafer-run/web` 404 fallback).
- **Profile menu ported** — `sidebar_grouped()` gained the logout / change-password / My Account dropdown that lived in the old `sidebar()`.
- **Cleanup** — deleted `layout::block_shell()`, `sidebar::sidebar()`, `assets::sidebar_js()`. `centered_page()` kept as raw escape hatch per spec.

Spec: `workspace/docs/superpowers/specs/2026-05-01-solobase-ui-cleanup-phase-2-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-01-solobase-ui-cleanup-phase-2-shell-adoption.md`

## Verified locally

- 423 unit tests pass (`cargo test -p solobase-core --lib`)
- Smoke server on `:8093` (`SOLOBASE_LISTEN=127.0.0.1:8093 ./target/debug/solobase`):
  - `/` → 302 → `/b/auth/login` (anon) / `/b/auth/dashboard` (authed)
  - `/b/auth/login` renders `auth-split__brand` + `auth-split__form`, no palette
  - `/b/admin/` (admin) renders all 4 sidebar groups (Workspace / Data / Communication / System), `topbar__crumbs`, palette modal mounted
  - `/b/admin/` (anon) returns styled 403 via `status_page` template
- `cargo +nightly fmt --all` applied

## Known follow-ups (not in this PR)

- **`/b/admin/settings/email` route 404s until Phase 3** — the sidebar entry is wired now; Phase 3 builds the consolidated settings route + redirects. Acceptable 1-phase gap.
- **`wafer-run/web` 404 still serves plain JSON** — for unknown root-level paths (e.g. `/totally-not-a-thing`) that hit the `/**` fallback, you get the wafer-run/web JSON 404, not the styled status_page. Wiring that to status_page requires a wafer-run cross-repo change; deferred. solobase-core's `/b/*` 404s correctly use status_page.
- **`data_table_v1` / `empty_state_v1` / `pagination_v1` retirement** — Phase 3 ports the callers onto the new templates and removes the v1 shims.
- **`palette_actions()` verb registry** — deferred per design Q3-C; ⌘K currently navigates to routes only. Verbs land alongside form ports in Phases 3–5.
- **Visual snapshot baseline** — deferred to Phase 3 (when admin-port visuals start landing). Existing playwright tests are functional smoke against solobase-web.

## Test plan

- [ ] CI Format & Lint passes (nightly rustfmt enforced)
- [ ] CI Tests pass (≥423 unit tests)
- [ ] CI WASM Build passes
- [ ] CI E2E (Playwright) passes against solobase-web
- [ ] CI Security Audit + TypeScript SDK pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)