### PR TITLE
fix(core): gate reqwest/stream behind `llm` for wasm builds

### DIFF
--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -22,7 +22,12 @@ wasm = ["wafer-run/wasm"]
 # futures that are not Send on wasm32-unknown-unknown. Browser LLM
 # support arrives in Phase C via a separate `BrowserLlmService`.
 # Gate the whole block module off so wasm32 builds compile clean.
-llm = ["dep:tokio", "dep:tokio-stream"]
+#
+# `reqwest/stream` is gated here too because it pulls `wasm-streams 0.4`
+# on wasm32, which conflicts with `worker`'s `wasm-streams 0.5` — see
+# the FFI symbol clash in `worker-build`. OAuth providers don't need
+# streaming bodies; only the SSE LLM provider does.
+llm = ["dep:tokio", "dep:tokio-stream", "reqwest/stream"]
 # Native ONNX-backed embedding block (suppers-ai/fastembed) + SQLite
 # vector service. Pulls in wafer-block-fastembed (ONNX Runtime) and
 # enables the `vectors` feature of wafer-block-sqlite (sqlite-vec).
@@ -99,8 +104,10 @@ tokio = { workspace = true, optional = true }
 tokio-stream = { version = "0.1", optional = true }
 # HTTP client used by the OAuth provider implementations (always on) and
 # the LLM provider streaming service (gated behind `llm`). The `stream`
-# feature is required for SSE streaming in the LLM block.
-reqwest = { workspace = true, features = ["stream"] }
+# sub-feature — required for SSE streaming in the LLM block — is added
+# by the `llm` feature, not here, because it pulls `wasm-streams 0.4`
+# on wasm32 which conflicts with `worker`'s `wasm-streams 0.5`.
+reqwest = { workspace = true }
 
 # URL parsing/building for OAuth authorize_url assembly.
 url = "2"


### PR DESCRIPTION
## Summary

`solobase-core` enabled `reqwest/stream` unconditionally. On `wasm32-unknown-unknown` that pulls `wasm-streams 0.4`. The `worker` crate (Cloudflare Workers SDK) pulls `wasm-streams 0.5`. Both define the same `#[wasm_bindgen]` FFI exports (`intounderlyingsink_close`, `intounderlyingsink_write`, `__wbg_intounderlyingbytesource_free`, plus a long tail of `__wbindgen_describe_*` symbols). `worker-build` failed at link time:

```
rust-lld: error: duplicate symbol: intounderlyingsink_close
rust-lld: error: duplicate symbol: __wbg_intounderlyingbytesource_free
...
```

`stream` is needed only by the SSE-streaming LLM provider, which is already gated behind the `llm` feature (wasm-incompatible — pulls tokio's `rt-multi-thread`). OAuth providers (github / google / microsoft) don't use it. Move `reqwest/stream` from the base reqwest dep into the `llm` feature.

## Outcome

| Configuration | reqwest/stream | wasm-streams pulled |
|---|---|---|
| Native default (sqlite + storage-local + llm) | yes (via `llm`) | none on host |
| Native, `--no-default-features --features sqlite,storage-local` | no | none |
| `solobase-cloudflare` (default-features off, no `llm`) | no | only 0.5 (via `worker`) ✓ |

## Verification

- [x] `cargo tree -i wasm-streams --target wasm32-unknown-unknown --no-default-features --features target-cloudflare` from wafer-site returns only `wasm-streams 0.5.0`. Pre-fix: both 0.4.2 + 0.5.0.
- [x] `cargo build --lib --release --target wasm32-unknown-unknown --no-default-features --features target-cloudflare` from wafer-site links clean. Pre-fix: linker error after `worker-build`.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all green.
- [x] `cargo +nightly fmt --all -- --check` clean.

## Why this isn't bundled with #80

#80 is the env-driven config refactor. This is a Cargo.toml dependency-feature fix discovered while validating that PR's end-to-end flow. Independent change, easier to review and revert separately. They can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)