### PR TITLE
feat(http-pipeline): stream text/event-stream responses end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4705,6 +4705,7 @@ dependencies = [
  "wafer-run",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 

--- a/crates/solobase-browser/Cargo.toml
+++ b/crates/solobase-browser/Cargo.toml
@@ -18,6 +18,11 @@ web-sys = { version = "0.3", features = [
     "console",
 ] }
 js-sys = "0.3"
+# Bridges a Rust `Stream<Item = JsValue>` to a JS `ReadableStream`. Used by
+# `convert::output_to_response` so streaming feature blocks (text/event-stream
+# responses, etc.) can flush body chunks to the browser as they're produced
+# instead of buffering the entire response.
+wasm-streams = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { workspace = true }

--- a/crates/solobase-browser/assets/webllm-engine.js
+++ b/crates/solobase-browser/assets/webllm-engine.js
@@ -1,12 +1,21 @@
 // webllm-engine.js — page-side WebLLM engine + SW postMessage bridge.
 //
 // Runs in the window (WebGPU is window-only). Receives requests from the SW
-// via navigator.serviceWorker.message, runs WebLLM, streams chunks back.
+// via navigator.serviceWorker.message, runs WebLLM, streams frames back.
+//
+// Page → SW message shapes (see bridge.js for the consuming side):
+//   { type: 'llm-unload-response', id, error? }            // one-shot
+//   { type: 'llm-stream-frame',    id, kind, payload? }    // streams
+//     `kind` ∈ {'chunk','progress','done','error'};
+//     create-engine emits 'progress' frames during the cold model download
+//     and a terminal 'done' / 'error'; chat emits 'chunk' frames per token
+//     and a terminal 'done' / 'error'. The unified envelope means one
+//     dispatch arm in bridge.js and one Rust pump function for both ops.
 //
 // The @mlc-ai/web-llm import is lazy: a top-level static import would block
 // DOMContentLoaded for every page that loads this script (it's a multi-MB
 // jsdelivr ESM bundle), and most page loads never end up invoking the LLM.
-// Defer the import until handleCreateEngine actually needs it.
+// Defer the import until a handler actually needs it.
 
 let _CreateMLCEngine = null;
 async function loadCreateMLCEngine() {
@@ -18,14 +27,18 @@ async function loadCreateMLCEngine() {
 
 let _engine = null;
 let _engineModel = null;
-const _activeStreams = new Map(); // id -> AbortController
+const _activeStreams = new Map(); // id -> AbortController (chat only)
 
-async function swReply(payload) {
+async function swPost(payload) {
     const reg = await navigator.serviceWorker.ready;
     reg.active?.postMessage(payload);
 }
 
-async function handleCreateEngine(msg) {
+async function swStreamFrame(id, kind, payload) {
+    await swPost({ type: 'llm-stream-frame', id, kind, payload });
+}
+
+async function handleCreateEngineStream(msg) {
     try {
         if (_engineModel !== msg.modelId) {
             if (_engine) {
@@ -34,12 +47,22 @@ async function handleCreateEngine(msg) {
                 _engineModel = null;
             }
             const CreateMLCEngine = await loadCreateMLCEngine();
-            _engine = await CreateMLCEngine(msg.modelId, { /* progress swallowed */ });
+            // WebLLM emits InitProgressReport ticks (~1/sec during shard
+            // fetch) with a free-form `text` description like
+            // "Fetching params [3/14]: 23%". We forward `text` as the
+            // progress payload — gizza-app.js parses a percent out of it
+            // for the UI bar; consumers that just want to keep the SSE
+            // stream "warm" can ignore the contents.
+            _engine = await CreateMLCEngine(msg.modelId, {
+                initProgressCallback: (report) => {
+                    swStreamFrame(msg.id, 'progress', String(report?.text ?? ''));
+                },
+            });
             _engineModel = msg.modelId;
         }
-        await swReply({ type: 'llm-create-engine-response', id: msg.id });
+        await swStreamFrame(msg.id, 'done');
     } catch (e) {
-        await swReply({ type: 'llm-create-engine-response', id: msg.id, error: String(e) });
+        await swStreamFrame(msg.id, 'error', String(e));
     }
 }
 
@@ -50,15 +73,15 @@ async function handleUnload(msg) {
             _engine = null;
             _engineModel = null;
         }
-        await swReply({ type: 'llm-unload-response', id: msg.id });
+        await swPost({ type: 'llm-unload-response', id: msg.id });
     } catch (e) {
-        await swReply({ type: 'llm-unload-response', id: msg.id, error: String(e) });
+        await swPost({ type: 'llm-unload-response', id: msg.id, error: String(e) });
     }
 }
 
 async function handleChatStream(msg) {
     if (!_engine) {
-        await swReply({ type: 'llm-chat-stream-error', id: msg.id, error: 'no engine loaded' });
+        await swStreamFrame(msg.id, 'error', 'no engine loaded');
         return;
     }
     const ac = new AbortController();
@@ -72,15 +95,11 @@ async function handleChatStream(msg) {
         });
         for await (const chunk of iterator) {
             if (ac.signal.aborted) break;
-            await swReply({
-                type: 'llm-chat-stream-chunk',
-                id: msg.id,
-                chunk: JSON.stringify(chunk),
-            });
+            await swStreamFrame(msg.id, 'chunk', JSON.stringify(chunk));
         }
-        await swReply({ type: 'llm-chat-stream-done', id: msg.id });
+        await swStreamFrame(msg.id, 'done');
     } catch (e) {
-        await swReply({ type: 'llm-chat-stream-error', id: msg.id, error: String(e) });
+        await swStreamFrame(msg.id, 'error', String(e));
     } finally {
         _activeStreams.delete(msg.id);
     }
@@ -101,10 +120,10 @@ navigator.serviceWorker.addEventListener('message', (event) => {
     const msg = event.data;
     if (!msg || !msg.type) return;
     switch (msg.type) {
-        case 'llm-create-engine-request': handleCreateEngine(msg); break;
-        case 'llm-unload-request':        handleUnload(msg); break;
-        case 'llm-chat-stream-request':   handleChatStream(msg); break;
-        case 'llm-stream-cancel':         handleCancel(msg); break;
+        case 'llm-create-engine-stream-request': handleCreateEngineStream(msg); break;
+        case 'llm-unload-request':               handleUnload(msg); break;
+        case 'llm-chat-stream-request':          handleChatStream(msg); break;
+        case 'llm-stream-cancel':                handleCancel(msg); break;
     }
 });
 

--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -317,11 +317,16 @@ globalThis.__solobaseCompleteAssetLoad = _completeAssetLoad;
 //
 // Mirrors the loadAsset pattern: correlation-id keyed postMessage to a window
 // client; resolvers kept in a Map; sw.js routes replies via globalThis hook.
-// Streams use an async queue so Rust can `await` one chunk at a time while
-// many chunks are buffered in flight.
+//
+// One-shot operations (currently only `llmUnloadEngine`) use
+// `_pendingLlmRequests`. Streamed operations (chat, create-engine) share a
+// single `_activeLlmStreams` Map and a single page→SW frame envelope:
+//   { type: 'llm-stream-frame', id, kind: 'chunk'|'progress'|'done'|'error', payload? }
+// Each stream is a queue + waiter list so Rust can `await` one frame at a
+// time while many frames are buffered in flight.
 
-const _pendingLlmRequests = new Map();   // id -> { resolve, reject } (one-shot: create, unload)
-const _activeLlmStreams   = new Map();   // id -> { pushChunk, closeOk, closeErr, queue, waiters }
+const _pendingLlmRequests = new Map();   // id -> { resolve, reject } (one-shot)
+const _activeLlmStreams   = new Map();   // id -> { push, closeOk, closeErr, queue, waiters }
 
 async function _postToWindowClient(payload) {
     const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: false });
@@ -335,18 +340,29 @@ function _mkLlmId(prefix) {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/**
- * Create + initialise a WebLLM engine on the page. Resolves when loaded.
- * @param {string} modelId
- * @returns {Promise<void>}
- */
-export async function llmCreateEngine(modelId) {
-    const id = _mkLlmId('llm-create');
-    const replyPromise = new Promise((resolve, reject) => {
-        _pendingLlmRequests.set(id, { resolve, reject });
+/** Create the queue/waiter pair for a new stream and register it. */
+function _registerStream(id) {
+    const queue = [];
+    const waiters = [];
+    const push = (frame) => {
+        if (waiters.length > 0) waiters.shift()(frame);
+        else queue.push(frame);
+    };
+    _activeLlmStreams.set(id, {
+        push,
+        closeOk: () => push({ kind: 'done' }),
+        closeErr: (err) => push({ kind: 'error', payload: err }),
+        queue,
+        waiters,
     });
-    await _postToWindowClient({ type: 'llm-create-engine-request', id, modelId });
-    return await replyPromise;
+}
+
+/** Start a streamed LLM operation. Returns the stream id. */
+async function _startLlmStream(requestType, idPrefix, extraPayload) {
+    const id = _mkLlmId(idPrefix);
+    _registerStream(id);
+    await _postToWindowClient({ type: requestType, id, ...extraPayload });
+    return id;
 }
 
 /**
@@ -364,40 +380,41 @@ export async function llmUnloadEngine(modelId) {
 }
 
 /**
- * Start a streaming chat completion. Returns a stream id the caller pumps
- * with `llmNextChunk`.
+ * Create + initialise a WebLLM engine on the page. Returns a stream id; the
+ * caller pumps `llmNextStreamFrame` to receive `progress` frames as the model
+ * downloads, terminating with `done` (success) or `error`.
+ *
+ * Streamed (rather than one-shot) so the SW fetch handler emits SSE bytes
+ * during the multi-minute cold download — without that, Chrome's idle
+ * keep-alive eventually drops the request and the page sees ERR_FAILED.
+ *
+ * @param {string} modelId
+ * @returns {Promise<string>} stream id
+ */
+export async function llmCreateEngineStream(modelId) {
+    return _startLlmStream('llm-create-engine-stream-request', 'llm-create', { modelId });
+}
+
+/**
+ * Start a streaming chat completion. Returns a stream id; pump with
+ * `llmNextStreamFrame`. Frames are `{kind:'chunk', payload:<openai chunk
+ * JSON>}` then a terminal `{kind:'done'}` or `{kind:'error', payload}`.
  * @param {string} bodyJson - JSON request body as built by Rust encode_request_body
  * @returns {Promise<string>} stream id
  */
 export async function llmChatStream(bodyJson) {
-    const id = _mkLlmId('llm-stream');
-    const queue = [];     // { kind: 'chunk'|'done'|'error', payload? }
-    const waiters = [];   // Array<(frame) => void>
-    const pushChunk = (frame) => {
-        if (waiters.length > 0) {
-            waiters.shift()(frame);
-        } else {
-            queue.push(frame);
-        }
-    };
-    _activeLlmStreams.set(id, {
-        pushChunk,
-        closeOk: () => pushChunk({ kind: 'done' }),
-        closeErr: (err) => pushChunk({ kind: 'error', payload: err }),
-        queue,
-        waiters,
-    });
-    await _postToWindowClient({ type: 'llm-chat-stream-request', id, body: bodyJson });
-    return id;
+    return _startLlmStream('llm-chat-stream-request', 'llm-chat', { body: bodyJson });
 }
 
 /**
- * Pull the next frame from a stream. Blocks until a frame arrives.
- * After a terminal frame (done/error) the stream entry is removed.
+ * Pull the next frame from any LLM stream (chat OR create-engine). Blocks
+ * until a frame arrives. After a terminal frame (done/error) the stream
+ * entry is removed.
  * @param {string} id
- * @returns {Promise<string>} JSON-encoded frame: {kind:'chunk',payload}|{kind:'done'}|{kind:'error',payload}
+ * @returns {Promise<string>} JSON-encoded frame:
+ *   {kind:'chunk',payload}|{kind:'progress',payload}|{kind:'done'}|{kind:'error',payload}
  */
-export async function llmNextChunk(id) {
+export async function llmNextStreamFrame(id) {
     const stream = _activeLlmStreams.get(id);
     if (!stream) {
         return JSON.stringify({ kind: 'error', payload: 'unknown stream id' });
@@ -425,7 +442,7 @@ export async function llmCancelStream(id) {
         // Rust side has already broken out of its loop).
         stream.closeErr('cancelled');
         // Remove the entry now rather than waiting for the (possibly never
-        // called) next llmNextChunk to notice the terminal frame — the Rust
+        // called) next pump call to notice the terminal frame — the Rust
         // side breaks its loop immediately after calling cancel_stream.
         _activeLlmStreams.delete(id);
     }
@@ -437,14 +454,13 @@ export async function llmCancelStream(id) {
  * or active stream by id.
  *
  * Page → SW message shapes:
- *   { type: 'llm-create-engine-response', id, error? }
- *   { type: 'llm-unload-response', id, error? }
- *   { type: 'llm-chat-stream-chunk', id, chunk }    // chunk = OpenAI chunk JSON string
- *   { type: 'llm-chat-stream-done', id }
- *   { type: 'llm-chat-stream-error', id, error }
+ *   { type: 'llm-unload-response', id, error? }                         (one-shot)
+ *   { type: 'llm-stream-frame', id, kind, payload? }                    (streams)
+ *     where `kind` is 'chunk' | 'progress' | 'done' | 'error' and
+ *     `payload` is the chunk/progress/error string (omitted for 'done').
  */
 export function _completeLlmMessage(msg) {
-    if (msg.type === 'llm-create-engine-response' || msg.type === 'llm-unload-response') {
+    if (msg.type === 'llm-unload-response') {
         const pending = _pendingLlmRequests.get(msg.id);
         if (!pending) return;
         _pendingLlmRequests.delete(msg.id);
@@ -452,14 +468,12 @@ export function _completeLlmMessage(msg) {
         else pending.resolve();
         return;
     }
-    const stream = _activeLlmStreams.get(msg.id);
-    if (!stream) return;
-    if (msg.type === 'llm-chat-stream-chunk') {
-        stream.pushChunk({ kind: 'chunk', payload: msg.chunk });
-    } else if (msg.type === 'llm-chat-stream-done') {
-        stream.closeOk();
-    } else if (msg.type === 'llm-chat-stream-error') {
-        stream.closeErr(msg.error ?? 'unknown error');
+    if (msg.type === 'llm-stream-frame') {
+        const stream = _activeLlmStreams.get(msg.id);
+        if (!stream) return;
+        if (msg.kind === 'done') stream.closeOk();
+        else if (msg.kind === 'error') stream.closeErr(msg.payload ?? 'unknown error');
+        else stream.push({ kind: msg.kind, payload: msg.payload });
     }
 }
 

--- a/crates/solobase-browser/src/bridge.rs
+++ b/crates/solobase-browser/src/bridge.rs
@@ -93,9 +93,11 @@ extern "C" {
 
     // ─── LLM bridge ───────────────────────────────────────────────────────────
 
-    /// Create + initialize a WebLLM engine on the page. Resolves when loaded.
-    #[wasm_bindgen(js_name = llmCreateEngine, catch)]
-    pub async fn llm_create_engine(model_id: &str) -> Result<JsValue, JsValue>;
+    /// Start creating + initialising a WebLLM engine on the page. Returns the
+    /// stream id; pump with `llm_next_stream_frame` to receive `progress`
+    /// frames during the cold download and a terminal `done` / `error`.
+    #[wasm_bindgen(js_name = llmCreateEngineStream, catch)]
+    pub async fn llm_create_engine_stream(model_id: &str) -> Result<JsValue, JsValue>;
 
     /// Unload the engine on the page.
     #[wasm_bindgen(js_name = llmUnloadEngine, catch)]
@@ -105,11 +107,12 @@ extern "C" {
     #[wasm_bindgen(js_name = llmChatStream, catch)]
     pub async fn llm_chat_stream(body_json: &str) -> Result<JsValue, JsValue>;
 
-    /// Pull the next frame from a stream.
+    /// Pull the next frame from any LLM stream (chat or create-engine).
     /// Frame JSON: `{kind:'chunk', payload:<openai chunk json>}` |
+    ///             `{kind:'progress', payload:<stage text>}` |
     ///             `{kind:'done'}` | `{kind:'error', payload:<string>}`.
-    #[wasm_bindgen(js_name = llmNextChunk, catch)]
-    pub async fn llm_next_chunk(stream_id: &str) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(js_name = llmNextStreamFrame, catch)]
+    pub async fn llm_next_stream_frame(stream_id: &str) -> Result<JsValue, JsValue>;
 
     /// Cancel an in-flight stream.
     #[wasm_bindgen(js_name = llmCancelStream, catch)]

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -1,3 +1,4 @@
+use futures::{SinkExt, StreamExt};
 use js_sys::{ArrayBuffer, Uint8Array};
 use wafer_block::{
     meta::{
@@ -5,11 +6,12 @@ use wafer_block::{
         META_REQ_RESOURCE, META_RESP_CONTENT_TYPE, META_RESP_COOKIE_PREFIX,
         META_RESP_HEADER_PREFIX, META_RESP_STATUS,
     },
+    stream::StreamEvent,
     streams::{
         input::InputStream,
         output::{OutputStream, TerminalNotResponse},
     },
-    ErrorCode, Message, MetaAccess,
+    ErrorCode, Message, MetaAccess, MetaEntry,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -262,12 +264,176 @@ fn make_response(
     }
 }
 
-/// Convert a WAFER `OutputStream` into a browser `web_sys::Response` by
-/// buffering the entire stream.
+/// True for content-types that should stream body chunks to the browser as
+/// they're produced rather than buffer the entire response. Today: SSE and
+/// generic byte streams (which feature blocks use for downloads / archives).
+fn is_streaming_content_type(ct: &str) -> bool {
+    let lower = ct.to_ascii_lowercase();
+    lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
+}
+
+/// Pull `Meta` events off the front of an `OutputStream`, stopping at the
+/// first non-Meta event. Returns the accumulated meta and the next event
+/// (if any). Used by `output_to_response` to peek the response's headers
+/// before deciding whether to stream the body or buffer it.
+async fn drain_leading_meta(
+    output: &mut OutputStream,
+) -> (Vec<MetaEntry>, Option<StreamEvent>) {
+    let mut meta = Vec::new();
+    while let Some(ev) = output.next().await {
+        match ev {
+            StreamEvent::Meta(entry) => meta.push(entry),
+            other => return (meta, Some(other)),
+        }
+    }
+    (meta, None)
+}
+
+/// Build a `ReadableStream` body that pipes remaining `Chunk` events from an
+/// `OutputStream` to the browser. The first chunk (already pulled from the
+/// stream) is pushed first, then the loop drains the rest.
 ///
-/// Mirrors `wafer_output_to_response()` from `wafer-block-http-listener`.
-pub async fn output_to_response(output: OutputStream) -> Result<web_sys::Response, JsValue> {
-    match output.collect_buffered().await {
+/// Terminal events (`Complete`, `Error`, `Drop`, `Continue`) close the stream.
+/// `Error` after we've already started writing the body is the stream just
+/// being aborted — there's no way to flip the HTTP status mid-response, so
+/// we close the stream and let the browser surface the truncation.
+/// Build a JS `ReadableStream` that yields `first_chunk` and then every
+/// subsequent `Chunk` event from `remaining`. Mid-body `Meta` is dropped
+/// (too late to apply to HTTP headers); any terminal closes the stream.
+fn make_streaming_body(
+    first_chunk: Vec<u8>,
+    mut remaining: OutputStream,
+) -> wasm_streams::ReadableStream {
+    use futures::channel::mpsc;
+    let (mut tx, rx) = mpsc::channel::<Result<JsValue, JsValue>>(8);
+
+    // Channel cap is 8 and we have one item to send — try_send fits. If it
+    // fails (caller dropped the stream before consuming) we just discard.
+    let _ = tx.try_send(Ok(JsValue::from(Uint8Array::from(first_chunk.as_slice()))));
+
+    wasm_bindgen_futures::spawn_local(async move {
+        while let Some(ev) = remaining.next().await {
+            match ev {
+                StreamEvent::Chunk(bytes) => {
+                    let val: Result<JsValue, JsValue> =
+                        Ok(JsValue::from(Uint8Array::from(bytes.as_slice())));
+                    if tx.send(val).await.is_err() {
+                        // Browser dropped the response stream — stop pumping.
+                        return;
+                    }
+                }
+                // Mid-body Meta is too late to apply to HTTP headers; drop it.
+                StreamEvent::Meta(_) => {}
+                // Any terminal closes the body. Error after partial body has
+                // already streamed bytes can't change the HTTP status — log
+                // and close cleanly so the browser sees a normal end-of-body.
+                StreamEvent::Error(err) => {
+                    web_sys::console::warn_1(
+                        &format!("solobase-browser: streaming response aborted: {}", err.message)
+                            .into(),
+                    );
+                    return;
+                }
+                StreamEvent::Complete { .. } | StreamEvent::Drop | StreamEvent::Continue(_) => {
+                    return;
+                }
+            }
+        }
+    });
+
+    wasm_streams::ReadableStream::from_stream(rx)
+}
+
+/// Convert a WAFER `OutputStream` into a browser `web_sys::Response`.
+///
+/// Two paths:
+/// 1. **Buffered** (default) — for blocks that emit `Chunk(bytes), Complete{meta}`
+///    via `respond_with_meta`. Status, headers, and body all live in the
+///    terminal `Complete{meta}` for those blocks, so we have to read the
+///    whole stream before we can build the `Response`. Same behaviour as
+///    before this commit.
+/// 2. **Streaming** — for blocks that emit leading `Meta` events declaring
+///    `Content-Type: text/event-stream` (or `application/octet-stream`)
+///    BEFORE the first `Chunk`. We build a `Response` with a `ReadableStream`
+///    body and pipe subsequent chunks straight to the browser, so a
+///    multi-minute SSE response doesn't get held back behind a buffer that
+///    flushes at the very end (which Chrome's idle keep-alive treats as a
+///    hung fetch and drops with `net::ERR_FAILED`).
+pub async fn output_to_response(mut output: OutputStream) -> Result<web_sys::Response, JsValue> {
+    // Peek leading Meta events without consuming Chunks. The streaming path
+    // is signalled by an early Content-Type meta; buffered blocks send no
+    // Meta before their first Chunk, so this just returns an empty vec for
+    // them and the loop below falls through to `collect_buffered`.
+    let (leading_meta, next_event) = drain_leading_meta(&mut output).await;
+
+    let leading_ct = MetaAccess::get(&leading_meta, META_RESP_CONTENT_TYPE)
+        .or_else(|| MetaAccess::get(&leading_meta, "Content-Type"));
+
+    if let (Some(ct), Some(StreamEvent::Chunk(first))) = (leading_ct, &next_event) {
+        if is_streaming_content_type(ct) {
+            return build_streaming_response(leading_meta, first.clone(), output);
+        }
+    }
+
+    // Buffered path — drain the rest, prepending whatever we've already
+    // pulled (leading meta + the next event we peeked).
+    let (terminal_result, mut prelude_meta, mut prelude_body) = match next_event {
+        Some(StreamEvent::Chunk(b)) => {
+            // Continue collecting from where we are. Build a synthetic stream
+            // that yields the rest of `output` and replays the chunk we just
+            // peeked at the front.
+            (output.collect_buffered().await, leading_meta, b)
+        }
+        Some(StreamEvent::Complete { meta }) => {
+            // Terminal landed before any chunk — this is a header-only OK.
+            // Combine prelude + terminal meta and emit an empty body.
+            let mut all_meta = leading_meta;
+            all_meta.extend(meta);
+            return finalise_buffered(Ok(buffered_view(Vec::new(), all_meta)));
+        }
+        Some(StreamEvent::Error(err)) => {
+            return finalise_buffered(Err(TerminalNotResponse::Error(*err)));
+        }
+        Some(StreamEvent::Drop) => {
+            return finalise_buffered(Err(TerminalNotResponse::Drop));
+        }
+        Some(StreamEvent::Continue(msg)) => {
+            return finalise_buffered(Err(TerminalNotResponse::Continue(msg)));
+        }
+        Some(StreamEvent::Meta(_)) => unreachable!("drain_leading_meta consumes Meta events"),
+        None => {
+            // Stream ended after meta-only with no terminal — malformed.
+            return finalise_buffered(Err(TerminalNotResponse::Malformed));
+        }
+    };
+
+    match terminal_result {
+        Ok(buf) => {
+            // Merge the leading meta we drained earlier with the buffered tail.
+            prelude_meta.extend(buf.meta);
+            prelude_body.extend(buf.body);
+            finalise_buffered(Ok(buffered_view(prelude_body, prelude_meta)))
+        }
+        Err(other) => finalise_buffered(Err(other)),
+    }
+}
+
+/// Local mirror of `wafer_block::streams::output::BufferedOutput` so we can
+/// re-enter the buffered finaliser with a synthetic value built from the
+/// leading-meta drain. Carries body bytes + accumulated meta.
+struct BufferedView {
+    body: Vec<u8>,
+    meta: Vec<MetaEntry>,
+}
+
+fn buffered_view(body: Vec<u8>, meta: Vec<MetaEntry>) -> BufferedView {
+    BufferedView { body, meta }
+}
+
+fn finalise_buffered(
+    result: Result<BufferedView, TerminalNotResponse>,
+) -> Result<web_sys::Response, JsValue> {
+    match result {
         Ok(buf) => {
             let status = get_status_code(&buf.meta, 200);
             let headers = Headers::new()?;
@@ -324,3 +490,32 @@ pub async fn output_to_response(output: OutputStream) -> Result<web_sys::Respons
         }
     }
 }
+
+/// Build a streaming `web_sys::Response` from the leading meta (carrying
+/// status + headers) and an `OutputStream` whose remaining events should be
+/// piped into the body.
+fn build_streaming_response(
+    leading_meta: Vec<MetaEntry>,
+    first_chunk: Vec<u8>,
+    remaining: OutputStream,
+) -> Result<web_sys::Response, JsValue> {
+    let status = get_status_code(&leading_meta, 200);
+    let headers = Headers::new()?;
+    apply_response_meta(&headers, &leading_meta)?;
+
+    let has_ct = MetaAccess::contains_key(&leading_meta, META_RESP_CONTENT_TYPE)
+        || MetaAccess::contains_key(&leading_meta, "Content-Type");
+    if !has_ct {
+        // Streaming bodies without an explicit Content-Type fall back to
+        // octet-stream rather than the JSON default the buffered path uses.
+        headers.set("Content-Type", "application/octet-stream")?;
+    }
+
+    let stream = make_streaming_body(first_chunk, remaining);
+    let raw_js = stream.into_raw();
+    let init = ResponseInit::new();
+    init.set_status(status);
+    init.set_headers(&headers);
+    web_sys::Response::new_with_opt_readable_stream_and_init(Some(&raw_js), &init)
+}
+

--- a/crates/solobase-browser/src/llm/bridge.rs
+++ b/crates/solobase-browser/src/llm/bridge.rs
@@ -2,13 +2,14 @@
 //!
 //! Glue around the `llm*` functions in `bridge.js`. Turns the async
 //! postMessage exchanges into typed Rust calls. Not testable in native —
-//! exercised via the `BrowserLlmService` integration (Task 7) and the
-//! browser smoke test (Task 10).
+//! exercised via the `BrowserLlmService` integration and the browser smoke
+//! test.
 
 use wafer_core::interfaces::llm::service::LlmError;
 
 use crate::bridge::{
-    llm_cancel_stream, llm_chat_stream, llm_create_engine, llm_next_chunk, llm_unload_engine,
+    llm_cancel_stream, llm_chat_stream, llm_create_engine_stream, llm_next_stream_frame,
+    llm_unload_engine,
 };
 
 fn js_err(e: wasm_bindgen::JsValue) -> LlmError {
@@ -18,11 +19,13 @@ fn js_err(e: wasm_bindgen::JsValue) -> LlmError {
     ))
 }
 
-pub async fn create_engine(model_id: &str) -> Result<(), LlmError> {
-    llm_create_engine(model_id)
-        .await
-        .map(|_| ())
-        .map_err(js_err)
+/// Start an LLM engine load. Returns the stream id; pump with `next_chunk`
+/// to receive `Progress` frames during the cold download and a terminal
+/// `Done` (success) or `Error`.
+pub async fn start_create_engine_stream(model_id: &str) -> Result<String, LlmError> {
+    let v = llm_create_engine_stream(model_id).await.map_err(js_err)?;
+    v.as_string()
+        .ok_or_else(|| LlmError::BackendError("webllm bridge: stream id not a string".into()))
 }
 
 pub async fn unload_engine(model_id: &str) -> Result<(), LlmError> {
@@ -38,40 +41,42 @@ pub async fn start_chat_stream(body_json: &str) -> Result<String, LlmError> {
         .ok_or_else(|| LlmError::BackendError("webllm bridge: stream id not a string".into()))
 }
 
-/// One frame pulled from the page-side stream.
+/// One frame pulled from the page-side stream. Chat streams emit `Chunk`
+/// (OpenAI chunk JSON) frames; create-engine streams emit `Progress` (stage
+/// text) frames. Both terminate with `Done` or `Error`.
 pub enum StreamFrame {
-    /// OpenAI chunk JSON string (pass to `openai_codec::StreamingDecoder::feed`).
+    /// OpenAI chunk JSON string (chat). Pass to `openai_codec::StreamingDecoder::feed`.
     Chunk(String),
+    /// Free-form stage text (create-engine). Surface as `LoadProgress::stage`.
+    Progress(String),
     Done,
     Error(String),
 }
 
 pub async fn next_chunk(stream_id: &str) -> Result<StreamFrame, LlmError> {
-    let v = llm_next_chunk(stream_id).await.map_err(js_err)?;
+    let v = llm_next_stream_frame(stream_id).await.map_err(js_err)?;
     let s = v
         .as_string()
         .ok_or_else(|| LlmError::BackendError("webllm bridge: frame not a string".into()))?;
     let frame: serde_json::Value = serde_json::from_str(&s)
         .map_err(|e| LlmError::BackendError(format!("webllm bridge: frame parse: {e}")))?;
     let kind = frame.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let payload = || {
+        frame
+            .get("payload")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
     match kind {
-        "chunk" => {
-            let payload = frame
-                .get("payload")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            Ok(StreamFrame::Chunk(payload))
-        }
+        "chunk" => Ok(StreamFrame::Chunk(payload())),
+        "progress" => Ok(StreamFrame::Progress(payload())),
         "done" => Ok(StreamFrame::Done),
-        "error" => {
-            let msg = frame
-                .get("payload")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            Ok(StreamFrame::Error(msg))
-        }
+        "error" => Ok(StreamFrame::Error(if payload().is_empty() {
+            "unknown".to_string()
+        } else {
+            payload()
+        })),
         other => Err(LlmError::BackendError(format!(
             "webllm bridge: unknown frame kind '{other}'"
         ))),

--- a/crates/solobase-browser/src/llm/service.rs
+++ b/crates/solobase-browser/src/llm/service.rs
@@ -111,6 +111,18 @@ impl LlmService for BrowserLlmService {
                             break;
                         }
                     },
+                    StreamFrame::Progress(_) => {
+                        // Progress frames belong to create-engine streams, not chat.
+                        // The page-side handlers don't cross-emit, so this branch
+                        // only fires on a wire bug — surface as a backend error so
+                        // we don't silently drop frames.
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(
+                                "webllm: unexpected progress frame on chat stream".into(),
+                            )))
+                            .await;
+                        break;
+                    }
                     StreamFrame::Done => break,
                     StreamFrame::Error(msg) => {
                         let _ = tx
@@ -158,7 +170,10 @@ impl LlmService for BrowserLlmService {
                 }
             }));
         }
-        let (mut tx, rx) = mpsc::channel::<Result<LoadProgress, LlmError>>(8);
+        // Channel buffer must be large enough that a burst of progress frames
+        // from WebLLM (1/sec during shard fetch) doesn't backpressure the
+        // spawn_local task. 32 is comfortably above WebLLM's tick rate.
+        let (mut tx, rx) = mpsc::channel::<Result<LoadProgress, LlmError>>(32);
         let loaded_model = Rc::clone(&self.loaded_model);
         let model_id = model_id.to_string();
 
@@ -166,28 +181,70 @@ impl LlmService for BrowserLlmService {
             if cancel.is_cancelled() {
                 return;
             }
-            let result = bridge::create_engine(&model_id).await;
-            // Re-check cancellation AFTER the await — model downloads run for
-            // tens of seconds and the consumer may have abandoned the load.
-            // We don't tell the page-side engine to abort (WebLLM has no
-            // cancel-load primitive), but we must avoid writing stale state
-            // and avoid sending on a channel whose receiver is gone.
-            if cancel.is_cancelled() {
-                // If the load happened to succeed, unload it so the page
-                // doesn't sit on an engine nobody asked for. Best-effort —
-                // ignore errors.
-                if result.is_ok() {
-                    let _ = bridge::unload_engine(&model_id).await;
-                }
-                return;
-            }
-            match result {
-                Ok(()) => {
-                    *loaded_model.borrow_mut() = Some(model_id.clone());
-                    let _ = tx.send(Ok(LoadProgress::new("ready"))).await;
-                }
+            // Start the page-side load. The returned stream will emit one
+            // `Progress` frame per WebLLM `initProgressCallback` tick (~1/sec
+            // during a cold download) and terminate with `Done` or `Error`.
+            // This is what keeps the SW fetch handler producing SSE bytes —
+            // a one-shot await over a multi-minute download lets Chrome's
+            // idle keep-alive drop the request mid-flight.
+            let stream_id = match bridge::start_create_engine_stream(&model_id).await {
+                Ok(id) => id,
                 Err(e) => {
                     let _ = tx.send(Err(e)).await;
+                    return;
+                }
+            };
+
+            loop {
+                if cancel.is_cancelled() {
+                    // WebLLM has no cancel-load primitive — the page-side
+                    // CreateMLCEngine call will run to completion. We
+                    // best-effort unload after the fact so the page doesn't
+                    // sit on an engine nobody asked for. Errors here are
+                    // intentionally swallowed.
+                    let _ = bridge::cancel_stream(&stream_id).await;
+                    let _ = bridge::unload_engine(&model_id).await;
+                    return;
+                }
+                let frame = match bridge::next_chunk(&stream_id).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        return;
+                    }
+                };
+                match frame {
+                    StreamFrame::Progress(stage) => {
+                        if tx.send(Ok(LoadProgress::new(stage))).await.is_err() {
+                            // Consumer dropped — best-effort unload (the
+                            // download is still in flight on the page).
+                            let _ = bridge::cancel_stream(&stream_id).await;
+                            let _ = bridge::unload_engine(&model_id).await;
+                            return;
+                        }
+                    }
+                    StreamFrame::Done => {
+                        *loaded_model.borrow_mut() = Some(model_id.clone());
+                        let _ = tx.send(Ok(LoadProgress::new("ready"))).await;
+                        return;
+                    }
+                    StreamFrame::Error(msg) => {
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(format!("webllm: {msg}"))))
+                            .await;
+                        return;
+                    }
+                    StreamFrame::Chunk(_) => {
+                        // Chunk frames belong to chat streams. As with the
+                        // mirrored arm in `chat_stream`, a wire bug is the
+                        // only way to land here — surface as a backend error.
+                        let _ = tx
+                            .send(Err(LlmError::BackendError(
+                                "webllm: unexpected chunk frame on create-engine stream".into(),
+                            )))
+                            .await;
+                        return;
+                    }
                 }
             }
         });

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -3,6 +3,8 @@
 //! Both Cloudflare and native adapters call `handle_request()` after
 //! converting their platform-specific HTTP types into a WAFER Message.
 
+use futures::StreamExt;
+use wafer_block::stream::StreamEvent;
 use wafer_core::clients::database as db;
 use wafer_run::{
     block::BlockInfo, context::Context, meta::*, streams::output::TerminalNotResponse, types::*,
@@ -83,14 +85,30 @@ pub async fn handle_request(
     let user_id = msg.user_id().to_string();
     let start_ms = crate::blocks::helpers::now_millis();
 
-    // 3. Route to block — collect the stream so we can log status/body metadata.
-    let stream = routing::route_to_block(ctx, msg, input, features, extra_routes).await;
+    // 3. Route to block.
+    let mut stream = routing::route_to_block(ctx, msg, input, features, extra_routes).await;
+
+    // 3a. If the block declares a streaming Content-Type up front (SSE, raw
+    //     byte stream), don't drain the response into memory just to grab a
+    //     status code for the audit log. The whole point of those formats is
+    //     bytes flowing while the producer is still working — buffering
+    //     defeats that. Skip request_logs for these responses; the trade is
+    //     intentional and acceptable for v1 (callers reach for SSE for
+    //     long-lived progress / chat streams which aren't the audit-worthy
+    //     short request/responses that request_logs is built for).
+    let (leading_meta, next_event) = drain_leading_meta(&mut stream).await;
+    if let Some(ct) = leading_content_type(&leading_meta) {
+        if is_streaming_content_type(ct) {
+            return rebuild_streaming(leading_meta, next_event, stream);
+        }
+    }
+
     let (status_label, status_code, error_message, reply): (
         &'static str,
         i64,
         String,
         OutputStream,
-    ) = match stream.collect_buffered().await {
+    ) = match collect_buffered_with_prelude(stream, leading_meta, next_event).await {
         Ok(buf) => {
             let code = buf
                 .meta
@@ -155,4 +173,150 @@ pub async fn handle_request(
 /// Used by the pipeline after intercepting the stream for logging.
 fn replay_buffered(body: Vec<u8>, meta: Vec<MetaEntry>) -> OutputStream {
     OutputStream::respond_with_meta(body, meta)
+}
+
+/// Pull `Meta` events off the front of an `OutputStream`, stopping at the
+/// first non-`Meta` event. Returns the accumulated meta and the next event
+/// (if any). Lets the pipeline peek the response's headers before deciding
+/// whether to stream the body or buffer + log.
+async fn drain_leading_meta(stream: &mut OutputStream) -> (Vec<MetaEntry>, Option<StreamEvent>) {
+    let mut meta = Vec::new();
+    while let Some(ev) = stream.next().await {
+        match ev {
+            StreamEvent::Meta(entry) => meta.push(entry),
+            other => return (meta, Some(other)),
+        }
+    }
+    (meta, None)
+}
+
+fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
+    for entry in meta {
+        if entry.key == META_RESP_CONTENT_TYPE || entry.key == "Content-Type" {
+            return Some(entry.value.as_str());
+        }
+    }
+    None
+}
+
+fn is_streaming_content_type(ct: &str) -> bool {
+    let lower = ct.to_ascii_lowercase();
+    lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
+}
+
+/// Replay leading meta + the peeked event + remaining stream events into a
+/// fresh `OutputStream`. Used for streaming responses where the pipeline
+/// doesn't want to drain into memory.
+fn rebuild_streaming(
+    leading_meta: Vec<MetaEntry>,
+    next_event: Option<StreamEvent>,
+    rest: OutputStream,
+) -> OutputStream {
+    OutputStream::from_producer(move |sink, _cancel| async move {
+        for entry in leading_meta {
+            if sink.send_meta(entry).await.is_err() {
+                return;
+            }
+        }
+        let mut rest = rest;
+        match next_event {
+            Some(StreamEvent::Chunk(b)) => {
+                if sink.send_chunk(b).await.is_err() {
+                    return;
+                }
+            }
+            Some(StreamEvent::Meta(_)) => unreachable!("drain_leading_meta consumed all leading Meta"),
+            Some(StreamEvent::Complete { meta }) => {
+                let _ = sink.complete(meta).await;
+                return;
+            }
+            Some(StreamEvent::Error(err)) => {
+                let _ = sink.error(*err).await;
+                return;
+            }
+            Some(StreamEvent::Drop) => {
+                let _ = sink.drop_request().await;
+                return;
+            }
+            Some(StreamEvent::Continue(m)) => {
+                let _ = sink.continue_with(m).await;
+                return;
+            }
+            None => {
+                let _ = sink.complete(vec![]).await;
+                return;
+            }
+        }
+        // Pump the rest of the events.
+        while let Some(ev) = rest.next().await {
+            match ev {
+                StreamEvent::Chunk(b) => {
+                    if sink.send_chunk(b).await.is_err() {
+                        return;
+                    }
+                }
+                StreamEvent::Meta(entry) => {
+                    if sink.send_meta(entry).await.is_err() {
+                        return;
+                    }
+                }
+                StreamEvent::Complete { meta } => {
+                    let _ = sink.complete(meta).await;
+                    return;
+                }
+                StreamEvent::Error(err) => {
+                    let _ = sink.error(*err).await;
+                    return;
+                }
+                StreamEvent::Drop => {
+                    let _ = sink.drop_request().await;
+                    return;
+                }
+                StreamEvent::Continue(m) => {
+                    let _ = sink.continue_with(m).await;
+                    return;
+                }
+            }
+        }
+    })
+}
+
+/// Drain remaining stream events into a buffer, prepending the leading meta
+/// + the already-peeked next event. Returns the same shape as
+/// `OutputStream::collect_buffered` so the buffered branch in handle_request
+/// can keep working unchanged.
+async fn collect_buffered_with_prelude(
+    rest: OutputStream,
+    leading_meta: Vec<MetaEntry>,
+    next_event: Option<StreamEvent>,
+) -> Result<wafer_run::streams::output::BufferedResponse, TerminalNotResponse> {
+    use wafer_run::streams::output::BufferedResponse;
+
+    let mut body = Vec::new();
+    let mut meta = leading_meta;
+    let mut rest = rest;
+
+    // Two phases share the same accumulator+terminal logic: process the
+    // already-peeked event, then drain the rest. Capture the "next event to
+    // consider" in a small generator that yields the peek first then pulls
+    // from `rest`.
+    let mut peeked = next_event;
+    loop {
+        let ev = match peeked.take() {
+            Some(e) => Some(e),
+            None => rest.next().await,
+        };
+        match ev {
+            Some(StreamEvent::Chunk(b)) => body.extend(b),
+            Some(StreamEvent::Meta(entry)) => meta.push(entry),
+            Some(StreamEvent::Complete { meta: m }) => {
+                meta.extend(m);
+                return Ok(BufferedResponse { body, meta });
+            }
+            Some(StreamEvent::Error(err)) => return Err(TerminalNotResponse::Error(*err)),
+            Some(StreamEvent::Drop) => return Err(TerminalNotResponse::Drop),
+            Some(StreamEvent::Continue(m)) => return Err(TerminalNotResponse::Continue(m)),
+            None => return Err(TerminalNotResponse::Malformed),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on #91. Today every WAFER block response is buffered twice on the way to the browser:

1. \`solobase-core/pipeline.rs::handle_request\` does \`stream.collect_buffered().await\` so it can grab the status code for the audit log before replaying the bytes downstream.
2. \`solobase-browser/convert.rs::output_to_response\` does the same so it can build a \`web_sys::Response\` whose body is a known-size \`BufferSource\`.

Fine for JSON request/responses. Not fine for SSE — a \`text/event-stream\` response that takes minutes to produce frames (e.g. a WebLLM cold model load) gets withheld from the browser until the producer sends the terminal \`Complete\`, at which point Chrome's idle keep-alive has long since dropped the fetch and the page sees \`net::ERR_FAILED\`.

This PR teaches both layers a streaming codepath, gated on the block declaring \`Content-Type: text/event-stream\` (or \`application/octet-stream\`) as a leading \`StreamEvent::Meta\` BEFORE the first \`Chunk\`. The buffered codepath is unchanged for every other response.

- **\`solobase-browser/src/convert.rs\`** — \`output_to_response\` peeks leading Meta events, then either builds a \`Response\` with a \`ReadableStream\` body (via the new \`wasm-streams\` dep) and pipes the rest of the events into it, or falls through to the existing buffered path. The peek/replay logic is shared with the buffered finaliser so leading Meta isn't lost.
- **\`solobase-core/src/pipeline.rs\`** — same peek; on the streaming path the response is rebuilt and returned untouched (no \`collect_buffered\`, no \`request_logs\` write). The trade is intentional: SSE responses are long-lived progress / chat streams, not the short request/responses that \`request_logs\` is built to audit. If we ever want them logged we can attach a terminal-observing wrapper, but that's a separate change.
- **\`solobase-browser/Cargo.toml\`** — adds \`wasm-streams = "0.4"\`. Browser-only dep; doesn't reach Cloudflare-worker builds where the wasm-streams 0.4/0.5 conflict with \`worker = 0.7\` lives.

## Cooperating change required from feature blocks

A block that wants to stream MUST emit:

\`\`\`rust
sink.send_meta(MetaEntry { key: META_RESP_CONTENT_TYPE, value: "text/event-stream" }).await?;
sink.send_meta(MetaEntry { key: META_RESP_STATUS, value: "200" }).await?;
// then loop:
sink.send_chunk(sse_frame_bytes).await?;
sink.complete(vec![]).await?;
\`\`\`

i.e. status + content-type as leading Meta, body as Chunks. The existing \`respond_with_meta(bytes, meta)\` helper bundles meta into the terminal Complete and is therefore *not* a streaming producer — it stays buffered, which is the right default. Use \`OutputStream::from_producer\` when streaming is intended. The \`gizza-ai/agent\` block's load-model endpoint is the first consumer; that's a follow-up gizza-ai PR.

## Test plan

- [x] \`cargo check -p solobase-browser --target wasm32-unknown-unknown\` clean
- [x] \`cargo check -p solobase-core\` clean
- [x] \`cargo test -p solobase-core --lib\` — 551 tests pass (no behaviour change for existing JSON endpoints)
- [x] \`cargo test -p solobase-browser --lib\` — 58 tests pass
- [ ] End-to-end SSE streaming smoke verified once the gizza-ai consumer (follow-up PR) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)