### PR TITLE
fix(browser): hash dev builds + recoverable SW self-destruct

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -1,9 +1,45 @@
+// Persists across the navigations sw.js triggers when it self-destructs,
+// so the very next page load hits the recovery path (below) instead of
+// re-registering the SW with the same stale browser-cached modules.
+const SW_RECOVER_KEY = '__solobase_sw_recover';
+
 async function boot() {
     const status = document.getElementById('status');
     if (!('serviceWorker' in navigator)) {
         status.textContent = 'Service Workers not supported in this browser.';
         return;
     }
+
+    // Recovery path: a previous boot's SW self-destructed and signalled the
+    // page to set the breaker. Wipe all SW + cache state, force a fresh
+    // document fetch via a cache-busting query string, and let the next
+    // load proceed normally.
+    if (sessionStorage.getItem(SW_RECOVER_KEY)) {
+        sessionStorage.removeItem(SW_RECOVER_KEY);
+        status.textContent = 'Recovering from stale cache...';
+        try {
+            const regs = await navigator.serviceWorker.getRegistrations();
+            for (const r of regs) await r.unregister();
+            const keys = await caches.keys();
+            for (const k of keys) await caches.delete(k);
+        } catch (e) {
+            console.error('[__APP_NAME__] cache wipe failed:', e);
+        }
+        const url = new URL(window.location.href);
+        url.searchParams.set('_freshen', String(Date.now()));
+        window.location.replace(url.toString());
+        return;
+    }
+
+    // Listen for self-destruct notices. The SW posts this message just
+    // before re-navigating its clients, so by the time the navigation
+    // lands, the breaker is set and the recovery path above runs.
+    navigator.serviceWorker.addEventListener('message', (event) => {
+        if (event.data?.type === 'sw-self-destruct') {
+            sessionStorage.setItem(SW_RECOVER_KEY, '1');
+        }
+    });
+
     try {
         status.textContent = 'Registering Service Worker...';
         const registration = await navigator.serviceWorker.register('/sw.js', {

--- a/crates/solobase-browser/assets/sw.js.tmpl
+++ b/crates/solobase-browser/assets/sw.js.tmpl
@@ -18,10 +18,22 @@ async function selfDestruct(reason) {
         await self.registration.unregister();
         const clients = await self.clients.matchAll({ type: 'window' });
         for (const c of clients) {
-            // Re-navigate the page so the next request goes to the network
-            // (no controller now that we've unregistered) and loader.js runs
-            // again with the fresh /sw.js.
-            try { c.navigate(c.url); } catch (e) { console.warn('[__APP_NAME__] navigate() failed:', e); }
+            // Notify the page so loader.js sets its sessionStorage breaker
+            // BEFORE the navigation below. The breaker routes the next load
+            // through a recovery path (clear caches, drop any lingering SW,
+            // bust the document cache, reload once) — that breaks
+            // stale-module loops where a fresh `*_bg.wasm` can't link
+            // against a browser-cached previous-build `*.js`.
+            try {
+                c.postMessage({ type: 'sw-self-destruct', reason });
+            } catch (e) {
+                console.warn('[__APP_NAME__] postMessage failed:', e);
+            }
+            try {
+                c.navigate(c.url);
+            } catch (e) {
+                console.warn('[__APP_NAME__] navigate() failed:', e);
+            }
         }
     } catch (e) {
         console.error('[__APP_NAME__] self-destruct cleanup failed:', e);
@@ -144,17 +156,19 @@ async function handleFetch(request) {
         return await handle_request(request);
     } catch (error) {
         console.error('[__APP_NAME__] Error handling request:', error);
-        // wasm-bindgen surfaces a `RuntimeError` for an `unreachable` trap.
-        // Once the wasm instance traps it's permanently broken — every
-        // subsequent host call will fail. Self-destruct so the user doesn't
-        // get stuck behind a dead SW.
-        if (error instanceof WebAssembly.RuntimeError) {
-            await selfDestruct(`wasm trap during request: ${error}`);
-            return fetch(request);
+        // wasm-bindgen surfaces a `RuntimeError` for an `unreachable` trap;
+        // ensureInitialized() also synthesises errors for `init()` /
+        // `initialize()` failures (most often caused by a stale browser
+        // module cache pointing at filenames the new build no longer has).
+        // Both modes mean the wasm instance is unusable for the rest of
+        // this SW's life, so self-destruct (which posts the breaker
+        // message and triggers a re-navigation) and fall through to
+        // network — that lets the browser fetch the static boot HTML
+        // instead of seeing the raw error JSON, which is what runs
+        // loader.js's recovery path.
+        if (!poisoned) {
+            await selfDestruct(`error handling request: ${error}`);
         }
-        return new Response(
-            JSON.stringify({ error: 'internal_error', message: String(error) }),
-            { status: 500, headers: { 'Content-Type': 'application/json' } }
-        );
+        return fetch(request);
     }
 }

--- a/crates/solobase-browser/src/tools/bundle/mod.rs
+++ b/crates/solobase-browser/src/tools/bundle/mod.rs
@@ -80,10 +80,17 @@ fn base_to_title(base: &str) -> String {
         .join(" ")
 }
 
-pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool, app: AppConfig) -> Result<()> {
-    if dev {
-        return run_dev(pkg_dir, app);
-    }
+pub fn run(pkg_dir: &Path, repo_dir: &Path, app: AppConfig) -> Result<()> {
+    // --- Cleanup -------------------------------------------------------------
+    // Dev rebuilds re-run wasm-pack, which writes the un-hashed pair (e.g.
+    // `gizza_ai.js`, `gizza_ai_bg.wasm`) and then hits the same hashing path
+    // we're about to run again. Without cleanup, hashed copies from prior
+    // builds (`gizza_ai-abc123.js`, `gizza_ai_bg-def456.wasm`) accumulate in
+    // `pkg/`. Worse, a stale Service Worker registered against an old hash
+    // can keep finding the file via the SW bypass list and serve outdated
+    // bytes long after the user thought it was gone. Sweep them up so each
+    // build leaves a clean directory.
+    remove_previously_hashed(pkg_dir)?;
 
     // --- Discovery -----------------------------------------------------------
     let pair = discover_wasm_pair(pkg_dir)?;
@@ -203,42 +210,42 @@ pub fn run(pkg_dir: &Path, repo_dir: &Path, dev: bool, app: AppConfig) -> Result
     Ok(())
 }
 
-fn run_dev(pkg_dir: &Path, app: AppConfig) -> Result<()> {
-    let pair = discover_wasm_pair(pkg_dir)?;
-    if pair.is_none() {
-        eprintln!(
-            "warning: no *_bg.wasm found in {}; using fallback placeholder values",
-            pkg_dir.display()
-        );
+/// Sweep up `{base}-{8-hex}.js` and `{base}_bg-{8-hex}.wasm` files in
+/// `pkg_dir` left behind by previous bundle runs. Cheap (a single `read_dir`
+/// scan) and safe — the regex matches only the exact short-hash format we
+/// emit, so user files like `app-1.js` or `app_bg-final.wasm` are untouched.
+fn remove_previously_hashed(pkg_dir: &Path) -> Result<()> {
+    let entries = match std::fs::read_dir(pkg_dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(()),
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if is_hashed_artifact(&name) {
+            let _ = std::fs::remove_file(entry.path());
+        }
     }
-
-    let (wasm_js_val, wasm_bin_val, wasm_js_prefix_val, base_name_owned) =
-        if let Some((base, js, wasm)) = pair {
-            let prefix = format!("/{base}");
-            let js_url = format!("/{js}");
-            let wasm_url = format!("/{wasm}");
-            (js_url, wasm_url, prefix, base)
-        } else {
-            (
-                "/app.js".to_string(),
-                "/app_bg.wasm".to_string(),
-                "/app".to_string(),
-                "app".to_string(),
-            )
-        };
-
-    let vars = build_template_vars(
-        "dev".to_string(),
-        wasm_js_val,
-        wasm_bin_val,
-        wasm_js_prefix_val,
-        &base_name_owned,
-        &app,
-    );
-    render_if_exists(pkg_dir, "sw.js.tmpl", "sw.js", &vars)?;
-    render_if_exists(pkg_dir, "loader.js.tmpl", "loader.js", &vars)?;
-    render_if_exists(pkg_dir, "index.html.tmpl", "index.html", &vars)?;
     Ok(())
+}
+
+/// Match `*-XXXXXXXX.js` or `*_bg-XXXXXXXX.wasm` where X is hex.
+fn is_hashed_artifact(name: &str) -> bool {
+    if let Some(stem) = name.strip_suffix(".js") {
+        return ends_with_short_hash(stem, "-");
+    }
+    if let Some(stem) = name.strip_suffix(".wasm") {
+        return ends_with_short_hash(stem, "_bg-");
+    }
+    false
+}
+
+fn ends_with_short_hash(stem: &str, sep: &str) -> bool {
+    let Some(idx) = stem.rfind(sep) else {
+        return false;
+    };
+    let suffix = &stem[idx + sep.len()..];
+    suffix.len() == 8 && suffix.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Build the complete template variable map from the resolved values and

--- a/crates/solobase-browser/tests/bundle_integration.rs
+++ b/crates/solobase-browser/tests/bundle_integration.rs
@@ -20,7 +20,7 @@ fn end_to_end_renames_rewrites_and_templates() {
     let tmp = tempfile::tempdir().unwrap();
     copy_dir(&fixture_path(), tmp.path());
 
-    run(tmp.path(), tmp.path(), /* dev */ false, default_app()).expect("bundler ok");
+    run(tmp.path(), tmp.path(), default_app()).expect("bundler ok");
 
     let manifest_body = fs::read_to_string(tmp.path().join("asset-manifest.json")).unwrap();
     assert!(manifest_body.contains("\"buildId\""));
@@ -64,8 +64,8 @@ fn deterministic_across_runs() {
     let tmp2 = tempfile::tempdir().unwrap();
     copy_dir(&fixture_path(), tmp1.path());
     copy_dir(&fixture_path(), tmp2.path());
-    solobase_browser::tools::bundle::run(tmp1.path(), tmp1.path(), false, default_app()).unwrap();
-    solobase_browser::tools::bundle::run(tmp2.path(), tmp2.path(), false, default_app()).unwrap();
+    solobase_browser::tools::bundle::run(tmp1.path(), tmp1.path(), default_app()).unwrap();
+    solobase_browser::tools::bundle::run(tmp2.path(), tmp2.path(), default_app()).unwrap();
 
     let m1 = fs::read_to_string(tmp1.path().join("asset-manifest.json")).unwrap();
     let m2 = fs::read_to_string(tmp2.path().join("asset-manifest.json")).unwrap();

--- a/crates/solobase/src/cli/flows/embed_web.rs
+++ b/crates/solobase/src/cli/flows/embed_web.rs
@@ -38,7 +38,10 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
         extra_bypass_prefix: cfg.assets.extra_bypass_prefix.clone(),
     };
     solobase_browser::assets::write_to(&dist_dir)?;
-    solobase_browser::tools::bundle::run(&dist_dir, repo_root, !release, app)?;
+    solobase_browser::tools::bundle::run(&dist_dir, repo_root, app)?;
+    // `release` no longer flips the bundle path — every build is hashed so
+    // dev iterations don't get pinned to stale browser-cached modules.
+    let _ = release;
 
     // 4. Apply overlays.
     overlays::apply_overlays(&cfg, repo_root, &dist_dir)?;

--- a/crates/solobase/src/cli/flows/sealed_web.rs
+++ b/crates/solobase/src/cli/flows/sealed_web.rs
@@ -46,7 +46,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     };
 
     solobase_browser::assets::write_to(&dist)?;
-    solobase_browser::tools::bundle::run(&dist, repo_root, !release, app)?;
+    solobase_browser::tools::bundle::run(&dist, repo_root, app)?;
 
     // 5. Apply overlays from solobase.toml if present.
     if let Some((cfg, root)) = cfg {


### PR DESCRIPTION
## Summary

Eliminates a class of cache-loop bugs where a fresh deploy could leave a browser tab in an infinite reload cycle: stale browser-cached modules → wasm \`LinkError\` → SW \`selfDestruct\` → page reload → same stale cache → repeat.

Two prongs:

### 1. Hash dev builds (root cause)

\`tools::bundle::run\` had an \`if dev { return run_dev() }\` shortcut that skipped content hashing in dev mode. Two consecutive dev builds both served \`/<base>.js\` and \`/<base>_bg.wasm\` at identical URLs — so any browser-cached copy of the previous build's bytes won the URL race against the new wasm-pack output, causing \`LinkError\` when the cached \`*.js\` couldn't link against the fresh \`*_bg.wasm\`.

Removing the shortcut means dev builds now run the same hash-and-rename path as release. Each build produces unique URLs (\`gizza_ai-<8hex>.js\`, \`gizza_ai_bg-<8hex>.wasm\`) so the browser cache cannot collide across builds. Old hashed pairs from prior builds are swept up by a new \`remove_previously_hashed()\` step so \`pkg/\` doesn't accumulate dead bytes.

The \`dev: bool\` parameter is dropped from \`bundle::run\`.

### 2. Make SW self-destruct actually recoverable (safety net)

Even with hashing, edge cases exist where a stale SW is registered against a hash whose files no longer exist. The previous implementation half-handled this:

- \`selfDestruct\` re-navigated clients without any breaker, so the page had no way to short-circuit the next load.
- The fetch-handler catch returned a 500 JSON for non-RuntimeError init failures. Browsers render JSON inline, so no JS ran on the resulting page and no recovery could fire.
- \`selfDestruct\` only fired for \`WebAssembly.RuntimeError\` (wasm trap), not for the much more common \`TypeError\` (compile failed because the bypassed wasm URL 404'd).

After this change:

- \`selfDestruct\` posts \`{ type: 'sw-self-destruct' }\` to all window clients before re-navigating. \`loader.js\` listens and writes a \`sessionStorage\` breaker.
- The fetch-handler catch falls through to network for any init/runtime error, so the browser fetches the static boot HTML — \`loader.js\` runs, sees the breaker, wipes all SW + Cache Storage state, and reloads with a \`?_freshen=\` query string to bust the document cache. Next load boots cleanly.
- Self-destruct triggers on every error, not just \`RuntimeError\`.

## Files

- \`crates/solobase-browser/src/tools/bundle/mod.rs\` — drop \`run_dev\`, unify on hashing path, add \`remove_previously_hashed()\` cleanup, drop \`dev\` parameter from \`bundle::run\`.
- \`crates/solobase-browser/assets/sw.js.tmpl\` — \`selfDestruct\` posts breaker message; fetch-handler catch falls through to network on any init failure.
- \`crates/solobase-browser/assets/loader.js.tmpl\` — listen for self-destruct message, set sessionStorage breaker, run recovery path on next load.
- \`crates/solobase/src/cli/flows/{embed_web,sealed_web}.rs\` — drop \`dev\` arg from \`bundle::run\` calls.
- \`crates/solobase-browser/tests/bundle_integration.rs\` — drop \`false\` arg from test calls.

## Test plan

- [x] \`cargo test -p solobase-browser\` — 58 unit + 2 integration pass
- [x] \`cargo install --path crates/solobase --force\` succeeds
- [x] Fresh dev build of gizza-ai produces \`gizza_ai-<hash>.js\` + \`gizza_ai_bg-<hash>.wasm\`, \`sw.js\` imports the hashed name, \`asset-manifest.json\` is generated
- [x] Planted decoy hashed files (\`gizza_ai-aaaaaaaa.js\`, \`gizza_ai_bg-bbbbbbbb.wasm\`) are cleaned up by the next build
- [x] Manual: gizza-ai loads end-to-end (composer renders, picker CTA visible, model-picker.css present) on the freshly built artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)