### PR TITLE
refactor(llm): consume wafer_core::clients::llm typed client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5924,6 +5925,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5936,6 +5938,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5946,6 +5949,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5965,6 +5969,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5974,6 +5979,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5989,6 +5995,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6000,6 +6007,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6010,6 +6018,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde",
@@ -6021,6 +6030,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6030,6 +6040,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6044,6 +6055,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6061,6 +6073,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6070,6 +6083,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6080,6 +6094,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6094,6 +6109,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6104,6 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6120,6 +6137,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6131,6 +6149,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6147,6 +6166,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6156,6 +6176,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6184,6 +6205,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -10,7 +10,7 @@ use wafer_core::clients::{
     config, database as db,
     database::{Filter, FilterOp, ListOptions, SortField},
 };
-use wafer_run::{context::Context, types::*, InputStream, OutputStream};
+use wafer_run::{context::Context, types::*, OutputStream};
 
 use super::SETTINGS_COLLECTION;
 use crate::{
@@ -558,33 +558,12 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 /// Returns an empty vec on any failure — the picker falls back to the
 /// "Default (remote)" option and the user can still send a request.
 async fn load_models(ctx: &dyn Context, original_msg: &Message) -> Vec<serde_json::Value> {
-    let mut call_msg = Message::new(wafer_run::common::ServiceOp::LLM_LIST_MODELS);
-    call_msg.set_meta("req.action", wafer_run::common::ServiceOp::LLM_LIST_MODELS);
-    let user_id = original_msg.user_id().to_string();
-    if !user_id.is_empty() {
-        call_msg.set_meta("auth.user_id", &user_id);
-    }
-    let user_roles = original_msg.get_meta("auth.user_roles").to_string();
-    if !user_roles.is_empty() {
-        call_msg.set_meta("auth.user_roles", &user_roles);
-    }
-
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::empty())
-        .await;
-    let Ok(buf) = out.collect_buffered().await else {
+    let _ = original_msg;
+    // The picker keys off `model_id` / `display_name` / `backend_id`. A
+    // dispatch failure is treated as "no models" so the picker still renders —
+    // the user can fall back to the default remote option.
+    let Ok(models) = wafer_core::clients::llm::list_models(ctx).await else {
         return vec![];
-    };
-    // The service block returns a MessagePack-encoded `Vec<ModelInfo>`.
-    // Decode then convert each model into a JSON value for template
-    // rendering (the picker keys off `model_id` / `display_name` /
-    // `backend_id`). A decode failure is treated as "no models" so the
-    // picker still renders — the user can fall back to the default remote
-    // option.
-    let models: Vec<wafer_block::wire::llm::ModelInfo> = match wafer_block::codec::decode(&buf.body)
-    {
-        Ok(v) => v,
-        Err(_) => return vec![],
     };
     models
         .into_iter()

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -8,14 +8,13 @@
 //! response or a Server-Sent Events stream.
 
 use futures::StreamExt;
-use wafer_block::{
-    codec,
-    wire::llm::{
-        ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole, ChunkDelta,
-        LoadModelRequest, ModelInfo, ModelStatus, StatusRequest, UnloadModelRequest,
+use wafer_core::clients::{
+    database as db,
+    llm::{
+        self as llm_client, ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole,
+        ChunkDelta, LoadModelRequest, NativeTypedFrameStream, StatusRequest, UnloadModelRequest,
     },
 };
-use wafer_core::clients::database as db;
 use wafer_run::{
     context::Context,
     meta::META_RESP_CONTENT_TYPE,
@@ -134,34 +133,18 @@ async fn resolve_backend_id(
 
 /// Build the `Message` used to dispatch `llm.chat` to `wafer-run/llm`,
 /// forwarding auth metadata from the incoming request.
-fn build_chat_call_msg(original_msg: &Message) -> Message {
-    let mut call_msg = Message::new(wafer_run::common::ServiceOp::LLM_CHAT);
-    // req.action mirrors the kind for observability. The wafer-run/llm block
-    // dispatches on kind alone, but downstream inspectors key off req.action.
-    call_msg.set_meta("req.action", wafer_run::common::ServiceOp::LLM_CHAT);
-    let user_id = original_msg.user_id().to_string();
-    if !user_id.is_empty() {
-        call_msg.set_meta("auth.user_id", &user_id);
-    }
-    let user_roles = original_msg.get_meta("auth.user_roles").to_string();
-    if !user_roles.is_empty() {
-        call_msg.set_meta("auth.user_roles", &user_roles);
-    }
-    call_msg
-}
-
 /// Common prelude for both chat handlers: parse the body, persist the user
 /// message, load history, resolve provider + model, build the `ChatRequest`,
-/// and dispatch to `wafer-run/llm`.
+/// and call `wafer-run/llm` via the typed client.
 ///
-/// Returns the streaming `OutputStream` from the service on success, or a
+/// Returns the typed `ChatChunk` stream from the service on success, or a
 /// ready-to-return error stream on any failure.
 async fn dispatch_chat(
     block: &LlmBlock,
     ctx: &dyn Context,
     msg: &Message,
     input: InputStream,
-) -> Result<(String, OutputStream), OutputStream> {
+) -> Result<(String, NativeTypedFrameStream<ChatChunk>), OutputStream> {
     let raw = input.collect_to_bytes().await;
     let body: ChatRequestBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -194,9 +177,8 @@ async fn dispatch_chat(
         Err(e) => return Err(err_internal(e)),
     };
 
-    // 5. Build the service request and dispatch. The wire request is encoded
-    //    via MessagePack — the new `wafer-run/llm` handler decodes via
-    //    `codec::decode` (no JSON path).
+    // 5. Build the service request and dispatch via the typed client.
+    let _ = msg; // auth-meta propagation removed — see PR description.
     let chat_req = ChatRequest {
         backend_id,
         model,
@@ -205,21 +187,11 @@ async fn dispatch_chat(
         tools: Vec::new(),
         extra: serde_json::Value::Null,
     };
-    let payload = match codec::encode(&chat_req) {
-        Ok(p) => p,
-        Err(e) => {
-            return Err(err_internal(&format!(
-                "serialize chat request: {}",
-                e.message
-            )))
-        }
+    let stream = match llm_client::chat_stream(ctx, &chat_req).await {
+        Ok(s) => s,
+        Err(e) => return Err(err_internal(&format!("llm chat dispatch: {}", e.message))),
     };
-
-    let call_msg = build_chat_call_msg(msg);
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::from_bytes(payload))
-        .await;
-    Ok((thread_id, out))
+    Ok((thread_id, stream))
 }
 
 /// Buffered chat handler: collects the full `ChatChunk` stream, concatenates
@@ -230,28 +202,19 @@ pub(super) async fn handle_chat(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    let (thread_id, out) = match dispatch_chat(block, ctx, msg, input).await {
+    let (thread_id, mut stream) = match dispatch_chat(block, ctx, msg, input).await {
         Ok(x) => x,
         Err(err) => return err,
     };
 
-    // Drain the service stream, concatenating `ChunkDelta::Text` bytes into
-    // the assistant reply. Propagate any error terminal as a 500. Each frame
-    // from the new `wafer-run/llm` handler is one MessagePack-encoded
-    // `ChatChunk`; decode per-frame rather than buffering and decoding once
-    // (concatenating MessagePack frames yields a sequence, not a single
-    // value, so there is no "buffered" single-decode option here).
+    // Drain the typed `ChatChunk` stream, concatenating `ChunkDelta::Text`
+    // bytes into the assistant reply. Propagate any error terminal as a 500.
     let mut content = String::new();
     let mut model_used = String::new();
-    let mut body_stream = Box::pin(out.body_stream_or_error());
-    while let Some(item) = body_stream.next().await {
-        let bytes = match item {
-            Ok(b) => b,
-            Err(e) => return err_internal(&format!("llm service error: {}", e.message)),
-        };
-        let chunk: ChatChunk = match codec::decode(&bytes) {
+    while let Some(item) = stream.next().await {
+        let chunk = match item {
             Ok(c) => c,
-            Err(e) => return err_internal(&format!("decode ChatChunk: {}", e.message)),
+            Err(e) => return err_internal(&format!("llm service error: {}", e.message)),
         };
         match chunk.delta {
             ChunkDelta::Text(s) => content.push_str(&s),
@@ -296,9 +259,10 @@ pub(super) async fn handle_chat_stream(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    // Run the shared prelude. On success we own the service's streaming
-    // `OutputStream`; we re-emit it as SSE with a body-level content-type.
-    let (thread_id, out) = match dispatch_chat(block, ctx, msg, input).await {
+    // Run the shared prelude. On success we own the typed `ChatChunk`
+    // stream; we re-emit each chunk as JSON SSE with a body-level
+    // content-type.
+    let (thread_id, stream) = match dispatch_chat(block, ctx, msg, input).await {
         Ok(x) => x,
         Err(err) => return err,
     };
@@ -332,9 +296,9 @@ pub(super) async fn handle_chat_stream(
             })
             .await;
 
-        let mut body_stream = Box::pin(out.body_stream_or_error());
-        while let Some(item) = body_stream.next().await {
-            let Ok(bytes) = item else {
+        let mut stream = stream;
+        while let Some(item) = stream.next().await {
+            let Ok(chunk) = item else {
                 // Mid-stream service error: emit an `event: error` frame then
                 // stop. The consumer sees a final SSE event instead of an
                 // abrupt disconnect.
@@ -342,23 +306,12 @@ pub(super) async fn handle_chat_stream(
                 let _ = sink.send_chunk(frame).await;
                 return;
             };
-            // Each frame is a MessagePack-encoded `ChatChunk`. Decode and
-            // re-encode as JSON for the SSE wire — clients consume JSON.
-            let chunk: ChatChunk = match codec::decode(&bytes) {
-                Ok(c) => c,
-                Err(_) => {
-                    let frame = b"event: error\ndata: {}\n\n".to_vec();
-                    let _ = sink.send_chunk(frame).await;
-                    return;
-                }
-            };
-            let json = match serde_json::to_vec(&chunk) {
-                Ok(j) => j,
-                Err(_) => {
-                    let frame = b"event: error\ndata: {}\n\n".to_vec();
-                    let _ = sink.send_chunk(frame).await;
-                    return;
-                }
+            // Re-encode the typed chunk as JSON for the SSE wire — clients
+            // consume JSON.
+            let Ok(json) = serde_json::to_vec(&chunk) else {
+                let frame = b"event: error\ndata: {}\n\n".to_vec();
+                let _ = sink.send_chunk(frame).await;
+                return;
             };
             let mut frame = Vec::with_capacity(json.len() + 8);
             frame.extend_from_slice(b"data: ");
@@ -696,20 +649,6 @@ fn extract_model_path(msg: &Message) -> (String, String) {
 
 /// Build a `Message` to dispatch an LLM-service op, forwarding auth metadata
 /// from the incoming HTTP request.
-fn build_llm_service_msg(original: &Message, kind: &'static str) -> Message {
-    let mut call_msg = Message::new(kind);
-    call_msg.set_meta("req.action", kind);
-    let user_id = original.user_id().to_string();
-    if !user_id.is_empty() {
-        call_msg.set_meta("auth.user_id", &user_id);
-    }
-    let user_roles = original.get_meta("auth.user_roles").to_string();
-    if !user_roles.is_empty() {
-        call_msg.set_meta("auth.user_roles", &user_roles);
-    }
-    call_msg
-}
-
 /// `GET /b/llm/api/models` — aggregated list across all registered LLM
 /// backends. Authenticated (any logged-in user).
 pub(super) async fn list_models(
@@ -717,21 +656,10 @@ pub(super) async fn list_models(
     ctx: &dyn Context,
     _msg: &Message,
 ) -> OutputStream {
-    let call_msg = build_llm_service_msg(_msg, wafer_run::common::ServiceOp::LLM_LIST_MODELS);
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::empty())
-        .await;
-    let buf = match out.collect_buffered().await {
-        Ok(b) => b,
-        Err(e) => return err_internal(&format!("llm list_models failed: {e:?}")),
-    };
-    // The service block returns a MessagePack-encoded `Vec<ModelInfo>` in
-    // a single buffered chunk. Decode then re-serialize to JSON for the UI.
-    let models: Vec<ModelInfo> = match codec::decode(&buf.body) {
-        Ok(v) => v,
-        Err(e) => return err_internal(&format!("decode list_models: {}", e.message)),
-    };
-    ok_json(&serde_json::json!({ "models": models }))
+    match llm_client::list_models(ctx).await {
+        Ok(models) => ok_json(&serde_json::json!({ "models": models })),
+        Err(e) => err_internal(&format!("llm list_models failed: {}", e.message)),
+    }
 }
 
 /// `GET /b/llm/api/models/:backend_id/:model_id/status` — per-(backend, model)
@@ -746,27 +674,13 @@ pub(super) async fn model_status(
         return err_bad_request("Missing backend_id or model_id");
     }
     let req = StatusRequest {
-        backend_id: backend_id.clone(),
-        model_id: model_id.clone(),
+        backend_id,
+        model_id,
     };
-    let body = match codec::encode(&req) {
-        Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize status req: {}", e.message)),
-    };
-
-    let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_STATUS);
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::from_bytes(body))
-        .await;
-    let buf = match out.collect_buffered().await {
-        Ok(b) => b,
-        Err(e) => return err_internal(&format!("llm status failed: {e:?}")),
-    };
-    let status: ModelStatus = match codec::decode(&buf.body) {
-        Ok(v) => v,
-        Err(e) => return err_internal(&format!("decode status: {}", e.message)),
-    };
-    ok_json(&serde_json::json!({ "status": status }))
+    match llm_client::status(ctx, &req).await {
+        Ok(status) => ok_json(&serde_json::json!({ "status": status })),
+        Err(e) => err_internal(&format!("llm status failed: {}", e.message)),
+    }
 }
 
 /// `POST /b/llm/api/models/:backend_id/:model_id/load` — start a model
@@ -784,18 +698,14 @@ pub(super) async fn load_model(
         return err_bad_request("Missing backend_id or model_id");
     }
     let req = LoadModelRequest {
-        backend_id: backend_id.clone(),
-        model_id: model_id.clone(),
+        backend_id,
+        model_id,
     };
-    let body = match codec::encode(&req) {
-        Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize load req: {}", e.message)),
+    let stream = match llm_client::load_model_stream(ctx, &req).await {
+        Ok(s) => s,
+        Err(e) => return err_internal(&format!("llm load_model failed: {}", e.message)),
     };
-
-    let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_LOAD_MODEL);
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::from_bytes(body))
-        .await;
+    let _ = msg;
 
     OutputStream::from_producer(move |sink, _cancel| async move {
         let _ = sink
@@ -805,30 +715,18 @@ pub(super) async fn load_model(
             })
             .await;
 
-        let mut body_stream = Box::pin(out.body_stream_or_error());
-        while let Some(item) = body_stream.next().await {
-            let Ok(bytes) = item else {
+        let mut stream = stream;
+        while let Some(item) = stream.next().await {
+            let Ok(progress) = item else {
                 let frame = b"event: error\ndata: {}\n\n".to_vec();
                 let _ = sink.send_chunk(frame).await;
                 return;
             };
-            // Each frame is a MessagePack-encoded `LoadProgress`. Decode and
-            // re-encode as JSON for the SSE wire.
-            let progress: wafer_block::wire::llm::LoadProgress = match codec::decode(&bytes) {
-                Ok(p) => p,
-                Err(_) => {
-                    let frame = b"event: error\ndata: {}\n\n".to_vec();
-                    let _ = sink.send_chunk(frame).await;
-                    return;
-                }
-            };
-            let json = match serde_json::to_vec(&progress) {
-                Ok(j) => j,
-                Err(_) => {
-                    let frame = b"event: error\ndata: {}\n\n".to_vec();
-                    let _ = sink.send_chunk(frame).await;
-                    return;
-                }
+            // Re-encode the typed progress event as JSON for the SSE wire.
+            let Ok(json) = serde_json::to_vec(&progress) else {
+                let frame = b"event: error\ndata: {}\n\n".to_vec();
+                let _ = sink.send_chunk(frame).await;
+                return;
             };
             let mut frame = Vec::with_capacity(json.len() + 8);
             frame.extend_from_slice(b"data: ");
@@ -857,21 +755,13 @@ pub(super) async fn unload_model(
         return err_bad_request("Missing backend_id or model_id");
     }
     let req = UnloadModelRequest {
-        backend_id: backend_id.clone(),
-        model_id: model_id.clone(),
+        backend_id,
+        model_id,
     };
-    let body = match codec::encode(&req) {
-        Ok(b) => b,
-        Err(e) => return err_internal(&format!("serialize unload req: {}", e.message)),
-    };
-
-    let call_msg = build_llm_service_msg(msg, wafer_run::common::ServiceOp::LLM_UNLOAD_MODEL);
-    let out = ctx
-        .call_block("wafer-run/llm", call_msg, InputStream::from_bytes(body))
-        .await;
-    match out.collect_buffered().await {
-        Ok(_) => ok_json(&serde_json::json!({ "unloaded": true })),
-        Err(e) => err_internal(&format!("llm unload_model failed: {e:?}")),
+    let _ = msg;
+    match llm_client::unload_model(ctx, &req).await {
+        Ok(()) => ok_json(&serde_json::json!({ "unloaded": true })),
+        Err(e) => err_internal(&format!("llm unload_model failed: {}", e.message)),
     }
 }
 


### PR DESCRIPTION
## Summary

Drops the direct \`ctx.call_block(\"wafer-run/llm\", ...)\` + \`wafer_block::codec\` calls in solobase-core's LLM block in favour of the typed native client shipped in wafer-run main as wafer-run#40 (\`wafer_core::clients::llm\`).

This is the consumer side of the fourth follow-up from the binary-transport plan. PR-A (the typed client itself) merged as wafer-run#40.

## What changed

Six call sites migrated:

| Site | Before | After |
|---|---|---|
| \`routes.rs::dispatch_chat\` | \`codec::encode(&chat_req)\` + \`call_block\` | \`llm_client::chat_stream(ctx, &chat_req)\` |
| \`routes.rs::list_models\` | \`call_block\` + \`codec::decode::<Vec<ModelInfo>>\` | \`llm_client::list_models(ctx)\` |
| \`routes.rs::model_status\` | \`codec::encode\` + \`call_block\` + \`codec::decode\` | \`llm_client::status(ctx, &req)\` |
| \`routes.rs::load_model\` | \`call_block\` streaming + per-frame \`codec::decode::<LoadProgress>\` | \`llm_client::load_model_stream(ctx, &req)\` |
| \`routes.rs::unload_model\` | \`call_block\` + \`collect_buffered\` | \`llm_client::unload_model(ctx, &req)\` |
| \`pages.rs::load_models\` | \`call_block\` + \`codec::decode::<Vec<ModelInfo>>\` | \`wafer_core::clients::llm::list_models(ctx)\` |

\`dispatch_chat\` now returns \`NativeTypedFrameStream<ChatChunk>\` instead of a raw \`OutputStream\`, so \`handle_chat\` / \`handle_chat_stream\` consume typed chunks directly — no per-frame \`codec::decode\` in the consumer. Same shape for \`load_model\`'s SSE producer over \`LoadProgress\`.

Net diff: **+91 / −200 lines** in solobase-core's llm module.

## Behaviour change worth flagging

\`build_chat_call_msg\` + \`build_llm_service_msg\` helpers are deleted. They propagated \`auth.user_id\` / \`auth.user_roles\` into the call_block message, but **neither the \`wafer-run/llm\` block nor any WRAP rule reads them** (verified by grep in \`wafer-run/crates/wafer-core/src/interfaces/llm/\` and \`wafer-run/crates/wafer-core/src/wrap/\`).

The other typed clients (network, storage, vector) don't propagate auth meta either, so this matches the established pattern. If LLM-side observability later needs the user identity, it should land as an explicit field on \`ChatRequest\` rather than implicit meta plumbing.

If you'd rather preserve the propagation as a tracing belt-and-suspenders, push back and I'll add an \`auth_msg: Option<&Message>\` parameter to the typed client.

## Test plan

- [x] \`cargo build -p solobase-core\` against upstream wafer-run main (\`7a9883fb\`) — clean
- [x] \`cargo test -p solobase-core blocks::llm\` — 109 pass, 0 fail
- [x] \`cargo clippy -p solobase-core --all-targets\` — no new warnings on \`blocks/llm/\` files (4 \`manual_let_else\` lints my edits introduced were converted to \`let-else\` in the same commit)
- [ ] End-to-end smoke test in browser: chat completion, list models, model status, load/unload — not run; recommend manual verify before merge if any of these flows changed in the last few weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)