### PR TITLE
refactor(auth/repo): typed db::* client; unblocks Plan A2 finish (PR -0.5)

### DIFF
--- a/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.postgres.sql
@@ -16,20 +16,22 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__users (
 );
 
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__local_credentials (
-    user_id        TEXT PRIMARY KEY REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
+    id             TEXT PRIMARY KEY,
+    user_id        TEXT NOT NULL UNIQUE REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
     password_hash  TEXT NOT NULL,
     must_reset     BOOLEAN NOT NULL DEFAULT FALSE,
     created_at     TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__provider_links (
+    id             TEXT PRIMARY KEY,
     provider       TEXT NOT NULL,
     provider_ref   TEXT NOT NULL,
     user_id        TEXT NOT NULL REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
     provider_login TEXT NOT NULL,
     access_token   TEXT NOT NULL,
     linked_at      TEXT NOT NULL,
-    PRIMARY KEY (provider, provider_ref)
+    UNIQUE (provider, provider_ref)
 );
 
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__orgs (
@@ -79,7 +81,8 @@ CREATE INDEX IF NOT EXISTS suppers_ai__auth__cli_exchange_codes_expires_at_idx
     ON suppers_ai__auth__cli_exchange_codes (expires_at);
 
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__bootstrap_tokens (
-    token_hash     BYTEA PRIMARY KEY,
+    id             TEXT PRIMARY KEY,
+    token_hash     TEXT NOT NULL UNIQUE,
     created_at     TEXT NOT NULL,
     expires_at     TEXT NOT NULL
 );

--- a/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.sqlite.sql
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__users (
 
 -- Local credentials (empty for OAuth-only users)
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__local_credentials (
-    user_id        TEXT PRIMARY KEY REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
+    id             TEXT PRIMARY KEY,
+    user_id        TEXT NOT NULL UNIQUE REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
     password_hash  TEXT NOT NULL,
     must_reset     INTEGER NOT NULL DEFAULT 0,
     created_at     TEXT NOT NULL
@@ -26,13 +27,14 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__local_credentials (
 
 -- Provider links (github/google/microsoft)
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__provider_links (
+    id             TEXT PRIMARY KEY,
     provider       TEXT NOT NULL,
     provider_ref   TEXT NOT NULL,
     user_id        TEXT NOT NULL REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
     provider_login TEXT NOT NULL,
     access_token   TEXT NOT NULL,
     linked_at      TEXT NOT NULL,
-    PRIMARY KEY (provider, provider_ref)
+    UNIQUE (provider, provider_ref)
 );
 
 -- Orgs
@@ -85,9 +87,12 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__cli_exchange_codes (
 CREATE INDEX IF NOT EXISTS suppers_ai__auth__cli_exchange_codes_expires_at_idx
     ON suppers_ai__auth__cli_exchange_codes (expires_at);
 
--- Bootstrap tokens (first-run admin seeding)
+-- Bootstrap tokens (first-run admin seeding). token_hash stored as hex-encoded
+-- TEXT (lowercase, 64 chars for sha256) so the typed db::* client can use the
+-- synthetic id PK; the hash is unique per token, indexed for is_valid lookups.
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__bootstrap_tokens (
-    token_hash     BLOB PRIMARY KEY,
+    id             TEXT PRIMARY KEY,
+    token_hash     TEXT NOT NULL UNIQUE,
     created_at     TEXT NOT NULL,
     expires_at     TEXT NOT NULL
 );

--- a/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
@@ -24,15 +24,31 @@ pub async fn insert(
     token_hash: Vec<u8>,
     expires_at: &str,
 ) -> Result<(), RepoError> {
+    use std::collections::HashMap;
+
+    use serde_json::Value;
+    let id = uuid::Uuid::now_v7().to_string();
     let now = now_iso();
-    db::exec_raw(
-        ctx,
-        &format!("INSERT INTO {TABLE} (token_hash, created_at, expires_at) VALUES (?, ?, ?)"),
-        &[json!(token_hash), json!(now), json!(expires_at)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("bootstrap_tokens insert: {e}")))?;
+    let hex = hex_encode(&token_hash);
+    let mut data: HashMap<String, Value> = HashMap::new();
+    data.insert("id".into(), json!(id));
+    data.insert("token_hash".into(), json!(hex));
+    data.insert("created_at".into(), json!(now));
+    data.insert("expires_at".into(), json!(expires_at));
+
+    db::create(ctx, TABLE, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("bootstrap_tokens insert: {e}")))?;
     Ok(())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 /// Returns true iff an unexpired row exists with the given hash.
@@ -41,12 +57,75 @@ pub async fn insert(
 /// schema stores.
 pub async fn is_valid(ctx: &dyn Context, token_hash: &[u8]) -> Result<bool, RepoError> {
     let now = now_iso();
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT 1 AS one FROM {TABLE} WHERE token_hash = ? AND expires_at >= ?"),
-        &[json!(token_hash), json!(now)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("bootstrap_tokens lookup: {e}")))?;
-    Ok(!rows.is_empty())
+    let hex = hex_encode(token_hash);
+    let opts = db::ListOptions {
+        filters: vec![
+            db::Filter {
+                field: "token_hash".into(),
+                operator: db::FilterOp::Equal,
+                value: json!(hex),
+            },
+            db::Filter {
+                field: "expires_at".into(),
+                operator: db::FilterOp::GreaterEqual,
+                value: json!(now),
+            },
+        ],
+        limit: 1,
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("bootstrap_tokens lookup: {e}")))?;
+    Ok(!res.records.is_empty())
+}
+
+#[cfg(test)]
+mod typed_client_tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    fn future_iso(secs: i64) -> String {
+        (chrono::Utc::now() + chrono::Duration::seconds(secs))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    }
+
+    fn past_iso(secs: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn insert_then_validate_round_trips_under_wrap() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let hash = vec![0xab_u8; 32];
+        insert(&ctx, hash.clone(), &future_iso(3600)).await.unwrap();
+        assert!(is_valid(&ctx, &hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn unknown_hash_is_invalid() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let hash = vec![0xcd_u8; 32];
+        assert!(!is_valid(&ctx, &hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn expired_hash_is_invalid() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let hash = vec![0xef_u8; 32];
+        insert(&ctx, hash.clone(), &past_iso(3600)).await.unwrap();
+        assert!(!is_valid(&ctx, &hash).await.unwrap());
+    }
 }

--- a/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
@@ -51,21 +51,18 @@ pub async fn insert(
     password_hash: &str,
     must_reset: bool,
 ) -> Result<(), RepoError> {
+    let id = uuid::Uuid::now_v7().to_string();
     let now = now_iso();
-    db::exec_raw(
-        ctx,
-        &format!(
-            "INSERT INTO {TABLE} (user_id, password_hash, must_reset, created_at) VALUES (?, ?, ?, ?)",
-        ),
-        &[
-            json!(user_id),
-            json!(password_hash),
-            json!(if must_reset { 1 } else { 0 }),
-            json!(now),
-        ],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("local_credentials insert: {e}")))?;
+    let mut data: HashMap<String, Value> = HashMap::new();
+    data.insert("id".into(), json!(id));
+    data.insert("user_id".into(), json!(user_id));
+    data.insert("password_hash".into(), json!(password_hash));
+    data.insert("must_reset".into(), json!(if must_reset { 1 } else { 0 }));
+    data.insert("created_at".into(), json!(now));
+
+    db::create(ctx, TABLE, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("local_credentials insert: {e}")))?;
     Ok(())
 }
 
@@ -73,15 +70,60 @@ pub async fn find_by_user_id(
     ctx: &dyn Context,
     user_id: &str,
 ) -> Result<Option<LocalCredentialRow>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE user_id = ?"),
-        &[json!(user_id)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("local_credentials select: {e}")))?;
-    match rows.first() {
-        Some(r) => Ok(Some(row_from_map(&r.data)?)),
-        None => Ok(None),
+    use wafer_block::ErrorCode;
+    match db::get_by_field(ctx, TABLE, "user_id", json!(user_id)).await {
+        Ok(rec) => Ok(Some(row_from_map(&rec.data)?)),
+        Err(e) if e.code == ErrorCode::NOT_FOUND => Ok(None),
+        Err(e) => Err(RepoError::Db(format!("local_credentials select: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod typed_client_tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    async fn seed_user(ctx: &TestContext, user_id: &str) {
+        wafer_core::clients::database::exec_raw(
+            ctx,
+            "INSERT INTO suppers_ai__auth__users \
+             (id, email, display_name, role, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            &[
+                json!(user_id),
+                json!(format!("{user_id}@example.com")),
+                json!(user_id),
+                json!("user"),
+                json!("2026-01-01T00:00:00Z"),
+                json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn insert_then_find_round_trip_under_wrap() {
+        // Seed user before enabling WRAP so the exec_raw fixture INSERT is not
+        // subject to the WRAP check (same pattern as sessions.rs seed helpers).
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        let ctx = ctx.with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        insert(&ctx, "user-a", "$argon2id$dummy", false)
+            .await
+            .unwrap();
+        let got = find_by_user_id(&ctx, "user-a").await.unwrap().unwrap();
+        assert_eq!(got.user_id, "user-a");
+        assert_eq!(got.password_hash, "$argon2id$dummy");
+        assert!(!got.must_reset);
+    }
+
+    #[tokio::test]
+    async fn find_by_unknown_user_returns_none() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        assert!(find_by_user_id(&ctx, "ghost").await.unwrap().is_none());
     }
 }

--- a/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
@@ -29,11 +29,14 @@ fn now_iso() -> String {
 
 fn row_from_map(m: &HashMap<String, Value>) -> Result<LocalCredentialRow, RepoError> {
     let s = |k: &str| m.get(k).and_then(Value::as_str).map(str::to_owned);
-    let must_reset = m
-        .get("must_reset")
-        .and_then(|v| v.as_i64())
-        .map(|n| n != 0)
-        .unwrap_or(false);
+    // Mirror `RecordExt::bool_field` so the column round-trips across both
+    // sqlite (INTEGER 0/1) and postgres (BOOLEAN -> JSON bool).
+    let must_reset = match m.get("must_reset") {
+        Some(Value::Bool(b)) => *b,
+        Some(Value::Number(n)) => n.as_i64().unwrap_or(0) != 0,
+        Some(Value::String(s)) => s == "true" || s == "1",
+        _ => false,
+    };
     Ok(LocalCredentialRow {
         user_id: s("user_id").ok_or_else(|| RepoError::Db("missing user_id".into()))?,
         password_hash: s("password_hash")
@@ -125,5 +128,29 @@ mod typed_client_tests {
                 .await
                 .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         assert!(find_by_user_id(&ctx, "ghost").await.unwrap().is_none());
+    }
+
+    /// Postgres returns BOOLEAN columns as JSON `bool`; sqlite returns INTEGER
+    /// 0/1. `row_from_map` must accept both. Pure-shape test on the
+    /// deserializer — no DB roundtrip — so the assertion holds regardless of
+    /// which backend the test fixture happens to use.
+    #[test]
+    fn row_from_map_accepts_bool_int_and_string_must_reset() {
+        let mk = |v: Value| {
+            let mut m = HashMap::new();
+            m.insert("user_id".into(), json!("u"));
+            m.insert("password_hash".into(), json!("h"));
+            m.insert("must_reset".into(), v);
+            m.insert("created_at".into(), json!("2026-01-01T00:00:00Z"));
+            row_from_map(&m).unwrap()
+        };
+        assert!(mk(json!(true)).must_reset, "JSON bool true (postgres)");
+        assert!(!mk(json!(false)).must_reset, "JSON bool false (postgres)");
+        assert!(mk(json!(1)).must_reset, "JSON int 1 (sqlite)");
+        assert!(!mk(json!(0)).must_reset, "JSON int 0 (sqlite)");
+        assert!(mk(json!("true")).must_reset, "string 'true'");
+        assert!(mk(json!("1")).must_reset, "string '1'");
+        assert!(!mk(json!("false")).must_reset, "string 'false'");
+        assert!(!mk(Value::Null).must_reset, "missing/null defaults false");
     }
 }

--- a/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
@@ -57,31 +57,52 @@ fn row_from_map(m: &HashMap<String, Value>) -> Result<ProviderLink, RepoError> {
 
 /// Insert a link row, or update `user_id`, `provider_login`, `access_token`,
 /// `linked_at` in place when a row with the same `(provider, provider_ref)`
-/// already exists. Single SQL statement per spec §5 (OAuth callback).
+/// already exists. Manual two-step (list → update_by_filters or create) since
+/// `db::*` has no two-key upsert primitive.
 pub async fn upsert(ctx: &dyn Context, new: NewLink<'_>) -> Result<(), RepoError> {
     let now = now_iso();
-    db::exec_raw(
-        ctx,
-        &format!(
-            "INSERT INTO {TABLE} (provider, provider_ref, user_id, provider_login, access_token, linked_at) \
-             VALUES (?, ?, ?, ?, ?, ?) \
-             ON CONFLICT (provider, provider_ref) DO UPDATE SET \
-                 user_id = excluded.user_id, \
-                 provider_login = excluded.provider_login, \
-                 access_token = excluded.access_token, \
-                 linked_at = excluded.linked_at",
-        ),
-        &[
-            json!(new.provider),
-            json!(new.provider_ref),
-            json!(new.user_id),
-            json!(new.provider_login),
-            json!(new.access_token),
-            json!(now),
-        ],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("provider_links upsert: {e}")))?;
+    let filters = vec![
+        db::Filter {
+            field: "provider".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(new.provider),
+        },
+        db::Filter {
+            field: "provider_ref".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(new.provider_ref),
+        },
+    ];
+    let opts = db::ListOptions {
+        filters: filters.clone(),
+        limit: 1,
+        ..Default::default()
+    };
+    let existing = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("provider_links upsert lookup: {e}")))?;
+
+    let mut data: HashMap<String, Value> = HashMap::new();
+    data.insert("user_id".into(), json!(new.user_id));
+    data.insert("provider_login".into(), json!(new.provider_login));
+    data.insert("access_token".into(), json!(new.access_token));
+    data.insert("linked_at".into(), json!(now));
+
+    if existing.records.is_empty() {
+        // Insert: include the natural-key columns + a fresh synthetic id.
+        let id = uuid::Uuid::now_v7().to_string();
+        data.insert("id".into(), json!(id));
+        data.insert("provider".into(), json!(new.provider));
+        data.insert("provider_ref".into(), json!(new.provider_ref));
+        db::create(ctx, TABLE, data)
+            .await
+            .map_err(|e| RepoError::Db(format!("provider_links insert: {e}")))?;
+    } else {
+        // Update by the same (provider, provider_ref) filters — no synthetic id needed.
+        db::update_by_filters(ctx, TABLE, filters, data)
+            .await
+            .map_err(|e| RepoError::Db(format!("provider_links update: {e}")))?;
+    }
     Ok(())
 }
 
@@ -92,14 +113,26 @@ pub async fn find_by_provider_ref(
     provider: &str,
     provider_ref: &str,
 ) -> Result<Option<ProviderLink>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE provider = ? AND provider_ref = ?"),
-        &[json!(provider), json!(provider_ref)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("provider_links find: {e}")))?;
-    match rows.first() {
+    let opts = db::ListOptions {
+        filters: vec![
+            db::Filter {
+                field: "provider".into(),
+                operator: db::FilterOp::Equal,
+                value: json!(provider),
+            },
+            db::Filter {
+                field: "provider_ref".into(),
+                operator: db::FilterOp::Equal,
+                value: json!(provider_ref),
+            },
+        ],
+        limit: 1,
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("provider_links find: {e}")))?;
+    match res.records.first() {
         Some(r) => Ok(Some(row_from_map(&r.data)?)),
         None => Ok(None),
     }
@@ -109,7 +142,7 @@ pub async fn find_by_provider_ref(
 /// user can only have at most one link per provider (enforced by the
 /// OAuth callback upserting on provider+provider_ref and users being
 /// unique per provider account), so there's at most one row in practice;
-/// the `ORDER BY linked_at DESC LIMIT 1` just makes that explicit.
+/// the `sort` + `limit: 1` just makes that explicit.
 ///
 /// Used by `AuthService::verify_org_admin` to retrieve the access token it
 /// needs to call into the provider's org-membership endpoint.
@@ -118,16 +151,30 @@ pub async fn find_by_user_provider(
     user_id: &str,
     provider: &str,
 ) -> Result<Option<ProviderLink>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!(
-            "SELECT * FROM {TABLE} WHERE user_id = ? AND provider = ? ORDER BY linked_at DESC LIMIT 1"
-        ),
-        &[json!(user_id), json!(provider)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("provider_links find_by_user_provider: {e}")))?;
-    match rows.first() {
+    let opts = db::ListOptions {
+        filters: vec![
+            db::Filter {
+                field: "user_id".into(),
+                operator: db::FilterOp::Equal,
+                value: json!(user_id),
+            },
+            db::Filter {
+                field: "provider".into(),
+                operator: db::FilterOp::Equal,
+                value: json!(provider),
+            },
+        ],
+        sort: vec![db::SortField {
+            field: "linked_at".into(),
+            desc: true,
+        }],
+        limit: 1,
+        ..Default::default()
+    };
+    let res = db::list(ctx, TABLE, &opts)
+        .await
+        .map_err(|e| RepoError::Db(format!("provider_links find_by_user_provider: {e}")))?;
+    match res.records.first() {
         Some(r) => Ok(Some(row_from_map(&r.data)?)),
         None => Ok(None),
     }
@@ -164,6 +211,102 @@ pub async fn list_for_user(
         .await
         .map_err(|e| RepoError::Db(format!("provider_links list_for_user: {e}")))?;
     res.records.iter().map(|r| row_from_map(&r.data)).collect()
+}
+
+#[cfg(test)]
+mod typed_client_tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    async fn seed_user(ctx: &TestContext, user_id: &str) {
+        wafer_core::clients::database::exec_raw(
+            ctx,
+            "INSERT INTO suppers_ai__auth__users \
+             (id, email, display_name, role, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            &[
+                json!(user_id),
+                json!(format!("{user_id}@example.com")),
+                json!(user_id),
+                json!("user"),
+                json!("2026-01-01T00:00:00Z"),
+                json!("2026-01-01T00:00:00Z"),
+            ],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn upsert_inserts_then_updates_under_wrap() {
+        // Seed BEFORE enabling WRAP — exec_raw fixture denied otherwise.
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        let ctx = ctx.with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+
+        upsert(
+            &ctx,
+            NewLink {
+                provider: "github",
+                provider_ref: "gh-1",
+                user_id: "user-a",
+                provider_login: "alice",
+                access_token: "tok-old",
+            },
+        )
+        .await
+        .unwrap();
+        // Re-upsert with new access_token / login — should update in place,
+        // not insert a duplicate.
+        upsert(
+            &ctx,
+            NewLink {
+                provider: "github",
+                provider_ref: "gh-1",
+                user_id: "user-a",
+                provider_login: "alice2",
+                access_token: "tok-new",
+            },
+        )
+        .await
+        .unwrap();
+        let got = find_by_provider_ref(&ctx, "github", "gh-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.access_token, "tok-new");
+        assert_eq!(got.provider_login, "alice2");
+    }
+
+    #[tokio::test]
+    async fn find_by_user_provider_returns_most_recent() {
+        let ctx = TestContext::with_auth().await;
+        seed_user(&ctx, "user-a").await;
+        let ctx = ctx.with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+
+        upsert(
+            &ctx,
+            NewLink {
+                provider: "github",
+                provider_ref: "gh-1",
+                user_id: "user-a",
+                provider_login: "alice",
+                access_token: "tok-a",
+            },
+        )
+        .await
+        .unwrap();
+        let got = find_by_user_provider(&ctx, "user-a", "github")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.access_token, "tok-a");
+
+        let none = find_by_user_provider(&ctx, "user-a", "google")
+            .await
+            .unwrap();
+        assert!(none.is_none());
+    }
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/auth/repo/users.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/users.rs
@@ -52,41 +52,29 @@ fn row_from_map(m: &HashMap<String, Value>) -> Result<UserRow, RepoError> {
 pub async fn insert(ctx: &dyn Context, new: NewUser) -> Result<UserRow, RepoError> {
     let id = Uuid::now_v7().to_string();
     let now = now_iso();
-    db::exec_raw(
-        ctx,
-        &format!(
-            "INSERT INTO {TABLE} (id, email, display_name, avatar_url, role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ),
-        &[
-            json!(id),
-            json!(new.email),
-            json!(new.display_name),
-            match new.avatar_url.as_deref() {
-                Some(a) => json!(a),
-                None => Value::Null,
-            },
-            json!(new.role),
-            json!(now),
-            json!(now),
-        ],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("insert: {e}")))?;
+    let mut data: HashMap<String, Value> = HashMap::new();
+    data.insert("id".into(), json!(id));
+    data.insert("email".into(), json!(new.email));
+    data.insert("display_name".into(), json!(new.display_name));
+    if let Some(a) = new.avatar_url.as_deref() {
+        data.insert("avatar_url".into(), json!(a));
+    }
+    data.insert("role".into(), json!(new.role));
+    data.insert("created_at".into(), json!(now));
+    data.insert("updated_at".into(), json!(now));
 
-    find_by_id(ctx, &id).await?.ok_or(RepoError::NotFound)
+    let rec = db::create(ctx, TABLE, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("insert: {e}")))?;
+    row_from_map(&rec.data)
 }
 
 pub async fn find_by_email(ctx: &dyn Context, email: &str) -> Result<Option<UserRow>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE email = ?"),
-        &[json!(email)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("select by email: {e}")))?;
-    match rows.first() {
-        Some(r) => Ok(Some(row_from_map(&r.data)?)),
-        None => Ok(None),
+    use wafer_block::ErrorCode;
+    match db::get_by_field(ctx, TABLE, "email", json!(email)).await {
+        Ok(rec) => Ok(Some(row_from_map(&rec.data)?)),
+        Err(e) if e.code == ErrorCode::NOT_FOUND => Ok(None),
+        Err(e) => Err(RepoError::Db(format!("select by email: {e}"))),
     }
 }
 
@@ -95,28 +83,18 @@ pub async fn find_by_email(ctx: &dyn Context, email: &str) -> Result<Option<User
 /// Used by the block's bootstrap logic to decide whether to create the first
 /// admin user. A non-zero count means "already bootstrapped — no-op".
 pub async fn count(ctx: &dyn Context) -> Result<u64, RepoError> {
-    let rows = db::query_raw(ctx, &format!("SELECT COUNT(*) AS n FROM {TABLE}"), &[])
+    let n = db::count(ctx, TABLE, &[])
         .await
         .map_err(|e| RepoError::Db(format!("users count: {e}")))?;
-    let n = rows
-        .first()
-        .and_then(|r| r.data.get("n"))
-        .and_then(|v| v.as_i64())
-        .ok_or_else(|| RepoError::Db("count returned no rows".into()))?;
     Ok(n.max(0) as u64)
 }
 
 pub async fn find_by_id(ctx: &dyn Context, id: &str) -> Result<Option<UserRow>, RepoError> {
-    let rows = db::query_raw(
-        ctx,
-        &format!("SELECT * FROM {TABLE} WHERE id = ?"),
-        &[json!(id)],
-    )
-    .await
-    .map_err(|e| RepoError::Db(format!("select by id: {e}")))?;
-    match rows.first() {
-        Some(r) => Ok(Some(row_from_map(&r.data)?)),
-        None => Ok(None),
+    use wafer_block::ErrorCode;
+    match db::get(ctx, TABLE, id).await {
+        Ok(rec) => Ok(Some(row_from_map(&rec.data)?)),
+        Err(e) if e.code == ErrorCode::NOT_FOUND => Ok(None),
+        Err(e) => Err(RepoError::Db(format!("select by id: {e}"))),
     }
 }
 
@@ -222,5 +200,79 @@ mod email_verified_tests {
             RepoError::Db(_) => {}
             other => panic!("expected Db error, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod typed_client_tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    /// `repo::users::insert` must succeed when the auth block calls it under
+    /// WRAP enforcement (own-resource access). Today's `exec_raw` path
+    /// requires admin and would fail; this test guards the typed-client
+    /// rewrite.
+    #[tokio::test]
+    async fn insert_succeeds_under_wrap_for_auth_block() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let user = insert(
+            &ctx,
+            NewUser {
+                email: "a@b.c".into(),
+                display_name: "A".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .expect("insert under wrap");
+        assert_eq!(user.email, "a@b.c");
+        assert!(!user.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_email_returns_inserted_row_under_wrap() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        insert(
+            &ctx,
+            NewUser {
+                email: "x@y.z".into(),
+                display_name: "X".into(),
+                avatar_url: Some("https://example.com/a.png".into()),
+                role: "admin".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let got = find_by_email(&ctx, "x@y.z").await.unwrap().unwrap();
+        assert_eq!(got.role, "admin");
+        assert_eq!(got.avatar_url.as_deref(), Some("https://example.com/a.png"));
+    }
+
+    #[tokio::test]
+    async fn count_reports_zero_then_one() {
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        assert_eq!(count(&ctx).await.unwrap(), 0);
+        insert(
+            &ctx,
+            NewUser {
+                email: "c@d.e".into(),
+                display_name: "C".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(count(&ctx).await.unwrap(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Refactors the 4 critical-path auth repo modules off `db::exec_raw` / `db::query_raw` onto the typed `db::*` client, so the auth block can run them under WRAP without admin grants. Schema-level support: every Plan A2 table whose repo is being touched gains a synthetic `id TEXT PRIMARY KEY`; natural keys (`user_id`, `token_hash`, `(provider, provider_ref)`) become UNIQUE.

This is **PR -0.5** for the Plan A2 finish initiative — see `docs/superpowers/handoffs/2026-05-07-plan-a2-finish-attempt-handoff.md`. After this lands, PRs 1-5 of the existing plan can resume from a working baseline.

## Why

The Plan A2 stash (`bootstrap.rs`, `repo/*`, `AuthServiceImpl`) was tested against `TestContext::with_auth()` which bypasses WRAP. Production browser-WASM enforces WRAP — and `exec_raw` is admin-only by design. Three previous attempts (#90, #94, #96) hit successive layers of the WRAP cascade. This PR fixes the last (DML) layer.

## Changes

- **Migration 001** (sqlite + postgres): `local_credentials`, `provider_links`, `bootstrap_tokens` get synthetic `id TEXT PRIMARY KEY`. `bootstrap_tokens.token_hash` switches BLOB/BYTEA → hex-encoded TEXT UNIQUE. Other tables untouched (sessions/orgs/PAT/cli_codes).
- **`repo/users.rs`**: `insert` / `find_by_email` / `count` / `find_by_id` → typed `db::create / get_by_field / count / get`.
- **`repo/local_credentials.rs`**: `insert` → `db::create` (with synthetic UUIDv7 id). `find_by_user_id` → `db::get_by_field`.
- **`repo/bootstrap_tokens.rs`**: `insert` → `db::create` with hex-encoded hash. `is_valid` → `db::list` with two filters (`token_hash` Equal + `expires_at` GreaterEqual).
- **`repo/provider_links.rs`**: `upsert` → manual two-step (`db::list` → `db::update_by_filters` or `db::create`). `find_by_provider_ref` / `find_by_user_provider` → `db::list` with multi-filter ListOptions.
- **Tests**: new `typed_client_tests` modules in each refactored repo file using `TestContext::with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin")` to exercise the WRAP-enforced path. The seed-before-WRAP pattern (fixtures use `exec_raw` which WRAP would deny) matches the existing `repo/sessions.rs` test idiom.

## Out of scope

- `repo/sessions.rs` — already typed-client-clean post-PR #74.
- `repo/orgs.rs` / `repo/pats.rs` / `repo/cli_codes.rs` — deferred to PR 5 of the existing Plan A2 finish plan. Their schemas keep BLOB / composite PKs in this migration.
- `migrations/mod.rs` — still uses `exec_raw` for DDL execution; switching to `db::ddl` (wafer-run #42) is PR 1 of the existing plan, not here.

## Test plan

- [x] `cargo test -p solobase-core --lib blocks::auth` — 97 tests pass (4 new typed_client + existing).
- [x] `cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [ ] CI green (Format & Lint, Tests, WASM, E2E, Security, TS SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)