### PR TITLE
fix(e2e): smoke test waitUntil 'domcontentloaded' to avoid CDN-cold timeouts

### DIFF
--- a/crates/solobase-web/tests/e2e/smoke.spec.ts
+++ b/crates/solobase-web/tests/e2e/smoke.spec.ts
@@ -6,7 +6,12 @@ import { test, expect } from '@playwright/test';
  * path bug (both of which silently prevented SW registration).
  */
 test('service worker registers and controls the page', async ({ page }) => {
-  await page.goto('/');
+  // `domcontentloaded` is the right waitUntil here: the test exercises SW
+  // registration, which `loader.js` triggers as soon as the DOM is parsed.
+  // Default `load` waits for every <script type="module"> import to resolve,
+  // including `webllm-engine.js`'s jsdelivr fetch of @mlc-ai/web-llm — that's
+  // a multi-MB ESM bundle that times out the test on a cold CI cache.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
   // Read the controller scriptURL inside the waitForFunction predicate so the
   // value is captured atomically. solobase-web's loader.js redirects to
   // `/b/system/` as soon as the SW takes control, which would otherwise
@@ -22,7 +27,7 @@ test('service worker registers and controls the page', async ({ page }) => {
 });
 
 test('solobase-web admin UI at /b/system/ renders after SW activation', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => navigator.serviceWorker.controller !== null,
     null,


### PR DESCRIPTION
## Summary

solobase main CI's E2E (Playwright) job has been red for the last 30 runs. The smoke test fails with `page.goto: Test timeout of 60000ms exceeded` — but the page itself is interactive and the SW registers fine. The blocker is Playwright's default `waitUntil: 'load'`, which waits for every `<script type=\"module\">` import to resolve.

The loader page (`pkg/index.html`) imports `/webllm-engine.js`, which `import { CreateMLCEngine } from 'https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm'`. That ESM bundle is a few megabytes; on a cold CI cache it routinely takes longer than the 60s test timeout to fetch.

## Fix

Change `page.goto('/')` to `page.goto('/', { waitUntil: 'domcontentloaded' })` in both smoke tests. This is the semantically correct waitUntil: the tests assert SW registration and controller takeover, both of which happen well before the module imports finish. The existing `waitForFunction(() => navigator.serviceWorker.controller)` provides the actual assertion timing.

## Verification

- `npx playwright test tests/e2e/smoke.spec.ts` locally — both tests pass in 749ms (was timing out at 60s).

## Follow-up flagged in commit message

The loader page eagerly imports `/webllm-engine.js` and `/embed-engine.js` even though it just registers the SW and immediately redirects to `/b/system/`. SSR pages that actually use WebLLM/Transformers.js already inject those scripts via `SOLOBASE_SHARED__EMBEDDED_SCRIPTS`, so the hardcoded `<script>` tags in `crates/solobase-browser/assets/index.html.tmpl` are duplicate work that slows down first-paint-to-redirect for every user. Worth removing in a separate PR — out of scope here, since this PR is about getting CI green.

## Test plan
- [x] Local smoke test passes (749ms vs 60s timeout)
- [ ] CI confirms green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)