### PR TITLE
feat(auth): apply Plan A2 migrations on Init

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -712,6 +712,15 @@ impl Block for AuthBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if matches!(event.event_type, LifecycleType::Init) {
+            // PR 1 of Plan A2: apply the new auth schema on first boot.
+            // Idempotent (CREATE TABLE IF NOT EXISTS / DROP TABLE IF
+            // EXISTS) so re-boots are safe, and additive — the legacy
+            // TEXT-everything tables that `seed_admin_user` writes to
+            // co-exist with the new schema until PR 2 retires the
+            // legacy path.
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(ErrorCode::INTERNAL, format!("auth migrations: {e}"))
+            })?;
             seed_admin_user(ctx).await;
         }
         Ok(())

--- a/crates/solobase-core/tests/auth/lifecycle_init.rs
+++ b/crates/solobase-core/tests/auth/lifecycle_init.rs
@@ -1,0 +1,87 @@
+//! PR 1: confirm `migrations::apply` runs on `AuthBlock::lifecycle(Init)`.
+//!
+//! Builds an `AuthBlock` against a fresh `MigrationTestCtx` (which has NO
+//! migrations pre-applied — only the database + crypto service blocks
+//! routed) and dispatches a `LifecycleType::Init` event directly. The
+//! lifecycle handler must apply the Plan A2 migrations before the
+//! Plan A2 tables physically exist in `sqlite_master`. We probe
+//! `sqlite_master` directly (not `db::list`) because the SQLite service's
+//! `list` returns an empty `RecordList` for missing tables instead of
+//! erroring — which would mask a missing migration.
+
+use solobase_core::blocks::auth::AuthBlock;
+use wafer_core::clients::database as db;
+use wafer_run::{
+    block::Block,
+    types::{LifecycleEvent, LifecycleType},
+};
+
+use crate::common::MigrationTestCtx;
+
+async fn run_init(ctx: &MigrationTestCtx) {
+    let block = AuthBlock::default();
+    let event = LifecycleEvent {
+        event_type: LifecycleType::Init,
+        data: Vec::new(),
+    };
+    block
+        .lifecycle(ctx, event)
+        .await
+        .expect("lifecycle(Init) must succeed");
+}
+
+async fn auth_table_names(ctx: &MigrationTestCtx) -> Vec<String> {
+    let rows = db::query_raw(
+        ctx,
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'suppers_ai__auth__%'",
+        &[],
+    )
+    .await
+    .expect("query sqlite_master");
+    rows.iter()
+        .filter_map(|r| {
+            r.data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// `lifecycle(Init)` must create the `local_credentials` table — one of
+/// the Plan A2 tables that doesn't exist in the legacy `users`-only
+/// schema. Without `migrations::apply` wired into Init this assertion
+/// fails because nothing else in the production lifecycle materialises
+/// the table.
+#[tokio::test]
+async fn init_lifecycle_creates_local_credentials_table() {
+    let ctx = MigrationTestCtx::new();
+
+    let before = auth_table_names(&ctx).await;
+    assert!(
+        !before.contains(&"suppers_ai__auth__local_credentials".to_string()),
+        "preconditions: local_credentials must NOT exist before Init: {before:?}",
+    );
+
+    run_init(&ctx).await;
+
+    let after = auth_table_names(&ctx).await;
+    assert!(
+        after.contains(&"suppers_ai__auth__local_credentials".to_string()),
+        "local_credentials missing after Init (got {after:?})",
+    );
+}
+
+/// `lifecycle(Init)` must create the `bootstrap_tokens` table — the
+/// other Plan A2 table without a legacy counterpart.
+#[tokio::test]
+async fn init_lifecycle_creates_bootstrap_tokens_table() {
+    let ctx = MigrationTestCtx::new();
+    run_init(&ctx).await;
+
+    let after = auth_table_names(&ctx).await;
+    assert!(
+        after.contains(&"suppers_ai__auth__bootstrap_tokens".to_string()),
+        "bootstrap_tokens missing after Init (got {after:?})",
+    );
+}

--- a/crates/solobase-core/tests/auth/main.rs
+++ b/crates/solobase-core/tests/auth/main.rs
@@ -3,6 +3,7 @@
 mod bootstrap_run;
 mod common;
 mod fake_github;
+mod lifecycle_init;
 mod login_session_row;
 mod migrations_001;
 mod migrations_002;


### PR DESCRIPTION
## Summary

Step 1 of 5 of solobase Plan A2 finish (spec: `docs/superpowers/specs/2026-05-07-solobase-auth-plan-a2-finish-design.md`).

Wires `auth::migrations::apply` into the existing custom `AuthBlock::lifecycle(Init)` so the Plan A2 schema (users + local_credentials + bootstrap_tokens + provider_links + sessions + personal_access_tokens + cli_exchange_codes + orgs) materialises on every boot. The new schema lives alongside the legacy TEXT-everything tables that `seed_admin_user` still writes to until PR 2 retires the legacy path.

PR 5 later replaces the custom block with wafer-core's framework `AuthBlock` and migrates this wiring to `AuthServiceImpl::init` (the lifecycle hook landed in wafer-run via PR 0).

## Changes

- `crates/solobase-core/src/blocks/auth/mod.rs` — `lifecycle(Init)` now calls `migrations::apply` before `seed_admin_user`. Errors map to `WaferError::new(ErrorCode::INTERNAL, ...)`.
- `crates/solobase-core/tests/auth/lifecycle_init.rs` — new integration tests that dispatch `LifecycleType::Init` directly on `AuthBlock` against a fresh `MigrationTestCtx` (no migrations pre-applied) and assert the new tables exist by probing `sqlite_master`. Probes `sqlite_master` rather than `db::list` because the SQLite service silently returns an empty result when a table is missing.
- `crates/solobase-core/tests/auth/main.rs` — module declaration.

## Test plan

- [x] `cargo test -p solobase-core --test auth lifecycle_init` — 2 passed
- [x] `cargo test -p solobase-core --test auth` — 53 passed (no regressions)
- [x] `bash scripts/audit-wrap-grants.sh` — clean (no new findings; this PR adds no cross-block db calls beyond what migrations already had)
- [x] `cargo +nightly fmt --all` — clean
- [x] Verified the new tests FAIL on `origin/main` lifecycle (only `users` table exists post-Init) and PASS once `migrations::apply` is wired in.

## Notes

- `Cargo.lock` not committed (verified clean).
- Idempotent: re-running `lifecycle(Init)` on an already-migrated DB is a no-op (every `CREATE TABLE` is `IF NOT EXISTS`, every `DROP TABLE` is `IF EXISTS`).