### PR TITLE
fix(auth): seed_admin_user writes all CollectionSchema columns

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -345,6 +345,14 @@ pub async fn seed_admin_user(ctx: &dyn Context) {
         }
     };
 
+    // Write every column declared in `USERS_COLLECTION`'s `CollectionSchema`
+    // (see `BlockInfo::collections` below). The cloudflare D1 backend
+    // materializes table schemas from data shape on first insert, and
+    // queries that filter on never-written columns (e.g. the admin user
+    // list's `WHERE deleted_at IS NULL`) fail with "no such column" until
+    // some other write adds that column. Writing the full set of declared
+    // columns here — even empty/null defaults — makes the table land
+    // complete on first cold-start.
     let mut data = json_map(serde_json::json!({
         "email": admin_email,
         "password_hash": password_hash,
@@ -354,7 +362,15 @@ pub async fn seed_admin_user(ctx: &dyn Context) {
         // first sign-in. Without this, the seeded admin would land in the
         // "unverified" state on /b/userportal/security and the require-
         // verification config could lock them out of their own deployment.
-        "email_verified": true
+        "email_verified": true,
+        "avatar_url": "",
+        "oauth_provider": "",
+        "verification_token": "",
+        "reset_token": "",
+        "reset_token_expires": null,
+        "last_verification_sent": null,
+        "last_login_at": null,
+        "deleted_at": null,
     }));
     super::helpers::stamp_created(&mut data);
 


### PR DESCRIPTION
## Summary

**Root cause** of the wafer.run "Failed to load users: internal database error" on the admin Users tab: D1 (and native sqlite) materialize the table schema from data shape on first insert. `seed_admin_user` writes 7 columns (`email, password_hash, name, disabled, email_verified` + auto-stamped `created_at/updated_at`), but the `USERS_COLLECTION` `CollectionSchema` (auth/mod.rs:399-412) declares 13 fields including `deleted_at` — and every admin list query filters `WHERE deleted_at IS NULL`. The unwritten columns never exist, so the list query fails with "no such column" until some other writer happens to add them.

PR #95's schema-evolution (ALTER TABLE ADD COLUMN on first insert with new keys) fixes the *write* path; queries against missing columns have no equivalent retry.

## Fix

Make `seed_admin_user` write every column declared in the schema, with empty/null defaults for the ones a seeded admin wouldn't naturally populate (`avatar_url`, `oauth_provider`, `verification_token`, `reset_token`, `reset_token_expires`, `last_verification_sent`, `last_login_at`, `deleted_at`). On a fresh deploy this materializes the table with the full column set on first cold-start.

## Migration

**Existing wafer.run deployment must do a complete redeploy** to pick up the corrected schema:

```bash
# 1. Drop the broken table (preserves D1 db, drops the users data — there
#    was only one user (admin) anyway, will be re-seeded on cold-start)
wrangler d1 execute wafer-site-prod --remote \
  --command "DROP TABLE IF EXISTS suppers_ai__auth__users"

# 2. Redeploy with the fix landed
ENV_FILE=.env.prod ./scripts/deploy-cloudflare.sh deploy
```

After cold-start: `seed_admin_user` runs against the empty table and writes all 13 columns; admin list query starts working.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo check -p solobase-core --lib` clean
- [x] `cargo test -p solobase-core` — all auth tests pass (including bootstrap_admin and login flows)
- [ ] CI green
- [ ] After redeploy + cold-start: admin Users tab loads on wafer.run

## Follow-up (out of scope)

Longer term, `D1Service::create()` should consult the block's `CollectionSchema` to materialize the table with all declared columns up front, rather than inferring from data shape on first write. That removes the foot-gun for every collection, not just users. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)