### PR TITLE
fix(browser): self-heal stale SW + force update on every page load

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -11,6 +11,15 @@ async function boot() {
             scope: '/',
             updateViaCache: 'none',
         });
+        // Force an update check on every page load. `register()` only checks
+        // when the script bytes differ from the cached copy, and even then
+        // browsers may delay the check up to 24h. Calling update() explicitly
+        // means a deploy is picked up the next time the user visits the page,
+        // not the next time the browser feels like polling. controllerchange
+        // (wired below) handles the reload once the new SW takes over.
+        try { await registration.update(); } catch (e) {
+            console.warn('[__APP_NAME__] SW update check failed:', e);
+        }
         const sw = registration.installing || registration.waiting || registration.active;
         if (sw && sw.state !== 'activated') {
             await new Promise((resolve) => {

--- a/crates/solobase-browser/assets/sw.js.tmpl
+++ b/crates/solobase-browser/assets/sw.js.tmpl
@@ -3,15 +3,49 @@ import init, { initialize, handle_request } from '__WASM_JS__';
 
 let initialized = false;
 let initPromise = null;
+// Set after a fatal wasm error (init failure or runtime trap). A poisoned SW
+// stops handling fetches with wasm and unregisters itself so the next page
+// load picks up a fresh registration. Without this, a stale SW from a prior
+// deploy whose hashed asset URL no longer exists keeps returning 5xx forever
+// — the user has to manually unregister via DevTools to recover.
+let poisoned = false;
+
+async function selfDestruct(reason) {
+    if (poisoned) return;
+    poisoned = true;
+    console.error('[__APP_NAME__] SW self-destructing:', reason);
+    try {
+        await self.registration.unregister();
+        const clients = await self.clients.matchAll({ type: 'window' });
+        for (const c of clients) {
+            // Re-navigate the page so the next request goes to the network
+            // (no controller now that we've unregistered) and loader.js runs
+            // again with the fresh /sw.js.
+            try { c.navigate(c.url); } catch (e) { console.warn('[__APP_NAME__] navigate() failed:', e); }
+        }
+    } catch (e) {
+        console.error('[__APP_NAME__] self-destruct cleanup failed:', e);
+    }
+}
 
 async function ensureInitialized() {
     if (initialized) return;
     if (initPromise) return await initPromise;
     initPromise = (async () => {
         console.log('[__APP_NAME__] Loading WASM module...');
-        await init();
+        try {
+            await init();
+        } catch (e) {
+            await selfDestruct(`wasm module load failed: ${e}`);
+            throw e;
+        }
         console.log('[__APP_NAME__] Initializing runtime...');
-        await initialize();
+        try {
+            await initialize();
+        } catch (e) {
+            await selfDestruct(`runtime initialize() failed: ${e}`);
+            throw e;
+        }
         initialized = true;
         console.log('[__APP_NAME__] Runtime ready.');
     })();
@@ -91,11 +125,24 @@ self.addEventListener('fetch', (event) => {
 });
 
 async function handleFetch(request) {
+    if (poisoned) {
+        // wasm is dead — let the network serve this. The page should already
+        // be in the middle of a re-navigation triggered by selfDestruct().
+        return fetch(request);
+    }
     try {
         await ensureInitialized();
         return await handle_request(request);
     } catch (error) {
         console.error('[__APP_NAME__] Error handling request:', error);
+        // wasm-bindgen surfaces a `RuntimeError` for an `unreachable` trap.
+        // Once the wasm instance traps it's permanently broken — every
+        // subsequent host call will fail. Self-destruct so the user doesn't
+        // get stuck behind a dead SW.
+        if (error instanceof WebAssembly.RuntimeError) {
+            await selfDestruct(`wasm trap during request: ${error}`);
+            return fetch(request);
+        }
         return new Response(
             JSON.stringify({ error: 'internal_error', message: String(error) }),
             { status: 500, headers: { 'Content-Type': 'application/json' } }


### PR DESCRIPTION
## Summary

After every deploy, users with a stale Service Worker from the previous build are stuck — the OLD SW imports content-hashed JS modules that no longer exist on the server, so every fetch through it 5xx's, and there's no recovery short of opening DevTools → Application → Service Workers → Unregister. That's the friction this PR removes.

Two changes in `crates/solobase-browser/assets/`:

### 1. `sw.js.tmpl` — self-destruct on unrecoverable wasm failure

A new `selfDestruct(reason)` helper calls `self.registration.unregister()` and re-navigates every controlled client. Triggered by:

- `init()` failure (wasm module 404'd because the asset hash rotated)
- `initialize()` failure (runtime startup blew up)
- `WebAssembly.RuntimeError` thrown out of `handle_request()` (the wasm instance trapped on `unreachable` and is permanently dead)

After self-destruct the SW sets a `poisoned` flag; subsequent fetches fall through to `fetch(request)` so navigation completes against the network. The next page load has no controller, `loader.js` re-runs, and a fresh `/sw.js` is registered.

Non-fatal per-request errors (bugs in a feature block) still return the existing `500 internal_error` JSON — only the genuinely irrecoverable cases nuke the SW.

### 2. `loader.js.tmpl` — explicit `registration.update()` on every page load

`register()` only checks for an updated SW when the cached bytes differ, and even then browsers may defer the check for up to 24h. Calling `registration.update()` explicitly means a deploy is detected the next time the user visits the page. The existing `controllerchange` listener handles the reload once the new SW activates.

## Behavior after this lands

- Healthy session: nothing changes — SW handles fetches as before.
- Deploy → user revisits: `update()` finds a new SW, installs it, `controllerchange` reloads. Same flow as today, just no waiting on the polling tick.
- Deploy where the OLD SW's pinned asset hashes are gone: the old SW's first failed fetch triggers `selfDestruct`, the page re-navigates, fresh SW takes over. **No more manual unregister.**
- Wasm trap mid-session: the SW unregisters, the page reloads, and the next visit gets a clean instance.

## Test plan

- [x] `cargo test -p solobase-browser --lib` (37 passed)
- [x] Templates still render (no new placeholders introduced)
- [ ] Manual: artificially break a deployed wasm hash, visit page → confirm self-destruct + auto-recovery
- [ ] Manual: trigger a wasm panic via a deliberate `unreachable!()` in a block → confirm SW unregisters and page reloads to a working state

## Out of scope

This PR doesn't add a build-id check between loader and SW (e.g. send the loader's build id to the SW and have the SW self-destruct if it ever sees a different one). Worth doing later if the update timing still feels slow in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
