### PR TITLE
fix(wasm): explicitly register suppers-ai/* blocks on wasm32

### DIFF
--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -99,3 +99,52 @@ pub fn register_llm(
         std::sync::Arc::new(llm::LlmBlock::new(provider_llm_svc)),
     )
 }
+
+/// Register every solobase feature block on wasm32 builds.
+///
+/// On native, each block self-registers via `register_static_block!` (gated
+/// `cfg(not(target_arch = "wasm32"))` because linkme's distributed_slice
+/// only emits on ELF/Mach-O/PE — see `wafer_run::builder::WaferBuilder::build`).
+/// On wasm32 that path is a no-op, so the runtime starts with zero
+/// `suppers-ai/*` blocks and the SolobaseRouter dispatches into a void —
+/// every feature route returns `block 'suppers-ai/<name>' not found`.
+///
+/// This helper mirrors the linkme manifest so wasm builds get the same
+/// block set. Keep this list in sync with the `register_static_block!`
+/// invocations across `crate::blocks::*` and with the `all_block_infos`
+/// wasm32 fallback above.
+///
+/// Excludes `suppers-ai/llm` (constructed in `SolobaseBuilder::build` with
+/// `Arc<ProviderLlmService>`) and `suppers-ai/fastembed` (native-only,
+/// requires `feature = "native-embedding"`).
+#[cfg(target_arch = "wasm32")]
+pub fn register_all_static_blocks(
+    wafer: &mut wafer_run::Wafer,
+) -> Result<(), wafer_run::RuntimeError> {
+    use std::sync::Arc;
+
+    wafer.register_block("suppers-ai/admin", Arc::new(admin::AdminBlock::new()))?;
+    wafer.register_block("suppers-ai/auth", Arc::new(auth::AuthBlock::new()))?;
+    wafer.register_block("suppers-ai/email", Arc::new(email::EmailBlock::new()))?;
+    wafer.register_block("suppers-ai/files", Arc::new(files::FilesBlock::new()))?;
+    wafer.register_block(
+        "suppers-ai/legalpages",
+        Arc::new(legalpages::LegalPagesBlock::new()),
+    )?;
+    wafer.register_block(
+        "suppers-ai/messages",
+        Arc::new(messages::MessagesBlock::new()),
+    )?;
+    wafer.register_block(
+        "suppers-ai/products",
+        Arc::new(products::ProductsBlock::new()),
+    )?;
+    wafer.register_block("suppers-ai/system", Arc::new(system::SystemBlock::new()))?;
+    wafer.register_block(
+        "suppers-ai/userportal",
+        Arc::new(userportal::UserPortalBlock::new()),
+    )?;
+    wafer.register_block("suppers-ai/vector", Arc::new(vector::VectorBlock::new()))?;
+
+    Ok(())
+}

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -297,6 +297,14 @@ impl SolobaseBuilder {
                 Arc::new(wafer_block_security_headers::SecurityHeadersBlock::new()),
             )?;
             wafer.register_block("wafer-run/web", Arc::new(wafer_block_web::WebBlock::new()))?;
+
+            // Solobase feature blocks (suppers-ai/*) self-register via
+            // `register_static_block!` on native, but linkme's distributed_slice
+            // doesn't emit on wasm32 — see `crate::blocks::register_all_static_blocks`
+            // for the full reasoning. Without this call the wasm runtime has only
+            // wafer-run/* middleware and the SolobaseRouter resolves every feature
+            // route to a `block 'suppers-ai/<name>' not found` error.
+            crate::blocks::register_all_static_blocks(&mut wafer)?;
         }
 
         wafer.add_block_config(


### PR DESCRIPTION
## Summary

The wasm32 build of solobase-web has been shipping with **none of the `suppers-ai/*` feature blocks registered**. Every feature route — `/b/auth/...`, `/b/admin/...`, `/b/static/...`, `/b/files/...`, etc. — resolves through `SolobaseRouter` to `ctx.call_block("suppers-ai/<name>", ...)`, which hits an empty registry and returns:

```
{"error":"NotFound","message":"block 'suppers-ai/<name>' not found"}
```

This is what the live `https://demo.solobase.dev/` is doing today (the `/b/static/app-*.css` and `/b/static/htmx-*.min.js` 404s in the user report) and is the root cause behind the wasm `unreachable` trap that follows once the page tries to recover.

### Why it broke

`linkme`'s `distributed_slice` only emits link-section entries on ELF/Mach-O/PE — see the `cfg(not(target_arch = "wasm32"))` gate on `WaferBuilder::build`'s `load_inventory_blocks` call. Every `register_static_block!` invocation across `crates/solobase-core/src/blocks/*` is correspondingly gated `cfg(not(target_arch = "wasm32"))`. `solobase-core/src/builder.rs` already mirrors this for the `wafer-run/*` middleware (cors, inspector, readonly-guard, router, security-headers, web) inside an explicit `cfg(target_arch = "wasm32")` block — but the `suppers-ai/*` feature blocks have no equivalent path.

### The fix

- Add `register_all_static_blocks(wafer)` in `blocks/mod.rs` gated `cfg(target_arch = "wasm32")`. Mirrors the wasm32 branch of `all_block_infos` that already manually enumerates the same set of blocks, so adding/removing a block now touches both helpers in the same module.
- Call it from the existing `cfg(target_arch = "wasm32")` block in `builder.rs` immediately after the `wafer-run/*` middleware registration.

Excluded:
- `suppers-ai/llm` — already constructed in `SolobaseBuilder::build` with `Arc<ProviderLlmService>`, gated by `feature = "llm"`.
- `suppers-ai/fastembed` — native-only, gated by `feature = "native-embedding"`.

### Verification

Local repro with `wasm-pack build --dev`, swap into `pkg/`, serve via `python3 -m http.server`:

| route | before | after |
| --- | --- | --- |
| `GET /b/auth/login` | 404 `block 'suppers-ai/auth' not found` | 200, renders Sign In HTML |
| `GET /b/static/app-deadbeef.css` | 404 `block 'suppers-ai/system' not found` | 200, returns embedded CSS |
| `GET /b/static/htmx-deadbeef.min.js` | 404 same | 200, returns embedded htmx |
| `GET /health` | already 200 | 200 `{"status":"ok"}` |

Combined with #50 (boot_redirect → `/`), `https://demo.solobase.dev/` will land on a working login page.

## Test plan

- [x] `cargo check -p solobase` passes
- [x] `cargo test -p solobase-core --lib` (387 passed)
- [x] `wasm-pack build --target web --dev` builds clean
- [x] Local server: `/b/auth/login`, `/b/static/*`, `/health` all return 200 + correct content
- [ ] Playwright smoke from #50 (`yarn workspace solobase-web test:e2e`) lands on login form
- [ ] After deploy, `https://demo.solobase.dev/` works end-to-end (instruct users to clear stale SW first)

## Out of scope

The `unreachable` panic the user originally reported on the live wasm did not reproduce in the local debug build. Hypothesis: it's a downstream symptom — once `/b/static/...` returns JSON `404` instead of the expected CSS/JS, a subsequent fetch hits a release-only code path that traps. With the blocks registered the broken-state path goes away entirely, and the deployed wasm should stop tripping it. If the panic surfaces post-deploy, follow up with a wasm-debug rebuild to symbolicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
