### PR TITLE
fix(auth): OAuth button check uses modern config (DB > env), not legacy std::env

### DIFF
--- a/crates/solobase-core/src/blocks/auth/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/pages/mod.rs
@@ -95,21 +95,36 @@ fn site_config(settings: &HashMap<String, String>) -> SiteConfig {
     }
 }
 
-/// True if the provider's full credential triple (CLIENT_ID + CLIENT_SECRET
-/// + REDIRECT_URL) is present in process env. Mirrors the check used by
-/// `providers::registry::build_providers`, so the login page only surfaces
-/// buttons that will actually succeed when clicked.
-fn oauth_provider_configured(provider: &str) -> bool {
+/// True if the provider has all three credentials needed for the modern
+/// single-callback OAuth flow (`/auth/oauth/login`, `/auth/oauth/callback`):
+///
+/// - `SUPPERS_AI__AUTH__OAUTH_<PROVIDER>_CLIENT_ID`
+/// - `SUPPERS_AI__AUTH__OAUTH_<PROVIDER>_CLIENT_SECRET`
+/// - `SUPPERS_AI__AUTH__OAUTH_REDIRECT_URI` (single URI, provider-agnostic;
+///    the provider is encoded in the signed `state` JWT)
+///
+/// These match what `oauth.rs` actually reads when building the auth_url.
+/// On cloudflare the values come from D1 via `load_variables`; on native
+/// they fall through to process env via `get()`. The legacy
+/// `SOLOBASE_SHARED__AUTH__<PROVIDER>__*` triple was tied to a per-provider
+/// callback path that's no longer wired up — checking it here would cause
+/// the button to silently disappear whenever a deployment configures the
+/// modern triple correctly.
+fn oauth_provider_configured(settings: &HashMap<String, String>, provider: &str) -> bool {
     let up = provider.to_ascii_uppercase();
-    !std::env::var(format!("SOLOBASE_SHARED__AUTH__{up}__CLIENT_ID"))
-        .unwrap_or_default()
+    !get(
+        settings,
+        &format!("SUPPERS_AI__AUTH__OAUTH_{up}_CLIENT_ID"),
+        "",
+    )
+    .is_empty()
+        && !get(
+            settings,
+            &format!("SUPPERS_AI__AUTH__OAUTH_{up}_CLIENT_SECRET"),
+            "",
+        )
         .is_empty()
-        && !std::env::var(format!("SOLOBASE_SHARED__AUTH__{up}__CLIENT_SECRET"))
-            .unwrap_or_default()
-            .is_empty()
-        && !std::env::var(format!("SOLOBASE_SHARED__AUTH__{up}__REDIRECT_URL"))
-            .unwrap_or_default()
-            .is_empty()
+        && !get(settings, "SUPPERS_AI__AUTH__OAUTH_REDIRECT_URI", "").is_empty()
 }
 
 /// Display label for an OAuth provider button.
@@ -300,7 +315,7 @@ pub async fn login_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         ["github", "google", "microsoft"]
             .iter()
             .copied()
-            .filter(|p| oauth_provider_configured(p))
+            .filter(|p| oauth_provider_configured(&settings, p))
             .collect()
     } else {
         Vec::new()


### PR DESCRIPTION
## Summary

The login page renders OAuth provider buttons based on `oauth_provider_configured()` — a sync helper that read `std::env::var("SOLOBASE_SHARED__AUTH__<PROVIDER>__{CLIENT_ID,CLIENT_SECRET,REDIRECT_URL}")`. Two problems:

1. **Wrong source on cloudflare**. CF Workers don't have a process env; `solobase-cloudflare` reads runtime config from D1 via `load_variables(ctx)`. So `std::env::var` was always empty on cloudflare deploys → no OAuth buttons ever rendered, no matter how the worker was configured.
2. **Wrong key namespace**. The legacy `SOLOBASE_SHARED__AUTH__<P>__*` triple was tied to per-provider callback paths (`/b/auth/callback/<provider>`) that aren't wired up in production — only the tests call `with_providers()` to populate the legacy `ProviderRegistry`. The actual OAuth flow (`oauth.rs::handle_oauth_login`) reads the modern triple, not this one.

## Fix

`oauth_provider_configured(settings, provider)` now:

1. Takes the same `&HashMap<String,String>` populated by `load_variables(ctx)` that the rest of the page uses, routing lookups through `get()` (DB > env > default) — so it works on both native and cloudflare.
2. Checks the modern triple, matching what `oauth.rs::handle_oauth_login` actually reads:
   - `SUPPERS_AI__AUTH__OAUTH_<PROVIDER>_CLIENT_ID`
   - `SUPPERS_AI__AUTH__OAUTH_<PROVIDER>_CLIENT_SECRET`
   - `SUPPERS_AI__AUTH__OAUTH_REDIRECT_URI` (single, provider-agnostic — the provider lives in the signed `state` JWT round-tripped through OAuth)

## Caught by

First real OAuth login attempt on https://wafer.run. Configuring `SOLOBASE_SHARED__ENABLE_OAUTH=true` plus the full modern triple in D1 produced a working `/b/auth/oauth/login?provider=github` (returns the correct `auth_url` with the right `state` JWT), but the **login page never showed a "Continue with GitHub" button** because the legacy-env-var check failed.

After the fix: button renders, `data-provider="github"` confirmed in the live HTML.

## Verification

- [x] `cargo check -p solobase-core` clean
- [x] `cargo test -p solobase-core --lib` — 551 tests pass, no regression
- [x] End-to-end on https://wafer.run/b/auth/login: `oauth-button` class + `data-provider="github"` + `Continue with GitHub` text all present in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)