### PR TITLE
fix(e2e): lazy-load @mlc-ai/web-llm + smoke test waitUntil 'commit'

### DIFF
--- a/crates/solobase-browser/assets/webllm-engine.js
+++ b/crates/solobase-browser/assets/webllm-engine.js
@@ -2,8 +2,19 @@
 //
 // Runs in the window (WebGPU is window-only). Receives requests from the SW
 // via navigator.serviceWorker.message, runs WebLLM, streams chunks back.
+//
+// The @mlc-ai/web-llm import is lazy: a top-level static import would block
+// DOMContentLoaded for every page that loads this script (it's a multi-MB
+// jsdelivr ESM bundle), and most page loads never end up invoking the LLM.
+// Defer the import until handleCreateEngine actually needs it.
 
-import { CreateMLCEngine } from 'https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm';
+let _CreateMLCEngine = null;
+async function loadCreateMLCEngine() {
+    if (_CreateMLCEngine) return _CreateMLCEngine;
+    const mod = await import('https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm');
+    _CreateMLCEngine = mod.CreateMLCEngine;
+    return _CreateMLCEngine;
+}
 
 let _engine = null;
 let _engineModel = null;
@@ -22,6 +33,7 @@ async function handleCreateEngine(msg) {
                 _engine = null;
                 _engineModel = null;
             }
+            const CreateMLCEngine = await loadCreateMLCEngine();
             _engine = await CreateMLCEngine(msg.modelId, { /* progress swallowed */ });
             _engineModel = msg.modelId;
         }

--- a/crates/solobase-web/tests/e2e/smoke.spec.ts
+++ b/crates/solobase-web/tests/e2e/smoke.spec.ts
@@ -6,12 +6,18 @@ import { test, expect } from '@playwright/test';
  * path bug (both of which silently prevented SW registration).
  */
 test('service worker registers and controls the page', async ({ page }) => {
-  // `domcontentloaded` is the right waitUntil here: the test exercises SW
-  // registration, which `loader.js` triggers as soon as the DOM is parsed.
-  // Default `load` waits for every <script type="module"> import to resolve,
-  // including `webllm-engine.js`'s jsdelivr fetch of @mlc-ai/web-llm — that's
-  // a multi-MB ESM bundle that times out the test on a cold CI cache.
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  // `commit` is the right waitUntil here: this test exercises SW registration,
+  // which `loader.js` triggers as soon as it parses (registration is async on
+  // top of that). The downstream `waitForFunction(() => navigator.serviceWorker
+  // .controller)` provides the actual assertion timing. Default `load` blocks
+  // on every subresource; even `domcontentloaded` is delayed by deferred and
+  // module scripts. Neither fires reliably here because the loader page imports
+  // `/webllm-engine.js` and `/embed-engine.js` (type="module"), and a slow
+  // jsdelivr CDN response for either one used to push the goto past the 60s
+  // test timeout. Lazy-loading the WebLLM ESM (see webllm-engine.js) removed
+  // most of the slowness, but `commit` is still the semantically correct
+  // waitUntil for an SW-registration smoke and survives future regressions.
+  await page.goto('/', { waitUntil: 'commit' });
   // Read the controller scriptURL inside the waitForFunction predicate so the
   // value is captured atomically. solobase-web's loader.js redirects to
   // `/b/system/` as soon as the SW takes control, which would otherwise
@@ -27,7 +33,7 @@ test('service worker registers and controls the page', async ({ page }) => {
 });
 
 test('solobase-web admin UI at /b/system/ renders after SW activation', async ({ page }) => {
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.goto('/', { waitUntil: 'commit' });
   await page.waitForFunction(
     () => navigator.serviceWorker.controller !== null,
     null,


### PR DESCRIPTION
## Summary

CI's E2E (Playwright) job has been red because `page.goto: Test timeout of 60000ms exceeded`. PR #48 took a first crack at it (switched to `waitUntil: 'domcontentloaded'`), but that assumption was wrong: DCL is delayed by deferred and module scripts per the HTML spec, so PR #47 still failed the same way after #48 merged because #47 adds a second `<script type=\"module\">` (`embed-engine.js`) to the loader.

This PR addresses both root causes.

## 1. Lazy-load WebLLM (the actual root cause)

\`webllm-engine.js\` had a top-level static import:

\`\`\`js
import { CreateMLCEngine } from 'https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm';
\`\`\`

The @mlc-ai/web-llm ESM bundle is multi-megabyte; on a cold CI cache the jsdelivr fetch routinely takes longer than the 60s test timeout. **And most page loads never invoke the LLM** — admin UI doesn't use it, the loader page just registers the SW and redirects.

Defer the import to first \`handleCreateEngine()\` call. The first user-driven \"Load model\" pays the import cost; every other page load completes instantly.

## 2. Smoke test \`waitUntil: 'commit'\` (defense-in-depth + correct semantics)

\`'commit'\` fires on first response byte, which is the semantically correct waitUntil for a SW-registration smoke. The actual assertion timing comes from the downstream \`waitForFunction(() => navigator.serviceWorker.controller)\`. Survives future regressions where someone re-introduces a slow blocking import.

## Verification

\`\`\`
npx playwright test tests/e2e/smoke.spec.ts
2 passed (657ms)
\`\`\`

(Was timing out at 60s on CI for #47 even after #48 landed.)

## Test plan
- [x] Local smoke test passes (657ms)
- [ ] CI confirms green on this PR
- [ ] After merge, re-run #47 CI to confirm it goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)