### PR TITLE
fix(cloudflare): D1Service::create adds missing columns on schema mismatch

### DIFF
--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -13,7 +13,7 @@
 //! working on a fresh D1 without external migrations — same behavior as
 //! a fresh native sqlite file.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use wafer_core::interfaces::database::service::{
     Column, DatabaseError, DatabaseService, Filter, FilterOp, ListOptions, Record, RecordList,
@@ -30,6 +30,59 @@ pub struct D1DatabaseService {
 impl D1DatabaseService {
     pub fn new(db: D1Database) -> Self {
         Self { db }
+    }
+
+    /// For each key in `data` that isn't already a column on `table`,
+    /// run `ALTER TABLE ... ADD COLUMN ... TEXT`. Best-effort: errors
+    /// (e.g. "duplicate column name" from a concurrent insert that
+    /// already added the column) are silently dropped — the caller's
+    /// subsequent INSERT will surface any real schema problem.
+    ///
+    /// `table` and the data keys are assumed to have already been
+    /// run through `sanitize_ident`.
+    async fn add_missing_columns(&self, table: &str, data: &HashMap<String, serde_json::Value>) {
+        let existing = match self.list_table_columns(table).await {
+            Ok(cols) => cols,
+            // If we can't even read the schema, skip and let INSERT fail
+            // with a real message rather than masking a deeper problem.
+            Err(_) => return,
+        };
+        for key in data.keys() {
+            let safe_key = sanitize_ident(key);
+            if existing.contains(&safe_key.to_lowercase()) {
+                continue;
+            }
+            let _ = self
+                .db
+                .prepare(&format!(
+                    "ALTER TABLE {} ADD COLUMN {} TEXT",
+                    table, safe_key
+                ))
+                .run()
+                .await;
+        }
+    }
+
+    /// Names of columns currently on `table`, lowercased for
+    /// case-insensitive comparison. Returns an empty set on missing
+    /// table — callers fall back to the same behaviour as if the table
+    /// had no extra columns to skip.
+    async fn list_table_columns(&self, table: &str) -> Result<HashSet<String>, DatabaseError> {
+        let stmt = self.db.prepare(&format!("PRAGMA table_info({})", table));
+        let result = match stmt.all().await {
+            Ok(r) => r,
+            Err(e) if is_no_such_table(&e.to_string()) => return Ok(HashSet::new()),
+            Err(e) => return Err(db_err(e)),
+        };
+        let rows: Vec<serde_json::Value> = result.results().map_err(db_err)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                r.get("name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_lowercase)
+            })
+            .collect())
     }
 }
 
@@ -151,6 +204,18 @@ impl DatabaseService for D1DatabaseService {
             .run()
             .await
             .map_err(|e| db_err(format!("ensure_table {}: {e}", table)))?;
+
+        // Schema evolution: when the table already existed (e.g. seeded
+        // with a smaller column set by an earlier insert from a different
+        // code path), `IF NOT EXISTS` is a no-op — the new keys we're
+        // about to insert wouldn't have columns. Mirror native sqlite's
+        // `ensure_table` and ALTER TABLE ADD COLUMN for every data key
+        // not already on the table. Errors are intentionally swallowed:
+        // a concurrent insert may have added the same column already
+        // (D1 surfaces "duplicate column name" in that case), and we'd
+        // rather let the subsequent INSERT either succeed or fail with
+        // a clearer message than abort here on a benign race.
+        self.add_missing_columns(&table, &data).await;
 
         let mut columns = vec!["id".to_string()];
         let mut placeholders = vec!["?".to_string()];


### PR DESCRIPTION
## Summary

Follow-up to suppers-ai/solobase#88. That PR brought D1 to parity with native sqlite for the lazy-create case (`CREATE TABLE IF NOT EXISTS` on first insert) and explicitly deferred the schema-evolution case:

> Schema evolution: native's `ensure_table` does `ALTER TABLE ADD COLUMN` for new keys on existing tables. This PR's `ensure_table_sql` only handles initial creation. Add-column-on-mismatch is a follow-up if/when consumers need it on cloudflare.

We hit it bootstrapping wafer.run.

## Caught by

Bootstrap sequence on a fresh CF deploy:

1. `solobase-core::seed_admin_user()` ran on first cold start, inserted a row with columns `[id, email, name, password_hash, disabled, email_verified, created_at, updated_at]`. `ensure_table_sql` created `suppers_ai__auth__users` with exactly that column set.
2. First OAuth login on a subsequent request tried to insert a row with the superset `[..., avatar_url, oauth_provider]`. `CREATE TABLE IF NOT EXISTS` was a no-op (table already there). INSERT exploded with `Internal: internal database error`.

Native sqlite avoids this because `wafer-block-sqlite::ensure_table` queries `PRAGMA table_info` and ALTER TABLE ADD COLUMN for each data key not already on the table.

## What this PR does

Mirror the native behaviour in `D1DatabaseService`:

- `add_missing_columns(table, data)` runs after `ensure_table_sql`'s CREATE IF NOT EXISTS. For each data key not on the existing table, `ALTER TABLE ADD COLUMN ... TEXT`. Errors swallowed — concurrent inserts may have already added the same column ("duplicate column name" is benign), and we'd rather let the subsequent INSERT either succeed or fail with a clearer message than abort here.
- `list_table_columns(table)` reads `PRAGMA table_info` via D1; returns an empty set on missing-table errors so the caller treats absence the same as "no columns to skip" — the CREATE in `create()` will materialise the table.

## Why it matters

Every solobase feature that adds a column to an existing table will hit the same wall on already-booted CF deploys. Without this fix, each schema addition needs a manual `wrangler d1 execute "ALTER TABLE …"` per environment — exactly what we just did by hand.

With this fix, schema evolution lands transparently on cloudflare, same as native.

## Verification

- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown --lib` clean
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — no regression
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manual end-to-end on wafer.run: ALTERed `suppers_ai__auth__users` to add `avatar_url`/`oauth_provider`, then OAuth user creation succeeded. This PR makes that transparent on next first-insert per data shape.

## Cost

- +1 round-trip per `create()` for `PRAGMA table_info`. PRAGMA is cheap on D1.
- +1 per missing column for each `ALTER`. First insert per table-version pays the schema reconciliation; subsequent inserts of the same data shape are no-ops.

Same shape (and cost profile) as the native sqlite service has had since day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)