### PR TITLE
fix(web): point boot_redirect at / instead of unclaimed /b/system/

### DIFF
--- a/crates/solobase-web/js/manifest.json
+++ b/crates/solobase-web/js/manifest.json
@@ -2,7 +2,7 @@
   "name": "Solobase",
   "short_name": "Solobase",
   "description": "Full-stack application platform running entirely in your browser",
-  "start_url": "/b/system/",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "background_color": "#f5f5f5",

--- a/crates/solobase-web/solobase.toml
+++ b/crates/solobase-web/solobase.toml
@@ -1,7 +1,12 @@
 [app]
 name = "solobase-web"
 title = "Solobase"
-boot_redirect = "/b/system/"
+# `/` is intercepted by the SW and routed through `solobase_core::routing` —
+# anonymous users get a 302 to /b/auth/login, authenticated users to
+# /b/auth/dashboard. Don't aim this at /b/system/: that path isn't claimed
+# by any block and would 404 (the system block only serves /health and
+# /b/static/, despite its name).
+boot_redirect = "/"
 
 # solobase-web's PWA Web App Manifest. The file is app-specific (icons,
 # name, start_url); solobase-browser doesn't ship a default. Overlay it

--- a/crates/solobase-web/tests/e2e/smoke.spec.ts
+++ b/crates/solobase-web/tests/e2e/smoke.spec.ts
@@ -20,7 +20,7 @@ test('service worker registers and controls the page', async ({ page }) => {
   await page.goto('/', { waitUntil: 'commit' });
   // Read the controller scriptURL inside the waitForFunction predicate so the
   // value is captured atomically. solobase-web's loader.js redirects to
-  // `/b/system/` as soon as the SW takes control, which would otherwise
+  // `boot_redirect` as soon as the SW takes control, which would otherwise
   // destroy the execution context between a separate `waitForFunction` +
   // `evaluate` pair.
   const handle = await page.waitForFunction(
@@ -32,16 +32,20 @@ test('service worker registers and controls the page', async ({ page }) => {
   expect(controllerURL).toMatch(/\/sw\.js$/);
 });
 
-test('solobase-web admin UI at /b/system/ renders after SW activation', async ({ page }) => {
+test('boot redirect lands on the auth login page', async ({ page }) => {
+  // boot_redirect is "/" (intercepted by SW → wasm router → 302 →
+  // /b/auth/login for anonymous visitors). loader.js sets
+  // `window.location.href = boot_redirect` once the SW takes control;
+  // waiting for the resulting URL match avoids the
+  // `net::ERR_ABORTED; maybe frame was detached?` race that an explicit
+  // second goto would hit.
+  //
+  // Asserting on the rendered Sign In form rather than a non-empty body
+  // catches the regression where boot_redirect pointed at /b/system/ —
+  // an unclaimed path that returned a non-empty 404 page and silently
+  // passed the smoke.
   await page.goto('/', { waitUntil: 'commit' });
-  // loader.js redirects to `/b/system/` as soon as the SW takes control.
-  // Wait for that redirect to land instead of issuing our own goto — an
-  // explicit `page.goto('/b/system/')` here would race with the loader's
-  // `window.location.href` assignment and abort with
-  // `net::ERR_ABORTED; maybe frame was detached?`. The redirect itself
-  // exercises the SW serving the admin UI through WAFER, which is what
-  // this smoke is verifying.
-  await page.waitForURL(/\/b\/system\/?$/, { timeout: 20_000 });
-  const bodyText = await page.locator('body').textContent();
-  expect(bodyText ?? '').not.toBe('');
+  await page.waitForURL(/\/b\/auth\/login/, { timeout: 30_000 });
+  await expect(page.locator('input#email')).toBeVisible();
+  await expect(page.locator('input#password')).toBeVisible();
 });


### PR DESCRIPTION
## Summary

`solobase-web/solobase.toml` had `boot_redirect = "/b/system/"`, which `loader.js` navigates to once the SW takes control. But the `suppers-ai/system` block only claims `/health` and `/b/static/` — it never registered a route for `/b/system/`. The router falls through to `crate::ui::not_found_response` and serves a 404. That's the visible failure on `https://demo.solobase.dev/`:

```
GET https://demo.solobase.dev/b/system/ 404 (Not Found)
boot @ /loader.js:40
```

This PR points `boot_redirect` at `/` instead. The router maps `/` to a 302 → `/b/auth/login` (anon) or `/b/auth/dashboard` (authed) via `root_redirect` (`solobase-core/src/routing.rs:278`), so the browser lands on a real, registered page. PWA `start_url` updated to match.

The smoke test caught this in the wrong way: it navigated to `/b/system/` and asserted on a non-empty body, which the 404 page satisfied. Replaced with a navigation-then-form check on the login page so the next time `boot_redirect` points at an unclaimed path, CI fails loudly.

## Test plan

- [x] `cargo check -p solobase` passes
- [x] `cargo test -p solobase --lib parse_minimal_config` passes
- [ ] Playwright smoke (`yarn workspace solobase-web test:e2e` or equivalent) lands on `/b/auth/login` and renders the email/password form
- [ ] After deploy + SW update, `https://demo.solobase.dev/` lands on the login page (clear stale SW first)

## Out of scope

The `unreachable` panic in the deployed wasm (separate symptom downstream of the 404 path) needs a wasm-debug rebuild to symbolicate — tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
