### PR TITLE
test(test_support): WRAP-enforcement scaffold + sessions/security regression + raw_sql follow-up to PR #77

### DIFF
--- a/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
@@ -135,18 +135,35 @@ pub async fn find_by_user_provider(
 
 /// Return all OAuth provider links owned by `user_id`, ordered by
 /// `linked_at` ASC for stable rendering on the security page.
+///
+/// Uses the typed `db::list` client (not raw SQL) because this is the
+/// only entry point in this module called cross-block — userportal's
+/// `/b/userportal/security` page reads it. Raw SQL is admin-only under
+/// WRAP, so the cross-block call must go through the namespaced path.
+/// The other lookups in this module (`find_by_provider_ref`,
+/// `find_by_user_provider`) remain on raw SQL because they're called
+/// only by auth itself (the resource owner — own-resource access is
+/// always permitted, regardless of typed-vs-raw).
 pub async fn list_for_user(
     ctx: &dyn Context,
     user_id: &str,
 ) -> Result<Vec<ProviderLink>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE user_id = ? ORDER BY linked_at ASC"),
-        &[json!(user_id)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("provider_links list_for_user: {e}")))?;
-    rows.iter().map(|r| row_from_map(&r.data)).collect()
+    let opts = db::ListOptions {
+        filters: vec![db::Filter {
+            field: "user_id".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(user_id),
+        }],
+        sort: vec![db::SortField {
+            field: "linked_at".into(),
+            desc: false,
+        }],
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("provider_links list_for_user: {e}")))?;
+    res.records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/userportal/pages/security.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/security.rs
@@ -287,4 +287,69 @@ mod tests {
         assert!(html.contains("github"));
         assert!(html.contains("alice"));
     }
+
+    // --- WRAP regression: catches a future removal of the userportal
+    // grant on `auth::repo::provider_links::TABLE`. Without it, the
+    // /b/userportal/security page silently renders "No external accounts
+    // linked" even after a real OAuth link. PR #77 added the grant.
+
+    #[tokio::test]
+    async fn wrap_denies_provider_links_list_without_grant() {
+        // Seed before opting in to WRAP — `seed_user` uses raw SQL.
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        upsert(
+            &ctx,
+            NewLink {
+                provider: "github",
+                provider_ref: "gh-1",
+                user_id: "user-a",
+                provider_login: "alice",
+                access_token: "tok",
+            },
+        )
+        .await
+        .unwrap();
+
+        let ctx = ctx.with_wrap("suppers-ai/userportal", Vec::new(), "suppers-ai/admin");
+
+        use crate::blocks::auth::repo::provider_links;
+        let err = provider_links::list_for_user(&ctx, "user-a")
+            .await
+            .expect_err("WRAP must deny provider_links list_for_user without grant");
+        assert!(
+            format!("{err:?}").contains("WRAP"),
+            "error must mention WRAP, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrap_allows_provider_links_list_with_auth_block_grants() {
+        use crate::blocks::auth::AuthBlock;
+        use wafer_run::block::Block;
+
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        upsert(
+            &ctx,
+            NewLink {
+                provider: "github",
+                provider_ref: "gh-1",
+                user_id: "user-a",
+                provider_login: "alice",
+                access_token: "tok",
+            },
+        )
+        .await
+        .unwrap();
+
+        let auth_grants = AuthBlock::default().info().grants;
+        let ctx = ctx.with_wrap("suppers-ai/userportal", auth_grants, "suppers-ai/admin");
+
+        use crate::blocks::auth::repo::provider_links;
+        let links = provider_links::list_for_user(&ctx, "user-a")
+            .await
+            .expect("auth's production grants must cover userportal provider_links read");
+        assert_eq!(links.len(), 1);
+    }
 }

--- a/crates/solobase-core/src/blocks/userportal/pages/security.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/security.rs
@@ -325,8 +325,9 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_allows_provider_links_list_with_auth_block_grants() {
-        use crate::blocks::auth::AuthBlock;
         use wafer_run::block::Block;
+
+        use crate::blocks::auth::AuthBlock;
 
         let ctx = TestContext::with_auth().await;
         seed_user(&ctx, "user-a").await;

--- a/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
@@ -441,8 +441,9 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_allows_sessions_list_with_auth_block_grants() {
-        use crate::blocks::auth::AuthBlock;
         use wafer_run::block::Block;
+
+        use crate::blocks::auth::AuthBlock;
 
         let ctx = TestContext::with_auth().await;
         seed_user(&ctx, "user-a").await;
@@ -459,8 +460,9 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_allows_sessions_delete_with_auth_block_grants() {
-        use crate::blocks::auth::AuthBlock;
         use wafer_run::block::Block;
+
+        use crate::blocks::auth::AuthBlock;
 
         let ctx = TestContext::with_auth().await;
         seed_user(&ctx, "user-a").await;

--- a/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
@@ -412,4 +412,66 @@ mod tests {
             "no badge expected when cookie hash doesn't match any row"
         );
     }
+
+    // --- WRAP regression: catches a future removal of the userportal
+    // grant on `auth::repo::sessions::TABLE`. Without it, /b/userportal/
+    // sessions silently returns the empty state for every authenticated
+    // user. PR #77 added the grant; these tests fail closed if it's removed.
+
+    #[tokio::test]
+    async fn wrap_denies_sessions_list_without_grant() {
+        // Seed BEFORE enabling WRAP — `seed_user` uses raw SQL, which WRAP
+        // restricts to the admin block. In production, rows are seeded by
+        // owner/admin paths; userportal only reads them. The test mirrors
+        // that lifecycle.
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
+
+        let ctx = ctx.with_wrap("suppers-ai/userportal", Vec::new(), "suppers-ai/admin");
+
+        let err = sessions::list_for_user(&ctx, "user-a")
+            .await
+            .expect_err("WRAP must deny list_for_user without grant");
+        assert!(
+            format!("{err:?}").contains("WRAP"),
+            "error must mention WRAP, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrap_allows_sessions_list_with_auth_block_grants() {
+        use crate::blocks::auth::AuthBlock;
+        use wafer_run::block::Block;
+
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
+
+        let auth_grants = AuthBlock::default().info().grants;
+        let ctx = ctx.with_wrap("suppers-ai/userportal", auth_grants, "suppers-ai/admin");
+
+        let rows = sessions::list_for_user(&ctx, "user-a")
+            .await
+            .expect("auth's production grants must cover userportal sessions read");
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn wrap_allows_sessions_delete_with_auth_block_grants() {
+        use crate::blocks::auth::AuthBlock;
+        use wafer_run::block::Block;
+
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
+
+        let auth_grants = AuthBlock::default().info().grants;
+        let ctx = ctx.with_wrap("suppers-ai/userportal", auth_grants, "suppers-ai/admin");
+
+        let removed = sessions::delete_for_user(&ctx, "user-a", &[0x01u8; 32])
+            .await
+            .expect("auth's production grants must cover userportal sessions write");
+        assert_eq!(removed, 1);
+    }
 }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -17,7 +17,7 @@ use wafer_run::{
     block::Block,
     context::Context,
     streams::output::{BufferedResponse, TerminalNotResponse},
-    types::{ErrorCode, Message, WaferError},
+    types::{ErrorCode, Message, ResourceGrant, WaferError},
     InputStream, OutputStream,
 };
 
@@ -31,6 +31,13 @@ pub struct TestContext {
     pub config: Arc<Mutex<HashMap<String, String>>>,
     /// Placeholder for dynamically registered blocks — populated by Task 6.
     pub blocks: Arc<Mutex<HashMap<String, Arc<dyn Block>>>>,
+    /// WRAP-enforcement caller identity. `None` = WRAP checks skipped (the
+    /// default — keeps existing tests untouched). Set via [`with_wrap`].
+    caller_id: Option<String>,
+    /// Grants visible to the WRAP check. Empty unless [`with_wrap`] populates.
+    wrap_grants: Vec<ResourceGrant>,
+    /// Admin block id for the WRAP check (`""` = no admin override).
+    wrap_admin_block: String,
 }
 
 impl TestContext {
@@ -48,7 +55,36 @@ impl TestContext {
             database_block,
             config: Arc::new(Mutex::new(HashMap::new())),
             blocks: Arc::new(Mutex::new(HashMap::new())),
+            caller_id: None,
+            wrap_grants: Vec::new(),
+            wrap_admin_block: String::new(),
         }
+    }
+
+    /// Opt the test into WRAP enforcement on `call_block`.
+    ///
+    /// Until called, `call_block` ignores `wrap.resource` meta — this matches
+    /// pre-existing test behaviour. After calling, the same WRAP rules the
+    /// production runtime applies (own-resource, admin override, grant match)
+    /// gate every `call_block` invocation that carries `wrap.resource` meta.
+    /// Typed clients (`wafer_core::clients::database::*`, etc.) set this
+    /// meta automatically, so this is what makes a test exercise grants.
+    ///
+    /// `caller_id` is the block id the test is acting as — typically the
+    /// block whose handler is under test. `grants` is the list visible to
+    /// the WRAP check; tests that want to exercise a real block's grants
+    /// should source them from `<Block>::default().info().grants` rather
+    /// than re-listing grant literals.
+    pub fn with_wrap(
+        mut self,
+        caller_id: &str,
+        grants: Vec<ResourceGrant>,
+        admin_block: &str,
+    ) -> Self {
+        self.caller_id = Some(caller_id.to_string());
+        self.wrap_grants = grants;
+        self.wrap_admin_block = admin_block.to_string();
+        self
     }
 
     /// Build a `TestContext` with the auth-block migrations applied.
@@ -82,6 +118,33 @@ impl TestContext {
 #[async_trait::async_trait]
 impl Context for TestContext {
     async fn call_block(&self, name: &str, msg: Message, input: InputStream) -> OutputStream {
+        // WRAP enforcement (only when the test opted in via `with_wrap`).
+        // Mirrors `RuntimeContext::call_block` in wafer-run/crates/wafer-run/
+        // src/context.rs:138-163 — same `check_access` callsite shape so
+        // tests see identical permission behaviour to production.
+        if let Some(ref caller) = self.caller_id {
+            let resource = msg.get_meta(wafer_block::meta::META_WRAP_RESOURCE);
+            if !resource.is_empty() {
+                let is_write = msg.get_meta(wafer_block::meta::META_WRAP_ACCESS) == "write";
+                let rt_str = msg.get_meta(wafer_block::meta::META_WRAP_RESOURCE_TYPE);
+                let rt = if rt_str.is_empty() {
+                    None
+                } else {
+                    wafer_run::types::ResourceType::parse(rt_str)
+                };
+                if let Err(e) = wafer_block::wrap::check_access(
+                    Some(caller.as_str()),
+                    resource,
+                    is_write,
+                    rt.as_ref(),
+                    &self.wrap_grants,
+                    &self.wrap_admin_block,
+                ) {
+                    return OutputStream::error(e);
+                }
+            }
+        }
+
         match name {
             "wafer-run/database" => self.database_block.handle(self, msg, input).await,
             other => {
@@ -406,5 +469,62 @@ mod tests {
         let resp = ctx.call_block("test/echo", msg, InputStream::empty()).await;
         let body = output_html(resp).await;
         assert_eq!(body, "/echo-me");
+    }
+
+    #[tokio::test]
+    async fn with_wrap_denies_unowned_resource_without_grant() {
+        // Caller "block-x" tries to read auth-owned table; no grants → denied.
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("test/block-x", Vec::new(), "suppers-ai/admin");
+
+        let result = db::list(
+            &ctx,
+            "suppers_ai__auth__users",
+            &db::ListOptions::default(),
+        )
+        .await;
+
+        let err = result.expect_err("WRAP must deny call without grant");
+        assert!(
+            err.to_string().contains("WRAP"),
+            "error must mention WRAP, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_wrap_allows_call_when_grant_matches() {
+        let grants = vec![ResourceGrant::read(
+            "test/block-x",
+            "suppers_ai__auth__users",
+        )];
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("test/block-x", grants, "suppers-ai/admin");
+
+        // Empty users table — listing must succeed (zero rows is success).
+        let res = db::list(
+            &ctx,
+            "suppers_ai__auth__users",
+            &db::ListOptions::default(),
+        )
+        .await
+        .expect("WRAP must allow listing with matching grant");
+        assert_eq!(res.records.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn without_with_wrap_grants_are_unchecked() {
+        // Default TestContext (no `with_wrap`) keeps WRAP-bypassing legacy
+        // behaviour so existing tests aren't disturbed.
+        let ctx = TestContext::with_auth().await;
+        let res = db::list(
+            &ctx,
+            "suppers_ai__auth__users",
+            &db::ListOptions::default(),
+        )
+        .await
+        .expect("call must succeed without with_wrap");
+        assert_eq!(res.records.len(), 0);
     }
 }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -474,16 +474,13 @@ mod tests {
     #[tokio::test]
     async fn with_wrap_denies_unowned_resource_without_grant() {
         // Caller "block-x" tries to read auth-owned table; no grants → denied.
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("test/block-x", Vec::new(), "suppers-ai/admin");
+        let ctx = TestContext::with_auth().await.with_wrap(
+            "test/block-x",
+            Vec::new(),
+            "suppers-ai/admin",
+        );
 
-        let result = db::list(
-            &ctx,
-            "suppers_ai__auth__users",
-            &db::ListOptions::default(),
-        )
-        .await;
+        let result = db::list(&ctx, "suppers_ai__auth__users", &db::ListOptions::default()).await;
 
         let err = result.expect_err("WRAP must deny call without grant");
         assert!(
@@ -498,18 +495,15 @@ mod tests {
             "test/block-x",
             "suppers_ai__auth__users",
         )];
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("test/block-x", grants, "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("test/block-x", grants, "suppers-ai/admin");
 
         // Empty users table — listing must succeed (zero rows is success).
-        let res = db::list(
-            &ctx,
-            "suppers_ai__auth__users",
-            &db::ListOptions::default(),
-        )
-        .await
-        .expect("WRAP must allow listing with matching grant");
+        let res = db::list(&ctx, "suppers_ai__auth__users", &db::ListOptions::default())
+            .await
+            .expect("WRAP must allow listing with matching grant");
         assert_eq!(res.records.len(), 0);
     }
 
@@ -518,13 +512,9 @@ mod tests {
         // Default TestContext (no `with_wrap`) keeps WRAP-bypassing legacy
         // behaviour so existing tests aren't disturbed.
         let ctx = TestContext::with_auth().await;
-        let res = db::list(
-            &ctx,
-            "suppers_ai__auth__users",
-            &db::ListOptions::default(),
-        )
-        .await
-        .expect("call must succeed without with_wrap");
+        let res = db::list(&ctx, "suppers_ai__auth__users", &db::ListOptions::default())
+            .await
+            .expect("call must succeed without with_wrap");
         assert_eq!(res.records.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Builds on PR #77's grant fix with the regression mechanism that would have caught the gap at PR-time, and surfaces a follow-up bug PR #77 didn't address.

**1. `TestContext::with_wrap(caller_id, grants, admin_block)` builder.** The existing `solobase_core::test_support::TestContext` runs handlers without WRAP enforcement, which is why every Phase 4/5 cross-block typed-client gap shipped to main with green CI. The new `with_wrap` opt-in mirrors `RuntimeContext::call_block`'s WRAP check (same `wafer_block::wrap::check_access` callsite shape) so tests can exercise grants the same way production does. Default behaviour is unchanged — existing tests don't see WRAP unless they call `with_wrap`.

**2. WRAP regression tests for sessions + security pages.** Three tests on `auth::repo::sessions::list_for_user` / `delete_for_user` and two on `auth::repo::provider_links::list_for_user` that:
- Confirm WRAP denies the call when the userportal grant is absent.
- Confirm `AuthBlock::default().info().grants` (the production grants) cover the call. If a future change removes the userportal grant from `auth/mod.rs`, these tests fail closed.

Both `wrap_allows_*_with_auth_block_grants` tests are the actual regression guard — they don't construct grants in the test, they pull them out of the AuthBlock's `BlockInfo`, so the test couples directly to the production declaration.

**3. `provider_links::list_for_user` raw-SQL → typed-`db::list` fix.** Surfacing while writing the security regression test. PR #77 added the `read("suppers-ai/userportal", provider_links::TABLE)` grant on auth, but the underlying repo function uses `db::query_raw`, which under WRAP routes through the `__raw_sql__` resource — admin-only. The grant alone wasn't sufficient; the cross-block call would still have been denied at runtime on a real OAuth-linked account. Conversion to `db::list` with a `Filter`/`SortField` keeps the same return shape and ordering. The other lookups in `provider_links.rs` (`find_by_provider_ref`, `find_by_user_provider`) stay on raw SQL because they're called only by auth itself — own-resource access bypasses WRAP regardless of typed vs. raw.

## Why TestContext defaults to WRAP-bypass

Adding `with_wrap` was tempted to be the new default, but flipping it would break every existing test that uses `db::exec_raw` for fixture seeding (raw SQL is admin-only, and most tests don't act as admin). The opt-in shape preserves the cheap-test ergonomic while making cross-block coverage tests possible. Each new cross-block typed-client call in a future PR should add a `with_wrap` test using `<CallingBlock>::default().info().grants` to validate coverage.

## Test plan
- [x] `cargo test -p solobase-core` — 551 unit + 51 doc + 7 integration green (was 543 unit; 8 added: 3 in test_support, 3 in sessions, 2 in security)
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] My touched files are clippy-clean (workspace-wide `clippy --all-targets -- -D warnings` has 163 pre-existing lint hits unrelated to this PR; I checked the count is unchanged from origin/main)
- [ ] Manual smoke: log in as a normal user, link a GitHub OAuth provider via the OAuth flow, navigate to `/b/userportal/security`, confirm the linked-account row renders without a 500 (deferred — needs a real OAuth-configured test instance)

## Out of scope

- **Tier 1 WRAP coverage** (raw `ctx.call_block_buffered` HTTP-style cross-block calls — `auth → /b/userportal/internal/list-buttons`, `llm → /b/messages/api/contexts/{id}/entries`) bypass WRAP entirely today because they don't set `wrap.resource` meta. That's a design question (should HTTP RPC-style calls be in WRAP scope?) that wants its own spec, not a fix here.
- **Other typed-client gaps.** The Tier 2 sweep across Phase 4/5 surfaces (vector, files, chat, admin storage) found no further gaps beyond the userportal/auth pair PR #77 fixed. Re-run the audit when new cross-block typed-client calls land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)