### PR TITLE
ci: trigger on .playwright-mcp/** changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - 'Cargo.lock'
       - 'scripts/**'
       - '.github/workflows/ci.yml'
+      # Visual-baseline PNGs live outside crates/. Without this, baseline-only
+      # commits (e.g. from regen-visual-baselines.yml) skip CI and the PR
+      # shows "no checks" — blocking merge.
+      - '.playwright-mcp/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/**` to `ci.yml`'s `pull_request: paths:` filter so baseline-only commits trigger CI.
- Without this, the auto-commits from the new `regen-visual-baselines.yml` workflow skip CI entirely — the PR shows "no checks" and merge is blocked. (Currently affects PR #75 and PR #77.)

## Test plan
- [ ] Land this PR.
- [ ] Rebase PR #75 and PR #77 onto new main → push → CI re-runs E2E with the CI-canonical baselines from the regen workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)