### PR TITLE
fix(messages): grant suppers-ai/llm read access to contexts + entries

### DIFF
--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -33,6 +33,7 @@ impl Default for MessagesBlock {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for MessagesBlock {
     fn info(&self) -> BlockInfo {
+        use wafer_block::types::ResourceGrant;
         use wafer_run::{types::CollectionSchema, AuthLevel};
 
         BlockInfo::new(
@@ -43,6 +44,15 @@ impl Block for MessagesBlock {
         )
         .instance_mode(InstanceMode::Singleton)
         .requires(vec!["wafer-run/database".into()])
+        // The chat UI in `suppers-ai/llm` reads thread + entry rows directly
+        // via the typed `db::list` client (see `llm/pages.rs`). Without these
+        // grants the WRAP runtime denies the call and the chat sidebar
+        // renders empty in production. Surfaced by the static
+        // `scripts/audit-wrap-grants.sh` audit (PR #84).
+        .grants(vec![
+            ResourceGrant::read("suppers-ai/llm", service::CONTEXTS_COLLECTION),
+            ResourceGrant::read("suppers-ai/llm", service::ENTRIES_COLLECTION),
+        ])
         .collections(vec![
             CollectionSchema::new(service::CONTEXTS_COLLECTION)
                 .field("type", "string")


### PR DESCRIPTION
## Summary

Closes the 2 real WRAP gaps surfaced by PR #84's audit script. The chat UI in `suppers-ai/llm` (`llm/pages.rs:128`/`:149`) directly reads thread + entry rows via the typed `db::list` client; without these grants the WRAP runtime denies the call and the chat sidebar renders empty in production.

```rust
.grants(vec![
    ResourceGrant::read("suppers-ai/llm", service::CONTEXTS_COLLECTION),
    ResourceGrant::read("suppers-ai/llm", service::ENTRIES_COLLECTION),
])
```

## Why this wasn't caught by PR #81's manual sweep

PR #81's description: \"Tier 2 sweep across Phase 4/5 surfaces (vector, files, chat, admin storage) found no further gaps.\" The chat unit tests (`render_messages_pane_*` in `llm/pages.rs::tests`) exercise only the formatting layer with pre-supplied data — they never traverse the actual `db::list` call path. The sweep relied on those tests + grep, missed the gap. PR #84's static audit catches it because it walks every `db::*` callsite regardless of whether the calling block has tests for that path.

## Audit before/after

Before:
```
MISSING grants (3):
  llm/pages.rs:128:        suppers-ai/llm → suppers_ai__messages__contexts
  llm/pages.rs:149:        suppers-ai/llm → suppers_ai__messages__entries
  llm/migrations.rs:126:   suppers-ai/llm → suppers_ai__provider_llm__providers
```

After:
```
MISSING grants (1):
  llm/migrations.rs:126:   suppers-ai/llm → suppers_ai__provider_llm__providers (legacy migration — benign, errors swallowed on NotFound)
```

## Test plan

- [x] `cargo check -p solobase-core` clean
- [x] `cargo test -p solobase-core --lib messages` — 9 passed
- [x] `cargo +nightly fmt --all` clean
- [ ] Verify chat sidebar renders threads in production after merge (requires PR #84 + this PR + a real WRAP-enforced solobase instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)