### PR TITLE
ci(regen): detect untracked baselines via git status

### DIFF
--- a/.github/workflows/regen-visual-baselines.yml
+++ b/.github/workflows/regen-visual-baselines.yml
@@ -122,12 +122,15 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          if git diff --quiet -- '.playwright-mcp/'; then
+          # Use `git status --porcelain` instead of `git diff` so this also
+          # picks up untracked baselines — i.e. ones that were deleted in
+          # the PR's prior commit and recreated by --update-snapshots.
+          if [ -z "$(git status --porcelain '.playwright-mcp/')" ]; then
             echo "::notice::No baseline drift — nothing to commit."
             exit 0
           fi
           echo "Baseline diff detected:"
-          git diff --stat -- '.playwright-mcp/'
+          git status --porcelain '.playwright-mcp/'
           git add .playwright-mcp/
           git commit -m "test(ui): regen visual baselines from CI render (auto-committed by regen-visual-baselines.yml against ${TARGET_BRANCH})"
           git push origin "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary
- Fix `regen-visual-baselines.yml` so it detects untracked baselines, not just modified tracked ones.
- Discovered while landing PR #75: when the PR deletes a baseline (because it was wrong) and the regen workflow recreates it via `--update-snapshots`, the file is *untracked* — `git diff` doesn't see it. Workflow reported "No baseline drift" and exited without pushing.

## Test plan
- [ ] Land this.
- [ ] Re-dispatch regen for `ui-phase-5d-storage-baselines` — should auto-commit the 2 missing mobile baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)