### PR TITLE
fix(cloudflare): pin worker-build to ^0.7

### DIFF
--- a/crates/solobase/src/cli/helpers/cloudflare/build.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/build.rs
@@ -4,22 +4,20 @@ use std::{path::Path, process::Command};
 
 use anyhow::{bail, Context, Result};
 
+/// Install `worker-build` pinned to `^0.7`. We always run this — `cargo
+/// install` is a no-op when the requested version is already present, and
+/// will downgrade if a newer (incompatible) version was installed.
+///
+/// Pin reason: worker-build 0.8.x rejects `worker < 0.8` and changed its
+/// output layout. Matches the version pin in `wrangler::base_toml`.
 pub fn ensure_worker_build_installed() -> Result<()> {
-    let status = Command::new("which")
-        .arg("worker-build")
-        .status()
-        .context("run `which worker-build`")?;
-    if status.success() {
-        return Ok(());
-    }
-    eprintln!("installing worker-build (one-time)...");
     let install = Command::new("cargo")
-        .args(["install", "worker-build", "--quiet"])
+        .args(["install", "worker-build", "--version", "^0.7", "--quiet"])
         .status()
-        .context("run `cargo install worker-build`")?;
+        .context("run `cargo install worker-build --version ^0.7`")?;
     if !install.success() {
         bail!(
-            "cargo install worker-build failed (exit {:?})",
+            "cargo install worker-build --version ^0.7 failed (exit {:?})",
             install.code()
         );
     }

--- a/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
@@ -69,10 +69,16 @@ fn base_toml(cfg: &CloudflareConfig) -> toml::Value {
     );
 
     let mut build = toml::map::Map::new();
+    // Pin to ^0.7 — worker-build 0.8.x rejects consumers using
+    // `worker < 0.8` (hard version check) and changed its output layout
+    // from `build/worker/shim.mjs` (which `main` points to) to
+    // `build/index.js`. Until we upgrade the `worker` crate, lock the
+    // toolchain to 0.7.x for both the local build and the wrangler-driven
+    // rebuild during deploy.
     build.insert(
         "command".into(),
         Value::String(
-            "cargo install worker-build --quiet && \
+            "cargo install worker-build --version ^0.7 --quiet && \
              worker-build --release --no-default-features \
              --features target-cloudflare"
                 .into(),


### PR DESCRIPTION
## Summary

`worker-build` 0.8.x rejects consumers using `worker < 0.8` (hard version check) and changed its output layout from `build/worker/shim.mjs` (which our wrangler.toml's `main` points at) to `build/index.js`. Pinning to `^0.7` for now — until we upgrade the `worker` crate dep itself, this matches our existing `worker = "0.7.5"`.

Two places to pin (both must, otherwise the version drifts):

1. **`cf_build::ensure_worker_build_installed`** — what `solobase build --target cloudflare` runs locally. Now always installs (cargo is a no-op when version matches; downgrades from 0.8.x if previously installed).
2. **The `[build] command` embedded in the generated `wrangler.toml`** — what `wrangler deploy` re-runs as part of its build pipeline. Without pinning here, every deploy silently `cargo install worker-build`s the latest and explodes at link-time:

   ```
   Error: Unsupported version worker@0.7.5, expected at least worker@0.8.1 in the Cargo.toml file
   ```

## Discovered by

First real deploy of wafer-site. The local `solobase build` "succeeded" with worker-build 0.8.1 (it wrote artifacts to the new `build/index.js` location and exited 0), but `wrangler deploy`'s embedded `cargo install worker-build --quiet && worker-build ...` re-ran from a different cwd, tripped the strict version check, and aborted.

## Verification

- [x] `cargo test -p solobase --test helpers_cloudflare_wrangler` — 3 pass.
- [x] `cargo +nightly fmt --all -- --check` clean.
- [x] End-to-end against wafer-site: `solobase build --target cloudflare` produced both `build/worker/shim.mjs` (back-compat re-export) and `build/index.js` + `build/index_bg.wasm` (real artifacts). `solobase deploy --target cloudflare` ran `wrangler deploy` successfully — 65 R2 objects uploaded, worker landed at `wafer-site.<subdomain>.workers.dev`.

## Future follow-up

Upgrading `worker = "0.7.5"` → `worker = "0.8.x"` is the right long-term fix. That'll require a code review (worker 0.7→0.8 may include API changes) plus updating the wrangler.toml `main` to point at `build/index.js` instead of `build/worker/shim.mjs`. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)