### PR TITLE
fix(builder): explicit register middleware blocks on wasm32

### DIFF
--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -269,6 +269,39 @@ impl SolobaseBuilder {
         // their respective wafer-block-* crates. The `use wafer_block_xxx as _`
         // anchors at the top of this file ensure the linker includes those crate
         // .o files so the linkme distributed-slice entries land in the binary.
+        //
+        // linkme's distributed_slice does not work on wasm32 (its link-section
+        // attributes only target ELF/Mach-O/PE — see linkme-impl/src/declaration.rs
+        // for the target_os match), so on wasm32 the auto-registration is a no-op.
+        // Register the six middleware blocks explicitly when targeting wasm32.
+        #[cfg(target_arch = "wasm32")]
+        {
+            wafer.register_block(
+                "wafer-run/cors",
+                Arc::new(wafer_block_cors::CorsBlock::new()),
+            )?;
+            wafer.register_block(
+                "wafer-run/inspector",
+                Arc::new(wafer_block_inspector::InspectorBlock::new()),
+            )?;
+            wafer.register_block(
+                "wafer-run/readonly-guard",
+                Arc::new(wafer_block_readonly_guard::ReadonlyGuardBlock::new()),
+            )?;
+            wafer.register_block(
+                "wafer-run/router",
+                Arc::new(wafer_block_router::RouterBlock::new()),
+            )?;
+            wafer.register_block(
+                "wafer-run/security-headers",
+                Arc::new(wafer_block_security_headers::SecurityHeadersBlock::new()),
+            )?;
+            wafer.register_block(
+                "wafer-run/web",
+                Arc::new(wafer_block_web::WebBlock::new()),
+            )?;
+        }
+
         wafer.add_block_config(
             "wafer-run/inspector",
             serde_json::json!({ "allow_anonymous": false }),

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -296,10 +296,7 @@ impl SolobaseBuilder {
                 "wafer-run/security-headers",
                 Arc::new(wafer_block_security_headers::SecurityHeadersBlock::new()),
             )?;
-            wafer.register_block(
-                "wafer-run/web",
-                Arc::new(wafer_block_web::WebBlock::new()),
-            )?;
+            wafer.register_block("wafer-run/web", Arc::new(wafer_block_web::WebBlock::new()))?;
         }
 
         wafer.add_block_config(


### PR DESCRIPTION
## Summary

`linkme`'s `distributed_slice` doesn't work on `wasm32` — its `link_section` attributes only target ELF/Mach-O/PE (see `linkme-impl/src/declaration.rs` for the `target_os` match). On `wasm32` the `register_static_block!` macro in `wafer-run` is a no-op, so all six middleware blocks (`cors`, `inspector`, `readonly-guard`, `router`, `security-headers`, `web`) end up unregistered at runtime.

Symptom: any `wasm32` consumer of `SolobaseBuilder` (gizza-ai, solobase-web, etc.) fails the moment a request goes through the flow chain — the runtime returns:

\`\`\`json
{"error":"internal_error","message":"block 'wafer-run/security-headers' not found"}
\`\`\`

(or `wafer-run/readonly-guard`, etc., depending on which middleware position the runtime hits first).

## Fix

Add an explicit registration block in `builder.rs` gated on `target_arch = "wasm32"` that constructs and registers each of the six middleware blocks. On native, the existing `linkme` path continues to work unchanged — same code path, same behaviour.

## Test plan

- [x] Native: \`cargo build\` and existing tests still pass (no functional change on native).
- [x] wasm32: built gizza-ai (\`solobase build\`), confirmed the boot probe passes — page reaches the rendered chat UI through the SW dispatch chain instead of the prior \`internal_error\` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)