### PR TITLE
feat(auth): apply Plan A2 migrations + bootstrap on Init (foundation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,8 @@ jobs:
           cd /tmp
           SOLOBASE_LISTEN="127.0.0.1:8093" \
           SOLOBASE_DB_PATH="/tmp/solobase-visual-baseline.db" \
-          SUPPERS_AI__AUTH__ADMIN_EMAIL="admin@example.com" \
-          SUPPERS_AI__AUTH__ADMIN_PASSWORD="admin123" \
+          SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL="admin@example.com" \
+          SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD="admin123" \
           SOLOBASE_BLOCK_ENABLED="suppers-ai/userportal,suppers-ai/vector" \
             solobase > /tmp/solobase-baseline.log 2>&1 &
           echo $! > /tmp/solobase-pid

--- a/.github/workflows/regen-visual-baselines.yml
+++ b/.github/workflows/regen-visual-baselines.yml
@@ -81,8 +81,8 @@ jobs:
           cd /tmp
           SOLOBASE_LISTEN="127.0.0.1:8093" \
           SOLOBASE_DB_PATH="/tmp/solobase-visual-baseline.db" \
-          SUPPERS_AI__AUTH__ADMIN_EMAIL="admin@example.com" \
-          SUPPERS_AI__AUTH__ADMIN_PASSWORD="admin123" \
+          SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL="admin@example.com" \
+          SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD="admin123" \
           SOLOBASE_BLOCK_ENABLED="suppers-ai/userportal,suppers-ai/vector" \
             solobase > /tmp/solobase-baseline.log 2>&1 &
           echo $! > /tmp/solobase-pid

--- a/crates/solobase-core/src/blocks/auth/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth/bootstrap.rs
@@ -13,9 +13,34 @@
 //!
 //! If the `users` table is non-empty, [`run`] is a no-op regardless of env —
 //! bootstrap is a first-run mechanism only, never a "re-seed" trigger.
+//!
+//! ## Transitional dual-write (PR 1+2 → PR 3)
+//!
+//! Until PR 3 migrates `login.rs`/`oauth.rs` to read credentials from
+//! `repo::local_credentials` and roles from the new schema, the legacy login
+//! handler still expects:
+//! - `users.password_hash` (legacy column on the same table)
+//! - `users.name`, `users.disabled`, `users.email_verified` (legacy fields)
+//! - a row in `suppers_ai__admin__user_roles` granting `admin`
+//!
+//! The Plan A2 migration creates `users` with the new schema only
+//! (no `password_hash`). To keep the existing login path working during the
+//! transition, the email+password bootstrap inserts the user row through
+//! `db::create()` — which auto-`ALTER`s the table to add any missing legacy
+//! columns via `ensure_table` — with BOTH the new (`display_name`, `role`,
+//! `email_verified` boolean) and legacy (`password_hash`, `name`, `disabled`)
+//! fields populated. It then writes the matching `local_credentials` row for
+//! the new schema and a role row in `suppers_ai__admin__user_roles` for the
+//! legacy code path.
+//!
+//! These dual writes are removed in PR 3 once login/oauth read from the new
+//! schema.
+
+use std::collections::HashMap;
 
 use sha2::{Digest, Sha256};
-use wafer_core::clients::crypto;
+use uuid::Uuid;
+use wafer_core::clients::{crypto, database as db};
 use wafer_run::{
     context::Context,
     types::{ErrorCode, WaferError},
@@ -67,20 +92,49 @@ async fn bootstrap_with_email_password(
     password: &str,
 ) -> Result<(), WaferError> {
     let hash = crypto::hash(ctx, password).await?;
-    let user = users::insert(
-        ctx,
-        users::NewUser {
-            email: email.to_string(),
-            display_name: "Admin".to_string(),
-            avatar_url: None,
-            role: "admin".to_string(),
-        },
-    )
-    .await
-    .map_err(internal)?;
-    local_credentials::insert(ctx, &user.id, &hash, false)
+    let id = Uuid::now_v7().to_string();
+    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    // Insert the user row through `db::create()` so `ensure_table` ALTERs in
+    // any missing legacy columns (transitional — see module doc). Populating
+    // both the new (`display_name`, `role`, `email_verified` as a bool) and
+    // legacy (`name`, `password_hash`, `disabled`, `email_verified` as the
+    // string "true") fields keeps the new repo and the legacy login.rs both
+    // working until PR 3 retires the legacy reads.
+    let mut data: HashMap<String, serde_json::Value> = HashMap::new();
+    data.insert("id".to_string(), serde_json::json!(id));
+    data.insert("email".to_string(), serde_json::json!(email));
+    // New schema (Plan A2)
+    data.insert("display_name".to_string(), serde_json::json!("Admin"));
+    data.insert("role".to_string(), serde_json::json!("admin"));
+    data.insert("email_verified".to_string(), serde_json::json!(true));
+    data.insert("created_at".to_string(), serde_json::json!(now.clone()));
+    data.insert("updated_at".to_string(), serde_json::json!(now.clone()));
+    // Legacy compat (removed in PR 3 once login.rs migrates to repo::*)
+    data.insert("name".to_string(), serde_json::json!("Admin"));
+    data.insert("password_hash".to_string(), serde_json::json!(hash.clone()));
+    data.insert("disabled".to_string(), serde_json::json!(false));
+    db::create(ctx, users::TABLE, data)
+        .await
+        .map_err(|e| internal(format!("insert bootstrap admin: {e}")))?;
+
+    // New-schema local_credentials row.
+    local_credentials::insert(ctx, &id, &hash, false)
         .await
         .map_err(internal)?;
+
+    // Legacy role row in `suppers_ai__admin__user_roles` so the legacy
+    // login.rs/oauth.rs `get_user_roles` lookup returns ["admin"]. Removed in
+    // PR 3 once those handlers read role from `users.role`.
+    let role_data: HashMap<String, serde_json::Value> = HashMap::from_iter([
+        ("user_id".to_string(), serde_json::json!(id)),
+        ("role".to_string(), serde_json::json!("admin")),
+        ("assigned_at".to_string(), serde_json::json!(now)),
+    ]);
+    db::create(ctx, crate::blocks::admin::USER_ROLES_COLLECTION, role_data)
+        .await
+        .map_err(|e| internal(format!("insert bootstrap admin role: {e}")))?;
+
     Ok(())
 }
 

--- a/crates/solobase-core/src/blocks/auth/config.rs
+++ b/crates/solobase-core/src/blocks/auth/config.rs
@@ -14,7 +14,11 @@
 
 use std::collections::HashMap;
 
-use wafer_run::types::{ConfigVar, InputType};
+use wafer_core::clients::config as config_client;
+use wafer_run::{
+    context::Context,
+    types::{ConfigVar, InputType},
+};
 
 /// `SOLOBASE_SHARED__AUTH__SESSION_LIFETIME_DAYS` — how many days a freshly
 /// issued session cookie stays valid.
@@ -200,6 +204,29 @@ impl AuthConfig {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
+        Self::from_map(&map)
+    }
+
+    /// Read the auth block's runtime config from `wafer-run/config`.
+    ///
+    /// Each key is fetched via `config::get_default` so missing/unconfigured
+    /// keys fall back to the declared defaults (matching the same fallback
+    /// behavior used by [`AuthConfig::from_map`]).
+    pub async fn from_ctx(ctx: &dyn Context) -> Self {
+        let mut map = HashMap::with_capacity(6);
+        for key in [
+            SESSION_LIFETIME_DAYS_KEY,
+            BOOTSTRAP_ADMIN_EMAIL_KEY,
+            BOOTSTRAP_ADMIN_PASSWORD_KEY,
+            BOOTSTRAP_ADMIN_TOKEN_KEY,
+            SIGNUP_ENABLED_KEY,
+            PASSWORD_MIN_LENGTH_KEY,
+        ] {
+            let v = config_client::get_default(ctx, key, "").await;
+            if !v.is_empty() {
+                map.insert(key.to_string(), v);
+            }
+        }
         Self::from_map(&map)
     }
 }

--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -5,10 +5,12 @@
 //! Falls back to `sqlite` when the config block is not registered — the same
 //! default solobase-native applies.
 //!
-//! Statements are executed one-by-one through `wafer-run/database`'s
-//! `exec_raw` message contract. The parser splits on bare `;` outside of
-//! `--` line comments. Embedded `;` inside string literals is NOT supported —
-//! the canonical migration files don't use any.
+//! Statements are executed one-by-one through the typed `db::ddl` client
+//! (rather than `db::exec_raw`) so the call goes through the WRAP `__ddl__`
+//! gate — any block can DDL its own tables without admin privileges. The
+//! parser splits on bare `;` outside of `--` line comments. Embedded `;`
+//! inside string literals is NOT supported — the canonical migration files
+//! don't use any.
 
 use wafer_core::clients::{config, database as db};
 use wafer_run::context::Context;
@@ -57,7 +59,11 @@ pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
     Ok(())
 }
 
-/// Execute each statement in `sql` via `db::exec_raw`.
+/// Execute each statement in `sql` via `db::ddl`.
+///
+/// Uses the typed DDL client (vs. `db::exec_raw`) so the runtime gates the
+/// call as a `__ddl__` resource and any block can DDL its own
+/// `{org}__{block}__*` tables without the admin block in the loop.
 ///
 /// Statements are split on `;` outside of `--` line comments so that a
 /// `-- ...;...` comment does not end a statement prematurely. Chunks with
@@ -68,9 +74,9 @@ async fn apply_script(ctx: &dyn Context, sql: &str) -> Result<(), String> {
             continue;
         }
         let trimmed = stmt.trim();
-        db::exec_raw(ctx, trimmed, &[])
+        db::ddl(ctx, trimmed)
             .await
-            .map_err(|e| format!("exec_raw failed on `{trimmed}`: {e}"))?;
+            .map_err(|e| format!("ddl failed on `{trimmed}`: {e}"))?;
     }
     Ok(())
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -82,8 +82,12 @@ mod helpers {
             .await
             .map_err(|e| format!("Failed to create user: {e}"))?;
 
-        let admin_email =
-            config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "").await;
+        let admin_email = config_client::get_default(
+            ctx,
+            crate::blocks::auth::config::BOOTSTRAP_ADMIN_EMAIL_KEY,
+            "",
+        )
+        .await;
         let user_email = user
             .data
             .get("email")
@@ -132,19 +136,19 @@ mod helpers {
     }
 
     /// Resolve user roles, idempotently granting `admin` if the user's email
-    /// matches the configured `SUPPERS_AI__AUTH__ADMIN_EMAIL` and they don't
-    /// already have it.
+    /// matches the configured `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL`
+    /// and they don't already have it.
     ///
     /// This closes a real footgun: roles are normally only assigned at signup
-    /// (`create_user_and_assign_role`), so changing `ADMIN_EMAIL` after a
-    /// user already exists never elevates them. With this helper, every login
-    /// re-checks the rule and grants admin once when appropriate.
+    /// (`create_user_and_assign_role`), so changing the bootstrap admin email
+    /// after a user already exists never elevates them. With this helper,
+    /// every login re-checks the rule and grants admin once when appropriate.
     ///
     /// Intentionally **upgrade-only**: never removes a role, never demotes.
-    /// Unsetting `ADMIN_EMAIL` does not revoke admin from anyone — that has
-    /// to be done explicitly via the admin UI / DB. Removing roles silently
-    /// on login would be an availability foot-gun (one typo in env locks
-    /// everyone out).
+    /// Unsetting `BOOTSTRAP_ADMIN_EMAIL` does not revoke admin from anyone —
+    /// that has to be done explicitly via the admin UI / DB. Removing roles
+    /// silently on login would be an availability foot-gun (one typo in env
+    /// locks everyone out).
     pub(super) async fn ensure_admin_role(
         ctx: &dyn Context,
         user_id: &str,
@@ -152,8 +156,12 @@ mod helpers {
     ) -> Vec<String> {
         let mut roles = get_user_roles(ctx, user_id).await;
 
-        let admin_email =
-            config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "").await;
+        let admin_email = config_client::get_default(
+            ctx,
+            crate::blocks::auth::config::BOOTSTRAP_ADMIN_EMAIL_KEY,
+            "",
+        )
+        .await;
         if admin_email.is_empty()
             || !email.eq_ignore_ascii_case(&admin_email)
             || roles.iter().any(|r| r == "admin")
@@ -172,7 +180,7 @@ mod helpers {
                 tracing::info!(
                     user_id = %user_id,
                     email = %email,
-                    "granted admin role on login (email matches ADMIN_EMAIL)"
+                    "granted admin role on login (email matches BOOTSTRAP_ADMIN_EMAIL)"
                 );
                 roles.push("admin".to_string());
             }
@@ -303,89 +311,6 @@ mod helpers {
     }
 }
 
-/// Seed a default admin user if no users exist yet.
-pub async fn seed_admin_user(ctx: &dyn Context) {
-    let count = db::count(ctx, USERS_COLLECTION, &[]).await.unwrap_or(0);
-    if count > 0 {
-        return;
-    }
-
-    let admin_email_env =
-        config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_EMAIL", "").await;
-    let admin_email = if admin_email_env.is_empty() {
-        tracing::warn!(
-            "SUPPERS_AI__AUTH__ADMIN_EMAIL not set — seeding admin@example.com; \
-             set SUPPERS_AI__AUTH__ADMIN_EMAIL in production"
-        );
-        "admin@example.com".to_string()
-    } else {
-        admin_email_env
-    };
-    let admin_password_env =
-        config_client::get_default(ctx, "SUPPERS_AI__AUTH__ADMIN_PASSWORD", "").await;
-
-    let (password_to_use, was_randomly_generated) = if !admin_password_env.is_empty() {
-        (admin_password_env, false)
-    } else {
-        let random_bytes = match crypto::random_bytes(ctx, 16).await {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!("Failed to generate random password: {e}");
-                return;
-            }
-        };
-        (hex_encode(&random_bytes), true)
-    };
-
-    let password_hash = match crypto::hash(ctx, &password_to_use).await {
-        Ok(h) => h,
-        Err(e) => {
-            tracing::error!("Failed to hash default admin password: {e}");
-            return;
-        }
-    };
-
-    let mut data = json_map(serde_json::json!({
-        "email": admin_email,
-        "password_hash": password_hash,
-        "name": "Admin",
-        "disabled": false,
-        // Seeded admins are inherently trusted — no email loop needed before
-        // first sign-in. Without this, the seeded admin would land in the
-        // "unverified" state on /b/userportal/security and the require-
-        // verification config could lock them out of their own deployment.
-        "email_verified": true
-    }));
-    super::helpers::stamp_created(&mut data);
-
-    match db::create(ctx, USERS_COLLECTION, data).await {
-        Ok(user) => {
-            let role_data = json_map(serde_json::json!({
-                "user_id": user.id,
-                "role": "admin",
-                "assigned_at": super::helpers::now_rfc3339()
-            }));
-            if let Err(e) = db::create(ctx, USER_ROLES_COLLECTION, role_data).await {
-                tracing::warn!("Failed to assign admin role to seeded user: {e}");
-            }
-            tracing::info!("==========================================================");
-            tracing::info!("Default admin user seeded:");
-            tracing::info!("  Email:    {}", admin_email);
-            if was_randomly_generated {
-                // Log password to stderr only — never persist in log aggregation
-                eprintln!("  ADMIN PASSWORD (one-time display): {}", password_to_use);
-                tracing::info!("  Password: (displayed on stderr — CHANGE IMMEDIATELY)");
-            } else {
-                tracing::info!("  Password: (set via SUPPERS_AI__AUTH__ADMIN_PASSWORD env var)");
-            }
-            tracing::info!("==========================================================");
-        }
-        Err(e) => {
-            tracing::error!("Failed to seed admin user: {e}");
-        }
-    }
-}
-
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for AuthBlock {
@@ -467,6 +392,12 @@ impl Block for AuthBlock {
                 BlockEndpoint::get("/b/auth/api/api-keys").summary("List API keys").auth(AuthLevel::Authenticated),
                 BlockEndpoint::post("/b/auth/api/api-keys").summary("Create API key").auth(AuthLevel::Authenticated),
             ])
+            // Plan A2 SOLOBASE_SHARED__AUTH__* vars (BOOTSTRAP_ADMIN_*,
+            // session lifetime, signup gate, password policy, OAuth provider
+            // triples) live in `config_vars::shared_config_vars` and must
+            // not be claimed by this block (SOLOBASE_SHARED__* belongs to
+            // the shared bucket, admin-writable). Block-scoped legacy
+            // SUPPERS_AI__AUTH__* keys remain here.
             .config_keys(vec![
                 ConfigVar::new(JWT_SECRET_KEY, "Secret key for signing auth tokens", "")
                     .name("JWT Secret")
@@ -478,9 +409,6 @@ impl Block for AuthBlock {
                     .input_type(InputType::Toggle),
                 ConfigVar::new("SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS", "Restrict signup to specific email domains (comma-separated)", "")
                     .name("Allowed Email Domains")
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__AUTH__ADMIN_EMAIL", "Email address that gets the admin role on signup", "")
-                    .name("Admin Email")
                     .optional(),
                 ConfigVar::new("SUPPERS_AI__AUTH__OAUTH_GOOGLE_CLIENT_ID", "Google OAuth client ID", "")
                     .name("Google Client ID")
@@ -501,10 +429,6 @@ impl Block for AuthBlock {
                     .optional(),
                 ConfigVar::new("SUPPERS_AI__AUTH__OAUTH_MICROSOFT_CLIENT_SECRET", "Microsoft OAuth client secret", "")
                     .name("Microsoft Client Secret")
-                    .input_type(InputType::Password)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__AUTH__ADMIN_PASSWORD", "Password for the default admin account", "")
-                    .name("Admin Password")
                     .input_type(InputType::Password)
                     .optional(),
                 ConfigVar::new("SUPPERS_AI__AUTH__INTERNAL_SECRET", "Secret for internal API authentication", "")
@@ -712,7 +636,24 @@ impl Block for AuthBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if matches!(event.event_type, LifecycleType::Init) {
-            seed_admin_user(ctx).await;
+            // Apply Plan A2 migrations: idempotent CREATE TABLE IF NOT EXISTS.
+            // Uses the typed db::ddl client (available to any block, not
+            // admin-only) so the browser-WASM runtime path works under WRAP
+            // enforcement.
+            crate::blocks::auth::migrations::apply(ctx)
+                .await
+                .map_err(|e| {
+                    WaferError::new(ErrorCode::INTERNAL, format!("auth migrations: {e}"))
+                })?;
+            // Bootstrap admin via env vars
+            // (SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL+PASSWORD or
+            // SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_TOKEN), writing to the
+            // Plan A2 users + local_credentials tables. Replaces the legacy
+            // seed_admin_user path which wrote inline password_hash to a
+            // different schema. Bootstrap dual-writes legacy compat fields
+            // until PR 3 migrates login.rs to repo::local_credentials.
+            let cfg = crate::blocks::auth::config::AuthConfig::from_ctx(ctx).await;
+            crate::blocks::auth::bootstrap::run(ctx, &cfg).await?;
         }
         Ok(())
     }

--- a/crates/solobase-core/src/blocks/auth/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/pages/mod.rs
@@ -640,9 +640,9 @@ const SETTINGS_KEYS: &[(&str, &str, &str, &str, bool, &str)] = &[
         "text",
     ),
     (
-        "SUPPERS_AI__AUTH__ADMIN_EMAIL",
-        "Admin Email",
-        "Email address that automatically gets the admin role on signup.",
+        "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL",
+        "Bootstrap Admin Email",
+        "Email address of the admin user created on first startup. Also automatically gets the admin role on signup.",
         "",
         false,
         "text",

--- a/crates/solobase-core/tests/auth/lifecycle_init_and_bootstrap.rs
+++ b/crates/solobase-core/tests/auth/lifecycle_init_and_bootstrap.rs
@@ -1,0 +1,175 @@
+//! PR 1+2: AuthBlock lifecycle(Init) applies migrations + runs bootstrap.
+//!
+//! The two changes ship together because PR 1 (migrations alone) is unsafe:
+//! migrations create the Plan A2 `users` schema (no `password_hash` column),
+//! but the legacy `seed_admin_user` writes a row with `password_hash`. The
+//! schema conflict broke the admin login row. This PR retires
+//! `seed_admin_user` and wires `bootstrap::run` (which writes the new schema
+//! plus transitional legacy compat fields) on the same Init event.
+//!
+//! Coverage:
+//! - Migrations create `local_credentials`/`bootstrap_tokens` (Plan A2 tables
+//!   that did not exist before this PR).
+//! - With env vars set, bootstrap seeds an admin user with a populated
+//!   `local_credentials` row + `display_name`/`role=admin` on `users`.
+
+use std::sync::Arc;
+
+use solobase_core::blocks::auth::{
+    config::AuthConfig,
+    repo::{local_credentials, users},
+    AuthBlock,
+};
+use wafer_block::core_types::{LifecycleEvent, LifecycleType};
+use wafer_core::clients::database as db;
+use wafer_run::block::Block;
+
+use crate::common::MigrationTestCtx;
+
+/// Drive `AuthBlock::lifecycle(Init)` against a freshly-built test context.
+async fn run_init(ctx: &MigrationTestCtx) {
+    let block = Arc::new(AuthBlock::new());
+    let event = LifecycleEvent {
+        event_type: LifecycleType::Init,
+        data: Vec::new(),
+    };
+    block
+        .lifecycle(ctx, event)
+        .await
+        .expect("lifecycle Init should succeed");
+}
+
+#[tokio::test]
+async fn init_creates_local_credentials_and_bootstrap_tokens_tables() {
+    let ctx = MigrationTestCtx::new();
+
+    // Sanity: tables don't exist before lifecycle.
+    let pre = db::query_raw(
+        &ctx,
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='suppers_ai__auth__local_credentials'",
+        &[],
+    )
+    .await
+    .expect("query sqlite_master");
+    assert!(
+        pre.is_empty(),
+        "local_credentials table must not exist pre-Init"
+    );
+
+    run_init(&ctx).await;
+
+    // Migrations created the tables — querying them via `db::query_raw`
+    // succeeds (would error with "no such table" otherwise).
+    let lc = db::query_raw(
+        &ctx,
+        "SELECT COUNT(*) AS n FROM suppers_ai__auth__local_credentials",
+        &[],
+    )
+    .await;
+    assert!(lc.is_ok(), "local_credentials missing: {:?}", lc);
+
+    let bt = db::query_raw(
+        &ctx,
+        "SELECT COUNT(*) AS n FROM suppers_ai__auth__bootstrap_tokens",
+        &[],
+    )
+    .await;
+    assert!(bt.is_ok(), "bootstrap_tokens missing: {:?}", bt);
+}
+
+#[tokio::test]
+async fn init_with_no_bootstrap_env_seeds_no_admin() {
+    // No env vars → bootstrap is a no-op even after migrations.
+    let ctx = MigrationTestCtx::new();
+    run_init(&ctx).await;
+
+    assert_eq!(
+        users::count(&ctx).await.expect("count"),
+        0,
+        "no env → no seeded admin"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_seeds_admin_dual_writes_legacy_and_new_schema() {
+    // This test bypasses lifecycle's `AuthConfig::from_ctx` (which would
+    // require a config block in the test ctx) and calls bootstrap directly
+    // with an explicit AuthConfig — same code path the lifecycle takes after
+    // config loading.
+    let ctx = MigrationTestCtx::new();
+    solobase_core::blocks::auth::migrations::apply(&ctx)
+        .await
+        .expect("migrations");
+
+    let cfg = AuthConfig::from_env_for_test(&[
+        (
+            "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL",
+            "boot@example.com",
+        ),
+        (
+            "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD",
+            "bootpass123",
+        ),
+    ]);
+    solobase_core::blocks::auth::bootstrap::run(&ctx, &cfg)
+        .await
+        .expect("bootstrap run");
+
+    // New-schema repo lookup sees the row.
+    let user = users::find_by_email(&ctx, "boot@example.com")
+        .await
+        .expect("repo call")
+        .expect("admin user inserted");
+    assert_eq!(user.role, "admin");
+    assert_eq!(user.display_name, "Admin");
+
+    // local_credentials row populated for new login path.
+    let cred = local_credentials::find_by_user_id(&ctx, &user.id)
+        .await
+        .expect("repo call")
+        .expect("local_credentials inserted");
+    assert!(!cred.password_hash.is_empty());
+
+    // Legacy compat fields written via dual-write so login.rs (which reads
+    // `password_hash` directly off `users`) keeps working until PR 3.
+    let legacy = db::query_raw(
+        &ctx,
+        "SELECT name, password_hash, disabled FROM suppers_ai__auth__users WHERE id = ?",
+        &[serde_json::json!(user.id)],
+    )
+    .await
+    .expect("legacy field query")
+    .into_iter()
+    .next()
+    .expect("user row");
+    assert_eq!(
+        legacy.data.get("name").and_then(|v| v.as_str()),
+        Some("Admin"),
+        "legacy name must be set for login.rs"
+    );
+    assert!(
+        legacy
+            .data
+            .get("password_hash")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "legacy password_hash must be set"
+    );
+
+    // Legacy admin role row in `suppers_ai__admin__user_roles` for the
+    // `helpers::get_user_roles` lookup login.rs uses.
+    let role_rows = db::query_raw(
+        &ctx,
+        "SELECT role FROM suppers_ai__admin__user_roles WHERE user_id = ?",
+        &[serde_json::json!(user.id)],
+    )
+    .await
+    .expect("role query");
+    assert!(
+        role_rows
+            .iter()
+            .any(|r| r.data.get("role").and_then(|v| v.as_str()) == Some("admin")),
+        "must seed legacy admin role row"
+    );
+}

--- a/crates/solobase-core/tests/auth/main.rs
+++ b/crates/solobase-core/tests/auth/main.rs
@@ -3,6 +3,7 @@
 mod bootstrap_run;
 mod common;
 mod fake_github;
+mod lifecycle_init_and_bootstrap;
 mod login_session_row;
 mod migrations_001;
 mod migrations_002;

--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -48,12 +48,12 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
     //    This is local-only (OPFS) so a simple default is acceptable.
     let _ = bridge::db_exec_raw(
         "INSERT OR IGNORE INTO suppers_ai__admin__variables (id, key, name, description, value, sensitive, created_at, updated_at)
-         VALUES ('var_admin_email', 'SUPPERS_AI__AUTH__ADMIN_EMAIL', 'Admin Email', 'Admin account email', 'admin@example.com', 0, datetime('now'), datetime('now'))",
+         VALUES ('var_admin_email', 'SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL', 'Bootstrap Admin Email', 'Admin account email', 'admin@example.com', 0, datetime('now'), datetime('now'))",
         "[]",
     );
     let _ = bridge::db_exec_raw(
         "INSERT OR IGNORE INTO suppers_ai__admin__variables (id, key, name, description, value, sensitive, created_at, updated_at)
-         VALUES ('var_admin_pass', 'SUPPERS_AI__AUTH__ADMIN_PASSWORD', 'Admin Password', 'Admin account password', 'admin123', 1, datetime('now'), datetime('now'))",
+         VALUES ('var_admin_pass', 'SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD', 'Bootstrap Admin Password', 'Admin account password', 'admin123', 1, datetime('now'), datetime('now'))",
         "[]",
     );
 

--- a/crates/solobase-web/tests/e2e/fixtures/global-setup.ts
+++ b/crates/solobase-web/tests/e2e/fixtures/global-setup.ts
@@ -27,8 +27,10 @@ import { dirname } from 'node:path';
  * `crates/solobase-core/src/blocks/auth/mod.rs::build_auth_cookie`).
  */
 
-export const ADMIN_EMAIL = process.env.SUPPERS_AI__AUTH__ADMIN_EMAIL ?? 'admin@example.com';
-export const ADMIN_PASSWORD = process.env.SUPPERS_AI__AUTH__ADMIN_PASSWORD ?? 'admin123';
+export const ADMIN_EMAIL =
+  process.env.SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL ?? 'admin@example.com';
+export const ADMIN_PASSWORD =
+  process.env.SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD ?? 'admin123';
 
 export const ADMIN_STATE_PATH = new URL('../../.auth/admin-state.json', import.meta.url).pathname;
 


### PR DESCRIPTION
## Summary

Combined PR 1+2 of solobase Plan A2 finish. The two changes ship together because PR 1 alone (wire migrations) couldn't ship — `seed_admin_user`'s writes to the legacy `users.password_hash` conflict with the Plan A2 `users` schema. Retiring `seed_admin_user` and wiring `bootstrap::run` is atomic.

- Wires `migrations::apply` (using the new typed `db::ddl` client from wafer-run #42, not admin-only `exec_raw`) + `bootstrap::run` into `AuthBlock::lifecycle(Init)`.
- Replaces `seed_admin_user` (deleted, ~70 LOC). `bootstrap::run` dual-writes legacy + Plan A2 schema on `suppers_ai__auth__users` plus a legacy admin role row on `suppers_ai__admin__user_roles` so the existing `login.rs`/`oauth.rs` keep working until PR 3 migrates them to `repo::local_credentials`. Dual-write is documented inline as transitional.
- Renames bootstrap env vars from `SUPPERS_AI__AUTH__ADMIN_*` to `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_*` (three-tier shared convention) and adds `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_TOKEN`. Updated touchpoints: `ci.yml`, `regen-visual-baselines.yml`, `solobase-web/src/config.rs` OPFS seed, e2e `global-setup.ts`, admin settings UI editable list in `pages/mod.rs`. `helpers::ensure_admin_role` and `helpers::create_user_and_assign_role` now read the new BOOTSTRAP_ADMIN_EMAIL key; the legacy ADMIN_EMAIL/ADMIN_PASSWORD ConfigVars on the AuthBlock are removed (the new keys live in `shared_config_vars`).
- Adds `AuthConfig::from_ctx` so the lifecycle hook can assemble the runtime config from `wafer-run/config` without each handler re-reading.

## Test plan

- [x] `cargo test -p solobase-core` — 614/614 pass (54 in tests/auth)
- [x] New test file: `tests/auth/lifecycle_init_and_bootstrap.rs` — covers Init creating Plan A2 tables, no-op without env vars, and dual-write of legacy + new schema fields when bootstrap runs with email+password.
- [x] `bash scripts/audit-wrap-grants.sh` — clean
- [x] `cargo +nightly fmt --all`
- [x] `cargo check -p solobase-web --target wasm32-unknown-unknown` — clean
- [ ] CI green (E2E is the regression risk: bootstrap dual-writes the legacy `password_hash` + admin role row so `login.rs` keeps working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)