### PR TITLE
refactor(llm-bridge): unify chat + create-engine streaming + emit progress

### DIFF
--- a/crates/solobase-browser/assets/webllm-engine.js
+++ b/crates/solobase-browser/assets/webllm-engine.js
@@ -1,12 +1,21 @@
 // webllm-engine.js — page-side WebLLM engine + SW postMessage bridge.
 //
 // Runs in the window (WebGPU is window-only). Receives requests from the SW
-// via navigator.serviceWorker.message, runs WebLLM, streams chunks back.
+// via navigator.serviceWorker.message, runs WebLLM, streams frames back.
+//
+// Page → SW message shapes (see bridge.js for the consuming side):
+//   { type: 'llm-unload-response', id, error? }            // one-shot
+//   { type: 'llm-stream-frame',    id, kind, payload? }    // streams
+//     `kind` ∈ {'chunk','progress','done','error'};
+//     create-engine emits 'progress' frames during the cold model download
+//     and a terminal 'done' / 'error'; chat emits 'chunk' frames per token
+//     and a terminal 'done' / 'error'. The unified envelope means one
+//     dispatch arm in bridge.js and one Rust pump function for both ops.
 //
 // The @mlc-ai/web-llm import is lazy: a top-level static import would block
 // DOMContentLoaded for every page that loads this script (it's a multi-MB
 // jsdelivr ESM bundle), and most page loads never end up invoking the LLM.
-// Defer the import until handleCreateEngine actually needs it.
+// Defer the import until a handler actually needs it.
 
 let _CreateMLCEngine = null;
 async function loadCreateMLCEngine() {
@@ -18,14 +27,18 @@ async function loadCreateMLCEngine() {
 
 let _engine = null;
 let _engineModel = null;
-const _activeStreams = new Map(); // id -> AbortController
+const _activeStreams = new Map(); // id -> AbortController (chat only)
 
-async function swReply(payload) {
+async function swPost(payload) {
     const reg = await navigator.serviceWorker.ready;
     reg.active?.postMessage(payload);
 }
 
-async function handleCreateEngine(msg) {
+async function swStreamFrame(id, kind, payload) {
+    await swPost({ type: 'llm-stream-frame', id, kind, payload });
+}
+
+async function handleCreateEngineStream(msg) {
     try {
         if (_engineModel !== msg.modelId) {
             if (_engine) {
@@ -34,12 +47,22 @@ async function handleCreateEngine(msg) {
                 _engineModel = null;
             }
             const CreateMLCEngine = await loadCreateMLCEngine();
-            _engine = await CreateMLCEngine(msg.modelId, { /* progress swallowed */ });
+            // WebLLM emits InitProgressReport ticks (~1/sec during shard
+            // fetch) with a free-form `text` description like
+            // "Fetching params [3/14]: 23%". We forward `text` as the
+            // progress payload — gizza-app.js parses a percent out of it
+            // for the UI bar; consumers that just want to keep the SSE
+            // stream "warm" can ignore the contents.
+            _engine = await CreateMLCEngine(msg.modelId, {
+                initProgressCallback: (report) => {
+                    swStreamFrame(msg.id, 'progress', String(report?.text ?? ''));
+                },
+            });
             _engineModel = msg.modelId;
         }
-        await swReply({ type: 'llm-create-engine-response', id: msg.id });
+        await swStreamFrame(msg.id, 'done');
     } catch (e) {
-        await swReply({ type: 'llm-create-engine-response', id: msg.id, error: String(e) });
+        await swStreamFrame(msg.id, 'error', String(e));
     }
 }
 
@@ -50,15 +73,15 @@ async function handleUnload(msg) {
             _engine = null;
             _engineModel = null;
         }
-        await swReply({ type: 'llm-unload-response', id: msg.id });
+        await swPost({ type: 'llm-unload-response', id: msg.id });
     } catch (e) {
-        await swReply({ type: 'llm-unload-response', id: msg.id, error: String(e) });
+        await swPost({ type: 'llm-unload-response', id: msg.id, error: String(e) });
     }
 }
 
 async function handleChatStream(msg) {
     if (!_engine) {
-        await swReply({ type: 'llm-chat-stream-error', id: msg.id, error: 'no engine loaded' });
+        await swStreamFrame(msg.id, 'error', 'no engine loaded');
         return;
     }
     const ac = new AbortController();
@@ -72,15 +95,11 @@ async function handleChatStream(msg) {
         });
         for await (const chunk of iterator) {
             if (ac.signal.aborted) break;
-            await swReply({
-                type: 'llm-chat-stream-chunk',
-                id: msg.id,
-                chunk: JSON.stringify(chunk),
-            });
+            await swStreamFrame(msg.id, 'chunk', JSON.stringify(chunk));
         }
-        await swReply({ type: 'llm-chat-stream-done', id: msg.id });
+        await swStreamFrame(msg.id, 'done');
     } catch (e) {
-        await swReply({ type: 'llm-chat-stream-error', id: msg.id, error: String(e) });
+        await swStreamFrame(msg.id, 'error', String(e));
     } finally {
         _activeStreams.delete(msg.id);
     }
@@ -101,10 +120,10 @@ navigator.serviceWorker.addEventListener('message', (event) => {
     const msg = event.data;
     if (!msg || !msg.type) return;
     switch (msg.type) {
-        case 'llm-create-engine-request': handleCreateEngine(msg); break;
-        case 'llm-unload-request':        handleUnload(msg); break;
-        case 'llm-chat-stream-request':   handleChatStream(msg); break;
-        case 'llm-stream-cancel':         handleCancel(msg); break;
+        case 'llm-create-engine-stream-request': handleCreateEngineStream(msg); break;
+        case 'llm-unload-request':               handleUnload(msg); break;
+        case 'llm-chat-stream-request':          handleChatStream(msg); break;
+        case 'llm-stream-cancel':                handleCancel(msg); break;
     }
 });
 

--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -317,11 +317,16 @@ globalThis.__solobaseCompleteAssetLoad = _completeAssetLoad;
 //
 // Mirrors the loadAsset pattern: correlation-id keyed postMessage to a window
 // client; resolvers kept in a Map; sw.js routes replies via globalThis hook.
-// Streams use an async queue so Rust can `await` one chunk at a time while
-// many chunks are buffered in flight.
+//
+// One-shot operations (currently only `llmUnloadEngine`) use
+// `_pendingLlmRequests`. Streamed operations (chat, create-engine) share a
+// single `_activeLlmStreams` Map and a single page→SW frame envelope:
+//   { type: 'llm-stream-frame', id, kind: 'chunk'|'progress'|'done'|'error', payload? }
+// Each stream is a queue + waiter list so Rust can `await` one frame at a
+// time while many frames are buffered in flight.
 
-const _pendingLlmRequests = new Map();   // id -> { resolve, reject } (one-shot: create, unload)
-const _activeLlmStreams   = new Map();   // id -> { pushChunk, closeOk, closeErr, queue, waiters }
+const _pendingLlmRequests = new Map();   // id -> { resolve, reject } (one-shot)
+const _activeLlmStreams   = new Map();   // id -> { push, closeOk, closeErr, queue, waiters }
 
 async function _postToWindowClient(payload) {
     const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: false });
@@ -335,18 +340,29 @@ function _mkLlmId(prefix) {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/**
- * Create + initialise a WebLLM engine on the page. Resolves when loaded.
- * @param {string} modelId
- * @returns {Promise<void>}
- */
-export async function llmCreateEngine(modelId) {
-    const id = _mkLlmId('llm-create');
-    const replyPromise = new Promise((resolve, reject) => {
-        _pendingLlmRequests.set(id, { resolve, reject });
+/** Create the queue/waiter pair for a new stream and register it. */
+function _registerStream(id) {
+    const queue = [];
+    const waiters = [];
+    const push = (frame) => {
+        if (waiters.length > 0) waiters.shift()(frame);
+        else queue.push(frame);
+    };
+    _activeLlmStreams.set(id, {
+        push,
+        closeOk: () => push({ kind: 'done' }),
+        closeErr: (err) => push({ kind: 'error', payload: err }),
+        queue,
+        waiters,
     });
-    await _postToWindowClient({ type: 'llm-create-engine-request', id, modelId });
-    return await replyPromise;
+}
+
+/** Start a streamed LLM operation. Returns the stream id. */
+async function _startLlmStream(requestType, idPrefix, extraPayload) {
+    const id = _mkLlmId(idPrefix);
+    _registerStream(id);
+    await _postToWindowClient({ type: requestType, id, ...extraPayload });
+    return id;
 }
 
 /**
@@ -364,40 +380,41 @@ export async function llmUnloadEngine(modelId) {
 }
 
 /**
- * Start a streaming chat completion. Returns a stream id the caller pumps
- * with `llmNextChunk`.
+ * Create + initialise a WebLLM engine on the page. Returns a stream id; the
+ * caller pumps `llmNextStreamFrame` to receive `progress` frames as the model
+ * downloads, terminating with `done` (success) or `error`.
+ *
+ * Streamed (rather than one-shot) so the SW fetch handler emits SSE bytes
+ * during the multi-minute cold download — without that, Chrome's idle
+ * keep-alive eventually drops the request and the page sees ERR_FAILED.
+ *
+ * @param {string} modelId
+ * @returns {Promise<string>} stream id
+ */
+export async function llmCreateEngineStream(modelId) {
+    return _startLlmStream('llm-create-engine-stream-request', 'llm-create', { modelId });
+}
+
+/**
+ * Start a streaming chat completion. Returns a stream id; pump with
+ * `llmNextStreamFrame`. Frames are `{kind:'chunk', payload:<openai chunk
+ * JSON>}` then a terminal `{kind:'done'}` or `{kind:'error', payload}`.
  * @param {string} bodyJson - JSON request body as built by Rust encode_request_body
  * @returns {Promise<string>} stream id
  */
 export async function llmChatStream(bodyJson) {
-    const id = _mkLlmId('llm-stream');
-    const queue = [];     // { kind: 'chunk'|'done'|'error', payload? }
-    const waiters = [];   // Array<(frame) => void>
-    const pushChunk = (frame) => {
-        if (waiters.length > 0) {
-            waiters.shift()(frame);
-        } else {
-            queue.push(frame);
-        }
-    };
-    _activeLlmStreams.set(id, {
-        pushChunk,
-        closeOk: () => pushChunk({ kind: 'done' }),
-        closeErr: (err) => pushChunk({ kind: 'error', payload: err }),
-        queue,
-        waiters,
-    });
-    await _postToWindowClient({ type: 'llm-chat-stream-request', id, body: bodyJson });
-    return id;
+    return _startLlmStream('llm-chat-stream-request', 'llm-chat', { body: bodyJson });
 }
 
 /**
- * Pull the next frame from a stream. Blocks until a frame arrives.
- * After a terminal frame (done/error) the stream entry is removed.
+ * Pull the next frame from any LLM stream (chat OR create-engine). Blocks
+ * until a frame arrives. After a terminal frame (done/error) the stream
+ * entry is removed.
  * @param {string} id
- * @returns {Promise<string>} JSON-encoded frame: {kind:'chunk',payload}|{kind:'done'}|{kind:'error',payload}
+ * @returns {Promise<string>} JSON-encoded frame:
+ *   {kind:'chunk',payload}|{kind:'progress',payload}|{kind:'done'}|{kind:'error',payload}
  */
-export async function llmNextChunk(id) {
+export async function llmNextStreamFrame(id) {
     const stream = _activeLlmStreams.get(id);
     if (!stream) {
         return JSON.stringify({ kind: 'error', payload: 'unknown stream id' });
@@ -425,7 +442,7 @@ export async function llmCancelStream(id) {
         // Rust side has already broken out of its loop).
         stream.closeErr('cancelled');
         // Remove the entry now rather than waiting for the (possibly never
-        // called) next llmNextChunk to notice the terminal frame — the Rust
+        // called) next pump call to notice the terminal frame — the Rust
         // side breaks its loop immediately after calling cancel_stream.
         _activeLlmStreams.delete(id);
     }
@@ -437,14 +454,13 @@ export async function llmCancelStream(id) {
  * or active stream by id.
  *
  * Page → SW message shapes:
- *   { type: 'llm-create-engine-response', id, error? }
- *   { type: 'llm-unload-response', id, error? }
- *   { type: 'llm-chat-stream-chunk', id, chunk }    // chunk = OpenAI chunk JSON string
- *   { type: 'llm-chat-stream-done', id }
- *   { type: 'llm-chat-stream-error', id, error }
+ *   { type: 'llm-unload-response', id, error? }                         (one-shot)
+ *   { type: 'llm-stream-frame', id, kind, payload? }                    (streams)
+ *     where `kind` is 'chunk' | 'progress' | 'done' | 'error' and
+ *     `payload` is the chunk/progress/error string (omitted for 'done').
  */
 export function _completeLlmMessage(msg) {
-    if (msg.type === 'llm-create-engine-response' || msg.type === 'llm-unload-response') {
+    if (msg.type === 'llm-unload-response') {
         const pending = _pendingLlmRequests.get(msg.id);
         if (!pending) return;
         _pendingLlmRequests.delete(msg.id);
@@ -452,14 +468,12 @@ export function _completeLlmMessage(msg) {
         else pending.resolve();
         return;
     }
-    const stream = _activeLlmStreams.get(msg.id);
-    if (!stream) return;
-    if (msg.type === 'llm-chat-stream-chunk') {
-        stream.pushChunk({ kind: 'chunk', payload: msg.chunk });
-    } else if (msg.type === 'llm-chat-stream-done') {
-        stream.closeOk();
-    } else if (msg.type === 'llm-chat-stream-error') {
-        stream.closeErr(msg.error ?? 'unknown error');
+    if (msg.type === 'llm-stream-frame') {
+        const stream = _activeLlmStreams.get(msg.id);
+        if (!stream) return;
+        if (msg.kind === 'done') stream.closeOk();
+        else if (msg.kind === 'error') stream.closeErr(msg.payload ?? 'unknown error');
+        else stream.push({ kind: msg.kind, payload: msg.payload });
     }
 }
 

--- a/crates/solobase-browser/src/bridge.rs
+++ b/crates/solobase-browser/src/bridge.rs
@@ -93,9 +93,11 @@ extern "C" {
 
     // ─── LLM bridge ───────────────────────────────────────────────────────────
 
-    /// Create + initialize a WebLLM engine on the page. Resolves when loaded.
-    #[wasm_bindgen(js_name = llmCreateEngine, catch)]
-    pub async fn llm_create_engine(model_id: &str) -> Result<JsValue, JsValue>;
+    /// Start creating + initialising a WebLLM engine on the page. Returns the
+    /// stream id; pump with `llm_next_stream_frame` to receive `progress`
+    /// frames during the cold download and a terminal `done` / `error`.
+    #[wasm_bindgen(js_name = llmCreateEngineStream, catch)]
+    pub async fn llm_create_engine_stream(model_id: &str) -> Result<JsValue, JsValue>;
 
     /// Unload the engine on the page.
     #[wasm_bindgen(js_name = llmUnloadEngine, catch)]
@@ -105,11 +107,12 @@ extern "C" {
     #[wasm_bindgen(js_name = llmChatStream, catch)]
     pub async fn llm_chat_stream(body_json: &str) -> Result<JsValue, JsValue>;
 
-    /// Pull the next frame from a stream.
+    /// Pull the next frame from any LLM stream (chat or create-engine).
     /// Frame JSON: `{kind:'chunk', payload:<openai chunk json>}` |
+    ///             `{kind:'progress', payload:<stage text>}` |
     ///             `{kind:'done'}` | `{kind:'error', payload:<string>}`.
-    #[wasm_bindgen(js_name = llmNextChunk, catch)]
-    pub async fn llm_next_chunk(stream_id: &str) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(js_name = llmNextStreamFrame, catch)]
+    pub async fn llm_next_stream_frame(stream_id: &str) -> Result<JsValue, JsValue>;
 
     /// Cancel an in-flight stream.
     #[wasm_bindgen(js_name = llmCancelStream, catch)]

--- a/crates/solobase-browser/src/llm/bridge.rs
+++ b/crates/solobase-browser/src/llm/bridge.rs
@@ -2,13 +2,14 @@
 //!
 //! Glue around the `llm*` functions in `bridge.js`. Turns the async
 //! postMessage exchanges into typed Rust calls. Not testable in native —
-//! exercised via the `BrowserLlmService` integration (Task 7) and the
-//! browser smoke test (Task 10).
+//! exercised via the `BrowserLlmService` integration and the browser smoke
+//! test.
 
 use wafer_core::interfaces::llm::service::LlmError;
 
 use crate::bridge::{
-    llm_cancel_stream, llm_chat_stream, llm_create_engine, llm_next_chunk, llm_unload_engine,
+    llm_cancel_stream, llm_chat_stream, llm_create_engine_stream, llm_next_stream_frame,
+    llm_unload_engine,
 };
 
 fn js_err(e: wasm_bindgen::JsValue) -> LlmError {
@@ -18,11 +19,13 @@ fn js_err(e: wasm_bindgen::JsValue) -> LlmError {
     ))
 }
 
-pub async fn create_engine(model_id: &str) -> Result<(), LlmError> {
-    llm_create_engine(model_id)
-        .await
-        .map(|_| ())
-        .map_err(js_err)
+/// Start an LLM engine load. Returns the stream id; pump with `next_chunk`
+/// to receive `Progress` frames during the cold download and a terminal
+/// `Done` (success) or `Error`.
+pub async fn start_create_engine_stream(model_id: &str) -> Result<String, LlmError> {
+    let v = llm_create_engine_stream(model_id).await.map_err(js_err)?;
+    v.as_string()
+        .ok_or_else(|| LlmError::BackendError("webllm bridge: stream id not a string".into()))
 }
 
 pub async fn unload_engine(model_id: &str) -> Result<(), LlmError> {
@@ -38,40 +41,42 @@ pub async fn start_chat_stream(body_json: &str) -> Result<String, LlmError> {
         .ok_or_else(|| LlmError::BackendError("webllm bridge: stream id not a string".into()))
 }
 
-/// One frame pulled from the page-side stream.
+/// One frame pulled from the page-side stream. Chat streams emit `Chunk`
+/// (OpenAI chunk JSON) frames; create-engine streams emit `Progress` (stage
+/// text) frames. Both terminate with `Done` or `Error`.
 pub enum StreamFrame {
-    /// OpenAI chunk JSON string (pass to `openai_codec::StreamingDecoder::feed`).
+    /// OpenAI chunk JSON string (chat). Pass to `openai_codec::StreamingDecoder::feed`.
     Chunk(String),
+    /// Free-form stage text (create-engine). Surface as `LoadProgress::stage`.
+    Progress(String),
     Done,
     Error(String),
 }
 
 pub async fn next_chunk(stream_id: &str) -> Result<StreamFrame, LlmError> {
-    let v = llm_next_chunk(stream_id).await.map_err(js_err)?;
+    let v = llm_next_stream_frame(stream_id).await.map_err(js_err)?;
     let s = v
         .as_string()
         .ok_or_else(|| LlmError::BackendError("webllm bridge: frame not a string".into()))?;
     let frame: serde_json::Value = serde_json::from_str(&s)
         .map_err(|e| LlmError::BackendError(format!("webllm bridge: frame parse: {e}")))?;
     let kind = frame.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let payload = || {
+        frame
+            .get("payload")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
     match kind {
-        "chunk" => {
-            let payload = frame
-                .get("payload")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            Ok(StreamFrame::Chunk(payload))
-        }
+        "chunk" => Ok(StreamFrame::Chunk(payload())),
+        "progress" => Ok(StreamFrame::Progress(payload())),
         "done" => Ok(StreamFrame::Done),
-        "error" => {
-            let msg = frame
-                .get("payload")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            Ok(StreamFrame::Error(msg))
-        }
+        "error" => Ok(StreamFrame::Error(if payload().is_empty() {
+            "unknown".to_string()
+        } else {
+            payload()
+        })),
         other => Err(LlmError::BackendError(format!(
             "webllm bridge: unknown frame kind '{other}'"
         ))),

--- a/crates/solobase-browser/src/llm/service.rs
+++ b/crates/solobase-browser/src/llm/service.rs
@@ -111,6 +111,18 @@ impl LlmService for BrowserLlmService {
                             break;
                         }
                     },
+                    StreamFrame::Progress(_) => {
+                        // Progress frames belong to create-engine streams, not chat.
+                        // The page-side handlers don't cross-emit, so this branch
+                        // only fires on a wire bug — surface as a backend error so
+                        // we don't silently drop frames.
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(
+                                "webllm: unexpected progress frame on chat stream".into(),
+                            )))
+                            .await;
+                        break;
+                    }
                     StreamFrame::Done => break,
                     StreamFrame::Error(msg) => {
                         let _ = tx
@@ -158,7 +170,10 @@ impl LlmService for BrowserLlmService {
                 }
             }));
         }
-        let (mut tx, rx) = mpsc::channel::<Result<LoadProgress, LlmError>>(8);
+        // Channel buffer must be large enough that a burst of progress frames
+        // from WebLLM (1/sec during shard fetch) doesn't backpressure the
+        // spawn_local task. 32 is comfortably above WebLLM's tick rate.
+        let (mut tx, rx) = mpsc::channel::<Result<LoadProgress, LlmError>>(32);
         let loaded_model = Rc::clone(&self.loaded_model);
         let model_id = model_id.to_string();
 
@@ -166,28 +181,70 @@ impl LlmService for BrowserLlmService {
             if cancel.is_cancelled() {
                 return;
             }
-            let result = bridge::create_engine(&model_id).await;
-            // Re-check cancellation AFTER the await — model downloads run for
-            // tens of seconds and the consumer may have abandoned the load.
-            // We don't tell the page-side engine to abort (WebLLM has no
-            // cancel-load primitive), but we must avoid writing stale state
-            // and avoid sending on a channel whose receiver is gone.
-            if cancel.is_cancelled() {
-                // If the load happened to succeed, unload it so the page
-                // doesn't sit on an engine nobody asked for. Best-effort —
-                // ignore errors.
-                if result.is_ok() {
-                    let _ = bridge::unload_engine(&model_id).await;
-                }
-                return;
-            }
-            match result {
-                Ok(()) => {
-                    *loaded_model.borrow_mut() = Some(model_id.clone());
-                    let _ = tx.send(Ok(LoadProgress::new("ready"))).await;
-                }
+            // Start the page-side load. The returned stream will emit one
+            // `Progress` frame per WebLLM `initProgressCallback` tick (~1/sec
+            // during a cold download) and terminate with `Done` or `Error`.
+            // This is what keeps the SW fetch handler producing SSE bytes —
+            // a one-shot await over a multi-minute download lets Chrome's
+            // idle keep-alive drop the request mid-flight.
+            let stream_id = match bridge::start_create_engine_stream(&model_id).await {
+                Ok(id) => id,
                 Err(e) => {
                     let _ = tx.send(Err(e)).await;
+                    return;
+                }
+            };
+
+            loop {
+                if cancel.is_cancelled() {
+                    // WebLLM has no cancel-load primitive — the page-side
+                    // CreateMLCEngine call will run to completion. We
+                    // best-effort unload after the fact so the page doesn't
+                    // sit on an engine nobody asked for. Errors here are
+                    // intentionally swallowed.
+                    let _ = bridge::cancel_stream(&stream_id).await;
+                    let _ = bridge::unload_engine(&model_id).await;
+                    return;
+                }
+                let frame = match bridge::next_chunk(&stream_id).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        return;
+                    }
+                };
+                match frame {
+                    StreamFrame::Progress(stage) => {
+                        if tx.send(Ok(LoadProgress::new(stage))).await.is_err() {
+                            // Consumer dropped — best-effort unload (the
+                            // download is still in flight on the page).
+                            let _ = bridge::cancel_stream(&stream_id).await;
+                            let _ = bridge::unload_engine(&model_id).await;
+                            return;
+                        }
+                    }
+                    StreamFrame::Done => {
+                        *loaded_model.borrow_mut() = Some(model_id.clone());
+                        let _ = tx.send(Ok(LoadProgress::new("ready"))).await;
+                        return;
+                    }
+                    StreamFrame::Error(msg) => {
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(format!("webllm: {msg}"))))
+                            .await;
+                        return;
+                    }
+                    StreamFrame::Chunk(_) => {
+                        // Chunk frames belong to chat streams. As with the
+                        // mirrored arm in `chat_stream`, a wire bug is the
+                        // only way to land here — surface as a backend error.
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(
+                                "webllm: unexpected chunk frame on create-engine stream".into(),
+                            )))
+                            .await;
+                        return;
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary

The SW↔page LLM bridge had two separate flavours: chat used a streaming queue/waiter pattern, `llmCreateEngine` was one-shot await. The one-shot flavour meant `BrowserLlmService::load_model` could only emit a single `LoadProgress::new("ready")` AFTER the entire WebLLM cold download completed (~minutes) — leaving any consuming SSE response empty until the very end, which Chrome's idle keep-alive treats as a hung fetch and drops with `net::ERR_FAILED`.

This PR unifies both ops onto the streaming primitive — same `_activeLlmStreams` Map, same frame envelope, same Rust pump:

- **`bridge.js`** — one frame envelope going page→SW: `{type:'llm-stream-frame', id, kind, payload?}` where `kind` is `'chunk'|'progress'|'done'|'error'`. Chat and create-engine become thin wrappers around `_startLlmStream`.
- **`webllm-engine.js`** — `handleCreateEngineStream` now passes `initProgressCallback` to WebLLM and forwards each tick as a `progress` frame with the WebLLM stage text. Both handlers share one `swStreamFrame(id, kind, payload)` helper.
- **`src/bridge.rs`** — `llmCreateEngine` → `llmCreateEngineStream`, `llmNextChunk` → `llmNextStreamFrame`. No back-compat aliases — the only callers were inside this crate.
- **`src/llm/bridge.rs`** — `StreamFrame` gains a `Progress(String)` variant.
- **`src/llm/service.rs::load_model`** — replaces the one-shot await with the streaming pump; every `Progress` frame becomes a `LoadProgress { stage }` event.

## Behaviour change

The shape `load_model` returns is unchanged (`BoxStream<Result<LoadProgress, …>>`). What's new is that the stream actually emits intermediate frames during the download, instead of staying silent until the end.

## Why now

Bridge-level prerequisite for two follow-ups:
1. **Streaming HTTP pipeline** in `solobase-core/pipeline.rs` and `solobase-browser/convert.rs` (today both `collect_buffered()` the entire response before replying — the "real" SSE flow needs them to forward chunks as they arrive).
2. **Gizza-ai agent block** consumes those frames over SSE so Chrome's keep-alive sees regular bytes during the model download instead of a 5-minute silent fetch.

Those are separate PRs. This PR is a self-contained refactor: even without (1) and (2), the producer side now does the right thing.

## Test plan

- [x] \`cargo check -p solobase-browser --target wasm32-unknown-unknown\` clean
- [x] \`cargo test -p solobase-browser --lib --target x86_64-unknown-linux-gnu\` — 58 tests pass
- [x] Built gizza-ai (downstream consumer via path) end-to-end via \`solobase build\`; no compile errors against the new bridge names
- [ ] End-to-end "model loads, chat works" smoke is gated on follow-up PRs; this PR alone doesn't fix the smoke test (the response pipeline still buffers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)