### PR TITLE
feat(auth): apply Plan A2 migrations on Init via db::ddl

### DIFF
--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -5,10 +5,12 @@
 //! Falls back to `sqlite` when the config block is not registered — the same
 //! default solobase-native applies.
 //!
-//! Statements are executed one-by-one through `wafer-run/database`'s
-//! `exec_raw` message contract. The parser splits on bare `;` outside of
-//! `--` line comments. Embedded `;` inside string literals is NOT supported —
-//! the canonical migration files don't use any.
+//! Statements are executed one-by-one through the `wafer-run/database`
+//! `db::ddl` typed client (which routes via the permissive `__ddl__` WRAP
+//! resource — any attributable block may DDL its own `{org}__{block}__*`
+//! tables). The parser splits on bare `;` outside of `--` line comments.
+//! Embedded `;` inside string literals is NOT supported — the canonical
+//! migration files don't use any.
 
 use wafer_core::clients::{config, database as db};
 use wafer_run::context::Context;
@@ -57,7 +59,7 @@ pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
     Ok(())
 }
 
-/// Execute each statement in `sql` via `db::exec_raw`.
+/// Execute each statement in `sql` via `db::ddl`.
 ///
 /// Statements are split on `;` outside of `--` line comments so that a
 /// `-- ...;...` comment does not end a statement prematurely. Chunks with
@@ -68,9 +70,9 @@ async fn apply_script(ctx: &dyn Context, sql: &str) -> Result<(), String> {
             continue;
         }
         let trimmed = stmt.trim();
-        db::exec_raw(ctx, trimmed, &[])
+        db::ddl(ctx, trimmed)
             .await
-            .map_err(|e| format!("exec_raw failed on `{trimmed}`: {e}"))?;
+            .map_err(|e| format!("ddl failed on `{trimmed}`: {e}"))?;
     }
     Ok(())
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -712,6 +712,15 @@ impl Block for AuthBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if matches!(event.event_type, LifecycleType::Init) {
+            // Apply auth-block schema migrations idempotently. Migrations
+            // route DDL through `db::ddl` (permissive `__ddl__` WRAP
+            // resource) so non-admin callers can boot under WRAP — this is
+            // the regression that closed PR #90.
+            crate::blocks::auth::migrations::apply(ctx)
+                .await
+                .map_err(|e| {
+                    WaferError::new(ErrorCode::INTERNAL, format!("auth migrations: {e}"))
+                })?;
             seed_admin_user(ctx).await;
         }
         Ok(())

--- a/crates/solobase-core/tests/auth/lifecycle_init.rs
+++ b/crates/solobase-core/tests/auth/lifecycle_init.rs
@@ -1,0 +1,93 @@
+//! `AuthBlock::lifecycle(Init)` must apply the auth-block migrations.
+//!
+//! Drives `AuthBlock` directly against a bare context that does NOT
+//! pre-apply migrations. After `lifecycle(Init)` returns, the §3 schema
+//! tables must exist — exercising the `db::ddl` path through the same
+//! WRAP-typed client production uses (the regression that closed PR #90
+//! was that migrations went through the admin-only `__raw_sql__` path,
+//! tripping browser-WASM boot under WRAP).
+
+use solobase_core::blocks::auth::AuthBlock;
+use wafer_core::clients::database as db;
+use wafer_run::{
+    block::Block,
+    types::{LifecycleEvent, LifecycleType},
+};
+
+use crate::common::MigrationTestCtx;
+
+const EXPECTED_TABLES: &[&str] = &[
+    "suppers_ai__auth__users",
+    "suppers_ai__auth__local_credentials",
+    "suppers_ai__auth__provider_links",
+    "suppers_ai__auth__orgs",
+    "suppers_ai__auth__sessions",
+    "suppers_ai__auth__personal_access_tokens",
+    "suppers_ai__auth__cli_exchange_codes",
+    "suppers_ai__auth__bootstrap_tokens",
+];
+
+#[tokio::test]
+async fn init_lifecycle_applies_auth_migrations() {
+    // Bare context — no pre-applied migrations. `MigrationTestCtx::new()`
+    // routes only `wafer-run/database` and `wafer-run/crypto`, leaving
+    // `wafer-run/config` to fall back, which is what production also does
+    // when no config block is registered for the auth backend key.
+    let ctx = MigrationTestCtx::new();
+
+    let block = AuthBlock::default();
+    block
+        .lifecycle(
+            &ctx,
+            LifecycleEvent {
+                event_type: LifecycleType::Init,
+                data: Vec::new(),
+            },
+        )
+        .await
+        .expect("Init lifecycle must succeed");
+
+    let rows = db::query_raw(
+        &ctx,
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'suppers_ai__auth__%'",
+        &[],
+    )
+    .await
+    .expect("query sqlite_master after Init");
+
+    let names: Vec<String> = rows
+        .iter()
+        .filter_map(|r| {
+            r.data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect();
+
+    for t in EXPECTED_TABLES {
+        assert!(
+            names.contains(&t.to_string()),
+            "table missing after Init: {t} (got {names:?})"
+        );
+    }
+}
+
+#[tokio::test]
+async fn init_lifecycle_is_idempotent() {
+    let ctx = MigrationTestCtx::new();
+    let block = AuthBlock::default();
+
+    for _ in 0..2 {
+        block
+            .lifecycle(
+                &ctx,
+                LifecycleEvent {
+                    event_type: LifecycleType::Init,
+                    data: Vec::new(),
+                },
+            )
+            .await
+            .expect("Init lifecycle must be idempotent across re-boots");
+    }
+}

--- a/crates/solobase-core/tests/auth/main.rs
+++ b/crates/solobase-core/tests/auth/main.rs
@@ -3,6 +3,7 @@
 mod bootstrap_run;
 mod common;
 mod fake_github;
+mod lifecycle_init;
 mod login_session_row;
 mod migrations_001;
 mod migrations_002;


### PR DESCRIPTION
## Summary

Step 1 of 5 of solobase Plan A2 finish (spec: `2026-05-07-solobase-auth-plan-a2-finish-design.md`), redone after PR #90 hit a WRAP/admin-only `exec_raw` block on browser-WASM. wafer-run PR #42 added typed `db::ddl` (permissive `__ddl__` WRAP resource for any attributable caller).

This PR:
- Migrations switch from `db::exec_raw` to `db::ddl` — works for non-admin callers under WRAP.
- AuthBlock `lifecycle(Init)` now calls `migrations::apply(ctx)` before `seed_admin_user` so the new schema (users + local_credentials + bootstrap_tokens + ...) exists on every boot.
- Native `AuthBlock` returns `None` from `block_capabilities()` (unrestricted) — capability narrowing is enforced for WASM blocks only and `BlockInfo::capabilities()` is documentation-only for natives, so no `caps(ddl)` declaration is needed.
- Adds lifecycle integration test (TDD-verified to fail without the wiring) driving `AuthBlock::lifecycle(Init)` directly against a bare context (`MigrationTestCtx`) that does NOT pre-apply migrations.

## Test plan

- [x] `cargo test -p solobase-core --test auth` — 53 passed
- [x] TDD: lifecycle test fails when `migrations::apply` call is removed
- [x] `bash scripts/audit-wrap-grants.sh` — clean
- [x] `cargo +nightly fmt --all` — no diff
- [ ] CI green, including E2E Playwright (regression that closed PR #90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)