### PR TITLE
Phase 4 PR-0: solobase-core test infrastructure

### DIFF
--- a/crates/solobase-core/src/blocks/auth/repo/orgs.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/orgs.rs
@@ -142,3 +142,56 @@ pub async fn upsert_claimed(
         .await?
         .ok_or_else(|| OrgsRepoError::Db("insert returned no row".into()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    #[tokio::test]
+    async fn find_by_name_returns_none_for_missing_org() {
+        let ctx = TestContext::with_auth().await;
+        let result = find_by_name(&ctx, "nonexistent").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_returns_inserted_org() {
+        let ctx = TestContext::with_auth().await;
+
+        // Create a user first (foreign key constraint on owner_user_id)
+        db::exec_raw(
+            &ctx,
+            "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            &[
+                json!("user-a"),
+                json!("alice@example.com"),
+                json!("Alice"),
+                json!("user"),
+                json!("2026-01-01T00:00:00Z"),
+                json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .unwrap();
+
+        upsert_claimed(
+            &ctx,
+            NewClaim {
+                name: "acme",
+                owner_user_id: "user-a",
+                verified_via: "github",
+                verified_ref: "gh-1",
+            },
+        )
+        .await
+        .unwrap();
+
+        let row = find_by_name(&ctx, "acme").await.unwrap().unwrap();
+        assert_eq!(row.name, "acme");
+        assert_eq!(row.owner_user_id.as_deref(), Some("user-a"));
+        assert_eq!(row.verified_via.as_deref(), Some("github"));
+        assert_eq!(row.verified_ref.as_deref(), Some("gh-1"));
+    }
+}

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -14,6 +14,9 @@ pub mod pipeline;
 pub mod routing;
 pub mod ui;
 
+#[cfg(test)]
+pub mod test_support;
+
 pub use features::FeatureConfig;
 pub use pipeline::handle_request;
 pub use routing::{ExtraRoute, RouteAccess};

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -1,0 +1,130 @@
+//! Test infrastructure for solobase-core integration tests.
+//!
+//! [`TestContext`] wires a real in-memory SQLite database (via the production
+//! `DatabaseBlock` + `SQLiteDatabaseService::open_in_memory()`) into a minimal
+//! [`Context`] implementation so unit and integration tests can exercise the
+//! full block client stack without running a server process.
+//!
+//! Additional capabilities (message helpers, auth state, extra block dispatch)
+//! are added in subsequent tasks.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use wafer_run::{
+    block::Block,
+    context::Context,
+    types::{ErrorCode, Message, WaferError},
+    InputStream, OutputStream,
+};
+
+/// Minimal test context backed by a real in-memory SQLite database.
+///
+/// Routes `"wafer-run/database"` calls to the production `DatabaseBlock`.
+/// Other named blocks can be registered via `blocks` (unused until Task 6).
+pub struct TestContext {
+    database_block: Arc<dyn Block>,
+    /// Placeholder for config values — populated by Task 5 (`with_auth`).
+    pub config: Arc<Mutex<HashMap<String, String>>>,
+    /// Placeholder for dynamically registered blocks — populated by Task 6.
+    pub blocks: Arc<Mutex<HashMap<String, Arc<dyn Block>>>>,
+}
+
+impl TestContext {
+    /// Construct a `TestContext` with a fresh in-memory SQLite database.
+    pub async fn new() -> Self {
+        let svc = Arc::new(
+            wafer_block_sqlite::service::SQLiteDatabaseService::open_in_memory()
+                .expect("open in-memory sqlite"),
+        );
+        let database_block: Arc<dyn Block> =
+            Arc::new(wafer_core::service_blocks::database::DatabaseBlock::new(svc));
+
+        Self {
+            database_block,
+            config: Arc::new(Mutex::new(HashMap::new())),
+            blocks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Context for TestContext {
+    async fn call_block(&self, name: &str, msg: Message, input: InputStream) -> OutputStream {
+        match name {
+            "wafer-run/database" => self.database_block.handle(self, msg, input).await,
+            other => {
+                // Check the dynamically registered blocks map before giving up.
+                let block = {
+                    let guard = self.blocks.lock().expect("blocks mutex poisoned");
+                    guard.get(other).cloned()
+                };
+                match block {
+                    Some(b) => b.handle(self, msg, input).await,
+                    None => OutputStream::error(WaferError::new(
+                        ErrorCode::NOT_FOUND,
+                        format!("block '{other}' not registered in TestContext"),
+                    )),
+                }
+            }
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+
+    fn config_get(&self, _key: &str) -> Option<&str> {
+        // TODO(test_support): returning None here is a deliberate stub.
+        // Borrowing a &str out of the Mutex<HashMap> would require holding the
+        // guard for the lifetime of the return value, which the `Context` trait
+        // signature (&self → Option<&str>) does not allow. Task 5 will either
+        // leak a value into a thread-local or switch to a pre-computed snapshot
+        // when `with_auth()` is called.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wafer_core::clients::database as db;
+
+    #[tokio::test]
+    async fn database_create_and_get_round_trip() {
+        let ctx = TestContext::new().await;
+
+        db::exec_raw(
+            &ctx,
+            "CREATE TABLE round_trip (id TEXT PRIMARY KEY, name TEXT)",
+            &[],
+        )
+        .await
+        .expect("create table");
+
+        db::exec_raw(
+            &ctx,
+            "INSERT INTO round_trip (id, name) VALUES (?, ?)",
+            &[serde_json::json!("r1"), serde_json::json!("alpha")],
+        )
+        .await
+        .expect("insert row");
+
+        let rows = db::query_raw(
+            &ctx,
+            "SELECT id, name FROM round_trip WHERE id = ?",
+            &[serde_json::json!("r1")],
+        )
+        .await
+        .expect("select");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "r1");
+        assert_eq!(
+            rows[0].data.get("name").and_then(|v| v.as_str()),
+            Some("alpha")
+        );
+    }
+}

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -87,6 +87,28 @@ impl Context for TestContext {
     }
 }
 
+/// Build an anonymous request `Message`. No `auth.user_id` meta set.
+pub fn anon_msg(action: &str, path: &str) -> Message {
+    let mut m = Message::new("http.request");
+    m.set_meta("req.action", action);
+    m.set_meta("req.resource", path);
+    m
+}
+
+/// Build an authenticated request `Message` for `user_id`. No admin role.
+pub fn auth_msg(action: &str, path: &str, user_id: &str) -> Message {
+    let mut m = anon_msg(action, path);
+    m.set_meta("auth.user_id", user_id);
+    m
+}
+
+/// Build an admin request `Message` (user_id `"admin_1"`, role `admin`).
+pub fn admin_msg(action: &str, path: &str) -> Message {
+    let mut m = auth_msg(action, path, "admin_1");
+    m.set_meta("auth.user_roles", "admin");
+    m
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,5 +148,29 @@ mod tests {
             rows[0].data.get("name").and_then(|v| v.as_str()),
             Some("alpha")
         );
+    }
+
+    #[test]
+    fn anon_msg_sets_action_and_path_with_no_user_id() {
+        let m = anon_msg("retrieve", "/b/auth/login");
+        assert_eq!(m.action(), "retrieve");
+        assert_eq!(m.path(), "/b/auth/login");
+        assert_eq!(m.user_id(), "");
+    }
+
+    #[test]
+    fn auth_msg_sets_user_id() {
+        let m = auth_msg("retrieve", "/b/auth/dashboard", "user-a");
+        assert_eq!(m.action(), "retrieve");
+        assert_eq!(m.path(), "/b/auth/dashboard");
+        assert_eq!(m.user_id(), "user-a");
+    }
+
+    #[test]
+    fn admin_msg_marks_admin_role() {
+        use crate::blocks::helpers::is_admin;
+        let m = admin_msg("retrieve", "/b/admin/users");
+        assert_eq!(m.user_id(), "admin_1");
+        assert!(is_admin(&m));
     }
 }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -206,8 +206,9 @@ pub async fn output_is_error(out: OutputStream, code: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use wafer_core::clients::database as db;
+
+    use super::*;
 
     #[tokio::test]
     async fn database_create_and_get_round_trip() {
@@ -367,8 +368,7 @@ mod tests {
     #[tokio::test]
     async fn registered_block_is_dispatched_through_call_block() {
         use async_trait::async_trait;
-        use wafer_run::block::Block as RunBlock;
-        use wafer_run::{BlockCategory, BlockInfo, LifecycleEvent};
+        use wafer_run::{block::Block as RunBlock, BlockCategory, BlockInfo, LifecycleEvent};
 
         struct EchoBlock;
 

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -40,14 +40,28 @@ impl TestContext {
             wafer_block_sqlite::service::SQLiteDatabaseService::open_in_memory()
                 .expect("open in-memory sqlite"),
         );
-        let database_block: Arc<dyn Block> =
-            Arc::new(wafer_core::service_blocks::database::DatabaseBlock::new(svc));
+        let database_block: Arc<dyn Block> = Arc::new(
+            wafer_core::service_blocks::database::DatabaseBlock::new(svc),
+        );
 
         Self {
             database_block,
             config: Arc::new(Mutex::new(HashMap::new())),
             blocks: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Build a `TestContext` with the auth-block migrations applied.
+    ///
+    /// Convenience constructor for tests that need the
+    /// `suppers_ai__auth__{users,orgs,sessions,provider_links,...}` schema
+    /// in place — most repo and handler tests do.
+    pub async fn with_auth() -> Self {
+        let ctx = Self::new().await;
+        crate::blocks::auth::migrations::apply(&ctx)
+            .await
+            .expect("apply auth migrations in test fixture");
+        ctx
     }
 }
 
@@ -286,5 +300,53 @@ mod tests {
             .status(200)
             .body(br#"{"ok":true}"#.to_vec(), "application/json");
         assert_eq!(output_json(out).await, serde_json::json!({"ok": true}));
+    }
+
+    #[tokio::test]
+    async fn with_auth_applies_orgs_and_users_tables() {
+        let ctx = TestContext::with_auth().await;
+        // Verify auth tables exist by inserting a user, then an org, then selecting.
+        db::exec_raw(
+            &ctx,
+            "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            &[
+                serde_json::json!("user-a"),
+                serde_json::json!("alice@example.com"),
+                serde_json::json!("Alice"),
+                serde_json::json!("user"),
+                serde_json::json!("2026-01-01T00:00:00Z"),
+                serde_json::json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .expect("insert user");
+
+        db::exec_raw(
+            &ctx,
+            "INSERT INTO suppers_ai__auth__orgs (id, name, owner_user_id, is_reserved, created_at) \
+             VALUES (?, ?, ?, 0, ?)",
+            &[
+                serde_json::json!("org-1"),
+                serde_json::json!("acme"),
+                serde_json::json!("user-a"),
+                serde_json::json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .expect("insert org");
+
+        let rows = db::query_raw(
+            &ctx,
+            "SELECT name FROM suppers_ai__auth__orgs WHERE id = ?",
+            &[serde_json::json!("org-1")],
+        )
+        .await
+        .expect("select org");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].data.get("name").and_then(|v| v.as_str()),
+            Some("acme")
+        );
     }
 }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -16,6 +16,7 @@ use std::{
 use wafer_run::{
     block::Block,
     context::Context,
+    streams::output::{BufferedResponse, TerminalNotResponse},
     types::{ErrorCode, Message, WaferError},
     InputStream, OutputStream,
 };
@@ -109,6 +110,72 @@ pub fn admin_msg(action: &str, path: &str) -> Message {
     m
 }
 
+/// Drain an `OutputStream` to a `BufferedResponse`. Panics if the stream
+/// terminates with anything other than `Complete`.
+///
+/// Tests should not see errors from handlers under test unless they're
+/// explicitly asserting on error paths — use `output_is_error` for that.
+pub async fn collect_or_panic(out: OutputStream) -> BufferedResponse {
+    match out.collect_buffered().await {
+        Ok(buf) => buf,
+        Err(TerminalNotResponse::Error(e)) => {
+            panic!("handler returned error: {} ({:?})", e.message, e.code)
+        }
+        Err(TerminalNotResponse::Drop) => panic!("handler dropped the request"),
+        Err(TerminalNotResponse::Continue(_)) => panic!("handler returned Continue"),
+        Err(TerminalNotResponse::Malformed) => panic!("handler returned malformed stream"),
+    }
+}
+
+/// Read the HTTP status from an `OutputStream`. Defaults to 200 if the
+/// handler didn't set a `resp.status` meta entry.
+pub async fn output_status(out: OutputStream) -> u16 {
+    let buf = collect_or_panic(out).await;
+    buf.meta
+        .iter()
+        .find(|m| m.key == "resp.status")
+        .and_then(|m| m.value.parse::<u16>().ok())
+        .unwrap_or(200)
+}
+
+/// Read a named response header (e.g. `"Location"` for redirects).
+/// The lookup is case-sensitive — pass the exact name handlers used in
+/// `set_header(name, _)`.
+pub async fn output_header(out: OutputStream, name: &str) -> Option<String> {
+    let key = format!("resp.header.{name}");
+    let buf = collect_or_panic(out).await;
+    buf.meta
+        .iter()
+        .find(|m| m.key == key)
+        .map(|m| m.value.clone())
+}
+
+/// Read the body as a UTF-8 string. Panics if the body is not valid UTF-8.
+pub async fn output_html(out: OutputStream) -> String {
+    let buf = collect_or_panic(out).await;
+    String::from_utf8(buf.body).expect("body was not valid UTF-8")
+}
+
+/// Read the body as raw bytes.
+pub async fn output_body(out: OutputStream) -> Vec<u8> {
+    collect_or_panic(out).await.body
+}
+
+/// Read the body as JSON. Returns `Value::Null` if the body fails to parse.
+pub async fn output_json(out: OutputStream) -> serde_json::Value {
+    let buf = collect_or_panic(out).await;
+    serde_json::from_slice(&buf.body).unwrap_or(serde_json::Value::Null)
+}
+
+/// True if the OutputStream terminated with an error matching `code`.
+/// The code string should match the ErrorCode debug format (e.g., "NotFound", "Internal").
+pub async fn output_is_error(out: OutputStream, code: &str) -> bool {
+    matches!(
+        out.collect_buffered().await,
+        Err(TerminalNotResponse::Error(e)) if format!("{:?}", e.code) == code
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,5 +239,52 @@ mod tests {
         let m = admin_msg("retrieve", "/b/admin/users");
         assert_eq!(m.user_id(), "admin_1");
         assert!(is_admin(&m));
+    }
+
+    #[tokio::test]
+    async fn output_status_reads_status_meta() {
+        use crate::blocks::helpers::ResponseBuilder;
+        let out = ResponseBuilder::new()
+            .status(302)
+            .body(Vec::new(), "text/plain");
+        assert_eq!(output_status(out).await, 302);
+    }
+
+    #[tokio::test]
+    async fn output_status_defaults_to_200_when_unset() {
+        use crate::blocks::helpers::ResponseBuilder;
+        let out = ResponseBuilder::new().body(Vec::new(), "text/plain");
+        assert_eq!(output_status(out).await, 200);
+    }
+
+    #[tokio::test]
+    async fn output_header_reads_named_header() {
+        use crate::blocks::helpers::ResponseBuilder;
+        let out = ResponseBuilder::new()
+            .status(302)
+            .set_header("Location", "/dashboard")
+            .body(Vec::new(), "text/plain");
+        assert_eq!(
+            output_header(out, "Location").await.as_deref(),
+            Some("/dashboard")
+        );
+    }
+
+    #[tokio::test]
+    async fn output_html_reads_body_as_utf8() {
+        use crate::blocks::helpers::ResponseBuilder;
+        let out = ResponseBuilder::new()
+            .status(200)
+            .body(b"<h1>hi</h1>".to_vec(), "text/html");
+        assert_eq!(output_html(out).await, "<h1>hi</h1>");
+    }
+
+    #[tokio::test]
+    async fn output_json_parses_body() {
+        use crate::blocks::helpers::ResponseBuilder;
+        let out = ResponseBuilder::new()
+            .status(200)
+            .body(br#"{"ok":true}"#.to_vec(), "application/json");
+        assert_eq!(output_json(out).await, serde_json::json!({"ok": true}));
     }
 }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -63,6 +63,20 @@ impl TestContext {
             .expect("apply auth migrations in test fixture");
         ctx
     }
+
+    /// Register a block under `name`. Calls to `ctx.call_block(name, ...)`
+    /// will route to this block's `handle()`.
+    ///
+    /// Used to wire up cross-block call tests — e.g. the dashboard handler
+    /// in the auth block calls `"suppers-ai/userportal"` for the buttons
+    /// list; tests register a real or fake `UserPortalBlock` so the call
+    /// resolves.
+    pub fn register_block(&mut self, name: &str, block: Arc<dyn Block>) {
+        self.blocks
+            .lock()
+            .expect("blocks mutex poisoned")
+            .insert(name.to_string(), block);
+    }
 }
 
 #[async_trait::async_trait]
@@ -348,5 +362,49 @@ mod tests {
             rows[0].data.get("name").and_then(|v| v.as_str()),
             Some("acme")
         );
+    }
+
+    #[tokio::test]
+    async fn registered_block_is_dispatched_through_call_block() {
+        use async_trait::async_trait;
+        use wafer_run::block::Block as RunBlock;
+        use wafer_run::{BlockCategory, BlockInfo, LifecycleEvent};
+
+        struct EchoBlock;
+
+        #[async_trait]
+        impl RunBlock for EchoBlock {
+            fn info(&self) -> BlockInfo {
+                BlockInfo::new("test/echo", "0.0.1", "echo@v1", "echoes the request path")
+                    .category(BlockCategory::Service)
+            }
+
+            async fn handle(
+                &self,
+                _ctx: &dyn Context,
+                msg: Message,
+                _input: InputStream,
+            ) -> OutputStream {
+                crate::blocks::helpers::ResponseBuilder::new()
+                    .status(200)
+                    .body(msg.path().as_bytes().to_vec(), "text/plain")
+            }
+
+            async fn lifecycle(
+                &self,
+                _ctx: &dyn Context,
+                _e: LifecycleEvent,
+            ) -> Result<(), WaferError> {
+                Ok(())
+            }
+        }
+
+        let mut ctx = TestContext::new().await;
+        ctx.register_block("test/echo", Arc::new(EchoBlock));
+
+        let msg = anon_msg("retrieve", "/echo-me");
+        let resp = ctx.call_block("test/echo", msg, InputStream::empty()).await;
+        let body = output_html(resp).await;
+        assert_eq!(body, "/echo-me");
     }
 }


### PR DESCRIPTION
## Summary

Adds `solobase_core::test_support` (gated `#[cfg(test)]`) — a real-sqlite-backed `TestContext` plus `Message` and `OutputStream` helpers so Phase 4 PRs can write proper unit tests for repo functions and SSR handlers.

- `TestContext::new()` — empty in-memory sqlite via `SQLiteDatabaseService::open_in_memory()` wrapped in the production `DatabaseBlock` (so tests exercise the same code path as production).
- `TestContext::with_auth()` — applies the auth-block migrations on construction.
- `TestContext::register_block(name, block)` — wires up cross-block dispatch (e.g. for the dashboard handler in Phase 4 PR-1 calling userportal's `list_buttons`).
- `anon_msg / auth_msg / admin_msg` — `Message` constructors using the verified meta keys solobase handlers read (`req.action`, `req.resource`, `auth.user_id`, `auth.user_roles`).
- `output_status / output_header / output_html / output_body / output_json / output_is_error` — drain `OutputStream` via the actual `collect_buffered` API and read `resp.status` / `resp.header.{name}` meta entries.
- Smoke test: `auth::repo::orgs::find_by_name` (existing function, previously untested) — first regression coverage on the orgs repo, validates the infrastructure works against real solobase code.

## Why

While preparing Phase 4 PR-1 Task 3 (`auth::repo::orgs::list_for_user` TDD), I found the plan's tests referenced infrastructure that didn't exist: `wafer_core::test_helpers::sqlite_context` (no such helper), `MockContext` (products-private, doesn't support `query_raw` for SELECTs), buffered-response API on `OutputStream` (it's actually a streaming type). Building this once unblocks all of Phase 4's repo and handler TDD; alternative paths (extending `MockContext` with SQL parsing, or reaching into `Wafer::builder()`) were either code smells or heavyweight.

Spec: \`docs/superpowers/specs/2026-05-03-solobase-test-infra-design.md\`
Plan: \`docs/superpowers/plans/2026-05-03-solobase-test-infra.md\`

## Test plan

- [x] \`cargo test --workspace --exclude solobase-web\` passes (533 tests, 0 failures)
- [x] \`cargo +nightly fmt --all -- --check\` passes
- [x] \`cargo clippy --workspace --exclude solobase-web\` introduces no new warnings (128 pre-existing, unchanged)
- [x] Round-trip test verifies CREATE TABLE + INSERT + SELECT through \`db::query_raw\` works against \`SQLiteDatabaseService::open_in_memory()\`
- [x] Cross-block dispatch test confirms \`register_block\` routes correctly via an inline \`EchoBlock\`
- [x] Smoke test against existing \`auth::repo::orgs::find_by_name\` passes (with FK-satisfying user-row seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)