### PR TITLE
feat(files): bucket-creation modal on /b/storage/

### DIFF
--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -54,11 +54,55 @@ pub fn render_buckets_table(rows: &[BucketRow]) -> Markup {
     }
 }
 
+/// Render the "+ New bucket" `<dialog>` modal. The form is wired by the
+/// `bucketCreateModal()` handler in `files-browser.js`: it intercepts
+/// submit, POSTs to `/b/storage/api/buckets`, and on success redirects to
+/// `/b/storage/{name}/`. Markup is rendered server-side so the page works
+/// even before the JS bundle finishes loading (the trigger is a no-op
+/// without JS — accepted v1 trade-off; the JSON API is still callable).
+pub fn render_new_bucket_modal() -> Markup {
+    html! {
+        dialog #new-bucket-modal .modal.modal--bucket-create {
+            form method="dialog" {
+                h3 { "New bucket" }
+                p .modal-error role="alert" hidden {}
+                label {
+                    span { "Name" }
+                    input
+                        type="text"
+                        name="name"
+                        required
+                        minlength="3"
+                        maxlength="63"
+                        // S3-compatible: lowercase letters, digits, hyphens; start/end alnum.
+                        pattern="[a-z0-9]([a-z0-9-]*[a-z0-9])?"
+                        autocomplete="off"
+                        spellcheck="false"
+                        placeholder="my-bucket";
+                }
+                small .form-hint {
+                    "3–63 characters. Lowercase letters, digits, and hyphens. Must start and end with a letter or digit."
+                }
+                label .checkbox-label {
+                    input type="checkbox" name="public" value="1";
+                    span { "Public (objects can be accessed by anonymous URL)" }
+                }
+                div .modal-actions {
+                    button type="button" data-action="cancel" .btn.btn--ghost.btn--md { "Cancel" }
+                    button type="submit" data-action="create" .btn.btn--primary.btn--md { "Create bucket" }
+                }
+            }
+        }
+    }
+}
+
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use crate::ui::{
-    self, nav_groups,
+    self,
+    components::{button, BtnVariant, CtrlSize},
+    nav_groups,
     shell::{Crumb, Topbar},
     shelled_response,
     templates::{list_page, PageHeader},
@@ -155,14 +199,30 @@ pub async fn bucket_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream 
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
 
+    let new_bucket_btn = button(
+        BtnVariant::Primary,
+        CtrlSize::Md,
+        "+ New bucket",
+        PreEscaped(r#"type="button" data-action="open-new-bucket""#.to_string()),
+    );
+
+    // The table cell carries the modal markup + JS so it lives inside the
+    // shelled response without needing a new template parameter.
+    let js_url = crate::ui::assets::files_browser_js_url();
+    let table_with_modal = html! {
+        (render_buckets_table(&rows))
+        (render_new_bucket_modal())
+        script src=(js_url) defer {}
+    };
+
     let body = list_page(
         PageHeader {
             title: "Files",
             subtitle: Some("Your buckets and their object counts."),
-            primary_action: None, // bucket creation modal arrives in Task 9 JS
+            primary_action: Some(new_bucket_btn),
         },
         None,
-        render_buckets_table(&rows),
+        table_with_modal,
         None,
     );
 
@@ -1229,6 +1289,74 @@ mod integration_tests {
         assert!(
             !body.contains(">secrets<"),
             "cross-user bucket leaked: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bucket_list_page_renders_new_bucket_button() {
+        let ctx = TestContext::with_auth().await;
+        let msg = admin_msg("retrieve", "/b/storage/");
+        let body = output_html(bucket_list_page(&ctx, &msg).await).await;
+
+        // Primary-action slot is populated (proves we're not still on
+        // `primary_action: None`).
+        assert!(
+            body.contains("page-header__action"),
+            "page-header action slot missing: {body}"
+        );
+        assert!(
+            body.contains("+ New bucket"),
+            "new-bucket button label missing: {body}"
+        );
+        assert!(
+            body.contains(r#"data-action="open-new-bucket""#),
+            "new-bucket trigger attribute missing: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bucket_list_page_renders_new_bucket_modal() {
+        let ctx = TestContext::with_auth().await;
+        let msg = admin_msg("retrieve", "/b/storage/");
+        let body = output_html(bucket_list_page(&ctx, &msg).await).await;
+
+        // Modal markup is server-rendered next to the table.
+        assert!(
+            body.contains(r#"id="new-bucket-modal""#),
+            "modal element missing: {body}"
+        );
+        assert!(
+            body.contains(r#"name="name""#),
+            "name input missing: {body}"
+        );
+        assert!(
+            body.contains(r#"name="public""#),
+            "public toggle missing: {body}"
+        );
+        assert!(
+            body.contains("Create bucket"),
+            "submit button missing: {body}"
+        );
+        // JS bundle is included with the cache-busting hash URL.
+        assert!(
+            body.contains("/b/static/files-browser-"),
+            "files-browser.js script tag missing: {body}"
+        );
+    }
+
+    #[test]
+    fn render_new_bucket_modal_validates_name_pattern_client_side() {
+        // The pattern is used by the browser for native validation; assert
+        // it's present so we don't regress accidentally to no client-side
+        // validation. Server-side validation lives in storage.rs.
+        let html = render_new_bucket_modal().into_string();
+        assert!(
+            html.contains(r#"pattern="[a-z0-9]([a-z0-9-]*[a-z0-9])?""#),
+            "client-side pattern attribute missing: {html}"
+        );
+        assert!(
+            html.contains(r#"minlength="3""#) && html.contains(r#"maxlength="63""#),
+            "length constraints missing: {html}"
         );
     }
 

--- a/crates/solobase-core/src/ui/assets/files-browser.js
+++ b/crates/solobase-core/src/ui/assets/files-browser.js
@@ -291,11 +291,107 @@
     }
   }
 
+  // S3-style bucket name validation. Rules per AWS S3:
+  //   - 3 to 63 characters
+  //   - lowercase letters, digits, hyphens; must start and end with letter/digit
+  //   - no consecutive hyphens, no `..`
+  //   - not formatted as an IP address
+  // Returns null when valid, otherwise an error message.
+  function validateBucketName(name) {
+    if (!name) return 'Bucket name is required.';
+    if (name.length < 3 || name.length > 63)
+      return 'Bucket name must be 3 to 63 characters.';
+    if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name))
+      return 'Use lowercase letters, digits, and hyphens; must start and end with a letter or digit.';
+    if (name.indexOf('--') !== -1) return 'Bucket name cannot contain consecutive hyphens.';
+    if (name.indexOf('..') !== -1) return 'Bucket name cannot contain consecutive dots.';
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(name)) return 'Bucket name cannot look like an IP address.';
+    return null;
+  }
+
+  function bucketCreateModal() {
+    const trigger = document.querySelector('[data-action="open-new-bucket"]');
+    const dlg = document.getElementById('new-bucket-modal');
+    if (!trigger || !dlg) return;
+
+    const form = dlg.querySelector('form');
+    const nameInput = dlg.querySelector('input[name="name"]');
+    const publicInput = dlg.querySelector('input[name="public"]');
+    const errEl = dlg.querySelector('.modal-error');
+    const cancelBtn = dlg.querySelector('[data-action="cancel"]');
+    const submitBtn = dlg.querySelector('[data-action="create"]');
+
+    function showError(msg) {
+      if (!errEl) return;
+      errEl.textContent = msg || '';
+      errEl.hidden = !msg;
+    }
+
+    function resetForm() {
+      if (form) form.reset();
+      showError('');
+    }
+
+    trigger.addEventListener('click', (e) => {
+      e.preventDefault();
+      resetForm();
+      dlg.showModal();
+      // Focus the name input on open.
+      if (nameInput) nameInput.focus();
+    });
+
+    cancelBtn.addEventListener('click', () => {
+      dlg.close();
+    });
+
+    // Native <dialog> already handles ESC-to-close; clear error on close.
+    dlg.addEventListener('close', resetForm);
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = (nameInput.value || '').trim();
+      const isPublic = publicInput ? !!publicInput.checked : false;
+      const validationError = validateBucketName(name);
+      if (validationError) {
+        showError(validationError);
+        nameInput.focus();
+        return;
+      }
+      submitBtn.disabled = true;
+      try {
+        const resp = await fetch('/b/storage/api/buckets', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: name, public: isPublic }),
+        });
+        if (resp.ok) {
+          // Redirect into the new bucket so the user can immediately upload.
+          window.location.href = '/b/storage/' + encodeURIComponent(name) + '/';
+          return;
+        }
+        let serverMsg = 'Failed to create bucket.';
+        try {
+          const j = await resp.json();
+          if (j && j.message) serverMsg = j.message;
+        } catch (_) {
+          /* ignore JSON parse error */
+        }
+        showError(serverMsg);
+        submitBtn.disabled = false;
+      } catch (err) {
+        showError('Network error. Please try again.');
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
   window.solobaseFilesBrowser = {
     init: function () {
       const boot = readBootstrap();
       // shareModal/kebab still useful even without bootstrap (e.g., shares page).
       kebabMenu();
+      // bucket-create modal lives on the bucket-list page (no boot bucket).
+      bucketCreateModal();
       if (!boot) return;
       dragDropHandler(boot);
       bulkSelect();


### PR DESCRIPTION
## Summary
- Adds **+ New bucket** primary action to the `/b/storage/` page header (was `primary_action: None`).
- Server-renders a `<dialog id="new-bucket-modal">` with a name input (required, S3 pattern `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, 3–63 chars), an optional public/private toggle, and cancel/submit buttons.
- Wires the form in `files-browser.js` via `bucketCreateModal()`: client-side S3 bucket name validation, `fetch POST /b/storage/api/buckets` (existing endpoint), redirect to `/b/storage/{name}/` on success, inline error from `json.message` on failure (matches the `wafer-block-http-listener` error envelope `{ error, message }`).
- Mirrors the existing `shareModal()` pattern — native `<dialog>`, ESC-to-close (browser default), focus management, idempotent init guard.

## Test plan
- [x] Unit tests for page handler (`TestContext::with_auth()`):
  - `bucket_list_page_renders_new_bucket_button` — page-header action slot, label, trigger attribute
  - `bucket_list_page_renders_new_bucket_modal` — modal element, name + public inputs, submit button, JS bundle URL
  - `render_new_bucket_modal_validates_name_pattern_client_side` — pattern + length attributes present
- [x] Full `cargo test -p solobase-core` green (578 tests).
- [x] `cargo build --release -p solobase` clean.
- [ ] Visual baseline regen for `admin-storage-desktop` — **not run from this session** (sandbox blocks executing the release binary). Maintainer: please run the snippet in the handoff before merge:
  ```bash
  pkill -f 'target/release/solobase'; sleep 1
  rm -f /tmp/solobase-baseline.db*
  WORKTREE=$(pwd)
  SOLOBASE_DB_PATH=/tmp/solobase-baseline.db \
    SUPPERS_AI__AUTH__ADMIN_EMAIL=admin@example.com \
    SUPPERS_AI__AUTH__ADMIN_PASSWORD=admin123 \
    SOLOBASE_BLOCK_ENABLED=suppers-ai/userportal \
    $WORKTREE/target/release/solobase &
  sleep 4 && curl -sf http://127.0.0.1:8090/health
  cd $WORKTREE/crates/solobase-web
  TEST_PORT=8090 npx playwright test --config=tests/playwright.config.ts \
      tests/e2e/visual-baseline.spec.ts \
      --grep 'admin admin-storage' --update-snapshots=all
  ```
- [ ] CI green
- [ ] Manual smoke (recommended pre-merge): open modal, create bucket "test", verify redirect to `/b/storage/test/`; create with invalid name (e.g. "Foo") → inline error.