### PR TITLE
fix(cloudflare): D1 lazy schema — match native sqlite semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,7 +5903,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5925,7 +5924,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5938,7 +5936,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5949,7 +5946,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5969,7 +5965,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5979,7 +5974,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5995,7 +5989,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6007,7 +6000,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6018,7 +6010,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde",
@@ -6030,7 +6021,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6040,7 +6030,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6055,7 +6044,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6073,7 +6061,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6083,7 +6070,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6094,7 +6080,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6109,7 +6094,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6120,7 +6104,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6137,7 +6120,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6149,7 +6131,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6166,7 +6147,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6176,7 +6156,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6205,7 +6184,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7a9883fb1ebcf2f4d95c486928eada47da97527a"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -2,6 +2,16 @@
 //!
 //! Implements the shared `DatabaseService` trait from wafer-core so D1Block
 //! can reuse the shared message handler.
+//!
+//! ## Lazy schema
+//!
+//! Mirrors `wafer-block-sqlite`'s lazy-schema semantics: reads against a
+//! missing table return empty/NotFound (instead of erroring), and the
+//! first `create()` against a collection runs `CREATE TABLE IF NOT EXISTS`
+//! to materialize the table from the data keys (TEXT columns, `id` as
+//! PRIMARY KEY). This keeps init code paths like `seed_reserved_orgs`
+//! working on a fresh D1 without external migrations — same behavior as
+//! a fresh native sqlite file.
 
 use std::collections::HashMap;
 
@@ -38,10 +48,11 @@ impl DatabaseService for D1DatabaseService {
             .bind(&[id.into()])
             .map_err(db_err)?;
 
-        let row = stmt
-            .first::<serde_json::Value>(None)
-            .await
-            .map_err(db_err)?;
+        let row = match stmt.first::<serde_json::Value>(None).await {
+            Ok(row) => row,
+            Err(e) if is_no_such_table(&e.to_string()) => return Err(DatabaseError::NotFound),
+            Err(e) => return Err(db_err(e)),
+        };
         match row {
             Some(val) => Ok(json_to_record(val)),
             None => Err(DatabaseError::NotFound),
@@ -55,14 +66,23 @@ impl DatabaseService for D1DatabaseService {
     ) -> Result<RecordList, DatabaseError> {
         let table = sanitize_ident(collection);
         let (where_sql, params) = build_where_clause(&opts.filters);
+        let limit_for_empty = if opts.limit > 0 { opts.limit } else { 100 };
 
         // Count query
         let count_sql = format!("SELECT COUNT(*) as cnt FROM {} WHERE {}", table, where_sql);
         let count_stmt = self.db.prepare(&count_sql).bind(&params).map_err(db_err)?;
-        let count_row = count_stmt
-            .first::<serde_json::Value>(None)
-            .await
-            .map_err(db_err)?;
+        let count_row = match count_stmt.first::<serde_json::Value>(None).await {
+            Ok(row) => row,
+            Err(e) if is_no_such_table(&e.to_string()) => {
+                return Ok(RecordList {
+                    records: Vec::new(),
+                    total_count: 0,
+                    page: 1,
+                    page_size: limit_for_empty,
+                });
+            }
+            Err(e) => return Err(db_err(e)),
+        };
         let total_count = count_row
             .and_then(|v| v.get("cnt").and_then(|c| c.as_i64()))
             .unwrap_or(0);
@@ -116,15 +136,25 @@ impl DatabaseService for D1DatabaseService {
         let id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().to_rfc3339();
 
-        let mut columns = vec!["id".to_string()];
-        let mut placeholders = vec!["?".to_string()];
-        let mut params: Vec<JsValue> = vec![id.clone().into()];
-
         let mut data = data;
         data.entry("created_at".to_string())
             .or_insert_with(|| serde_json::Value::String(now.clone()));
         data.entry("updated_at".to_string())
             .or_insert_with(|| serde_json::Value::String(now));
+
+        // Lazy schema: materialize the table on first insert. Mirrors the
+        // native sqlite service. The `id` column gets PRIMARY KEY; every
+        // other key from `data` becomes a TEXT column.
+        let ddl = ensure_table_sql(&table, data.keys().map(|k| k.as_str()));
+        self.db
+            .prepare(&ddl)
+            .run()
+            .await
+            .map_err(|e| db_err(format!("ensure_table {}: {e}", table)))?;
+
+        let mut columns = vec!["id".to_string()];
+        let mut placeholders = vec!["?".to_string()];
+        let mut params: Vec<JsValue> = vec![id.clone().into()];
 
         for (key, val) in &data {
             columns.push(sanitize_ident(key));
@@ -205,14 +235,18 @@ impl DatabaseService for D1DatabaseService {
 
         let sql = format!("SELECT COUNT(*) as cnt FROM {} WHERE {}", table, where_sql);
 
-        let row = self
+        let row = match self
             .db
             .prepare(&sql)
             .bind(&params)
             .map_err(db_err)?
             .first::<serde_json::Value>(None)
             .await
-            .map_err(db_err)?;
+        {
+            Ok(row) => row,
+            Err(e) if is_no_such_table(&e.to_string()) => return Ok(0),
+            Err(e) => return Err(db_err(e)),
+        };
 
         Ok(row
             .and_then(|v| v.get("cnt").and_then(|c| c.as_i64()))
@@ -234,14 +268,18 @@ impl DatabaseService for D1DatabaseService {
             col, table, where_sql
         );
 
-        let row = self
+        let row = match self
             .db
             .prepare(&sql)
             .bind(&params)
             .map_err(db_err)?
             .first::<serde_json::Value>(None)
             .await
-            .map_err(db_err)?;
+        {
+            Ok(row) => row,
+            Err(e) if is_no_such_table(&e.to_string()) => return Ok(0.0),
+            Err(e) => return Err(db_err(e)),
+        };
 
         Ok(row
             .and_then(|v| v.get("s").and_then(|s| s.as_f64()))
@@ -429,6 +467,47 @@ fn db_err(e: impl std::fmt::Display) -> DatabaseError {
     DatabaseError::Internal(e.to_string())
 }
 
+/// Build the `CREATE TABLE IF NOT EXISTS` DDL for lazy schema
+/// materialization. Mirrors `wafer-block-sqlite::ensure_table`: TEXT for
+/// every column; `id` is PRIMARY KEY (added if not in the data keys).
+///
+/// Pure function so it can be unit-tested without a D1 instance.
+pub(crate) fn ensure_table_sql<'a>(
+    table: &str,
+    data_keys: impl IntoIterator<Item = &'a str>,
+) -> String {
+    let safe_table = sanitize_ident(table);
+    let mut col_defs: Vec<String> = Vec::new();
+    let mut has_id = false;
+    for key in data_keys {
+        let safe_key = sanitize_ident(key);
+        if key == "id" {
+            col_defs.insert(0, "id TEXT PRIMARY KEY".to_string());
+            has_id = true;
+        } else {
+            col_defs.push(format!("{safe_key} TEXT"));
+        }
+    }
+    if !has_id {
+        col_defs.insert(0, "id TEXT PRIMARY KEY".to_string());
+    }
+    format!(
+        "CREATE TABLE IF NOT EXISTS {} ({})",
+        safe_table,
+        col_defs.join(", ")
+    )
+}
+
+/// Whether a D1 error message indicates the target table doesn't exist.
+/// D1 surfaces SQLite's `no such table: X` verbatim through the JsValue
+/// error; we string-match because the `worker::Error` type doesn't expose
+/// SQLite's structured error code.
+///
+/// Pure function so it can be unit-tested.
+pub(crate) fn is_no_such_table(msg: &str) -> bool {
+    msg.contains("no such table")
+}
+
 /// Convert a D1 result row (as JSON) into a Record.
 fn json_to_record(val: serde_json::Value) -> Record {
     if let serde_json::Value::Object(mut map) = val {
@@ -448,3 +527,11 @@ fn json_to_record(val: serde_json::Value) -> Record {
         }
     }
 }
+
+// Note: unit tests for `ensure_table_sql` and `is_no_such_table` are
+// omitted because `solobase-cloudflare` only compiles on
+// `wasm32-unknown-unknown` (the R2/D1 services hold `!Send` JsFutures).
+// `cargo test -p solobase-cloudflare` errors before reaching the test
+// module. End-to-end validation comes from a real CF deploy against an
+// empty D1: registry-block init must seed the reserved orgs without
+// erroring on "no such table".


### PR DESCRIPTION
## Summary

`D1DatabaseService` was strict-with-migrations while `SqliteDatabaseService` is schemaless-lazy. Code written against the shared `DatabaseService` trait (`get → if NotFound, create` patterns like `seed_reserved_orgs` in wafer-site's registry block) survives a fresh local sqlite file but explodes on a fresh D1 because:

- Native `list()` checks `if !table_exists()` → returns empty
- Native `create()` runs `ensure_table()` (CREATE TABLE IF NOT EXISTS) before INSERT
- D1's equivalents ran SQL directly and let the \"no such table\" error propagate

This PR brings D1 to parity:

| Method | Before | After |
|---|---|---|
| `get` | error → `Internal` | error matching \"no such table\" → `NotFound` |
| `list` / `count` / `sum` | error → `Internal` | error matching \"no such table\" → empty / 0 |
| `create` | INSERT directly, fail if missing | `CREATE TABLE IF NOT EXISTS` from data keys → INSERT |

`update_where` / `delete_where` are left strict — those operations on a missing table aren't a meaningful no-op (no rows to update/delete in a non-existent table is identical to error-out from a caller's perspective), and they weren't surfacing in any cold-start init path.

## Caught by

First real CF deploy of wafer-site (PR-stack: solobase #80, #82, #86 + site #15, #16). After all the build-side fixes, the worker landed but every route 500'd. `wrangler tail` showed:

```
warn: load_env_vars failed: no such table: suppers_ai__admin__variables
warn: load_block_settings failed: no such table: suppers_ai__admin__block_settings
solobase-cloudflare run error: wafer.start: block 'wafer-run/registry' init failed:
  Internal: registry seed: probing reserved org solobase: WaferError {
    code: Internal, message: \"internal database error\"
  }
```

`load_env_vars` and `load_block_settings` already degrade gracefully (warn-and-continue). The registry's reserved-org seed in `site/src/blocks/registry/db.rs:43` matches `Err(NotFound) → create` but treats other DB errors as fatal — which on D1 included \"no such table\" because the lazy creation never ran.

## Implementation

Two pure helpers extracted (in `database.rs`):

- `ensure_table_sql(table, data_keys)` — generates `CREATE TABLE IF NOT EXISTS … (id TEXT PRIMARY KEY, … TEXT)` from the insert payload's keys. Same shape as `wafer-block-sqlite::ensure_table`.
- `is_no_such_table(msg)` — string-match on D1's error format. D1 surfaces SQLite's `no such table: X` verbatim through the JsValue error; the `worker::Error` type doesn't expose a structured SQLite error code, so string-match is the available signal.

## Verification

- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown --lib` — clean
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — 551+ tests pass, no regression
- [x] `cargo +nightly fmt --all -- --check` — clean
- [ ] **Cannot unit-test the helpers**: `solobase-cloudflare` is wasm-only (D1/R2 services hold `!Send` JsFutures, per the original PR #61 design note), so `cargo test -p solobase-cloudflare` fails to compile on host. End-to-end validation comes from a real CF deploy against an empty D1 — registry seed must complete without erroring on \"no such table\".

## Out of scope

Schema evolution: native's `ensure_table` does `ALTER TABLE ADD COLUMN` for new keys on existing tables. This PR's `ensure_table_sql` only handles initial creation. Add-column-on-mismatch is a follow-up if/when consumers need it on cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)