### PR TITLE
perf(cloudflare): cache D1 config loads per isolate

### DIFF
--- a/crates/solobase-cloudflare/src/config_cache.rs
+++ b/crates/solobase-cloudflare/src/config_cache.rs
@@ -11,12 +11,13 @@
 //! handled by *this* isolate; other isolates pick up changes when they
 //! recycle naturally (or by future PR work that adds proper signalling).
 
-use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
-use solobase_core::cache::TtlCache;
-use solobase_core::features::BlockSettings;
+use solobase_core::{cache::TtlCache, features::BlockSettings};
 
 pub type ConfigSnapshot = (HashMap<String, String>, BlockSettings);
 

--- a/crates/solobase-cloudflare/src/config_cache.rs
+++ b/crates/solobase-cloudflare/src/config_cache.rs
@@ -1,0 +1,42 @@
+//! Per-isolate cache for config loaded from D1.
+//!
+//! On Cloudflare Workers, isolates are reused across requests within their
+//! lifetime. We exploit that by holding the loaded `(env_vars, block_settings)`
+//! in a static `TtlCache`. The first request in a fresh isolate triggers two
+//! D1 reads; subsequent requests read from RAM.
+//!
+//! `wasm32-unknown-unknown` can't tick `std::time::Instant`, so we use a
+//! `Duration::MAX` TTL — effectively "load once per isolate". Admin write
+//! paths can call `invalidate()` to force a fresh load on the next request
+//! handled by *this* isolate; other isolates pick up changes when they
+//! recycle naturally (or by future PR work that adds proper signalling).
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use solobase_core::cache::TtlCache;
+use solobase_core::features::BlockSettings;
+
+pub type ConfigSnapshot = (HashMap<String, String>, BlockSettings);
+
+static CACHE: OnceLock<TtlCache<ConfigSnapshot>> = OnceLock::new();
+
+fn cache() -> &'static TtlCache<ConfigSnapshot> {
+    CACHE.get_or_init(|| TtlCache::new(Duration::MAX))
+}
+
+pub async fn get_or_load<F, Fut>(loader: F) -> Arc<ConfigSnapshot>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ConfigSnapshot>,
+{
+    cache().get_or_load(loader).await
+}
+
+#[allow(dead_code)]
+pub fn invalidate() {
+    if let Some(c) = CACHE.get() {
+        c.invalidate();
+    }
+}

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! This crate is wasm-only; building for native targets is not supported.
 
-pub mod config_service;
 mod config_cache;
+pub mod config_service;
 pub mod convert;
 pub mod crypto_service;
 pub mod database;
@@ -149,8 +149,17 @@ where
     let db = make_d1_database_service(&env, runner::D1_BINDING)
         .map_err(|e| format!("D1 binding {:?}: {e}", runner::D1_BINDING))?;
 
-    // 2. Load env vars; merge protected worker::Env bindings on top.
-    let mut env_vars = runner::load_env_vars(&db).await;
+    // 2. Load env vars + block settings via per-isolate cache.
+    //    First request after isolate cold-start hits D1 twice; subsequent
+    //    requests serve from RAM. Merge protected worker::Env bindings on
+    //    top freshly each request — they're CF env bindings, not D1 vars.
+    let snapshot = config_cache::get_or_load(|| async {
+        let env_vars = runner::load_env_vars(&db).await;
+        let block_settings = runner::load_block_settings(&db).await;
+        (env_vars, block_settings)
+    })
+    .await;
+    let mut env_vars = snapshot.0.clone();
     for key in PROTECTED_ENV_KEYS {
         if let Ok(secret) = env.secret(key) {
             env_vars.insert(key.to_string(), secret.to_string());
@@ -173,7 +182,7 @@ where
     //    bucket Arc — `.storage()` consumes one and the post-build hook
     //    receives the other so it can register blocks that need direct R2
     //    access (e.g. a static-asset content block).
-    let block_settings = runner::load_block_settings(&db).await;
+    let block_settings = snapshot.1.clone();
     let builder = SolobaseBuilder::new()
         .database(db)
         .storage(bucket.clone())

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -9,6 +9,7 @@
 //! This crate is wasm-only; building for native targets is not supported.
 
 pub mod config_service;
+mod config_cache;
 pub mod convert;
 pub mod crypto_service;
 pub mod database;

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -61,4 +61,20 @@ mod tests {
         assert_eq!(*v, 42);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
+
+    #[tokio::test]
+    async fn second_call_within_ttl_does_not_refetch() {
+        let cache: TtlCache<u32> = TtlCache::new(Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+        let _ = cache.get_or_load(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            7
+        }).await;
+        let v = cache.get_or_load(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            99
+        }).await;
+        assert_eq!(*v, 7, "should return cached value, not new fetcher result");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "fetcher should not run twice");
+    }
 }

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -1,0 +1,64 @@
+//! TTL-based per-instance cache.
+//!
+//! Used by solobase-cloudflare to memoize D1 reads across requests within
+//! a Worker isolate's lifetime. Generic so the unit tests live here on the
+//! native target — the cloudflare crate has no `cargo test` surface.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use std::sync::Arc;
+
+pub struct TtlCache<T> {
+    state: Mutex<Option<(Arc<T>, Instant)>>,
+    ttl: Duration,
+}
+
+impl<T> TtlCache<T> {
+    pub const fn new(ttl: Duration) -> Self {
+        Self {
+            state: Mutex::new(None),
+            ttl,
+        }
+    }
+
+    /// Returns the cached value if fresh, otherwise runs `fetcher` and caches the result.
+    pub async fn get_or_load<F, Fut>(&self, fetcher: F) -> Arc<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        if let Some((value, loaded_at)) = &*self.state.lock().expect("TtlCache poisoned") {
+            if loaded_at.elapsed() < self.ttl {
+                return Arc::clone(value);
+            }
+        }
+        let fresh = fetcher().await;
+        let arc = Arc::new(fresh);
+        let mut guard = self.state.lock().expect("TtlCache poisoned");
+        *guard = Some((Arc::clone(&arc), Instant::now()));
+        arc
+    }
+
+    /// Force the next call to refetch. Used by admin-write paths.
+    pub fn invalidate(&self) {
+        *self.state.lock().expect("TtlCache poisoned") = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn first_call_runs_fetcher() {
+        let cache: TtlCache<u32> = TtlCache::new(Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+        let v = cache.get_or_load(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            42
+        }).await;
+        assert_eq!(*v, 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 pub struct TtlCache<T> {
-    state: Mutex<Option<(Arc<T>, Instant)>>,
+    state: Mutex<Option<(Arc<T>, Option<Instant>)>>,
     ttl: Duration,
 }
 
@@ -23,22 +23,31 @@ impl<T> TtlCache<T> {
     }
 
     /// Returns the cached value if fresh, otherwise runs `fetcher` and caches the result.
+    ///
+    /// `Instant::now()` and `Instant::elapsed()` panic on `wasm32-unknown-unknown`
+    /// (no `time` syscall). Callers targeting wasm pass `Duration::MAX` as the TTL —
+    /// the cache then never calls into `Instant`, on either the read or write side.
     pub async fn get_or_load<F, Fut>(&self, fetcher: F) -> Arc<T>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = T>,
     {
         if let Some((value, loaded_at)) = &*self.state.lock().expect("TtlCache poisoned") {
-            // `Duration::MAX` means "never expire" — short-circuit so we don't call
-            // `loaded_at.elapsed()`, which panics on `wasm32-unknown-unknown`.
-            if self.ttl == Duration::MAX || loaded_at.elapsed() < self.ttl {
+            if self.ttl == Duration::MAX
+                || loaded_at.as_ref().map_or(false, |t| t.elapsed() < self.ttl)
+            {
                 return Arc::clone(value);
             }
         }
         let fresh = fetcher().await;
         let arc = Arc::new(fresh);
+        let loaded_at = if self.ttl == Duration::MAX {
+            None
+        } else {
+            Some(Instant::now())
+        };
         let mut guard = self.state.lock().expect("TtlCache poisoned");
-        *guard = Some((Arc::clone(&arc), Instant::now()));
+        *guard = Some((Arc::clone(&arc), loaded_at));
         arc
     }
 

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -77,4 +77,25 @@ mod tests {
         assert_eq!(*v, 7, "should return cached value, not new fetcher result");
         assert_eq!(calls.load(Ordering::SeqCst), 1, "fetcher should not run twice");
     }
+
+    #[tokio::test]
+    async fn refetch_after_ttl_expires() {
+        let cache: TtlCache<u32> = TtlCache::new(Duration::from_millis(10));
+        let calls = AtomicUsize::new(0);
+
+        let _ = cache.get_or_load(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            1
+        }).await;
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let v = cache.get_or_load(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            2
+        }).await;
+
+        assert_eq!(*v, 2, "should refetch after TTL");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
 }

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -29,7 +29,9 @@ impl<T> TtlCache<T> {
         Fut: std::future::Future<Output = T>,
     {
         if let Some((value, loaded_at)) = &*self.state.lock().expect("TtlCache poisoned") {
-            if loaded_at.elapsed() < self.ttl {
+            // `Duration::MAX` means "never expire" — short-circuit so we don't call
+            // `loaded_at.elapsed()`, which panics on `wasm32-unknown-unknown`.
+            if self.ttl == Duration::MAX || loaded_at.elapsed() < self.ttl {
                 return Arc::clone(value);
             }
         }
@@ -102,7 +104,7 @@ mod tests {
             })
             .await;
 
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         let v = cache
             .get_or_load(|| async {
@@ -138,5 +140,37 @@ mod tests {
 
         assert_eq!(*v, 2);
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn duration_max_ttl_never_expires_and_returns_cached() {
+        let cache: TtlCache<u32> = TtlCache::new(Duration::MAX);
+        let calls = AtomicUsize::new(0);
+
+        let v1 = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                5
+            })
+            .await;
+
+        // Even after a sleep that would exceed any reasonable finite TTL,
+        // Duration::MAX means we should still hit the cache without ever
+        // calling `loaded_at.elapsed()`.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let v2 = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                999
+            })
+            .await;
+
+        assert_eq!(*v2, 5);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(
+            Arc::ptr_eq(&v1, &v2),
+            "same Arc should be returned for cache hits"
+        );
     }
 }

--- a/crates/solobase-core/src/cache.rs
+++ b/crates/solobase-core/src/cache.rs
@@ -4,9 +4,10 @@
 //! a Worker isolate's lifetime. Generic so the unit tests live here on the
 //! native target — the cloudflare crate has no `cargo test` surface.
 
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
-use std::sync::Arc;
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 pub struct TtlCache<T> {
     state: Mutex<Option<(Arc<T>, Instant)>>,
@@ -47,17 +48,20 @@ impl<T> TtlCache<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
 
     #[tokio::test]
     async fn first_call_runs_fetcher() {
         let cache: TtlCache<u32> = TtlCache::new(Duration::from_secs(60));
         let calls = AtomicUsize::new(0);
-        let v = cache.get_or_load(|| async {
-            calls.fetch_add(1, Ordering::SeqCst);
-            42
-        }).await;
+        let v = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                42
+            })
+            .await;
         assert_eq!(*v, 42);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
@@ -66,16 +70,24 @@ mod tests {
     async fn second_call_within_ttl_does_not_refetch() {
         let cache: TtlCache<u32> = TtlCache::new(Duration::from_secs(60));
         let calls = AtomicUsize::new(0);
-        let _ = cache.get_or_load(|| async {
-            calls.fetch_add(1, Ordering::SeqCst);
-            7
-        }).await;
-        let v = cache.get_or_load(|| async {
-            calls.fetch_add(1, Ordering::SeqCst);
-            99
-        }).await;
+        let _ = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                7
+            })
+            .await;
+        let v = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                99
+            })
+            .await;
         assert_eq!(*v, 7, "should return cached value, not new fetcher result");
-        assert_eq!(calls.load(Ordering::SeqCst), 1, "fetcher should not run twice");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "fetcher should not run twice"
+        );
     }
 
     #[tokio::test]
@@ -83,19 +95,48 @@ mod tests {
         let cache: TtlCache<u32> = TtlCache::new(Duration::from_millis(10));
         let calls = AtomicUsize::new(0);
 
-        let _ = cache.get_or_load(|| async {
-            calls.fetch_add(1, Ordering::SeqCst);
-            1
-        }).await;
+        let _ = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                1
+            })
+            .await;
 
         tokio::time::sleep(Duration::from_millis(25)).await;
 
-        let v = cache.get_or_load(|| async {
-            calls.fetch_add(1, Ordering::SeqCst);
-            2
-        }).await;
+        let v = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                2
+            })
+            .await;
 
         assert_eq!(*v, 2, "should refetch after TTL");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_refetch() {
+        let cache: TtlCache<u32> = TtlCache::new(Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let _ = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                1
+            })
+            .await;
+
+        cache.invalidate();
+
+        let v = cache
+            .get_or_load(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                2
+            })
+            .await;
+
+        assert_eq!(*v, 2);
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -13,6 +13,7 @@ pub trait FeatureConfig: wafer_run::MaybeSend + wafer_run::MaybeSync {
 
 /// Generic block settings backed by a HashMap.
 /// Blocks default to enabled unless explicitly disabled.
+#[derive(Clone)]
 pub struct BlockSettings {
     enabled: HashMap<String, bool>,
 }

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod blocks;
 pub mod builder;
+pub mod cache;
 pub mod config_vars;
 pub mod crypto;
 pub mod features;


### PR DESCRIPTION
## Summary
- Adds a generic `TtlCache<T>` to `solobase-core` (5 unit tests cover fresh fetch, hit-within-TTL, expiry refetch, invalidate, and the wasm `Duration::MAX` "never expire" path with `Arc` sharing).
- Wires it into `solobase-cloudflare` via a `static OnceLock<TtlCache<ConfigSnapshot>>` so `runner::load_env_vars` + `runner::load_block_settings` run once per Worker isolate instead of per request.
- `BlockSettings` gains `#[derive(Clone)]` so callers can clone the cached snapshot per request (it only holds a `HashMap<String, bool>` — trivially safe).
- Fixed a wasm correctness bug discovered in production: `Instant::now()` and `Instant::elapsed()` panic on `wasm32-unknown-unknown` ("time not implemented on this platform"). Both read and write paths now short-circuit when ttl == `Duration::MAX`, the sentinel the cloudflare wrapper uses.

This is **PR1 of a four-PR sequence** to drop wafer-site D1 traffic from ~415 queries/request to 0 reads + 1 write.

Spec: `workspace/docs/superpowers/specs/2026-05-09-d1-query-amplification-fix-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-09-d1-amplification-pr1-config-cache.md`

## Verification

Deployed to wafer.run and tail-verified the cache: across 8 sequential requests over 22 seconds, the loader log fired **once** (cold-isolate fill) — 7 subsequent requests served from RAM. Isolate persistence holds, so PR2-4 can proceed as planned (no KV mirror fallback needed).

```
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:42 PM
  (log) config_cache: loading from D1
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:47 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:50 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:53 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:55 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:45:59 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:46:01 PM
GET https://wafer.run/ - Ok @ 5/9/2026, 10:46:04 PM
```

D1 baseline at deploy (2026-05-09): **34,939 reads + 4,555 writes / 24h**. Will compare in 24h post-merge.

## Test plan
- [x] `cargo test -p solobase-core --lib cache::` — 5 passing
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown`
- [x] `cargo clippy -p solobase-cloudflare --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo +nightly fmt -- --check`
- [x] Deployed to wafer.run; tail confirms 1 D1 loader call per ~8 requests
- [ ] Compare `read_queries_24h` 24h after merge against pre-deploy baseline (34,939)

🤖 Generated with [Claude Code](https://claude.com/claude-code)