### PR TITLE
fix(demo): align seeded admin creds with documented values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
           cd /tmp
           SOLOBASE_LISTEN="127.0.0.1:8093" \
           SOLOBASE_DB_PATH="/tmp/solobase-visual-baseline.db" \
-          SUPPERS_AI__AUTH__ADMIN_EMAIL="admin@solobase.local" \
-          SUPPERS_AI__AUTH__ADMIN_PASSWORD="admin" \
+          SUPPERS_AI__AUTH__ADMIN_EMAIL="admin@example.com" \
+          SUPPERS_AI__AUTH__ADMIN_PASSWORD="admin123" \
           SOLOBASE_BLOCK_ENABLED="suppers-ai/userportal" \
             solobase > /tmp/solobase-baseline.log 2>&1 &
           echo $! > /tmp/solobase-pid

--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -44,16 +44,16 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
     );
 
     // 2. Seed default admin account for browser build.
-    //    Email: admin@solobase.local / Password: admin
+    //    Email: admin@example.com / Password: admin123
     //    This is local-only (OPFS) so a simple default is acceptable.
     let _ = bridge::db_exec_raw(
         "INSERT OR IGNORE INTO suppers_ai__admin__variables (id, key, name, description, value, sensitive, created_at, updated_at)
-         VALUES ('var_admin_email', 'SUPPERS_AI__AUTH__ADMIN_EMAIL', 'Admin Email', 'Admin account email', 'admin@solobase.local', 0, datetime('now'), datetime('now'))",
+         VALUES ('var_admin_email', 'SUPPERS_AI__AUTH__ADMIN_EMAIL', 'Admin Email', 'Admin account email', 'admin@example.com', 0, datetime('now'), datetime('now'))",
         "[]",
     );
     let _ = bridge::db_exec_raw(
         "INSERT OR IGNORE INTO suppers_ai__admin__variables (id, key, name, description, value, sensitive, created_at, updated_at)
-         VALUES ('var_admin_pass', 'SUPPERS_AI__AUTH__ADMIN_PASSWORD', 'Admin Password', 'Admin account password', 'admin', 1, datetime('now'), datetime('now'))",
+         VALUES ('var_admin_pass', 'SUPPERS_AI__AUTH__ADMIN_PASSWORD', 'Admin Password', 'Admin account password', 'admin123', 1, datetime('now'), datetime('now'))",
         "[]",
     );
 

--- a/crates/solobase-web/tests/e2e/fixtures/auth.ts
+++ b/crates/solobase-web/tests/e2e/fixtures/auth.ts
@@ -2,9 +2,8 @@ import type { Page } from '@playwright/test';
 
 /**
  * Log in as the seeded admin user. solobase-web seeds
- * `admin@solobase.local` / `admin` on first boot via
- * `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL` /
- * `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD`.
+ * `admin@example.com` / `admin123` on first boot via
+ * `SUPPERS_AI__AUTH__ADMIN_EMAIL` / `SUPPERS_AI__AUTH__ADMIN_PASSWORD`.
  *
  * Works against both the native solobase server (used for visual-baseline
  * snapshot generation, where argon2id runs in native Rust and is fast) and
@@ -17,8 +16,8 @@ import type { Page } from '@playwright/test';
  */
 export async function loginAsAdmin(page: Page): Promise<void> {
   await page.goto('/b/auth/login');
-  await page.fill('#email', 'admin@solobase.local');
-  await page.fill('#password', 'admin');
+  await page.fill('#email', 'admin@example.com');
+  await page.fill('#password', 'admin123');
   await page.click('#btn');
   // Native argon2id completes in milliseconds; allow up to 10s for the
   // login fetch + redirect to complete.

--- a/crates/solobase-web/tests/e2e/vector.spec.ts
+++ b/crates/solobase-web/tests/e2e/vector.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from '@playwright/test';
 
-const ADMIN_EMAIL = 'admin@solobase.local';
-const ADMIN_PASSWORD = 'admin';
+const ADMIN_EMAIL = 'admin@example.com';
+const ADMIN_PASSWORD = 'admin123';
 
 /**
  * Log in via the JSON API (POST /b/auth/api/login) and wait for the service


### PR DESCRIPTION
## Summary
- Browser WASM build seeded `admin@solobase.local` / `admin` while the demo modal in solobase-site advertised `admin@example.com` / `admin123` → users following the docs hit 401 on `demo.solobase.dev`.
- Update `crates/solobase-web/src/config.rs` seed to the documented creds.
- Update CI visual-baseline env vars, the `loginAsAdmin` helper, and `vector.spec.ts` constants to match, so native CI + browser e2e stay green.
- Comment in `auth.ts` previously referenced unused `BOOTSTRAP_ADMIN_*` env vars; corrected to the actual `SUPPERS_AI__AUTH__ADMIN_*` keys read by the seed.

## Caveat
`INSERT OR IGNORE` means existing `demo.solobase.dev` visitors keep the old row in OPFS — they need to clear site data (or sign in with the old creds and update the variables manually) to pick up the new defaults. New visitors get the new seed.

## Test plan
- [ ] CI passes (visual-baseline + e2e vector spec)
- [ ] Manual: clear demo.solobase.dev site data, reload, log in with `admin@example.com` / `admin123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)