### PR TITLE
feat(cloudflare): env-driven CloudflareConfig for clone-and-deploy

### DIFF
--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -78,7 +78,7 @@ pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result
 
 pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
     let cfg = env::load(repo_root)?;
-    let _ = env::require_deploy_env(&cfg)?; // validates account_id + CLOUDFLARE_API_TOKEN
+    let _ = env::require_api_token()?; // account_id already validated by load()
 
     build(repo_root, release).await?;
 

--- a/crates/solobase/src/cli/helpers/cloudflare/env.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/env.rs
@@ -1,20 +1,53 @@
-//! Resolve the [cloudflare] section from solobase.toml + env vars.
+//! Resolve the `[cloudflare]` section from solobase.toml + env vars.
+//!
+//! Resolution rule for env-overlayable fields: **env > toml > error**.
+//! That makes clone-and-deploy work: a fresh checkout has no deployer
+//! identifiers committed, and a `.env` supplies them at deploy time.
+//!
+//! Bindings (`d1.binding`, `r2.binding`) stay toml-only because they're
+//! code contracts — the worker reads `env.DB` / `env.STORAGE` by exact
+//! name, so changing one without changing the other breaks the worker.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 
-use super::wrangler::CloudflareConfig;
+use super::wrangler::{CloudflareConfig, D1Config, R2Config};
+
+/// Toml-shaped, pre-resolution. Every field that can be supplied via env
+/// is `Option<String>`.
+#[derive(Debug, Deserialize)]
+pub struct RawCloudflareConfig {
+    pub account_id: Option<String>,
+    pub worker_name: Option<String>,
+    pub compatibility_date: Option<String>,
+    pub d1: RawD1Config,
+    pub r2: RawR2Config,
+    pub wrangler_overrides_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawD1Config {
+    pub binding: String,
+    pub database_name: Option<String>,
+    pub database_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawR2Config {
+    pub binding: String,
+    pub bucket_name: Option<String>,
+}
 
 #[derive(Debug, Deserialize)]
 struct SolobaseTomlPartial {
-    cloudflare: Option<CloudflareConfig>,
+    cloudflare: Option<RawCloudflareConfig>,
 }
 
-/// Load `[cloudflare]` from `<repo_root>/solobase.toml`. Errors with a
-/// clear message if the file or section is missing.
-pub fn load(repo_root: &Path) -> Result<CloudflareConfig> {
+/// Parse `<repo_root>/solobase.toml` and return the unresolved `[cloudflare]`
+/// section. Errors with a clear message if the file or section is missing.
+pub fn parse(repo_root: &Path) -> Result<RawCloudflareConfig> {
     let path = repo_root.join("solobase.toml");
     let raw = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
     let parsed: SolobaseTomlPartial =
@@ -28,23 +61,90 @@ pub fn load(repo_root: &Path) -> Result<CloudflareConfig> {
     })
 }
 
-/// Validate that environment variables required for `deploy` are set.
-/// Returns the (account_id, api_token) pair on success.
-pub fn require_deploy_env(cfg: &CloudflareConfig) -> Result<(String, String)> {
-    let account_id = cfg
-        .account_id
-        .clone()
-        .or_else(|| std::env::var("CLOUDFLARE_ACCOUNT_ID").ok())
-        .ok_or_else(|| {
-            anyhow!(
-                "missing account_id: set [cloudflare.account_id] in solobase.toml \
-                 or env CLOUDFLARE_ACCOUNT_ID"
-            )
-        })?;
-    let api_token = std::env::var("CLOUDFLARE_API_TOKEN").map_err(|_| {
+impl RawCloudflareConfig {
+    /// Apply env-var overlay and validate every required field is present.
+    /// `env` is a getter so callers (and tests) can inject any source.
+    pub fn resolve<F: Fn(&str) -> Option<String>>(self, env: F) -> Result<CloudflareConfig> {
+        let account_id = pick(
+            env("CLOUDFLARE_ACCOUNT_ID"),
+            self.account_id,
+            "account_id",
+            "CLOUDFLARE_ACCOUNT_ID",
+        )?;
+        let worker_name = pick(
+            env("SOLOBASE_CLOUDFLARE_WORKER_NAME"),
+            self.worker_name,
+            "worker_name",
+            "SOLOBASE_CLOUDFLARE_WORKER_NAME",
+        )?;
+        let compatibility_date = pick(
+            env("SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE"),
+            self.compatibility_date,
+            "compatibility_date",
+            "SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE",
+        )?;
+        let d1_database_name = pick(
+            env("SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME"),
+            self.d1.database_name,
+            "d1.database_name",
+            "SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME",
+        )?;
+        let d1_database_id = pick(
+            env("SOLOBASE_CLOUDFLARE_D1_DATABASE_ID"),
+            self.d1.database_id,
+            "d1.database_id",
+            "SOLOBASE_CLOUDFLARE_D1_DATABASE_ID",
+        )?;
+        let r2_bucket_name = pick(
+            env("SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME"),
+            self.r2.bucket_name,
+            "r2.bucket_name",
+            "SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME",
+        )?;
+        Ok(CloudflareConfig {
+            account_id,
+            worker_name,
+            compatibility_date,
+            d1: D1Config {
+                binding: self.d1.binding,
+                database_name: d1_database_name,
+                database_id: d1_database_id,
+            },
+            r2: R2Config {
+                binding: self.r2.binding,
+                bucket_name: r2_bucket_name,
+            },
+            wrangler_overrides_path: self.wrangler_overrides_path,
+        })
+    }
+}
+
+fn pick(
+    env_val: Option<String>,
+    toml_val: Option<String>,
+    toml_key: &str,
+    env_var: &str,
+) -> Result<String> {
+    env_val.or(toml_val).ok_or_else(|| {
+        anyhow!(
+            "missing required cloudflare config: set [cloudflare.{toml_key}] in solobase.toml \
+             or env {env_var}"
+        )
+    })
+}
+
+/// Production entry point — parse + resolve via `std::env::var`.
+pub fn load(repo_root: &Path) -> Result<CloudflareConfig> {
+    let raw = parse(repo_root)?;
+    raw.resolve(|name| std::env::var(name).ok())
+}
+
+/// Validate that `CLOUDFLARE_API_TOKEN` is set. Required for `deploy`,
+/// not for `build`/`serve`.
+pub fn require_api_token() -> Result<String> {
+    std::env::var("CLOUDFLARE_API_TOKEN").map_err(|_| {
         anyhow!(
             "missing env CLOUDFLARE_API_TOKEN — required for `solobase deploy --target cloudflare`"
         )
-    })?;
-    Ok((account_id, api_token))
+    })
 }

--- a/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
@@ -1,12 +1,16 @@
 //! wrangler.toml generation + override merging.
+//!
+//! [`CloudflareConfig`] is the *resolved* shape consumed by [`generate`].
+//! Parsing solobase.toml + applying env-var overlays lives in
+//! [`super::env`], which produces this type.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct CloudflareConfig {
+    pub account_id: String,
     pub worker_name: String,
     pub compatibility_date: String,
     pub d1: D1Config,
@@ -14,18 +18,16 @@ pub struct CloudflareConfig {
     /// Path (relative to consumer repo root) to a TOML file whose contents
     /// are deep-merged over the generated defaults. None means "no overrides."
     pub wrangler_overrides_path: Option<PathBuf>,
-    /// Optional; falls back to env CLOUDFLARE_ACCOUNT_ID at deploy time.
-    pub account_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct D1Config {
     pub binding: String,
     pub database_name: String,
     pub database_id: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct R2Config {
     pub binding: String,
     pub bucket_name: String,

--- a/crates/solobase/tests/helpers_cloudflare_env.rs
+++ b/crates/solobase/tests/helpers_cloudflare_env.rs
@@ -1,10 +1,13 @@
-use std::fs;
+use std::{collections::HashMap, fs};
 
-use solobase::cli::helpers::cloudflare::env::{load, require_deploy_env};
+use solobase::cli::helpers::cloudflare::env::{
+    load, parse, require_api_token, RawCloudflareConfig,
+};
 use tempfile::tempdir;
 
-const VALID_TOML: &str = r#"
+const FULL_TOML: &str = r#"
 [cloudflare]
+account_id = "acct-toml"
 worker_name = "x"
 compatibility_date = "2026-05-01"
 
@@ -18,20 +21,140 @@ binding = "STORAGE"
 bucket_name = "x-bucket"
 "#;
 
-#[test]
-fn load_returns_cfg_when_section_present() {
+const BINDINGS_ONLY_TOML: &str = r#"
+[cloudflare]
+
+[cloudflare.d1]
+binding = "DB"
+
+[cloudflare.r2]
+binding = "STORAGE"
+"#;
+
+fn fake_env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    let map: HashMap<String, String> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    move |name: &str| map.get(name).cloned()
+}
+
+fn parse_str(s: &str) -> RawCloudflareConfig {
     let tmp = tempdir().unwrap();
-    fs::write(tmp.path().join("solobase.toml"), VALID_TOML).unwrap();
-    let cfg = load(tmp.path()).unwrap();
-    assert_eq!(cfg.worker_name, "x");
-    assert_eq!(cfg.d1.binding, "DB");
+    fs::write(tmp.path().join("solobase.toml"), s).unwrap();
+    parse(tmp.path()).unwrap()
 }
 
 #[test]
-fn load_errors_when_section_missing() {
+fn parse_returns_raw_with_optionals_when_only_bindings_present() {
+    let raw = parse_str(BINDINGS_ONLY_TOML);
+    assert_eq!(raw.d1.binding, "DB");
+    assert_eq!(raw.r2.binding, "STORAGE");
+    assert!(raw.account_id.is_none());
+    assert!(raw.worker_name.is_none());
+    assert!(raw.compatibility_date.is_none());
+    assert!(raw.d1.database_name.is_none());
+    assert!(raw.d1.database_id.is_none());
+    assert!(raw.r2.bucket_name.is_none());
+}
+
+#[test]
+fn resolve_uses_env_when_toml_missing_values() {
+    let raw = parse_str(BINDINGS_ONLY_TOML);
+    let env = fake_env(&[
+        ("CLOUDFLARE_ACCOUNT_ID", "acct-env"),
+        ("SOLOBASE_CLOUDFLARE_WORKER_NAME", "site-env"),
+        ("SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE", "2030-01-01"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME", "db-env"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_ID", "id-env"),
+        ("SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME", "bucket-env"),
+    ]);
+    let cfg = raw.resolve(env).unwrap();
+    assert_eq!(cfg.account_id, "acct-env");
+    assert_eq!(cfg.worker_name, "site-env");
+    assert_eq!(cfg.compatibility_date, "2030-01-01");
+    assert_eq!(cfg.d1.binding, "DB");
+    assert_eq!(cfg.d1.database_name, "db-env");
+    assert_eq!(cfg.d1.database_id, "id-env");
+    assert_eq!(cfg.r2.binding, "STORAGE");
+    assert_eq!(cfg.r2.bucket_name, "bucket-env");
+}
+
+#[test]
+fn resolve_uses_toml_when_env_empty() {
+    let raw = parse_str(FULL_TOML);
+    let cfg = raw.resolve(fake_env(&[])).unwrap();
+    assert_eq!(cfg.account_id, "acct-toml");
+    assert_eq!(cfg.worker_name, "x");
+    assert_eq!(cfg.compatibility_date, "2026-05-01");
+    assert_eq!(cfg.d1.database_name, "x");
+    assert_eq!(cfg.d1.database_id, "00000000-0000-0000-0000-000000000000");
+    assert_eq!(cfg.r2.bucket_name, "x-bucket");
+}
+
+#[test]
+fn resolve_env_overrides_toml() {
+    let raw = parse_str(FULL_TOML);
+    let env = fake_env(&[
+        ("CLOUDFLARE_ACCOUNT_ID", "acct-env-wins"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_ID", "id-env-wins"),
+        ("SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME", "bucket-env-wins"),
+    ]);
+    let cfg = raw.resolve(env).unwrap();
+    assert_eq!(cfg.account_id, "acct-env-wins");
+    assert_eq!(cfg.d1.database_id, "id-env-wins");
+    assert_eq!(cfg.r2.bucket_name, "bucket-env-wins");
+    // un-overridden fields stay from toml
+    assert_eq!(cfg.worker_name, "x");
+    assert_eq!(cfg.d1.database_name, "x");
+}
+
+#[test]
+fn resolve_errors_naming_env_var_for_missing_database_id() {
+    let raw = parse_str(BINDINGS_ONLY_TOML);
+    // Provide everything except D1 database_id
+    let env = fake_env(&[
+        ("CLOUDFLARE_ACCOUNT_ID", "a"),
+        ("SOLOBASE_CLOUDFLARE_WORKER_NAME", "w"),
+        ("SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE", "2026-05-01"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME", "n"),
+        ("SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME", "b"),
+    ]);
+    let err = raw.resolve(env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("SOLOBASE_CLOUDFLARE_D1_DATABASE_ID"),
+        "error should name the missing env var. got: {msg}"
+    );
+    assert!(
+        msg.contains("database_id"),
+        "error should also reference the toml key. got: {msg}"
+    );
+}
+
+#[test]
+fn resolve_errors_naming_env_var_for_missing_account_id() {
+    let raw = parse_str(BINDINGS_ONLY_TOML);
+    let env = fake_env(&[
+        ("SOLOBASE_CLOUDFLARE_WORKER_NAME", "w"),
+        ("SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE", "2026-05-01"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME", "n"),
+        ("SOLOBASE_CLOUDFLARE_D1_DATABASE_ID", "i"),
+        ("SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME", "b"),
+    ]);
+    let err = raw.resolve(env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("CLOUDFLARE_ACCOUNT_ID"),
+        "error should name CLOUDFLARE_ACCOUNT_ID. got: {msg}"
+    );
+}
+
+#[test]
+fn parse_errors_when_section_missing() {
     let tmp = tempdir().unwrap();
     fs::write(tmp.path().join("solobase.toml"), "# empty\n").unwrap();
-    let err = load(tmp.path()).unwrap_err();
+    let err = parse(tmp.path()).unwrap_err();
     assert!(
         err.to_string().contains("missing a [cloudflare] section"),
         "expected 'missing a [cloudflare] section' in: {err}"
@@ -39,16 +162,26 @@ fn load_errors_when_section_missing() {
 }
 
 #[test]
-fn require_deploy_env_errors_on_missing_token() {
+fn load_resolves_via_real_env() {
+    // Integration: writes a fully-populated toml and expects load() to
+    // succeed because the toml itself supplies all required values
+    // (independent of process env state).
     let tmp = tempdir().unwrap();
-    fs::write(tmp.path().join("solobase.toml"), VALID_TOML).unwrap();
-    let mut cfg = load(tmp.path()).unwrap();
-    cfg.account_id = Some("acct123".into());
-    // SAFETY: tests within this binary may be parallel; this could flake
-    // if another test sets CLOUDFLARE_API_TOKEN concurrently. Acceptable
-    // for v1; use `temp_env` crate later if it flakes.
-    std::env::remove_var("CLOUDFLARE_API_TOKEN");
-    let err = require_deploy_env(&cfg).unwrap_err();
+    fs::write(tmp.path().join("solobase.toml"), FULL_TOML).unwrap();
+    let cfg = load(tmp.path()).unwrap();
+    assert_eq!(cfg.d1.binding, "DB");
+    assert_eq!(cfg.r2.bucket_name, "x-bucket");
+}
+
+#[test]
+fn require_api_token_errors_when_unset() {
+    // SAFETY: tests in this binary may be parallel; this could flake if
+    // another test sets CLOUDFLARE_API_TOKEN concurrently.
+    // SAFETY: env mutation is unsafe on Rust 2024 edition; test-only.
+    unsafe {
+        std::env::remove_var("CLOUDFLARE_API_TOKEN");
+    }
+    let err = require_api_token().unwrap_err();
     assert!(
         err.to_string().contains("CLOUDFLARE_API_TOKEN"),
         "expected 'CLOUDFLARE_API_TOKEN' in: {err}"

--- a/crates/solobase/tests/helpers_cloudflare_wrangler.rs
+++ b/crates/solobase/tests/helpers_cloudflare_wrangler.rs
@@ -7,6 +7,7 @@ use tempfile::tempdir;
 
 fn sample_cfg() -> CloudflareConfig {
     CloudflareConfig {
+        account_id: "test-acct".into(),
         worker_name: "wafer-site".into(),
         compatibility_date: "2026-05-01".into(),
         d1: D1Config {
@@ -19,7 +20,6 @@ fn sample_cfg() -> CloudflareConfig {
             bucket_name: "wafer-site-assets".into(),
         },
         wrangler_overrides_path: None,
-        account_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Make every deployer-specific Cloudflare value resolvable from env vars so a fresh clone can deploy without committing identifiers
- Resolution rule: **env > toml > error**, with the error naming the missing env var
- Split `CloudflareConfig` into a raw (Deserialize, Optionals) shape and a resolved (all-required) shape so `wrangler::generate` keeps a clean precondition

New `SOLOBASE_CLOUDFLARE_*` env vars (per infra-config naming convention from solobase CLAUDE.md):
- `SOLOBASE_CLOUDFLARE_WORKER_NAME`
- `SOLOBASE_CLOUDFLARE_COMPATIBILITY_DATE`
- `SOLOBASE_CLOUDFLARE_D1_DATABASE_NAME`
- `SOLOBASE_CLOUDFLARE_D1_DATABASE_ID`
- `SOLOBASE_CLOUDFLARE_R2_BUCKET_NAME`

Existing wrangler-native names (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`) are kept as-is — not shadowed with a `SOLOBASE_*` alias.

Bindings (`d1.binding`, `r2.binding`) stay toml-only — they're code contracts the worker reads by exact name (`env.DB`, `env.STORAGE`), so changing one without changing the other breaks the worker.

`require_deploy_env` → `require_api_token`. Account-id validation now happens at `load()` time (it's required regardless of build vs deploy), and the deploy-only token check is the remaining gate.

## Test plan

- [x] `cargo test -p solobase --test helpers_cloudflare_env --test helpers_cloudflare_wrangler --test helpers_cloudflare_assets` (15 pass — 9 new env tests + 3 wrangler + 3 assets)
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` (all green)
- [x] `cargo clippy -p solobase --all-targets` (clean for changed files)
- [x] `cargo +nightly fmt --all -- --check`
- [ ] Consumer (wafer-site) PR strips deployer values from `solobase.toml` and adds a `.env.example` — see follow-up PR in suppers-ai/site.

## Follow-ups (out of scope)

- Wrangler subprocesses don't inherit `cfg.account_id` if the user provided it via toml only — wrangler reads `CLOUDFLARE_ACCOUNT_ID` from process env. Pre-existing behavior, not regressed by this PR. Fix would thread `account_id` through `cf_deploy::*` helpers via `Command::env`.
- Worker-build feature flag (`--features target-cloudflare`) is hardcoded in `wrangler::base_toml`. Per-consumer customization belongs in another change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)