### PR TITLE
feat(auth): JWT login persists session row to auth::repo::sessions

### DIFF
--- a/crates/solobase-core/src/blocks/auth/login.rs
+++ b/crates/solobase-core/src/blocks/auth/login.rs
@@ -4,7 +4,9 @@ use maud::{html, PreEscaped};
 use wafer_core::clients::{config, crypto, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{brand_panel, helpers::*, repo::sessions, service::hash_token, AuthBlock, USERS_COLLECTION};
+use super::{
+    brand_panel, helpers::*, repo::sessions, service::hash_token, AuthBlock, USERS_COLLECTION,
+};
 use crate::{
     blocks::{
         errors::{error_response, ErrorCode},
@@ -88,8 +90,7 @@ impl AuthBlock {
         // page can show this login. Failure must not block login — the
         // session row is a UX signal, not a security gate (auth is still
         // entirely JWT-based today).
-        if let Err(e) =
-            sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
+        if let Err(e) = sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
         {
             tracing::warn!(
                 user_id = %user.id,
@@ -275,8 +276,7 @@ impl AuthBlock {
 
         store_refresh_token(ctx, &user.id, &refresh_token, &family).await;
 
-        if let Err(e) =
-            sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
+        if let Err(e) = sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
         {
             tracing::warn!(
                 user_id = %user.id,
@@ -414,8 +414,7 @@ impl AuthBlock {
 
         store_refresh_token(ctx, &user_id, &refresh_token, &new_family).await;
 
-        if let Err(e) =
-            sessions::create_for_user(ctx, &user_id, hash_token(&access_token), 1).await
+        if let Err(e) = sessions::create_for_user(ctx, &user_id, hash_token(&access_token), 1).await
         {
             tracing::warn!(
                 user_id = %user_id,

--- a/crates/solobase-core/src/blocks/auth/login.rs
+++ b/crates/solobase-core/src/blocks/auth/login.rs
@@ -4,7 +4,7 @@ use maud::{html, PreEscaped};
 use wafer_core::clients::{config, crypto, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{brand_panel, helpers::*, AuthBlock, USERS_COLLECTION};
+use super::{brand_panel, helpers::*, repo::sessions, service::hash_token, AuthBlock, USERS_COLLECTION};
 use crate::{
     blocks::{
         errors::{error_response, ErrorCode},
@@ -83,6 +83,19 @@ impl AuthBlock {
 
         // Store refresh token
         store_refresh_token(ctx, &user.id, &refresh_token, &family).await;
+
+        // Persist a session row so the userportal `/b/userportal/sessions`
+        // page can show this login. Failure must not block login — the
+        // session row is a UX signal, not a security gate (auth is still
+        // entirely JWT-based today).
+        if let Err(e) =
+            sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
+        {
+            tracing::warn!(
+                user_id = %user.id,
+                "failed to persist session row for JWT login: {e}"
+            );
+        }
 
         // Update last login
         let upd =
@@ -262,6 +275,15 @@ impl AuthBlock {
 
         store_refresh_token(ctx, &user.id, &refresh_token, &family).await;
 
+        if let Err(e) =
+            sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await
+        {
+            tracing::warn!(
+                user_id = %user.id,
+                "failed to persist session row for JWT signup: {e}"
+            );
+        }
+
         let cookie = build_auth_cookie(&access_token, 86400, ctx).await;
 
         ResponseBuilder::new()
@@ -391,6 +413,15 @@ impl AuthBlock {
             };
 
         store_refresh_token(ctx, &user_id, &refresh_token, &new_family).await;
+
+        if let Err(e) =
+            sessions::create_for_user(ctx, &user_id, hash_token(&access_token), 1).await
+        {
+            tracing::warn!(
+                user_id = %user_id,
+                "failed to persist session row for JWT refresh: {e}"
+            );
+        }
 
         let cookie = build_auth_cookie(&access_token, 86400, ctx).await;
 

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -1,7 +1,26 @@
 //! Row-level access over `suppers_ai__auth__sessions`.
 //!
-//! `token_hash` is the sha256 of the raw session token — the raw token never
-//! lives past its issuance helper (see AuthService in a later task).
+//! `token_hash` is the sha256 of the raw token (a JWT for the live login flow,
+//! a `wafer_session_*` opaque token for the planned cookie flow). The raw
+//! token never lives past its issuance helper.
+//!
+//! ## Schema convention
+//!
+//! This module uses the **live TEXT-everything convention** — rows are
+//! materialised through `db::create` (which calls `ensure_table` on first
+//! insert) rather than the BLOB-keyed Plan A2 migration schema. The migration
+//! file `001_auth_schema.sqlite.sql` still defines a stricter schema for tests
+//! that opt into `with_auth()`, but production startup never applies migrations
+//! (the auth block's `Init` lifecycle only seeds the admin user, not the
+//! schema). Storing `token_hash` as a hex string in a TEXT column keeps the
+//! repo working in both cases:
+//!
+//! - In production, `ensure_table` materialises a TEXT-everything table on
+//!   first insert (mirroring how `users`, `user_roles`, and `tokens` already
+//!   work).
+//! - In tests using `with_auth()`, the migration's BLOB-keyed table already
+//!   exists; SQLite's loose typing accepts the hex string in the BLOB column,
+//!   and `ensure_table` adds the auto `id` column via `ALTER TABLE`.
 
 use std::collections::HashMap;
 
@@ -33,20 +52,33 @@ fn now_iso() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
-/// Decode a `Value` returned by the database client into a byte vector.
-///
-/// The sqlite service stores byte arrays passed in as `json!(&[u8])` as the
-/// JSON array text representation and returns them parsed back into
-/// `Value::Array` on read. The helper tolerates a couple of other shapes so
-/// the repo layer stays forgiving if a backend round-trips them differently.
-fn decode_bytes(v: &Value) -> Option<Vec<u8>> {
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
+}
+
+/// Decode a `token_hash` column value, accepting either:
+/// - A TEXT hex string (live convention used by production rows + new inserts).
+/// - A `Value::Array` of `u8`-coerced numbers (legacy migration BLOB rows
+///   round-tripped via `json!(&[u8])`).
+/// - A non-hex `Value::String` (legacy raw-bytes encoding).
+fn decode_token_hash(v: &Value) -> Option<Vec<u8>> {
     match v {
+        Value::String(s) => decode_hex(s).or_else(|| Some(s.as_bytes().to_vec())),
         Value::Array(arr) => Some(
             arr.iter()
                 .filter_map(|x| x.as_u64().map(|n| n as u8))
                 .collect(),
         ),
-        Value::String(s) => Some(s.as_bytes().to_vec()),
         _ => None,
     }
 }
@@ -55,7 +87,7 @@ fn row_from_map(m: &HashMap<String, Value>) -> Result<SessionRow, RepoError> {
     let s = |k: &str| m.get(k).and_then(Value::as_str).map(str::to_owned);
     let token_hash = m
         .get("token_hash")
-        .and_then(decode_bytes)
+        .and_then(decode_token_hash)
         .ok_or_else(|| RepoError::Db("missing token_hash".into()))?;
     Ok(SessionRow {
         token_hash,
@@ -66,38 +98,79 @@ fn row_from_map(m: &HashMap<String, Value>) -> Result<SessionRow, RepoError> {
     })
 }
 
+/// Build the column map written for both new inserts and update reads.
+fn row_to_data(new: &NewSession, now: &str) -> HashMap<String, Value> {
+    let mut data = HashMap::new();
+    data.insert("token_hash".into(), json!(hex_encode(&new.token_hash)));
+    data.insert("user_id".into(), json!(new.user_id));
+    data.insert("created_at".into(), json!(now));
+    data.insert("last_used_at".into(), json!(now));
+    data.insert("expires_at".into(), json!(new.expires_at));
+    data
+}
+
+/// Insert a new session row.
+///
+/// Each call creates a new row — sessions are not idempotent, every login or
+/// session-issuance call gets a fresh row keyed by its own `token_hash`.
 pub async fn insert(ctx: &dyn Context, new: NewSession) -> Result<(), RepoError> {
     let now = now_iso();
-    db::exec_raw(
+    let data = row_to_data(&new, &now);
+    db::create(ctx, TABLE, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("insert session: {e}")))?;
+    Ok(())
+}
+
+/// Convenience wrapper for the JWT login path: hashes nothing (the caller
+/// already computed `token_hash`), defaults `expires_at` to the access-token
+/// lifetime in days, and forwards to [`insert`].
+///
+/// Naming mirrors `delete_for_user`/`list_for_user` for symmetry.
+pub async fn create_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+    token_hash: Vec<u8>,
+    lifetime_days: u32,
+) -> Result<(), RepoError> {
+    let expires_at = (chrono::Utc::now() + chrono::Duration::days(lifetime_days as i64))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    insert(
         ctx,
-        &format!(
-            "INSERT INTO {TABLE} (token_hash, user_id, created_at, last_used_at, expires_at) VALUES (?, ?, ?, ?, ?)",
-        ),
-        &[
-            json!(new.token_hash),
-            json!(new.user_id),
-            json!(now),
-            json!(now),
-            json!(new.expires_at),
-        ],
+        NewSession {
+            token_hash,
+            user_id: user_id.to_string(),
+            expires_at,
+        },
     )
     .await
-    .map_err(|e| RepoError::Db(format!("insert session: {e}")))?;
-    Ok(())
+}
+
+async fn find_record_by_hash(
+    ctx: &dyn Context,
+    hash: &[u8],
+) -> Result<Option<wafer_core::clients::database::Record>, RepoError> {
+    let opts = db::ListOptions {
+        filters: vec![db::Filter {
+            field: "token_hash".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(hex_encode(hash)),
+        }],
+        limit: 1,
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("session lookup: {e}")))?;
+    Ok(res.records.into_iter().next())
 }
 
 pub async fn find_by_token_hash(
     ctx: &dyn Context,
     hash: &[u8],
 ) -> Result<Option<SessionRow>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE token_hash = ?"),
-        &[json!(hash)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("session select: {e}")))?;
-    match rows.first() {
+    match find_record_by_hash(ctx, hash).await? {
         Some(r) => Ok(Some(row_from_map(&r.data)?)),
         None => Ok(None),
     }
@@ -107,56 +180,76 @@ pub async fn find_by_token_hash(
 /// `hash`. Silently no-ops if the row is missing — callers treat liveness
 /// as a best-effort signal.
 pub async fn touch_last_used(ctx: &dyn Context, hash: &[u8]) -> Result<(), RepoError> {
-    let now = now_iso();
-    db::exec_raw(
-        ctx,
-        &format!("UPDATE {TABLE} SET last_used_at = ? WHERE token_hash = ?"),
-        &[json!(now), json!(hash)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("session touch: {e}")))?;
+    let Some(record) = find_record_by_hash(ctx, hash).await? else {
+        return Ok(());
+    };
+    let mut data = HashMap::new();
+    data.insert("last_used_at".into(), json!(now_iso()));
+    db::update(ctx, TABLE, &record.id, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("session touch: {e}")))?;
     Ok(())
 }
 
 /// Deletes the session row identified by `token_hash`. Returns the number of
 /// affected rows (0 if no such row exists).
 pub async fn delete_by_token_hash(ctx: &dyn Context, hash: &[u8]) -> Result<u64, RepoError> {
-    let affected = db::exec_raw(
-        ctx,
-        &format!("DELETE FROM {TABLE} WHERE token_hash = ?"),
-        &[json!(hash)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("session delete: {e}")))?;
-    Ok(affected.max(0) as u64)
+    let Some(record) = find_record_by_hash(ctx, hash).await? else {
+        return Ok(0);
+    };
+    db::delete(ctx, TABLE, &record.id)
+        .await
+        .map_err(|e| RepoError::Db(format!("session delete: {e}")))?;
+    Ok(1)
 }
 
 /// Deletes rows whose `expires_at < cutoff`. Returns the number deleted.
 ///
-/// `cutoff` is compared as an ISO-8601 string; the migration schema stores
-/// timestamps in the same text format.
+/// `cutoff` is compared as an ISO-8601 string; rows store timestamps in the
+/// same text format (see [`now_iso`]).
 pub async fn delete_expired(ctx: &dyn Context, cutoff: &str) -> Result<u64, RepoError> {
-    let affected = db::exec_raw(
-        ctx,
-        &format!("DELETE FROM {TABLE} WHERE expires_at < ?"),
-        &[json!(cutoff)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("delete expired: {e}")))?;
-    Ok(affected.max(0) as u64)
+    let opts = db::ListOptions {
+        filters: vec![db::Filter {
+            field: "expires_at".into(),
+            operator: db::FilterOp::LessThan,
+            value: json!(cutoff),
+        }],
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("delete expired list: {e}")))?;
+    let mut deleted = 0u64;
+    for record in res.records {
+        if db::delete(ctx, TABLE, &record.id).await.is_ok() {
+            deleted += 1;
+        }
+    }
+    Ok(deleted)
 }
 
 /// Return all active sessions for `user_id`, ordered by `last_used_at` DESC
 /// so the most recently active session sorts first.
 pub async fn list_for_user(ctx: &dyn Context, user_id: &str) -> Result<Vec<SessionRow>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE user_id = ? ORDER BY last_used_at DESC"),
-        &[json!(user_id)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("session list_for_user: {e}")))?;
-    rows.iter().map(|r| row_from_map(&r.data)).collect()
+    let opts = db::ListOptions {
+        filters: vec![db::Filter {
+            field: "user_id".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(user_id),
+        }],
+        sort: vec![db::SortField {
+            field: "last_used_at".into(),
+            desc: true,
+        }],
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("session list_for_user: {e}")))?;
+    res.records
+        .iter()
+        .map(|r| row_from_map(&r.data))
+        .collect()
 }
 
 /// Delete a session row, but only if it belongs to `user_id`. Returns 0 if
@@ -167,14 +260,21 @@ pub async fn delete_for_user(
     user_id: &str,
     hash: &[u8],
 ) -> Result<u64, RepoError> {
-    let affected = db::exec_raw(
-        ctx,
-        &format!("DELETE FROM {TABLE} WHERE token_hash = ? AND user_id = ?"),
-        &[json!(hash), json!(user_id)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("session delete_for_user: {e}")))?;
-    Ok(affected.max(0) as u64)
+    let Some(record) = find_record_by_hash(ctx, hash).await? else {
+        return Ok(0);
+    };
+    let owner = record
+        .data
+        .get("user_id")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if owner != user_id {
+        return Ok(0);
+    }
+    db::delete(ctx, TABLE, &record.id)
+        .await
+        .map_err(|e| RepoError::Db(format!("session delete_for_user: {e}")))?;
+    Ok(1)
 }
 
 #[cfg(test)]
@@ -190,26 +290,35 @@ mod tests_phase_4 {
         }
     }
 
+    /// Seed a user using the live (TEXT-everything) convention via
+    /// `db::create`, matching how `seed_admin_user` writes rows in
+    /// production. This sidesteps the migration's NOT NULL on
+    /// `display_name`/`role` so the test can use the unwired-migration
+    /// schema while still mirroring production.
+    async fn seed_user(ctx: &TestContext, user_id: &str) {
+        // Use exec_raw so we can pin the id (db::create would generate one).
+        db::exec_raw(
+            ctx,
+            "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            &[
+                json!(user_id),
+                json!(format!("{user_id}@example.com")),
+                json!(user_id),
+                json!("user"),
+                json!("2026-01-01T00:00:00Z"),
+                json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .unwrap();
+    }
+
     #[tokio::test]
     async fn list_for_user_returns_only_caller_sessions() {
         let ctx = TestContext::with_auth().await;
-        // Seed users (FK constraint).
         for user_id in ["user-a", "user-b"] {
-            wafer_core::clients::database::exec_raw(
-                &ctx,
-                "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \
-                 VALUES (?, ?, ?, ?, ?, ?)",
-                &[
-                    serde_json::json!(user_id),
-                    serde_json::json!(format!("{user_id}@example.com")),
-                    serde_json::json!(user_id),
-                    serde_json::json!("user"),
-                    serde_json::json!("2026-01-01T00:00:00Z"),
-                    serde_json::json!("2026-01-01T00:00:00Z"),
-                ],
-            )
-            .await
-            .unwrap();
+            seed_user(&ctx, user_id).await;
         }
         insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
         insert(&ctx, fake_session("user-a", 0x02)).await.unwrap();
@@ -225,21 +334,7 @@ mod tests_phase_4 {
     async fn delete_for_user_refuses_other_users_session() {
         let ctx = TestContext::with_auth().await;
         for user_id in ["user-a", "user-b"] {
-            wafer_core::clients::database::exec_raw(
-                &ctx,
-                "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \
-                 VALUES (?, ?, ?, ?, ?, ?)",
-                &[
-                    serde_json::json!(user_id),
-                    serde_json::json!(format!("{user_id}@example.com")),
-                    serde_json::json!(user_id),
-                    serde_json::json!("user"),
-                    serde_json::json!("2026-01-01T00:00:00Z"),
-                    serde_json::json!("2026-01-01T00:00:00Z"),
-                ],
-            )
-            .await
-            .unwrap();
+            seed_user(&ctx, user_id).await;
         }
         insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
         insert(&ctx, fake_session("user-b", 0x02)).await.unwrap();
@@ -258,5 +353,62 @@ mod tests_phase_4 {
             .unwrap();
         assert_eq!(affected, 1);
         assert_eq!(list_for_user(&ctx, "user-a").await.unwrap().len(), 0);
+    }
+
+    /// `find_by_token_hash` round-trips a freshly-inserted row, and the row's
+    /// `token_hash` is the same bytes that went in (proves the hex
+    /// encode/decode is symmetric).
+    #[tokio::test]
+    async fn find_by_token_hash_roundtrip() {
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        let raw_hash = vec![0xaa; 32];
+        insert(
+            &ctx,
+            NewSession {
+                token_hash: raw_hash.clone(),
+                user_id: "user-a".into(),
+                expires_at: "2099-01-01T00:00:00Z".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let found = find_by_token_hash(&ctx, &raw_hash).await.unwrap();
+        let row = found.expect("row missing after insert");
+        assert_eq!(row.token_hash, raw_hash);
+        assert_eq!(row.user_id, "user-a");
+    }
+
+    /// `delete_by_token_hash` returns 1 on hit, 0 on miss.
+    #[tokio::test]
+    async fn delete_by_token_hash_counts_rows() {
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
+        assert_eq!(
+            delete_by_token_hash(&ctx, &vec![0x99; 32]).await.unwrap(),
+            0
+        );
+        assert_eq!(
+            delete_by_token_hash(&ctx, &vec![0x01; 32]).await.unwrap(),
+            1
+        );
+        assert_eq!(list_for_user(&ctx, "user-a").await.unwrap().len(), 0);
+    }
+
+    /// `create_for_user` writes a row that `list_for_user` can find, and the
+    /// `expires_at` is in the future relative to `now_iso()`.
+    #[tokio::test]
+    async fn create_for_user_writes_visible_row() {
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        create_for_user(&ctx, "user-a", vec![0x42; 32], 1)
+            .await
+            .unwrap();
+        let rows = list_for_user(&ctx, "user-a").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].token_hash, vec![0x42; 32]);
+        // `expires_at` is one day in the future — strictly greater than now.
+        assert!(rows[0].expires_at.as_str() > now_iso().as_str());
     }
 }

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -246,10 +246,7 @@ pub async fn list_for_user(ctx: &dyn Context, user_id: &str) -> Result<Vec<Sessi
     let res = db::list(ctx, TABLE, &opts)
         .await
         .map_err(|e| RepoError::Db(format!("session list_for_user: {e}")))?;
-    res.records
-        .iter()
-        .map(|r| row_from_map(&r.data))
-        .collect()
+    res.records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 /// Delete a session row, but only if it belongs to `user_id`. Returns 0 if

--- a/crates/solobase-core/tests/auth/login_session_row.rs
+++ b/crates/solobase-core/tests/auth/login_session_row.rs
@@ -1,0 +1,213 @@
+//! `handle_login` writes a session row to `auth::repo::sessions` so the
+//! userportal `/b/userportal/sessions` page renders meaningful data after a
+//! JWT login.
+//!
+//! These tests exercise the production code path WITHOUT applying migrations
+//! — production never applies them either; the live `users` and `sessions`
+//! tables are materialised through `ensure_table` on first `db::create`. The
+//! tests use the `MigrationTestCtx` for its real `wafer-run/crypto` routing
+//! so password hashing and JWT signing work the same way as production.
+
+use serde_json::json;
+use solobase_core::blocks::{
+    auth::{repo::sessions, service::hash_token, AuthBlock, AUTH_BLOCK_ID},
+    userportal::UserPortalBlock,
+};
+use wafer_core::clients::{crypto, database as db};
+use wafer_run::{
+    block::Block,
+    streams::output::{BufferedResponse, TerminalNotResponse},
+    types::Message,
+    InputStream, OutputStream,
+};
+
+use crate::common::MigrationTestCtx;
+
+/// Drain an `OutputStream` to a `BufferedResponse`. Mirrors the helper in
+/// `solobase-core/src/test_support.rs` (which is `#[cfg(test)]` and not
+/// visible from integration tests).
+async fn collect_or_panic(out: OutputStream) -> BufferedResponse {
+    match out.collect_buffered().await {
+        Ok(buf) => buf,
+        Err(TerminalNotResponse::Error(e)) => {
+            panic!("handler returned error: {} ({:?})", e.message, e.code)
+        }
+        Err(TerminalNotResponse::Drop) => panic!("handler dropped the request"),
+        Err(TerminalNotResponse::Continue(_)) => panic!("handler returned Continue"),
+        Err(TerminalNotResponse::Malformed) => panic!("handler returned malformed stream"),
+    }
+}
+
+/// Seed a user via `db::create` (live TEXT-everything convention). Returns
+/// the user's id. Hashes the password through the registered crypto block
+/// the same way production `seed_admin_user` does. Adds an `email_verified`
+/// flag so the login flow doesn't gate on verification.
+async fn seed_password_user(ctx: &MigrationTestCtx, email: &str, password: &str) -> String {
+    let password_hash = crypto::hash(ctx, password).await.expect("hash password");
+    let mut data = std::collections::HashMap::new();
+    data.insert("email".to_string(), json!(email));
+    data.insert("password_hash".to_string(), json!(password_hash));
+    data.insert("name".to_string(), json!(""));
+    data.insert("disabled".to_string(), json!("false"));
+    data.insert("email_verified".to_string(), json!("true"));
+    let user = db::create(ctx, "suppers_ai__auth__users", data)
+        .await
+        .expect("create user");
+    user.id
+}
+
+fn login_msg() -> Message {
+    let mut m = Message::new("http.request");
+    m.set_meta("req.action", "create");
+    m.set_meta("req.resource", "/b/auth/api/login");
+    m
+}
+
+async fn invoke_login(ctx: &MigrationTestCtx, email: &str, password: &str) -> String {
+    let block = AuthBlock::default();
+    let body = json!({"email": email, "password": password}).to_string();
+    let msg = login_msg();
+    let out = block
+        .handle(ctx, msg, InputStream::from_bytes(body.into_bytes()))
+        .await;
+    let buf = collect_or_panic(out).await;
+    String::from_utf8(buf.body).expect("body utf8")
+}
+
+/// Run the login handler and consume the output stream regardless of whether
+/// it terminates with `Complete` or `Error` — used by the wrong-password test
+/// which expects an `Unauthenticated` error stream rather than a body.
+async fn invoke_login_drain(ctx: &MigrationTestCtx, email: &str, password: &str) {
+    let block = AuthBlock::default();
+    let body = json!({"email": email, "password": password}).to_string();
+    let msg = login_msg();
+    let out = block
+        .handle(ctx, msg, InputStream::from_bytes(body.into_bytes()))
+        .await;
+    // Discard the result — we only care about the side-effects (or lack
+    // thereof) on the database. An error stream is the expected outcome on
+    // the wrong-password path.
+    let _ = out.collect_buffered().await;
+}
+
+#[tokio::test]
+async fn login_creates_one_session_row_keyed_by_access_token_hash() {
+    let ctx = MigrationTestCtx::new();
+    let user_id = seed_password_user(&ctx, "alice@example.com", "hunter2hunter2").await;
+
+    let resp_body = invoke_login(&ctx, "alice@example.com", "hunter2hunter2").await;
+    let resp: serde_json::Value = serde_json::from_str(&resp_body)
+        .unwrap_or_else(|_| panic!("login body is not JSON: {resp_body}"));
+    let access_token = resp
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("access_token missing from login body: {resp_body}"))
+        .to_string();
+    assert!(
+        !access_token.is_empty(),
+        "login must return a non-empty access token"
+    );
+
+    let rows = sessions::list_for_user(&ctx, &user_id)
+        .await
+        .expect("list sessions");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one session row per login, got {}: {rows:?}",
+        rows.len()
+    );
+    assert_eq!(
+        rows[0].user_id, user_id,
+        "session row must reference the logged-in user"
+    );
+    assert_eq!(
+        rows[0].token_hash,
+        hash_token(&access_token),
+        "session row token_hash must equal sha256(access_token)"
+    );
+}
+
+#[tokio::test]
+async fn invalid_credentials_do_not_create_a_session_row() {
+    let ctx = MigrationTestCtx::new();
+    let user_id = seed_password_user(&ctx, "bob@example.com", "correct-horse").await;
+
+    invoke_login_drain(&ctx, "bob@example.com", "WRONG-password").await;
+
+    let rows = sessions::list_for_user(&ctx, &user_id)
+        .await
+        .expect("list sessions");
+    assert!(
+        rows.is_empty(),
+        "no session row may be written for a failed login: {rows:?}"
+    );
+}
+
+#[tokio::test]
+async fn two_logins_produce_two_distinct_session_rows() {
+    let ctx = MigrationTestCtx::new();
+    let user_id = seed_password_user(&ctx, "carol@example.com", "passw0rd-passw0rd").await;
+
+    let _ = invoke_login(&ctx, "carol@example.com", "passw0rd-passw0rd").await;
+    // Sleep so the second JWT's `iat`/`exp` claims differ — without this the
+    // two access tokens are byte-identical and produce the same token_hash,
+    // which the sessions table treats as the same row.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let _ = invoke_login(&ctx, "carol@example.com", "passw0rd-passw0rd").await;
+
+    let rows = sessions::list_for_user(&ctx, &user_id)
+        .await
+        .expect("list sessions");
+    assert_eq!(
+        rows.len(),
+        2,
+        "two logins must produce two session rows, got {}",
+        rows.len()
+    );
+    assert_ne!(
+        rows[0].token_hash, rows[1].token_hash,
+        "session rows must have distinct token_hash values"
+    );
+}
+
+/// End-to-end: after login writes a session row, the userportal sessions
+/// page renders one row per active session (and a Revoke button for each).
+/// This is what the user sees in their browser at `/b/userportal/sessions`.
+#[tokio::test]
+async fn userportal_sessions_page_renders_row_after_login() {
+    let ctx = MigrationTestCtx::new();
+    let user_id = seed_password_user(&ctx, "diana@example.com", "diana-password").await;
+
+    let _ = invoke_login(&ctx, "diana@example.com", "diana-password").await;
+
+    let block = UserPortalBlock;
+    let mut msg = Message::new("http.request");
+    msg.set_meta("req.action", "retrieve");
+    msg.set_meta("req.resource", "/b/userportal/sessions");
+    msg.set_meta("auth.user_id", &user_id);
+    let out = block.handle(&ctx, msg, InputStream::empty()).await;
+    let buf = collect_or_panic(out).await;
+    let html = String::from_utf8(buf.body).expect("body utf8");
+
+    assert!(
+        html.contains("Active sessions"),
+        "page must render the Active sessions header: {html}"
+    );
+    assert!(
+        html.contains(">Revoke<"),
+        "populated page must render at least one Revoke button: {html}"
+    );
+    assert!(
+        !html.contains("No active sessions"),
+        "populated page must not show the empty state: {html}"
+    );
+}
+
+/// Sanity check: `AUTH_BLOCK_ID` is the block name we'd register at runtime.
+/// If this drifts, every other test in this file is testing the wrong
+/// surface.
+#[tokio::test]
+async fn auth_block_id_is_what_we_target() {
+    assert_eq!(AUTH_BLOCK_ID, "suppers-ai/auth");
+}

--- a/crates/solobase-core/tests/auth/main.rs
+++ b/crates/solobase-core/tests/auth/main.rs
@@ -3,6 +3,7 @@
 mod bootstrap_run;
 mod common;
 mod fake_github;
+mod login_session_row;
 mod migrations_001;
 mod migrations_002;
 mod pat_issue;


### PR DESCRIPTION
## Summary
- JWT login handler now writes a session row to `auth::repo::sessions` keyed by SHA-256(access_token), so the userportal `/b/userportal/sessions` page renders meaningful rows after admin login.
- Same wire-up added to signup (verification-not-required path) and refresh — every freshly-issued JWT gets a session row.
- Session-row write failures log a warning but do not block login.

## Schema decision
**Live TEXT-everything via `db::create`/`db::list`/`db::delete` (not the Plan A2 BLOB-PK migration schema).** Production never applies the auth migrations — the auth block's \`Init\` lifecycle only runs \`seed_admin_user\`, which writes through \`db::create\` and lets \`ensure_table\` materialise the table on first insert. Applying the migrations unconditionally would conflict with \`seed_admin_user\`'s data shape (the migration enforces NOT NULL on \`users.display_name\` etc., which \`seed_admin_user\` doesn't supply). Pivoting \`auth::repo::sessions\` to the live convention is a 2-3hr targeted fix; rewiring the broader Plan A2 chain (pats, bootstrap_tokens, ...) is a larger follow-up.

\`token_hash\` is stored hex-encoded in a TEXT column. The public API (\`SessionRow.token_hash: Vec<u8>\`, \`NewSession\`, \`hash_token\`) is unchanged — \`service::hash_token\` callers and the userportal sessions page see the same shape they did before. Tests that opt into \`with_auth()\` (migration applied) still pass: SQLite's loose typing accepts the hex string in the BLOB column, and \`ensure_table\` adds the auto-\`id\` column via ALTER TABLE.

## Test plan
- [x] New unit tests in \`auth::repo::sessions\`: \`find_by_token_hash_roundtrip\`, \`delete_by_token_hash_counts_rows\`, \`create_for_user_writes_visible_row\` (plus the existing two preserved).
- [x] New integration tests in \`tests/auth/login_session_row.rs\`:
  - \`login_creates_one_session_row_keyed_by_access_token_hash\` — login → exactly 1 row, user_id matches, token_hash = SHA-256(access_token).
  - \`invalid_credentials_do_not_create_a_session_row\` — wrong password writes nothing.
  - \`two_logins_produce_two_distinct_session_rows\` — two logins, two distinct rows.
  - \`userportal_sessions_page_renders_row_after_login\` — end-to-end: login → row → page renders the Revoke button.
- [x] Existing \`session_issue\` integration tests still pass (uses migrations + \`session::issue_for\` → \`sessions::insert\`).
- [x] Full \`cargo test -p solobase-core\` passes (526 lib + 51 auth integration + others; 0 failures).
- [x] \`cargo build --release -p solobase\` succeeds.
- [ ] CI green