### PR TITLE
feat(auth): warn when ADMIN_EMAIL falls back to admin@example.com

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -304,8 +304,17 @@ pub async fn seed_admin_user(ctx: &dyn Context) {
         return;
     }
 
-    let admin_email =
-        config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "admin@example.com").await;
+    let admin_email_env =
+        config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "").await;
+    let admin_email = if admin_email_env.is_empty() {
+        tracing::warn!(
+            "SUPPERS_AI__AUTH__ADMIN_EMAIL not set — seeding admin@example.com; \
+             set SUPPERS_AI__AUTH__ADMIN_EMAIL in production"
+        );
+        "admin@example.com".to_string()
+    } else {
+        admin_email_env
+    };
     let admin_password_env =
         config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_PASSWORD", "").await;
 


### PR DESCRIPTION
## Summary
- `seed_admin_user` already generates a random `ADMIN_PASSWORD` (and prints it to stderr) when the env var is unset, but the equivalent `ADMIN_EMAIL` fallback to `admin@example.com` was silent — operators got a predictable email seeded with no log indication, half-defeating the random-password protection.
- Switch to the existing `get_default(ctx, "...", "")` + emptiness-check pattern already used in this file at L80/L150, and emit a `tracing::warn!` when the env var is missing, naming the variable to set in production.

## Why now
Discovered while debugging a wafer-site instance where `admin@example.com` had been seeded with the previous `admin123` default and was still sitting in the user table months later (re-seed only fires when zero users exist, so the original predictable account persisted across the random-password upgrade). With this warning, fresh deployments that forget to set `ADMIN_EMAIL` will see a loud signal in the boot logs.

## Demo creds
Demo deployments that want known credentials should set **both** env vars explicitly (e.g. `admin@example.com` / `admin123`) rather than relying on the silent fallback — same intent as the WASM demo update in #58 but applied via configuration instead of code.

## Test plan
- [ ] Boot solobase native with neither env var set → warn line appears, random password printed to stderr.
- [ ] Boot with `ADMIN_EMAIL` set, `ADMIN_PASSWORD` unset → no warn, random password still printed.
- [ ] Boot with both set → no warn, no random password line, deterministic seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)