### PR TITLE
feat: migrate to wafer-run binary transport (PR #34 lockstep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5881,7 +5881,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5947,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5957,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5996,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "serde",
@@ -6008,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6018,7 +6018,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6072,7 +6072,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6087,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6098,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6115,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6127,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6154,7 +6154,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6183,7 +6183,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#51528bc32410d900aa29a00f0c2c308c23d171e2"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4720,6 +4739,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "wafer-block",
  "wafer-block-config",
  "wafer-block-cors",
  "wafer-block-crypto",
@@ -5861,9 +5881,12 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
+ "chrono",
  "futures",
+ "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
@@ -5880,6 +5903,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5892,6 +5916,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5902,6 +5927,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5921,6 +5947,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5930,6 +5957,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5945,6 +5973,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5956,6 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5966,6 +5996,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "serde",
@@ -5977,6 +6008,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5986,6 +6018,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6000,6 +6033,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6017,6 +6051,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6026,6 +6061,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6036,6 +6072,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6050,6 +6087,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6060,6 +6098,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6076,6 +6115,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6087,6 +6127,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6103,6 +6144,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "serde",
  "serde_json",
@@ -6112,6 +6154,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6140,6 +6183,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=binary-transport-overhaul#65ceed124bdc652637c98eae944b73514a3a98d9"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,26 +16,26 @@ license = "MIT"
 
 [workspace.dependencies]
 # WAFER runtime (git deps pinned to rev)
-wafer-run = { git = "https://github.com/wafer-run/wafer-run", branch = "main", default-features = false }
-wafer-block = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-core = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-sql-utils = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-config = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-cors = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-crypto = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-http-listener = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-inspector = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-local-storage = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-logger = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-network = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-readonly-guard = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-router = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-s3 = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-security-headers = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-sqlite = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-web = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-postgres = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
-wafer-block-fastembed = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-run = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul", default-features = false }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-core = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-sql-utils = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-config = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-cors = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-crypto = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-http-listener = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-inspector = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-local-storage = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-logger = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-network = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-readonly-guard = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-router = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-s3 = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-security-headers = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-sqlite = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-web = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-postgres = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-block-fastembed = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
 
 # Core
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,26 +16,26 @@ license = "MIT"
 
 [workspace.dependencies]
 # WAFER runtime (git deps pinned to rev)
-wafer-run = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul", default-features = false }
-wafer-block = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-core = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-sql-utils = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-config = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-cors = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-crypto = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-http-listener = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-inspector = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-local-storage = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-logger = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-network = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-readonly-guard = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-router = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-s3 = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-security-headers = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-sqlite = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-web = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-postgres = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
-wafer-block-fastembed = { git = "https://github.com/wafer-run/wafer-run", branch = "binary-transport-overhaul" }
+wafer-run = { git = "https://github.com/wafer-run/wafer-run", branch = "main", default-features = false }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-core = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-sql-utils = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-config = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-cors = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-crypto = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-http-listener = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-inspector = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-local-storage = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-logger = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-network = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-readonly-guard = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-router = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-s3 = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-security-headers = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-sqlite = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-web = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-postgres = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
+wafer-block-fastembed = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
 
 # Core
 async-trait = "0.1"

--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -38,6 +38,9 @@ native-embedding = [
 wafer-run = { workspace = true, features = ["wasmi"] }
 # wafer-core for clients and interface traits
 wafer-core = { workspace = true }
+# wafer-block — wire types + codec used directly by feature blocks that
+# encode/decode service payloads (e.g. llm chunks, vector queries).
+wafer-block = { workspace = true }
 # SQL utilities (query builders, value conversion)
 wafer-sql-utils = { workspace = true }
 # SQL query builder (used via wafer-sql-utils, re-exported for complex conditions)

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -7,8 +7,10 @@
 //! Uses the `wafer-run/network` block to make HTTP requests to Mailgun,
 //! and `wafer-run/config` for MAILGUN_API_KEY, MAILGUN_DOMAIN, MAILGUN_FROM.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
-use wafer_core::clients::config;
+use wafer_core::clients::{config, network as net};
 use wafer_run::{
     block::{Block, BlockInfo},
     context::Context,
@@ -274,37 +276,22 @@ async fn send_email(
     // Base64 encode "api:{api_key}"
     let credentials = base64_encode(&format!("api:{}", api_key));
 
-    // Call network block
+    // Call network block via the typed client. The buffered helper consumes
+    // the two-frame response (header + body) and returns a typed
+    // `NetworkResponse` whose `status_code` we use to decide success.
     let url = format!("https://api.mailgun.net/v3/{}/messages", domain);
-    let network_req = serde_json::json!({
-        "method": "POST",
-        "url": url,
-        "headers": {
-            "Authorization": format!("Basic {}", credentials),
-            "Content-Type": "application/x-www-form-urlencoded",
-        },
-        "body": body.as_bytes().to_vec(),
-    });
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Authorization".to_string(),
+        format!("Basic {}", credentials),
+    );
+    headers.insert(
+        "Content-Type".to_string(),
+        "application/x-www-form-urlencoded".to_string(),
+    );
 
-    let network_msg = Message::new("network.do");
-    let req_bytes = serde_json::to_vec(&network_req).unwrap_or_default();
-
-    let out = ctx
-        .call_block(
-            "wafer-run/network",
-            network_msg,
-            InputStream::from_bytes(req_bytes),
-        )
-        .await;
-
-    match out.collect_buffered().await {
-        Ok(resp) => {
-            if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&resp.body) {
-                let status = v.get("status_code").and_then(|s| s.as_u64()).unwrap_or(0);
-                return (200..300).contains(&status);
-            }
-            false
-        }
+    match net::do_request(ctx, "POST", &url, &headers, Some(body.as_bytes())).await {
+        Ok(resp) => (200..300).contains(&resp.status_code),
         Err(_) => false,
     }
 }

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -600,10 +600,21 @@ async fn load_models(ctx: &dyn Context, original_msg: &Message) -> Vec<serde_jso
     let Ok(buf) = out.collect_buffered().await else {
         return vec![];
     };
-    // The service block returns `Vec<ModelInfo>` as a bare JSON array. A
-    // decode failure is treated as "no models" so the picker still renders —
-    // the user can fall back to the default remote option.
-    serde_json::from_slice::<Vec<serde_json::Value>>(&buf.body).unwrap_or_default()
+    // The service block returns a MessagePack-encoded `Vec<ModelInfo>`.
+    // Decode then convert each model into a JSON value for template
+    // rendering (the picker keys off `model_id` / `display_name` /
+    // `backend_id`). A decode failure is treated as "no models" so the
+    // picker still renders — the user can fall back to the default remote
+    // option.
+    let models: Vec<wafer_block::wire::llm::ModelInfo> =
+        match wafer_block::codec::decode(&buf.body) {
+            Ok(v) => v,
+            Err(_) => return vec![],
+        };
+    models
+        .into_iter()
+        .map(|m| serde_json::to_value(m).unwrap_or(serde_json::Value::Null))
+        .collect()
 }
 
 /// Render the `<option>` list for the remote-model picker.

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -606,11 +606,11 @@ async fn load_models(ctx: &dyn Context, original_msg: &Message) -> Vec<serde_jso
     // `backend_id`). A decode failure is treated as "no models" so the
     // picker still renders — the user can fall back to the default remote
     // option.
-    let models: Vec<wafer_block::wire::llm::ModelInfo> =
-        match wafer_block::codec::decode(&buf.body) {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
+    let models: Vec<wafer_block::wire::llm::ModelInfo> = match wafer_block::codec::decode(&buf.body)
+    {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
     models
         .into_iter()
         .map(|m| serde_json::to_value(m).unwrap_or(serde_json::Value::Null))

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -8,10 +8,14 @@
 //! response or a Server-Sent Events stream.
 
 use futures::StreamExt;
-use wafer_core::{
-    clients::database as db,
-    interfaces::llm::service::{ChatChunk, ChatMessage, ChatRequest, ChatRole, ChunkDelta},
+use wafer_block::{
+    codec,
+    wire::llm::{
+        ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole, ChunkDelta,
+        LoadModelRequest, ModelInfo, ModelStatus, StatusRequest, UnloadModelRequest,
+    },
 };
+use wafer_core::clients::database as db;
 use wafer_run::{
     context::Context,
     meta::META_RESP_CONTENT_TYPE,
@@ -55,20 +59,22 @@ fn role_from_str(role: &str) -> ChatRole {
     }
 }
 
-/// Build a text-content `ChatMessage` for the given role. `ChatMessage` is
-/// `#[non_exhaustive]`, so we delegate to the public ctor helpers rather
-/// than assembling the struct literally.
+/// Build a text-content `ChatMessage` for the given role.
+///
+/// `ChatRole::Tool` is unreachable via `role_from_str` (it coerces to
+/// `User`), but if it ever bubbles up here a tool-result message would
+/// require a `tool_call_id` we don't have — so coerce it to a user turn
+/// rather than emit an invalid Tool message.
 fn build_text_message(role: ChatRole, content: String) -> ChatMessage {
-    match role {
-        ChatRole::Assistant => ChatMessage::assistant(content),
-        ChatRole::System => ChatMessage::system(content),
-        // `Tool` is unreachable via `role_from_str` (it coerces to `User`),
-        // but handle it defensively — a tool-result message requires a
-        // `tool_call_id` which we don't have here, so treat it as a user
-        // turn. `ChatRole` is `#[non_exhaustive]`, so a wildcard covers any
-        // future variant until we have an explicit mapping for it.
-        ChatRole::Tool | ChatRole::User => ChatMessage::user(content),
-        _ => ChatMessage::user(content),
+    let role = match role {
+        ChatRole::Tool => ChatRole::User,
+        other => other,
+    };
+    ChatMessage {
+        role,
+        content: ChatContent::Text(content),
+        tool_call_id: None,
+        tool_calls: Vec::new(),
     }
 }
 
@@ -188,11 +194,20 @@ async fn dispatch_chat(
         Err(e) => return Err(err_internal(e)),
     };
 
-    // 5. Build the service request and dispatch.
-    let chat_req = ChatRequest::new(backend_id, model, messages);
-    let payload = match serde_json::to_vec(&chat_req) {
+    // 5. Build the service request and dispatch. The wire request is encoded
+    //    via MessagePack — the new `wafer-run/llm` handler decodes via
+    //    `codec::decode` (no JSON path).
+    let chat_req = ChatRequest {
+        backend_id,
+        model,
+        messages,
+        params: ChatParams::default(),
+        tools: Vec::new(),
+        extra: serde_json::Value::Null,
+    };
+    let payload = match codec::encode(&chat_req) {
         Ok(p) => p,
-        Err(e) => return Err(err_internal(&format!("serialize chat request: {e}"))),
+        Err(e) => return Err(err_internal(&format!("serialize chat request: {}", e.message))),
     };
 
     let call_msg = build_chat_call_msg(msg);
@@ -216,7 +231,11 @@ pub(super) async fn handle_chat(
     };
 
     // Drain the service stream, concatenating `ChunkDelta::Text` bytes into
-    // the assistant reply. Propagate any error terminal as a 500.
+    // the assistant reply. Propagate any error terminal as a 500. Each frame
+    // from the new `wafer-run/llm` handler is one MessagePack-encoded
+    // `ChatChunk`; decode per-frame rather than buffering and decoding once
+    // (concatenating MessagePack frames yields a sequence, not a single
+    // value, so there is no "buffered" single-decode option here).
     let mut content = String::new();
     let mut model_used = String::new();
     let mut body_stream = Box::pin(out.body_stream_or_error());
@@ -225,20 +244,17 @@ pub(super) async fn handle_chat(
             Ok(b) => b,
             Err(e) => return err_internal(&format!("llm service error: {}", e.message)),
         };
-        let chunk: ChatChunk = match serde_json::from_slice(&bytes) {
+        let chunk: ChatChunk = match codec::decode(&bytes) {
             Ok(c) => c,
-            Err(e) => return err_internal(&format!("decode ChatChunk: {e}")),
+            Err(e) => return err_internal(&format!("decode ChatChunk: {}", e.message)),
         };
         match chunk.delta {
             ChunkDelta::Text(s) => content.push_str(&s),
             // Tool-call and empty deltas are ignored in the buffered path.
-            // `ChunkDelta` is `#[non_exhaustive]` — the wildcard covers any
-            // future variant until we explicitly handle it.
             ChunkDelta::ToolCallStart { .. }
             | ChunkDelta::ToolCallArguments { .. }
             | ChunkDelta::ToolCallComplete { .. }
             | ChunkDelta::Empty => {}
-            _ => {}
         }
     }
     if model_used.is_empty() {
@@ -321,11 +337,27 @@ pub(super) async fn handle_chat_stream(
                 let _ = sink.send_chunk(frame).await;
                 return;
             };
-            // `bytes` is already valid JSON (one `ChatChunk` per chunk from
-            // the service). Emit as an SSE `data:` frame.
-            let mut frame = Vec::with_capacity(bytes.len() + 8);
+            // Each frame is a MessagePack-encoded `ChatChunk`. Decode and
+            // re-encode as JSON for the SSE wire — clients consume JSON.
+            let chunk: ChatChunk = match codec::decode(&bytes) {
+                Ok(c) => c,
+                Err(_) => {
+                    let frame = b"event: error\ndata: {}\n\n".to_vec();
+                    let _ = sink.send_chunk(frame).await;
+                    return;
+                }
+            };
+            let json = match serde_json::to_vec(&chunk) {
+                Ok(j) => j,
+                Err(_) => {
+                    let frame = b"event: error\ndata: {}\n\n".to_vec();
+                    let _ = sink.send_chunk(frame).await;
+                    return;
+                }
+            };
+            let mut frame = Vec::with_capacity(json.len() + 8);
             frame.extend_from_slice(b"data: ");
-            frame.extend_from_slice(&bytes);
+            frame.extend_from_slice(&json);
             frame.extend_from_slice(b"\n\n");
             if sink.send_chunk(frame).await.is_err() {
                 return;
@@ -636,16 +668,6 @@ pub(super) async fn delete_provider(
 // per-(backend_id, model_id) ops forwarded verbatim. These handlers only
 // marshal HTTP ⇄ service-block JSON — no business logic here.
 
-/// Request body for `llm.status`, `llm.load_model`, `llm.unload_model` on
-/// the service block. Mirrors the `StatusRequest` / `LoadModelRequest`
-/// / `UnloadModelRequest` structs in
-/// `wafer-core::interfaces::llm::handler`.
-#[derive(serde::Serialize)]
-struct BackendModelBody<'a> {
-    backend_id: &'a str,
-    model_id: &'a str,
-}
-
 /// Extract `(backend_id, model_id)` from
 /// `/b/llm/api/models/{backend_id}/{model_id}[/suffix]`.
 ///
@@ -698,11 +720,11 @@ pub(super) async fn list_models(
         Ok(b) => b,
         Err(e) => return err_internal(&format!("llm list_models failed: {e:?}")),
     };
-    // The service block returns a bare `Vec<ModelInfo>` (see `to_output`
-    // in the handler). Re-parse opaquely and wrap in the UI-friendly envelope.
-    let models: serde_json::Value = match serde_json::from_slice(&buf.body) {
+    // The service block returns a MessagePack-encoded `Vec<ModelInfo>` in
+    // a single buffered chunk. Decode then re-serialize to JSON for the UI.
+    let models: Vec<ModelInfo> = match codec::decode(&buf.body) {
         Ok(v) => v,
-        Err(e) => return err_internal(&format!("decode list_models: {e}")),
+        Err(e) => return err_internal(&format!("decode list_models: {}", e.message)),
     };
     ok_json(&serde_json::json!({ "models": models }))
 }
@@ -718,12 +740,13 @@ pub(super) async fn model_status(
     if backend_id.is_empty() || model_id.is_empty() {
         return err_bad_request("Missing backend_id or model_id");
     }
-    let body = match serde_json::to_vec(&BackendModelBody {
-        backend_id: &backend_id,
-        model_id: &model_id,
-    }) {
+    let req = StatusRequest {
+        backend_id: backend_id.clone(),
+        model_id: model_id.clone(),
+    };
+    let body = match codec::encode(&req) {
         Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize status req: {e}")),
+        Err(e) => return err_internal(&format!("serialize status req: {}", e.message)),
     };
 
     let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_STATUS);
@@ -734,9 +757,9 @@ pub(super) async fn model_status(
         Ok(b) => b,
         Err(e) => return err_internal(&format!("llm status failed: {e:?}")),
     };
-    let status: serde_json::Value = match serde_json::from_slice(&buf.body) {
+    let status: ModelStatus = match codec::decode(&buf.body) {
         Ok(v) => v,
-        Err(e) => return err_internal(&format!("decode status: {e}")),
+        Err(e) => return err_internal(&format!("decode status: {}", e.message)),
     };
     ok_json(&serde_json::json!({ "status": status }))
 }
@@ -755,12 +778,13 @@ pub(super) async fn load_model(
     if backend_id.is_empty() || model_id.is_empty() {
         return err_bad_request("Missing backend_id or model_id");
     }
-    let body = match serde_json::to_vec(&BackendModelBody {
-        backend_id: &backend_id,
-        model_id: &model_id,
-    }) {
+    let req = LoadModelRequest {
+        backend_id: backend_id.clone(),
+        model_id: model_id.clone(),
+    };
+    let body = match codec::encode(&req) {
         Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize load req: {e}")),
+        Err(e) => return err_internal(&format!("serialize load req: {}", e.message)),
     };
 
     let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_LOAD_MODEL);
@@ -783,10 +807,27 @@ pub(super) async fn load_model(
                 let _ = sink.send_chunk(frame).await;
                 return;
             };
-            // `bytes` is already the JSON encoding of one `LoadProgress`.
-            let mut frame = Vec::with_capacity(bytes.len() + 8);
+            // Each frame is a MessagePack-encoded `LoadProgress`. Decode and
+            // re-encode as JSON for the SSE wire.
+            let progress: wafer_block::wire::llm::LoadProgress = match codec::decode(&bytes) {
+                Ok(p) => p,
+                Err(_) => {
+                    let frame = b"event: error\ndata: {}\n\n".to_vec();
+                    let _ = sink.send_chunk(frame).await;
+                    return;
+                }
+            };
+            let json = match serde_json::to_vec(&progress) {
+                Ok(j) => j,
+                Err(_) => {
+                    let frame = b"event: error\ndata: {}\n\n".to_vec();
+                    let _ = sink.send_chunk(frame).await;
+                    return;
+                }
+            };
+            let mut frame = Vec::with_capacity(json.len() + 8);
             frame.extend_from_slice(b"data: ");
-            frame.extend_from_slice(&bytes);
+            frame.extend_from_slice(&json);
             frame.extend_from_slice(b"\n\n");
             if sink.send_chunk(frame).await.is_err() {
                 return;
@@ -810,12 +851,13 @@ pub(super) async fn unload_model(
     if backend_id.is_empty() || model_id.is_empty() {
         return err_bad_request("Missing backend_id or model_id");
     }
-    let body = match serde_json::to_vec(&BackendModelBody {
-        backend_id: &backend_id,
-        model_id: &model_id,
-    }) {
+    let req = UnloadModelRequest {
+        backend_id: backend_id.clone(),
+        model_id: model_id.clone(),
+    };
+    let body = match codec::encode(&req) {
         Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize unload req: {e}")),
+        Err(e) => return err_internal(&format!("serialize unload req: {}", e.message)),
     };
 
     let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_UNLOAD_MODEL);
@@ -987,7 +1029,7 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, ChatRole::User);
         assert!(
-            matches!(&msgs[0].content, wafer_core::interfaces::llm::service::ChatContent::Text(t) if t == "hi")
+            matches!(&msgs[0].content, wafer_block::wire::llm::ChatContent::Text(t) if t == "hi")
         );
     }
 
@@ -1001,7 +1043,7 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, ChatRole::Assistant);
         assert!(
-            matches!(&msgs[0].content, wafer_core::interfaces::llm::service::ChatContent::Text(t) if t == "yes")
+            matches!(&msgs[0].content, wafer_block::wire::llm::ChatContent::Text(t) if t == "yes")
         );
     }
 

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -207,7 +207,12 @@ async fn dispatch_chat(
     };
     let payload = match codec::encode(&chat_req) {
         Ok(p) => p,
-        Err(e) => return Err(err_internal(&format!("serialize chat request: {}", e.message))),
+        Err(e) => {
+            return Err(err_internal(&format!(
+                "serialize chat request: {}",
+                e.message
+            )))
+        }
     };
 
     let call_msg = build_chat_call_msg(msg);

--- a/crates/solobase-core/src/blocks/network.rs
+++ b/crates/solobase-core/src/blocks/network.rs
@@ -6,10 +6,15 @@
 
 use std::sync::Arc;
 
+use futures::StreamExt;
+use wafer_block::{
+    codec,
+    stream::StreamEvent,
+    wire::network::{Request as NetRequest, ResponseHeader as NetResponseHeader},
+};
 use wafer_core::{clients::database as db, interfaces::network::service::NetworkService};
 use wafer_run::{
-    block::Block, context::Context, streams::output::TerminalNotResponse, types::*, BlockInfo,
-    InputStream, OutputStream,
+    block::Block, context::Context, types::*, BlockInfo, InputStream, OutputStream,
 };
 
 use super::helpers::{json_map, now_millis};
@@ -27,22 +32,13 @@ impl SolobaseNetworkBlock {
     }
 }
 
-/// Parse the request payload to extract method + url for logging.
+/// Parse the request payload (a MessagePack-encoded `wire::network::Request`)
+/// to extract method + url for logging. Decode failures fall back to
+/// `UNKNOWN`/empty so logging never blocks the actual request.
 fn parse_request_info(body: &[u8]) -> (String, String) {
-    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) {
-        let method = v
-            .get("method")
-            .and_then(|m| m.as_str())
-            .unwrap_or("GET")
-            .to_uppercase();
-        let url = v
-            .get("url")
-            .and_then(|u| u.as_str())
-            .unwrap_or("")
-            .to_string();
-        (method, url)
-    } else {
-        ("UNKNOWN".into(), String::new())
+    match codec::decode::<NetRequest>(body) {
+        Ok(req) => (req.method.to_uppercase(), req.url),
+        Err(_) => ("UNKNOWN".into(), String::new()),
     }
 }
 
@@ -61,32 +57,44 @@ impl Block for SolobaseNetworkBlock {
         // Network access control is enforced by WRAP in call_block() before
         // reaching this handler. This block only handles logging + execution.
 
-        // Execute the actual request (re-wrap body as a fresh InputStream).
+        // Dispatch to the wrapped wafer-core network block. The response is a
+        // two-frame stream: a `wire::network::ResponseHeader` chunk followed
+        // by zero-or-more body chunks. We must preserve frame boundaries when
+        // forwarding — `collect_buffered` would concatenate header + body and
+        // break the downstream `buffered_header_and_body` decoder.
         let start = now_millis();
         let inner_out = self
             .inner
             .handle(ctx, msg, InputStream::from_bytes(body))
             .await;
-        let buffered = inner_out.collect_buffered().await;
+
+        // Drain the inner stream into a buffer of events so we can both log
+        // (via the decoded header's `status_code`) and forward verbatim.
+        let mut events: Vec<StreamEvent> = Vec::new();
+        let mut inner = inner_out;
+        while let Some(evt) = inner.next().await {
+            events.push(evt);
+        }
         let duration_ms = (now_millis() - start) as i64;
 
-        // Extract status code from response, then re-emit the buffered output.
-        let (status_code, error_message, result) = match buffered {
-            Ok(resp) => {
-                let status = serde_json::from_slice::<serde_json::Value>(&resp.body)
-                    .ok()
-                    .and_then(|v| v.get("status_code").and_then(|s| s.as_i64()))
-                    .unwrap_or(0);
-                // Re-emit as a buffered response, preserving meta if any.
-                let mut builder = crate::blocks::helpers::ResponseBuilder::new();
-                for entry in &resp.meta {
-                    builder = builder.set_header(&entry.key, &entry.value);
+        // Pick out the status_code from the first Chunk (the header frame).
+        let mut status_code: i64 = 0;
+        let mut error_message = String::new();
+        for evt in &events {
+            match evt {
+                StreamEvent::Chunk(bytes) => {
+                    if let Ok(header) = codec::decode::<NetResponseHeader>(bytes) {
+                        status_code = header.status_code as i64;
+                    }
+                    break;
                 }
-                let out = builder.body(resp.body, "");
-                (status, String::new(), out)
+                StreamEvent::Error(e) => {
+                    error_message = e.message.clone();
+                    break;
+                }
+                _ => continue,
             }
-            Err(terminal) => terminal_to_output(terminal),
-        };
+        }
 
         // Log the request (best-effort, don't fail the actual request)
         let _ = db::create(
@@ -103,7 +111,38 @@ impl Block for SolobaseNetworkBlock {
         )
         .await;
 
-        result
+        // Re-emit the captured events to the caller, preserving frame
+        // boundaries so the typed network client can decode header + body.
+        OutputStream::from_producer(move |sink, _cancel| async move {
+            for evt in events {
+                match evt {
+                    StreamEvent::Chunk(bytes) => {
+                        if sink.send_chunk(bytes).await.is_err() {
+                            return;
+                        }
+                    }
+                    StreamEvent::Meta(entry) => {
+                        let _ = sink.send_meta(entry).await;
+                    }
+                    StreamEvent::Complete { meta } => {
+                        let _ = sink.complete(meta).await;
+                        return;
+                    }
+                    StreamEvent::Error(e) => {
+                        let _ = sink.error(*e).await;
+                        return;
+                    }
+                    StreamEvent::Drop => {
+                        let _ = sink.drop_request().await;
+                        return;
+                    }
+                    StreamEvent::Continue(m) => {
+                        let _ = sink.continue_with(m).await;
+                        return;
+                    }
+                }
+            }
+        })
     }
 
     async fn lifecycle(
@@ -118,27 +157,6 @@ impl Block for SolobaseNetworkBlock {
 /// Create a new SolobaseNetworkBlock (caller must register it with the runtime).
 pub fn create(service: Arc<dyn NetworkService>) -> Arc<SolobaseNetworkBlock> {
     Arc::new(SolobaseNetworkBlock::new(service))
-}
-
-/// Convert a non-Complete terminal into a re-emitted OutputStream plus the
-/// status/error fields used for logging.
-fn terminal_to_output(terminal: TerminalNotResponse) -> (i64, String, OutputStream) {
-    match terminal {
-        TerminalNotResponse::Error(e) => {
-            let msg = e.message.clone();
-            (0, msg, OutputStream::error(e))
-        }
-        TerminalNotResponse::Drop => (0, String::new(), OutputStream::drop_request()),
-        TerminalNotResponse::Continue(m) => (0, String::new(), OutputStream::continue_with(m)),
-        TerminalNotResponse::Malformed => (
-            0,
-            "malformed inner response".into(),
-            OutputStream::error(WaferError::new(
-                ErrorCode::Internal,
-                "malformed inner response",
-            )),
-        ),
-    }
 }
 
 // Pattern matching tests are in wafer-block/src/wrap.rs (grant_matches_resource)

--- a/crates/solobase-core/src/blocks/network.rs
+++ b/crates/solobase-core/src/blocks/network.rs
@@ -13,9 +13,7 @@ use wafer_block::{
     wire::network::{Request as NetRequest, ResponseHeader as NetResponseHeader},
 };
 use wafer_core::{clients::database as db, interfaces::network::service::NetworkService};
-use wafer_run::{
-    block::Block, context::Context, types::*, BlockInfo, InputStream, OutputStream,
-};
+use wafer_run::{block::Block, context::Context, types::*, BlockInfo, InputStream, OutputStream};
 
 use super::helpers::{json_map, now_millis};
 

--- a/crates/solobase-core/src/blocks/products/tests/mock_context.rs
+++ b/crates/solobase-core/src/blocks/products/tests/mock_context.rs
@@ -3,6 +3,10 @@ use std::{
     sync::{atomic::AtomicU64, Arc, Mutex},
 };
 
+use wafer_block::{
+    codec,
+    wire::{config as cfg_wire, database as db_wire},
+};
 use wafer_core::clients::database::{Record, RecordList};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
@@ -64,14 +68,11 @@ impl MockContext {
     }
 
     fn handle_config_call(&self, _kind: &str, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            key: String,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: cfg_wire::GetRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
         match self.config.get(&req.key) {
-            Some(v) => Ok(serde_json::to_vec(&serde_json::json!({"value": v})).unwrap()),
+            Some(v) => codec::encode(&cfg_wire::GetResponse { value: v.clone() })
+                .map_err(|e| WaferError::new("internal", e.message)),
             None => Err(WaferError::new(
                 "not_found",
                 format!("config key '{}' not found", req.key),
@@ -82,13 +83,8 @@ impl MockContext {
     // --- Database operations ---
 
     fn db_get(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            id: String,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::GetRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
         let db = self.db.lock().unwrap();
         let records = db
             .get(&req.collection)
@@ -97,34 +93,12 @@ impl MockContext {
             .iter()
             .find(|r| r.id == req.id)
             .ok_or_else(|| WaferError::new("not_found", "not found"))?;
-        Ok(serde_json::to_vec(record).unwrap())
+        codec::encode(record).map_err(|e| WaferError::new("internal", e.message))
     }
 
     fn db_list(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            #[serde(default)]
-            filters: Vec<FilterDef>,
-            #[serde(default)]
-            sort: Vec<SortDef>,
-            #[serde(default = "default_limit")]
-            limit: i64,
-            #[serde(default)]
-            offset: i64,
-        }
-        fn default_limit() -> i64 {
-            1000
-        }
-        #[derive(serde::Deserialize)]
-        struct SortDef {
-            field: String,
-            #[serde(default)]
-            desc: bool,
-        }
-
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::ListRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let db = self.db.lock().unwrap();
         let empty = Vec::new();
@@ -149,9 +123,14 @@ impl MockContext {
             });
         }
 
+        // Tests serialize requests with `limit: 0` to mean "default", and the
+        // wire schema has no per-field default; preserve the previous mock
+        // behaviour by treating `limit == 0` as the legacy 1000 default.
+        let effective_limit = if req.limit == 0 { 1000 } else { req.limit };
+
         let total_count = filtered.len() as i64;
         let offset = req.offset.max(0) as usize;
-        let limit = req.limit.max(0) as usize;
+        let limit = effective_limit.max(0) as usize;
         let page_records: Vec<Record> = filtered
             .into_iter()
             .skip(offset)
@@ -159,8 +138,8 @@ impl MockContext {
             .cloned()
             .collect();
 
-        let page = if req.limit > 0 {
-            req.offset / req.limit + 1
+        let page = if effective_limit > 0 {
+            req.offset / effective_limit + 1
         } else {
             1
         };
@@ -168,36 +147,25 @@ impl MockContext {
             records: page_records,
             total_count,
             page,
-            page_size: req.limit,
+            page_size: effective_limit,
         };
-        Ok(serde_json::to_vec(&result).unwrap())
+        codec::encode(&result).map_err(|e| WaferError::new("internal", e.message))
     }
 
     fn db_create(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            data: HashMap<String, serde_json::Value>,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::CreateRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let id = self.next_id();
         let record = Record { id, data: req.data };
         let mut db = self.db.lock().unwrap();
         db.entry(req.collection).or_default().push(record.clone());
-        Ok(serde_json::to_vec(&record).unwrap())
+        codec::encode(&record).map_err(|e| WaferError::new("internal", e.message))
     }
 
     fn db_update(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            id: String,
-            data: HashMap<String, serde_json::Value>,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::UpdateRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let mut db = self.db.lock().unwrap();
         let records = db
@@ -210,17 +178,12 @@ impl MockContext {
         for (k, v) in req.data {
             record.data.insert(k, v);
         }
-        Ok(serde_json::to_vec(&record).unwrap())
+        codec::encode(record).map_err(|e| WaferError::new("internal", e.message))
     }
 
     fn db_delete(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            id: String,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::DeleteRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let mut db = self.db.lock().unwrap();
         let records = db
@@ -231,19 +194,15 @@ impl MockContext {
             .position(|r| r.id == req.id)
             .ok_or_else(|| WaferError::new("not_found", "not found"))?;
         records.remove(idx);
-        Ok(b"{}".to_vec())
+        // The native delete client returns the empty-buffer ack; emit an
+        // empty MessagePack payload so the typed client's `Ok(())` path
+        // succeeds.
+        Ok(Vec::new())
     }
 
     fn db_count(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            #[serde(default)]
-            filters: Vec<FilterDef>,
-        }
-
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::CountRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let db = self.db.lock().unwrap();
         let empty = Vec::new();
@@ -252,20 +211,13 @@ impl MockContext {
             .iter()
             .filter(|r| req.filters.iter().all(|f| matches_filter(r, f)))
             .count() as i64;
-        Ok(serde_json::to_vec(&serde_json::json!({"count": count})).unwrap())
+        codec::encode(&db_wire::CountResponse { count })
+            .map_err(|e| WaferError::new("internal", e.message))
     }
 
     fn db_sum(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            collection: String,
-            field: String,
-            #[serde(default)]
-            filters: Vec<FilterDef>,
-        }
-
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::SumRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         let db = self.db.lock().unwrap();
         let empty = Vec::new();
@@ -275,21 +227,16 @@ impl MockContext {
             .filter(|r| req.filters.iter().all(|f| matches_filter(r, f)))
             .filter_map(|r| r.data.get(&req.field).and_then(|v| v.as_f64()))
             .sum();
-        Ok(serde_json::to_vec(&serde_json::json!({"sum": sum})).unwrap())
+        codec::encode(&db_wire::SumResponse { sum })
+            .map_err(|e| WaferError::new("internal", e.message))
     }
 
     /// Minimal exec_raw support for atomic UPDATE ... WHERE id = ? AND status = ? patterns.
     /// Supports both numbered (?1, ?2) and positional (?) parameter styles, and
     /// handles quoted identifiers ("field") from sea_query builders.
     fn db_exec_raw(&self, data: &[u8]) -> Result<Vec<u8>, WaferError> {
-        #[derive(serde::Deserialize)]
-        struct Req {
-            query: String,
-            #[serde(default)]
-            args: Vec<serde_json::Value>,
-        }
-        let req: Req =
-            serde_json::from_slice(data).map_err(|e| WaferError::new("internal", e.to_string()))?;
+        let req: db_wire::ExecRawRequest =
+            codec::decode(data).map_err(|e| WaferError::new("internal", e.message))?;
 
         // Normalize: convert positional ? to numbered ?N and strip double-quotes from identifiers
         let normalized = normalize_sql(&req.query);
@@ -298,7 +245,8 @@ impl MockContext {
         // Match: UPDATE <table> SET ... WHERE id = ?N AND status IN (...)
         // or: UPDATE <table> SET ... WHERE id = ?N AND status = ?M
         if !query_upper.starts_with("UPDATE ") {
-            return Ok(serde_json::to_vec(&serde_json::json!({"rows_affected": 0})).unwrap());
+            return codec::encode(&db_wire::ExecRawResponse { rows_affected: 0 })
+                .map_err(|e| WaferError::new("internal", e.message));
         }
 
         // Extract table name (word after UPDATE)
@@ -410,7 +358,8 @@ impl MockContext {
         let records = match db.get_mut(&table) {
             Some(r) => r,
             None => {
-                return Ok(serde_json::to_vec(&serde_json::json!({"rows_affected": 0})).unwrap())
+                return codec::encode(&db_wire::ExecRawResponse { rows_affected: 0 })
+                    .map_err(|e| WaferError::new("internal", e.message))
             }
         };
 
@@ -433,7 +382,8 @@ impl MockContext {
             }
         }
 
-        Ok(serde_json::to_vec(&serde_json::json!({"rows_affected": rows_affected})).unwrap())
+        codec::encode(&db_wire::ExecRawResponse { rows_affected })
+            .map_err(|e| WaferError::new("internal", e.message))
     }
 }
 
@@ -483,14 +433,7 @@ fn normalize_sql(sql: &str) -> String {
 
 // --- Filter matching ---
 
-#[derive(serde::Deserialize)]
-struct FilterDef {
-    field: String,
-    operator: String,
-    value: serde_json::Value,
-}
-
-fn matches_filter(record: &Record, filter: &FilterDef) -> bool {
+fn matches_filter(record: &Record, filter: &db_wire::FilterDef) -> bool {
     let val = record.data.get(&filter.field);
     match filter.operator.as_str() {
         "eq" => val == Some(&filter.value),

--- a/crates/solobase-core/src/blocks/storage.rs
+++ b/crates/solobase-core/src/blocks/storage.rs
@@ -22,10 +22,12 @@
 
 use std::sync::Arc;
 
+use futures::StreamExt;
+use wafer_block::{codec, stream::StreamEvent, wire::storage as wire};
 use wafer_core::{clients::database as db, interfaces::storage::service::StorageService};
 use wafer_run::{
-    block::Block, context::Context, streams::output::TerminalNotResponse, types::*, BlockInfo,
-    InputStream, OutputStream, ResourceGrant, ResourceType,
+    block::Block, context::Context, types::*, BlockInfo, InputStream, OutputStream, ResourceGrant,
+    ResourceType,
 };
 
 use super::{
@@ -121,52 +123,87 @@ fn access_type_for_op(kind: &str) -> &'static str {
 /// Rewrite the folder/name field in the request body bytes.
 ///
 /// Returns the rewritten body bytes plus the resolved path info.
+///
+/// Bodies are MessagePack-encoded `wire::storage` request types (matching
+/// the binary transport overhaul). We decode the relevant typed request,
+/// rewrite the path field, and re-encode — no `serde_json::Value`
+/// round-trip, because that would lose the byte-fidelity guarantees
+/// needed for the schema-locked wire types (and silently strip
+/// non-string-encodable fields like `PutRequest.data`).
 fn rewrite_request_body(
     kind: &str,
     body: &[u8],
     caller: &str,
 ) -> Result<(Vec<u8>, ResolvedPath), WaferError> {
-    // For list_folders, no folder field to rewrite — handled by filtering results
-    if kind == "storage.list_folders" {
-        return Ok((
+    let invalid = |e: wafer_block::WaferError| {
+        WaferError::new(
+            ErrorCode::INVALID_ARGUMENT,
+            format!("invalid storage request: {}", e.message),
+        )
+    };
+    let encode_err = |e: wafer_block::WaferError| {
+        WaferError::new(
+            ErrorCode::INTERNAL,
+            format!("encoding storage request: {}", e.message),
+        )
+    };
+
+    match kind {
+        // No folder field to rewrite — handled by filtering results.
+        "storage.list_folders" => Ok((
             body.to_vec(),
             ResolvedPath {
                 path: caller.to_string(),
                 cross_block: false,
             },
-        ));
-    }
-
-    let mut v: serde_json::Value = serde_json::from_slice(body).map_err(|e| {
-        WaferError::new(
+        )),
+        "storage.create_folder" => {
+            let mut req: wire::CreateFolderRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.name);
+            req.name = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        "storage.delete_folder" => {
+            let mut req: wire::DeleteFolderRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.name);
+            req.name = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        "storage.put" => {
+            let mut req: wire::PutRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.folder);
+            req.folder = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        "storage.get" => {
+            let mut req: wire::GetRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.folder);
+            req.folder = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        "storage.delete" => {
+            let mut req: wire::DeleteRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.folder);
+            req.folder = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        "storage.list" => {
+            let mut req: wire::ListRequest = codec::decode(body).map_err(invalid)?;
+            let resolved = resolve_folder(caller, &req.folder);
+            req.folder = resolved.path.clone();
+            let bytes = codec::encode(&req).map_err(encode_err)?;
+            Ok((bytes, resolved))
+        }
+        other => Err(WaferError::new(
             ErrorCode::INVALID_ARGUMENT,
-            format!("invalid storage request: {e}"),
-        )
-    })?;
-
-    // For folder-level ops, rewrite the "name" field
-    if kind == "storage.create_folder" || kind == "storage.delete_folder" {
-        let name = v
-            .get("name")
-            .and_then(|n| n.as_str())
-            .unwrap_or("")
-            .to_string();
-        let resolved = resolve_folder(caller, &name);
-        v["name"] = serde_json::Value::String(resolved.path.clone());
-        let bytes = serde_json::to_vec(&v).unwrap_or_default();
-        return Ok((bytes, resolved));
+            format!("unknown storage op: {other}"),
+        )),
     }
-
-    // For object-level ops, rewrite the "folder" field
-    let folder = v
-        .get("folder")
-        .and_then(|f| f.as_str())
-        .unwrap_or("")
-        .to_string();
-    let resolved = resolve_folder(caller, &folder);
-    v["folder"] = serde_json::Value::String(resolved.path.clone());
-    let bytes = serde_json::to_vec(&v).unwrap_or_default();
-    Ok((bytes, resolved))
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -236,47 +273,66 @@ impl Block for SolobaseStorageBlock {
             }
         }
 
-        // Execute the actual storage operation, then collect to log status.
+        // Execute the actual storage operation. Frame boundaries must be
+        // preserved for two-frame ops (`storage.get` returns header + body),
+        // so we drain events into a buffer and replay them rather than
+        // calling `collect_buffered` (which would concatenate header + body
+        // into a single chunk and break downstream `buffered_header_and_body`
+        // decoding).
         let start = now_millis();
         let inner_out = self
             .inner
             .handle(ctx, msg.clone(), InputStream::from_bytes(rewritten_body))
             .await;
-        let buffered = inner_out.collect_buffered().await;
+        let mut events: Vec<StreamEvent> = Vec::new();
+        let mut inner = inner_out;
+        while let Some(evt) = inner.next().await {
+            events.push(evt);
+        }
         let duration_ms = (now_millis() - start) as i64;
 
-        let (status, result) = match buffered {
-            Ok(resp) => {
-                let mut builder = crate::blocks::helpers::ResponseBuilder::new();
-                for entry in &resp.meta {
-                    builder = builder.set_header(&entry.key, &entry.value);
-                }
-                let out = builder.body(resp.body, "");
-                (format!("OK ({duration_ms}ms)"), out)
+        let mut error_status: Option<String> = None;
+        for evt in &events {
+            if let StreamEvent::Error(e) = evt {
+                error_status = Some(format!("ERROR: {}", e.message));
+                break;
             }
-            Err(TerminalNotResponse::Error(e)) => {
-                let s = format!("ERROR: {}", e.message);
-                (s, OutputStream::error(e))
-            }
-            Err(TerminalNotResponse::Drop) => {
-                ("ERROR: dropped".into(), OutputStream::drop_request())
-            }
-            Err(TerminalNotResponse::Continue(m)) => {
-                ("ERROR: continue".into(), OutputStream::continue_with(m))
-            }
-            Err(TerminalNotResponse::Malformed) => (
-                "ERROR: malformed".into(),
-                OutputStream::error(WaferError::new(
-                    ErrorCode::Internal,
-                    "malformed inner response",
-                )),
-            ),
-        };
+        }
+        let status = error_status.unwrap_or_else(|| format!("OK ({duration_ms}ms)"));
 
         // Log the access (best-effort)
         let _ = log_storage_access(ctx, &caller, &msg.kind, &resolved.path, &status).await;
 
-        result
+        OutputStream::from_producer(move |sink, _cancel| async move {
+            for evt in events {
+                match evt {
+                    StreamEvent::Chunk(bytes) => {
+                        if sink.send_chunk(bytes).await.is_err() {
+                            return;
+                        }
+                    }
+                    StreamEvent::Meta(entry) => {
+                        let _ = sink.send_meta(entry).await;
+                    }
+                    StreamEvent::Complete { meta } => {
+                        let _ = sink.complete(meta).await;
+                        return;
+                    }
+                    StreamEvent::Error(e) => {
+                        let _ = sink.error(*e).await;
+                        return;
+                    }
+                    StreamEvent::Drop => {
+                        let _ = sink.drop_request().await;
+                        return;
+                    }
+                    StreamEvent::Continue(m) => {
+                        let _ = sink.continue_with(m).await;
+                        return;
+                    }
+                }
+            }
+        })
     }
 
     async fn lifecycle(
@@ -386,51 +442,51 @@ mod tests {
 
     #[test]
     fn test_rewrite_request_body_put() {
-        let body = serde_json::to_vec(&serde_json::json!({
-            "folder": "uploads",
-            "key": "photo.jpg",
-            "data": [],
-            "content_type": "image/jpeg"
-        }))
+        let body = codec::encode(&wire::PutRequest {
+            folder: "uploads".into(),
+            key: "photo.jpg".into(),
+            data: vec![],
+            content_type: "image/jpeg".into(),
+        })
         .unwrap();
         let (rewritten, resolved) =
             rewrite_request_body("storage.put", &body, "suppers-ai/files").unwrap();
         assert_eq!(resolved.path, "suppers-ai/files/uploads");
         assert!(!resolved.cross_block);
 
-        let v: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
-        assert_eq!(v["folder"], "suppers-ai/files/uploads");
+        let req: wire::PutRequest = codec::decode(&rewritten).unwrap();
+        assert_eq!(req.folder, "suppers-ai/files/uploads");
     }
 
     #[test]
     fn test_rewrite_request_body_cross_block() {
-        let body = serde_json::to_vec(&serde_json::json!({
-            "folder": "@wafer-run/web/public",
-            "key": "index.html"
-        }))
+        let body = codec::encode(&wire::GetRequest {
+            folder: "@wafer-run/web/public".into(),
+            key: "index.html".into(),
+        })
         .unwrap();
         let (rewritten, resolved) =
             rewrite_request_body("storage.get", &body, "suppers-ai/files").unwrap();
         assert_eq!(resolved.path, "wafer-run/web/public");
         assert!(resolved.cross_block);
 
-        let v: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
-        assert_eq!(v["folder"], "wafer-run/web/public");
+        let req: wire::GetRequest = codec::decode(&rewritten).unwrap();
+        assert_eq!(req.folder, "wafer-run/web/public");
     }
 
     #[test]
     fn test_rewrite_request_body_create_folder() {
-        let body = serde_json::to_vec(&serde_json::json!({
-            "name": "uploads",
-            "public": false
-        }))
+        let body = codec::encode(&wire::CreateFolderRequest {
+            name: "uploads".into(),
+            public: false,
+        })
         .unwrap();
         let (rewritten, resolved) =
             rewrite_request_body("storage.create_folder", &body, "suppers-ai/files").unwrap();
         assert_eq!(resolved.path, "suppers-ai/files/uploads");
         assert!(!resolved.cross_block);
 
-        let v: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
-        assert_eq!(v["name"], "suppers-ai/files/uploads");
+        let req: wire::CreateFolderRequest = codec::decode(&rewritten).unwrap();
+        assert_eq!(req.name, "suppers-ai/files/uploads");
     }
 }

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -35,11 +35,14 @@
 //! `{index}/{id}` handler.
 
 use wafer_core::{
-    clients::{database as db, vector as vclient},
-    interfaces::vector::{
-        get_model, service::VectorEntry, DistanceMetric, MetadataFilter, SearchMode,
-        VectorIndexConfig, DEFAULT_MODEL,
+    clients::{
+        database as db,
+        vector::{
+            self as vclient, DistanceMetric, MetadataFilter, SearchMode, VectorEntry,
+            VectorIndexConfig,
+        },
     },
+    interfaces::vector::{get_model, DEFAULT_MODEL},
 };
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 


### PR DESCRIPTION
## Summary

Migrate solobase from JSON-encoded `ctx.call_block` payloads to the new
MessagePack + streaming-ABI transport introduced by
[wafer-run/wafer-run#34](https://github.com/wafer-run/wafer-run/pull/34).

> **DO NOT MERGE until wafer-run/wafer-run#34 merges first.** Once #34 is
> green, repin `Cargo.toml` from `branch = \"binary-transport-overhaul\"`
> to either a fresh wafer-run version tag or the merged SHA. See the
> lockstep merge order: wafer-run → solobase → gizza-ai (gizza-ai depends
> on solobase-core via path).

Spec: `workspace/docs/superpowers/specs/2026-05-05-binary-transport-consumer-migration-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-05-binary-transport-consumer-migration.md` (Track 2 / B1-B6)

## Scope

This is the consumer-facing half of PR #34's atomic cutover. wafer-run
itself ships the producer side (typed clients, wire types, codec); this
PR rewrites every solobase site that previously hand-rolled
`serde_json::to_vec` + `ctx.call_block` against a wafer-run service
block.

### Migrated sites

| File | Change |
|---|---|
| `blocks/vector/pages.rs` | type imports flipped from `interfaces::vector::*` to `clients::vector::*` (re-exports of `wire::vector::*`) |
| `blocks/email.rs` | manual network payload → `clients::network::do_request` |
| `blocks/llm/routes.rs` | all 5 `wafer-run/llm` calls migrated to codec + `wire::llm::*`; SSE forwarders decode MessagePack chunks and re-emit JSON `data:` frames |
| `blocks/llm/pages.rs` | `list_models` decodes `Vec<wire::llm::ModelInfo>` |
| `blocks/network.rs` | `SolobaseNetworkBlock` decodes `wire::network::Request` for logging and **forwards events frame-by-frame** (collect_buffered would concat header+body and break the typed client's two-frame decoder) |
| `blocks/storage.rs` | `rewrite_request_body` decodes/encodes typed `wire::storage::*` per-kind; handler forwards events frame-by-frame |
| `blocks/products/tests/mock_context.rs` | in-memory DB mock now uses codec + `wire::database::*` so tests round-trip against the new wire format |

### Out of scope (per spec)

- HTTP request body JSON in solobase routes — that's HTTP wire format,
  unrelated.
- Custom block-to-block protocols (`suppers-ai/email`,
  `suppers-ai/messages`, `suppers-ai/userportal`) — both sides are
  consumer-controlled and stay on serde_json.
- Routing forwarders (`routing.rs:300/303/328`) — opaque byte
  forwarders, no decode happens here.

## Notable migration choices

**Chat streaming (`blocks/llm/routes.rs:215`).** The new `wafer-run/llm`
handler emits multi-frame `ChatChunk` responses; `collect_buffered`
would yield concatenated MessagePack frames, which can't be decoded as
a single value. The handler now drains the stream frame-by-frame via
`out.body_stream_or_error()`, decodes each chunk via `codec::decode`,
and emits JSON SSE `data:` frames so existing browser clients keep
working. There is no `clients::llm` typed client in wafer-core yet, so
encoding/decoding is done directly against `wafer_block::codec` +
`wafer_block::wire::llm::*`. Same pattern for `load_model` (LoadProgress
chunks).

**Frame-preservation in solobase wrapper blocks.** `network.rs` and
`storage.rs` both wrap their wafer-core counterparts and previously
called `collect_buffered` to log status before re-emitting via
`ResponseBuilder.body(...)`. After the binary-transport overhaul this
collapsed the two-frame `(ResponseHeader, body)` protocol into a single
chunk, breaking downstream `buffered_header_and_body` decoding. Both
wrappers now drain events into a `Vec<StreamEvent>` and replay them
verbatim via `OutputStream::from_producer`. (This was Risk 2 in the
spec — a hidden site the compiler couldn't catch.)

**`solobase-core` gains a direct `wafer-block` dep.** Already a
transitive via `wafer-core` / `wafer-run`, but importing
`wire::*` paths directly from `solobase-core` is cleaner than going
through clients re-exports for the cases (llm, storage rewriter,
products mock) that need types but no typed client.

## Test plan

- [x] `cargo check -p solobase-core -p solobase-native -p solobase-browser` clean against branch `binary-transport-overhaul`
- [x] `cargo test -p solobase-core` — 492 tests pass (437 lib + 46 lockfile + 1 + 7 + 1)
- [x] `cargo check -p solobase-core -p solobase-native -p solobase-browser --release` clean
- [ ] Manual smoke: admin panel functional, auth login succeeds, LLM chat round-trips a query through the migrated `wafer-run/llm` block
- [ ] Manual smoke: file download via `wafer-run/storage` (verifies the two-frame storage GET wrapper)

## References

- Producer PR: https://github.com/wafer-run/wafer-run/pull/34
- Consumer-migration spec: `workspace/docs/superpowers/specs/2026-05-05-binary-transport-consumer-migration-design.md`
- Track 1 (gizza-ai): https://github.com/gizza-ai/gizza-ai/pull/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)