### PR TITLE
fix(e2e): admin-UI smoke — wait for loader's redirect instead of racing it

### DIFF
--- a/crates/solobase-web/tests/e2e/smoke.spec.ts
+++ b/crates/solobase-web/tests/e2e/smoke.spec.ts
@@ -34,15 +34,14 @@ test('service worker registers and controls the page', async ({ page }) => {
 
 test('solobase-web admin UI at /b/system/ renders after SW activation', async ({ page }) => {
   await page.goto('/', { waitUntil: 'commit' });
-  await page.waitForFunction(
-    () => navigator.serviceWorker.controller !== null,
-    null,
-    { timeout: 20_000 },
-  );
-  // Navigate to the admin UI that solobase-web ships. Past the SW boundary,
-  // the UI block renders HTML served from WAFER. Any title/heading works —
-  // this smoke just confirms the runtime responds.
-  await page.goto('/b/system/');
+  // loader.js redirects to `/b/system/` as soon as the SW takes control.
+  // Wait for that redirect to land instead of issuing our own goto — an
+  // explicit `page.goto('/b/system/')` here would race with the loader's
+  // `window.location.href` assignment and abort with
+  // `net::ERR_ABORTED; maybe frame was detached?`. The redirect itself
+  // exercises the SW serving the admin UI through WAFER, which is what
+  // this smoke is verifying.
+  await page.waitForURL(/\/b\/system\/?$/, { timeout: 20_000 });
   const bodyText = await page.locator('body').textContent();
   expect(bodyText ?? '').not.toBe('');
 });


### PR DESCRIPTION
## Summary

After #49 fixed the first smoke test (SW registration), the second smoke test (\`solobase-web admin UI at /b/system/ renders after SW activation\`) started failing on #47 with:

\`\`\`
Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
   at smoke.spec.ts:45:14
\`\`\`

That's the explicit \`await page.goto('/b/system/')\` racing with \`loader.js\`'s \`window.location.href = '/b/system/'\` redirect — Chrome aborted the new navigation as the in-flight one took over. Pre-#49 this worked accidentally because \`waitUntil: 'load'\` blocked until the loader's redirect had fully resolved; with \`waitUntil: 'commit'\` (correctly used for the SW-registration smoke), \`page.goto('/')\` returns before the redirect happens, so the test's own goto collides.

## Fix

Replace the explicit \`page.goto('/b/system/')\` with \`await page.waitForURL(/\\/b\\/system\\/?$/, { timeout: 20_000 })\`.

The loader's redirect already exercises the SW serving the admin UI through WAFER (which is what this smoke is verifying). Duplicating the navigation with our own goto only invited the race.

## Verification

\`npx playwright test tests/e2e/smoke.spec.ts\` locally — both tests pass in 676ms.

## Test plan
- [x] Local smoke test passes
- [ ] CI confirms green
- [ ] Re-run #47 CI after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)