### PR TITLE
feat(auth): grant admin role idempotently on every login when ADMIN_EMAIL matches

### DIFF
--- a/crates/solobase-core/src/blocks/auth/login.rs
+++ b/crates/solobase-core/src/blocks/auth/login.rs
@@ -71,8 +71,8 @@ impl AuthBlock {
             return error_response(ErrorCode::EmailNotVerified, "Please verify your email before logging in. Check your inbox for the verification link.");
         }
 
-        // Get roles
-        let roles = get_user_roles(ctx, &user.id).await;
+        // Get roles, granting admin role idempotently when ADMIN_EMAIL matches
+        let roles = ensure_admin_role(ctx, &user.id, &email_lower).await;
 
         // Generate tokens
         let (access_token, refresh_token, family) =
@@ -356,7 +356,7 @@ impl AuthBlock {
         }
 
         let email = user.str_field("email").to_string();
-        let roles = get_user_roles(ctx, &user_id).await;
+        let roles = ensure_admin_role(ctx, &user_id, &email).await;
 
         // Revoke old refresh token family and issue new
         let family = claims

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -129,6 +129,61 @@ mod helpers {
         }
     }
 
+    /// Resolve user roles, idempotently granting `admin` if the user's email
+    /// matches the configured `SUPPERS_AI__AUTH__ADMIN_EMAIL` and they don't
+    /// already have it.
+    ///
+    /// This closes a real footgun: roles are normally only assigned at signup
+    /// (`create_user_and_assign_role`), so changing `ADMIN_EMAIL` after a
+    /// user already exists never elevates them. With this helper, every login
+    /// re-checks the rule and grants admin once when appropriate.
+    ///
+    /// Intentionally **upgrade-only**: never removes a role, never demotes.
+    /// Unsetting `ADMIN_EMAIL` does not revoke admin from anyone — that has
+    /// to be done explicitly via the admin UI / DB. Removing roles silently
+    /// on login would be an availability foot-gun (one typo in env locks
+    /// everyone out).
+    pub(super) async fn ensure_admin_role(
+        ctx: &dyn Context,
+        user_id: &str,
+        email: &str,
+    ) -> Vec<String> {
+        let mut roles = get_user_roles(ctx, user_id).await;
+
+        let admin_email =
+            config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "").await;
+        if admin_email.is_empty()
+            || !email.eq_ignore_ascii_case(&admin_email)
+            || roles.iter().any(|r| r == "admin")
+        {
+            return roles;
+        }
+
+        // Email matches and admin role is missing — grant it.
+        let role_data = json_map(serde_json::json!({
+            "user_id": user_id,
+            "role": "admin",
+            "assigned_at": crate::blocks::helpers::now_rfc3339(),
+        }));
+        match db::create(ctx, USER_ROLES_COLLECTION, role_data).await {
+            Ok(_) => {
+                tracing::info!(
+                    user_id = %user_id,
+                    email = %email,
+                    "granted admin role on login (email matches ADMIN_EMAIL)"
+                );
+                roles.push("admin".to_string());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    user_id = %user_id,
+                    "failed to grant admin role on login: {e}"
+                );
+            }
+        }
+        roles
+    }
+
     /// Returns (access_token, refresh_token, family).
     ///
     /// `auth_method` records *how* the user authenticated for this token —

--- a/crates/solobase-core/src/blocks/auth/oauth.rs
+++ b/crates/solobase-core/src/blocks/auth/oauth.rs
@@ -428,7 +428,7 @@ impl AuthBlock {
             }
         };
 
-        let roles = get_user_roles(ctx, &user.id).await;
+        let roles = ensure_admin_role(ctx, &user.id, &email).await;
         let (jwt_token, refresh_token, family) = match generate_tokens(
             ctx,
             &user.id,


### PR DESCRIPTION
## Summary
Closes a bootstrapping footgun discovered during wafer.run setup: roles are normally only assigned at signup, so setting \`SUPPERS_AI__AUTH__ADMIN_EMAIL\` after a user already exists never elevates them. With this change every login re-checks the rule and grants \`admin\` once when appropriate.

## Why
Real scenario from end-to-end testing: signed up via GitHub on 2026-04-23 before \`ADMIN_EMAIL\` was set. Set it later, logged in via OAuth → ended up at /b/admin/ with a 403 because the role was never re-evaluated. Manual DB \`UPDATE\` was required.

## Design
- New helper \`helpers::ensure_admin_role(ctx, user_id, email) -> Vec<String>\`. Reads ADMIN_EMAIL config; if it matches \`email\` (case-insensitive) AND \`admin\` isn't already in the user's roles, inserts the role row and appends to the returned list.
- Replaces \`get_user_roles\` at the three JWT-mint sites: OAuth callback (existing-user path), \`handle_login\` (password), \`handle_refresh\`. Read-only paths (\`/me\`, change-password UI) keep \`get_user_roles\` — they don't mint tokens.

## Intentionally upgrade-only
Never demotes. Unsetting \`ADMIN_EMAIL\` or pointing it at a different mailbox does NOT strip admin from the previous holder. Silent demotions on login would be an availability foot-gun (one typo locks every admin out). Removal stays an explicit operation.

## Test plan
- [x] \`cargo test --lib -p solobase-core\` → 423 passed
- [ ] Reviewer: log in as a non-admin email → no admin granted; log in as ADMIN_EMAIL → admin granted; log in again → no duplicate insert (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)