### PR TITLE
ci: wire WRAP-grant audit + allowlist 4 known-OK callsites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint — no full-page html! outside ui/
         run: bash scripts/grep-guard-html.sh
 
+      - name: Lint — WRAP-grant coverage on cross-block db::* callsites
+        run: bash scripts/audit-wrap-grants.sh
+
       - name: Checkout wafer-run
         run: git clone --depth 1 https://github.com/wafer-run/wafer-run.git "$GITHUB_WORKSPACE/../wafer-run"
 

--- a/crates/solobase-core/src/blocks/admin/custom_tables.rs
+++ b/crates/solobase-core/src/blocks/admin/custom_tables.rs
@@ -1,3 +1,9 @@
+// audit-allow-file: admin custom-tables — table names are user-defined at
+// runtime via the admin UI, so they don't follow the {org}__{block}__
+// convention that the static audit relies on. Authority is the admin role
+// itself (already required by the dispatcher); WRAP-grant coverage is not
+// the right gate for this surface.
+
 use std::collections::HashMap;
 
 use wafer_core::clients::{

--- a/crates/solobase-core/src/blocks/crud.rs
+++ b/crates/solobase-core/src/blocks/crud.rs
@@ -2,6 +2,11 @@
 //!
 //! These encapsulate the repeated list/get/create/update/delete patterns
 //! so each handler reduces to a one-liner for pure-CRUD operations.
+//!
+// audit-allow-file: pure pass-through helpers — every db::* call here takes
+// the table name as a `collection: &str` parameter from the caller. WRAP
+// coverage is the caller's responsibility; static analysis at this file
+// would flag every line as unresolved without surfacing a real bug.
 
 use std::collections::HashMap;
 

--- a/crates/solobase-core/src/blocks/llm/migrations.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations.rs
@@ -123,6 +123,7 @@ pub(super) async fn migrate_legacy_providers(
 ) -> Result<(), String> {
     // Step 1: read the legacy table. NotFound (table doesn't exist) = already
     // migrated — return cleanly. All other errors bubble up to the caller.
+    // audit-allow: legacy-block-table — `provider-llm` was renamed to `llm`; the old block no longer registers, so no grant can exist. Probe is one-shot and swallows NotFound on the steady-state path.
     let legacy = match db::list(ctx, LEGACY_COLLECTION, &ListOptions::default()).await {
         Ok(r) => r,
         Err(e) if e.code == ErrorCode::NotFound => {

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -124,6 +124,7 @@ async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> 
     // not in the registry's `prefixed_name` table. Counting that meta
     // table is what gives a correct per-index vector count.
     let meta_table = format!("{storage_name}_meta");
+    // audit-allow: own-block per-index meta table — `storage_name` was just read out of the vector registry (line above), so the owner is always `suppers-ai/vector`. The runtime table name is dynamic; static analysis can't see it.
     let count = db::count(ctx, &meta_table, &[]).await.unwrap_or(0);
 
     Some(IndexRow {

--- a/scripts/audit-wrap-grants.sh
+++ b/scripts/audit-wrap-grants.sh
@@ -28,6 +28,15 @@
 #     only checks Database access. Those grant types follow different rules.
 #   - Tables outside the `{org}__{block}__` convention (none currently exist
 #     in solobase-core but flagged if found).
+#
+# Pragmas to silence individual findings (use sparingly, always with a reason):
+#   // audit-allow: <reason>          — preceding line: skips one db::* callsite
+#   // audit-allow-file: <reason>     — top of file (first 30 lines): skips all
+#                                       db::* callsites in that file
+#
+# Use cases: legacy migrations probing renamed-block tables, generic helpers
+# whose tables are passed in by callers, runtime-built table names. Reason is
+# required after the colon — the audit isn't supposed to be silenced silently.
 
 set -euo pipefail
 
@@ -314,11 +323,46 @@ check_coverage() {
   echo "MISSING"
 }
 
-declare -i total=0 missing=0 unresolved=0 nonconv=0
+declare -i total=0 missing=0 unresolved=0 nonconv=0 allowed=0
 declare -A SEEN_PAIRS
 MISSING_LINES=()
 UNRESOLVED_LINES=()
 NONCONV_LINES=()
+ALLOWED_LINES=()
+
+# True if the file has a top-of-file `// audit-allow-file: <reason>` pragma
+# in its first 30 lines. Used for pure pass-through helper files (e.g.
+# `crud.rs` whose db::* calls all take the table name as a parameter — the
+# real audit happens at the callers).
+declare -A FILE_ALLOW_CACHE
+file_allows_audit_skip() {
+  local file="$1"
+  if [ -n "${FILE_ALLOW_CACHE[$file]:-}" ]; then
+    [ "${FILE_ALLOW_CACHE[$file]}" = "yes" ]
+    return $?
+  fi
+  if head -n 30 "$file" 2>/dev/null | grep -qE "//[[:space:]]*audit-allow-file:[[:space:]]*[^[:space:]]"; then
+    FILE_ALLOW_CACHE["$file"]="yes"
+    return 0
+  fi
+  FILE_ALLOW_CACHE["$file"]="no"
+  return 1
+}
+
+# Returns "yes" if the previous source line in $file (relative to $lineno)
+# carries a `// audit-allow:` pragma. Reason after the colon is required.
+has_allow_pragma() {
+  local file="$1" lineno="$2"
+  if [ "$lineno" -lt 2 ]; then
+    return 1
+  fi
+  local prev
+  prev="$(sed -n "$((lineno - 1))p" "$file" 2>/dev/null)"
+  if [[ "$prev" =~ //[[:space:]]*audit-allow:[[:space:]]*[^[:space:]] ]]; then
+    return 0
+  fi
+  return 1
+}
 
 while IFS= read -r line; do
   file="${line%%:*}"
@@ -336,6 +380,15 @@ while IFS= read -r line; do
     [ -n "${SEEN_PAIRS[$pair_key]:-}" ] && continue
     SEEN_PAIRS["$pair_key"]=1
     total=$((total + 1))
+    # Honor `// audit-allow: <reason>` (per-line) and `// audit-allow-file: <reason>`
+    # (top-of-file) pragmas. Used for legitimate exceptions: legacy migrations
+    # probing renamed-block tables, generic helpers whose tables are passed in
+    # by callers, runtime-built table names (e.g. vector's per-index `_meta`).
+    if file_allows_audit_skip "$file" || has_allow_pragma "$file" "$lineno"; then
+      allowed=$((allowed + 1))
+      ALLOWED_LINES+=("${file}:${lineno}: ${caller} → ${table}")
+      continue
+    fi
     if [[ "$table" == "<unresolved:"* ]]; then
       unresolved=$((unresolved + 1))
       UNRESOLVED_LINES+=("${file}:${lineno}: ${caller} → ${table}")
@@ -364,6 +417,7 @@ echo "WRAP grant audit — $(date)"
 echo
 echo "Indexed: ${#CONST_VALUE[@]} constants, ${#GRANTS[@]} grant decls,"
 echo "         ${total} unique (caller, table) pairs across db::* callsites."
+echo "         ${allowed} skipped via // audit-allow: pragmas."
 echo
 
 if [ "${#MISSING_LINES[@]}" -gt 0 ]; then

--- a/scripts/audit-wrap-grants.sh
+++ b/scripts/audit-wrap-grants.sh
@@ -168,19 +168,28 @@ done < <(grep -rEn "^use[[:space:]]" "$BLOCKS_DIR" 2>/dev/null || true)
 # Use grep -oE per-file to extract every match (a single line can contain
 # multiple alias pairs comma-separated inside one brace import).
 while IFS= read -r file; do
-  # First pass: pick up path-qualified aliases like `blocks::admin::VARIABLES_COLLECTION as VARIABLES`.
+  # First pass: pick up path-qualified aliases like `BLOCK::NAME as ALIAS`.
   # These also record the source block so the resolver disambiguates against
-  # bare-name collisions across blocks.
+  # bare-name collisions across blocks. The pattern matches both:
+  #   `blocks::admin::VARIABLES_COLLECTION as VARIABLES`  (single-line)
+  #   `        admin::VARIABLES_COLLECTION as VARIABLES,` (nested brace,
+  #     `blocks::` is on a previous line)
+  # We accept the second by matching just `BLOCK::NAME as ALIAS` and
+  # verifying BLOCK is a real block (has BLOCK_CONST entries).
   while IFS= read -r match; do
     [ -z "$match" ] && continue
-    if [[ "$match" =~ ^blocks::([a-z_]+)::([A-Z_]{4,})[[:space:]]+as[[:space:]]+([A-Z_]{2,})$ ]]; then
+    if [[ "$match" =~ ^([a-z_]+)::([A-Z_]{4,})[[:space:]]+as[[:space:]]+([A-Z_]{2,})$ ]]; then
       src_block="${BASH_REMATCH[1]}"
       src="${BASH_REMATCH[2]}"
       alias="${BASH_REMATCH[3]}"
-      FILE_USE_ALIAS["${file}::${alias}"]="$src"
-      FILE_USE_BLOCK["${file}::${alias}"]="$src_block"
+      # Only accept if `src_block::src` is known — filters out non-block
+      # path segments like `super::FOO as BAR`.
+      if [ -n "${BLOCK_CONST[${src_block}::${src}]:-}" ]; then
+        FILE_USE_ALIAS["${file}::${alias}"]="$src"
+        FILE_USE_BLOCK["${file}::${alias}"]="$src_block"
+      fi
     fi
-  done < <(grep -oE "blocks::[a-z_]+::[A-Z_]{4,}[[:space:]]+as[[:space:]]+[A-Z_]{2,}" "$file" 2>/dev/null || true)
+  done < <(grep -oE "[a-z_]+::[A-Z_]{4,}[[:space:]]+as[[:space:]]+[A-Z_]{2,}" "$file" 2>/dev/null || true)
   # Second pass: bare `X as Y` for everything else (super::-style, simple aliases).
   while IFS= read -r match; do
     [ -z "$match" ] && continue

--- a/scripts/audit-wrap-grants.sh
+++ b/scripts/audit-wrap-grants.sh
@@ -66,7 +66,20 @@ declare -A CONST_VALUE          # bare_name -> value (latest seen — global fal
 declare -A FILE_CONST_VALUE     # "${file}::${bare_name}" -> value (per-file definitions)
 declare -A FILE_CONST_NAMES     # file -> space-separated list of locally-defined names
 declare -A FILE_USE_ALIAS       # "${file}::${alias}" -> source_name (from `use ... as alias`)
+declare -A FILE_USE_BLOCK       # "${file}::${alias}" -> block_name (path of the `use` statement, when known)
 declare -A SIBLING_CONST        # "${dir}::${name}" -> value (for `super::NAME` lookups)
+declare -A BLOCK_CONST          # "${block_name}::${name}" -> value (disambiguates colliding bare names across blocks)
+
+# Strip the absolute prefix from a file path to get the block directory name.
+# e.g. crates/solobase-core/src/blocks/admin/mod.rs   -> admin
+#      crates/solobase-core/src/blocks/admin/pages/x.rs -> admin
+#      crates/solobase-core/src/blocks/network.rs    -> network
+file_to_block_name() {
+  local path="$1"
+  local rel="${path#$BLOCKS_DIR/}"
+  local first="${rel%%/*}"
+  echo "${first%.rs}"
+}
 
 while IFS= read -r line; do
   # Format: file:lineno:    pub const NAME: &str = "VALUE";
@@ -83,6 +96,11 @@ while IFS= read -r line; do
     # Index the const at the directory level so siblings can look it up via `super::NAME`.
     dir="$(dirname "$file")"
     SIBLING_CONST["${dir}::${name}"]="$value"
+    # Also index by block name so `crate::blocks::BLOCK::NAME` lookups
+    # disambiguate when the same bare name exists in multiple blocks
+    # (e.g. `VARIABLES_COLLECTION` exists in both admin and products).
+    block_name="$(file_to_block_name "$file")"
+    BLOCK_CONST["${block_name}::${name}"]="$value"
   fi
 # Anchor at start-of-line so we skip function-scoped constants like
 #   `        const PROVIDERS_COLLECTION = "..."`
@@ -150,12 +168,27 @@ done < <(grep -rEn "^use[[:space:]]" "$BLOCKS_DIR" 2>/dev/null || true)
 # Use grep -oE per-file to extract every match (a single line can contain
 # multiple alias pairs comma-separated inside one brace import).
 while IFS= read -r file; do
+  # First pass: pick up path-qualified aliases like `blocks::admin::VARIABLES_COLLECTION as VARIABLES`.
+  # These also record the source block so the resolver disambiguates against
+  # bare-name collisions across blocks.
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    if [[ "$match" =~ ^blocks::([a-z_]+)::([A-Z_]{4,})[[:space:]]+as[[:space:]]+([A-Z_]{2,})$ ]]; then
+      src_block="${BASH_REMATCH[1]}"
+      src="${BASH_REMATCH[2]}"
+      alias="${BASH_REMATCH[3]}"
+      FILE_USE_ALIAS["${file}::${alias}"]="$src"
+      FILE_USE_BLOCK["${file}::${alias}"]="$src_block"
+    fi
+  done < <(grep -oE "blocks::[a-z_]+::[A-Z_]{4,}[[:space:]]+as[[:space:]]+[A-Z_]{2,}" "$file" 2>/dev/null || true)
+  # Second pass: bare `X as Y` for everything else (super::-style, simple aliases).
   while IFS= read -r match; do
     [ -z "$match" ] && continue
     if [[ "$match" =~ ^([A-Z_]{4,})[[:space:]]+as[[:space:]]+([A-Z_]{2,})$ ]]; then
       src="${BASH_REMATCH[1]}"
       alias="${BASH_REMATCH[2]}"
-      if [ -n "${CONST_VALUE[$src]:-}" ]; then
+      # Don't overwrite a path-qualified entry from the first pass.
+      if [ -z "${FILE_USE_ALIAS[${file}::${alias}]:-}" ] && [ -n "${CONST_VALUE[$src]:-}" ]; then
         FILE_USE_ALIAS["${file}::${alias}"]="$src"
       fi
     fi
@@ -193,15 +226,46 @@ resolve_token() {
   fi
   # Stripped bare identifier (drop `module::path::` prefix).
   local bare="${tok##*::}"
+  # 0a. `crate::blocks::BLOCK::NAME` — full path. Disambiguates colliding
+  #     bare names across blocks (e.g. `VARIABLES_COLLECTION` exists in
+  #     both admin and products).
+  if [[ "$tok" =~ blocks::([a-z_]+)::([A-Z_]+)$ ]]; then
+    local qblock="${BASH_REMATCH[1]}"
+    local qname="${BASH_REMATCH[2]}"
+    if [ -n "${BLOCK_CONST[${qblock}::${qname}]:-}" ]; then
+      echo "${BLOCK_CONST[${qblock}::${qname}]}"
+      return
+    fi
+  fi
+  # 0b. `super::SIBLING::NAME` from a top-level block file — `super` exits
+  #     to the `blocks/` parent, then `SIBLING` enters the named sibling
+  #     block. Used by grant declarations like
+  #     `ResourceGrant::read(super::auth::AUTH_BLOCK_ID, ...)`.
+  if [[ "$tok" =~ ^super::([a-z_]+)::([A-Z_]+)$ ]]; then
+    local sblock="${BASH_REMATCH[1]}"
+    local sname="${BASH_REMATCH[2]}"
+    if [ -n "${BLOCK_CONST[${sblock}::${sname}]:-}" ]; then
+      echo "${BLOCK_CONST[${sblock}::${sname}]}"
+      return
+    fi
+  fi
   # 1. Per-file definition.
   if [ -n "${FILE_CONST_VALUE[${file}::${bare}]:-}" ]; then
     echo "${FILE_CONST_VALUE[${file}::${bare}]}"
     return
   fi
-  # 2. Per-file `use ... as` alias — chase to the source name. Look in
-  #    sibling modules first, then fall through to the global map.
+  # 2. Per-file `use ... as` alias — if the alias was indexed with a
+  #    specific source block, prefer that. Otherwise chase to the source
+  #    name through sibling modules, then global.
   if [ -n "${FILE_USE_ALIAS[${file}::${bare}]:-}" ]; then
     local src="${FILE_USE_ALIAS[${file}::${bare}]}"
+    if [ -n "${FILE_USE_BLOCK[${file}::${bare}]:-}" ]; then
+      local src_block="${FILE_USE_BLOCK[${file}::${bare}]}"
+      if [ -n "${BLOCK_CONST[${src_block}::${src}]:-}" ]; then
+        echo "${BLOCK_CONST[${src_block}::${src}]}"
+        return
+      fi
+    fi
     local parent_dir="$(dirname "$file")"
     if [ -n "${SIBLING_CONST[${parent_dir}::${src}]:-}" ]; then
       echo "${SIBLING_CONST[${parent_dir}::${src}]}"


### PR DESCRIPTION
## Summary

Three changes that together turn the static audit shipped in PR #84 into an enforcing CI check:

1. **Pragma support in `scripts/audit-wrap-grants.sh`.** Two forms:
   - `// audit-allow: <reason>` on the line above a `db::*` call — skips one callsite.
   - `// audit-allow-file: <reason>` in the first 30 lines — skips every `db::*` call in that file.
   - Reason after the colon is required (no silent silencing).

2. **Allowlist 4 callsites the audit can't statically resolve but that are not real WRAP gaps.**

| Site | Why allowlisted |
|---|---|
| `llm/migrations.rs:126` | Legacy `provider-llm` table; block was renamed to `llm`, no grant can exist, errors swallowed on `NotFound` (steady-state path). |
| `crud.rs` (file-level) | Generic CRUD helpers whose tables are passed in by callers; WRAP coverage is the caller's job. |
| `admin/custom_tables.rs` (file-level) | Admin-defined runtime tables that don't follow the `{org}__{block}__` convention. Auth gate is the admin role itself, not WRAP. |
| `vector/service.rs:127` | Own-block per-index `_meta` table whose name is built at runtime from the registry row read on the immediately-preceding line. |

3. **Add the audit as a Format-and-Lint step in `ci.yml`.** Runs alongside `grep-guard-html.sh`. Future cross-block `db::*` callsites without a covering grant fail CI at PR-time, not at runtime.

## Audit on main now

```
WRAP grant audit
Indexed: 67 constants, 13 grant decls,
         44 unique (caller, table) pairs across db::* callsites.
         4 skipped via // audit-allow: pragmas.

OK — no missing WRAP grants.
```

## Test plan

- [x] `bash scripts/audit-wrap-grants.sh` clean on main + all 4 changes
- [x] `cargo check -p solobase-core` clean
- [x] `cargo +nightly fmt --all` clean
- [ ] CI on this PR runs the audit step and passes (verifies the wiring works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)