### PR TITLE
perf(cloudflare): D1 migrations + cached schema check

### DIFF
--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -3,17 +3,22 @@
 //! Implements the shared `DatabaseService` trait from wafer-core so D1Block
 //! can reuse the shared message handler.
 //!
-//! ## Lazy schema
+//! ## Lazy schema (cached)
 //!
 //! Mirrors `wafer-block-sqlite`'s lazy-schema semantics: reads against a
 //! missing table return empty/NotFound (instead of erroring), and the
 //! first `create()` against a collection runs `CREATE TABLE IF NOT EXISTS`
-//! to materialize the table from the data keys (TEXT columns, `id` as
-//! PRIMARY KEY). This keeps init code paths like `seed_reserved_orgs`
-//! working on a fresh D1 without external migrations — same behavior as
-//! a fresh native sqlite file.
+//! + `PRAGMA table_info` to materialize the table from the data keys.
+//!
+//! Schema checks are cached per-isolate via `SCHEMA_CACHE`. After a table
+//! is verified once, subsequent inserts to the same columns skip the
+//! schema work entirely. Migrations applied at deploy time pre-populate
+//! most tables so even cold-isolate first-requests benefit.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::OnceLock,
+};
 
 use wafer_core::interfaces::database::service::{
     Column, DatabaseError, DatabaseService, Filter, FilterOp, ListOptions, Record, RecordList,
@@ -84,6 +89,73 @@ impl D1DatabaseService {
             })
             .collect())
     }
+
+    /// Ensure `table` exists and has columns for every key in `data`.
+    /// First call per (isolate, table) runs CREATE TABLE + PRAGMA + ALTER
+    /// as needed; subsequent calls hit the in-memory cache and skip the
+    /// schema work entirely.
+    async fn ensure_schema(
+        &self,
+        table: &str,
+        data: &HashMap<String, serde_json::Value>,
+    ) -> Result<(), DatabaseError> {
+        let needed: HashSet<String> = data
+            .keys()
+            .map(|k| sanitize_ident(k).to_lowercase())
+            .collect();
+
+        // Fast path: cached set covers all needed columns.
+        {
+            let cache = schema_cache().lock().expect("schema cache poisoned");
+            if let Some(known) = cache.get(table) {
+                if needed.iter().all(|k| known.contains(k)) {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Slow path: ensure the table exists with the needed columns.
+        let ddl = ensure_table_sql(table, data.keys().map(|k| k.as_str()));
+        self.db
+            .prepare(&ddl)
+            .run()
+            .await
+            .map_err(|e| db_err(format!("ensure_table {}: {e}", table)))?;
+        self.add_missing_columns(table, data).await;
+
+        // Re-read the column set and update the cache so subsequent
+        // inserts see the now-superset and take the fast path.
+        if let Ok(cols) = self.list_table_columns(table).await {
+            schema_cache()
+                .lock()
+                .expect("schema cache poisoned")
+                .insert(table.to_string(), cols);
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-isolate schema cache
+// ---------------------------------------------------------------------------
+
+/// Per-isolate cache of "tables we've already verified exist with these
+/// columns" — keyed by sanitized table name, value is the lowercased
+/// column-name set.
+///
+/// On every Worker request we'd otherwise run `CREATE TABLE IF NOT EXISTS`
+/// + `PRAGMA table_info` for every insert. This cache makes that work
+/// run once per (isolate, table) pair instead — first request after a
+/// cold isolate pays the cost; warm-isolate requests skip both queries.
+///
+/// Migrations applied at deploy time pre-populate most tables so the
+/// "first cold-start request" cost is reduced too — but the cache is the
+/// safety net for any block whose schema isn't declared via
+/// CollectionSchema (and so isn't in the generated migrations).
+static SCHEMA_CACHE: OnceLock<std::sync::Mutex<HashMap<String, HashSet<String>>>> = OnceLock::new();
+
+fn schema_cache() -> &'static std::sync::Mutex<HashMap<String, HashSet<String>>> {
+    SCHEMA_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
 // Safety: wasm32-unknown-unknown is single-threaded.
@@ -195,27 +267,12 @@ impl DatabaseService for D1DatabaseService {
         data.entry("updated_at".to_string())
             .or_insert_with(|| serde_json::Value::String(now));
 
-        // Lazy schema: materialize the table on first insert. Mirrors the
-        // native sqlite service. The `id` column gets PRIMARY KEY; every
-        // other key from `data` becomes a TEXT column.
-        let ddl = ensure_table_sql(&table, data.keys().map(|k| k.as_str()));
-        self.db
-            .prepare(&ddl)
-            .run()
-            .await
-            .map_err(|e| db_err(format!("ensure_table {}: {e}", table)))?;
-
-        // Schema evolution: when the table already existed (e.g. seeded
-        // with a smaller column set by an earlier insert from a different
-        // code path), `IF NOT EXISTS` is a no-op — the new keys we're
-        // about to insert wouldn't have columns. Mirror native sqlite's
-        // `ensure_table` and ALTER TABLE ADD COLUMN for every data key
-        // not already on the table. Errors are intentionally swallowed:
-        // a concurrent insert may have added the same column already
-        // (D1 surfaces "duplicate column name" in that case), and we'd
-        // rather let the subsequent INSERT either succeed or fail with
-        // a clearer message than abort here on a benign race.
-        self.add_missing_columns(&table, &data).await;
+        // Lazy schema: materialize the table on first insert. Cached per
+        // isolate — first call per (isolate, table) runs CREATE TABLE IF
+        // NOT EXISTS + PRAGMA table_info + any ALTER TABLE ADD COLUMN
+        // needed; subsequent calls hit the in-memory cache and skip all
+        // schema work.
+        self.ensure_schema(&table, &data).await?;
 
         let mut columns = vec!["id".to_string()];
         let mut placeholders = vec!["?".to_string()];

--- a/crates/solobase-cloudflare/src/schema.rs
+++ b/crates/solobase-cloudflare/src/schema.rs
@@ -426,21 +426,8 @@ const MIGRATIONS: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_suppers_ai__admin__request_logs_created ON suppers_ai__admin__request_logs (created_at)",
 
     // =========================================================================
-    // ADMIN BLOCK — outbound network request logs and rules
+    // ADMIN BLOCK — network rules
     // =========================================================================
-
-    "CREATE TABLE IF NOT EXISTS suppers_ai__admin__network_request_logs (
-        id TEXT PRIMARY KEY,
-        source_block TEXT DEFAULT '',
-        method TEXT DEFAULT '',
-        url TEXT DEFAULT '',
-        status_code INTEGER DEFAULT 0,
-        duration_ms INTEGER DEFAULT 0,
-        error_message TEXT DEFAULT '',
-        created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
-    )",
-    "CREATE INDEX IF NOT EXISTS idx_suppers_ai__admin__network_request_logs_created ON suppers_ai__admin__network_request_logs (created_at)",
 
     "CREATE TABLE IF NOT EXISTS suppers_ai__admin__network_rules (
         id TEXT PRIMARY KEY,

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -12,7 +12,6 @@ pub(crate) const PERMISSIONS_COLLECTION: &str = "suppers_ai__admin__permissions"
 pub(crate) const USER_ROLES_COLLECTION: &str = "suppers_ai__admin__user_roles";
 pub(crate) const AUDIT_LOGS_COLLECTION: &str = "suppers_ai__admin__audit_logs";
 pub(crate) const REQUEST_LOGS_COLLECTION: &str = "suppers_ai__admin__request_logs";
-pub(crate) const NETWORK_REQUEST_LOGS_COLLECTION: &str = "suppers_ai__admin__network_request_logs";
 pub(crate) const STORAGE_ACCESS_LOGS_COLLECTION: &str = "suppers_ai__admin__storage_access_logs";
 pub(crate) const STORAGE_RULES_COLLECTION: &str = "suppers_ai__admin__storage_rules";
 pub const BLOCK_SETTINGS_COLLECTION: &str = "suppers_ai__admin__block_settings";
@@ -98,14 +97,6 @@ impl Block for AdminBlock {
                     .field_default("client_ip", "string", "")
                     .field_default("user_id", "string", "")
                     .index(&["created_at"]),
-                CollectionSchema::new(NETWORK_REQUEST_LOGS_COLLECTION)
-                    .field_default("source_block", "string", "")
-                    .field_default("method", "string", "")
-                    .field_default("url", "string", "")
-                    .field_default("status_code", "int", "0")
-                    .field_default("duration_ms", "int", "0")
-                    .field_default("error_message", "string", "")
-                    .index(&["created_at"]),
                 CollectionSchema::new(STORAGE_ACCESS_LOGS_COLLECTION)
                     .field_default("source_block", "string", "")
                     .field_default("operation", "string", "")
@@ -126,8 +117,7 @@ impl Block for AdminBlock {
                 wafer_run::ResourceGrant::read_write(super::auth::AUTH_BLOCK_ID, USER_ROLES_COLLECTION),
                 wafer_run::ResourceGrant::read(super::auth::AUTH_BLOCK_ID, VARIABLES_COLLECTION),
                 wafer_run::ResourceGrant::read("suppers-ai/userportal", BLOCK_SETTINGS_COLLECTION),
-                // Infrastructure logging: network/storage wrappers + pipeline write logs
-                wafer_run::ResourceGrant::read_write("*", NETWORK_REQUEST_LOGS_COLLECTION),
+                // Infrastructure logging: storage wrapper + pipeline write logs
                 wafer_run::ResourceGrant::read_write("*", STORAGE_ACCESS_LOGS_COLLECTION),
                 wafer_run::ResourceGrant::read_write("*", REQUEST_LOGS_COLLECTION),
                 // Default: allow all blocks to make outbound network requests.
@@ -360,9 +350,6 @@ impl Block for AdminBlock {
             // Network detail fragments (htmx)
             if action == "retrieve" && sub == "/network/detail/inbound" {
                 return pages::network_inbound_detail(ctx, &msg).await;
-            }
-            if action == "retrieve" && sub == "/network/detail/outbound" {
-                return pages::network_outbound_detail(ctx, &msg).await;
             }
 
             // WRAP grants CRUD (htmx)

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -5,7 +5,6 @@ use wafer_sql_utils::{query, value::sea_values_to_json, Backend};
 
 use crate::{
     blocks::admin::{
-        NETWORK_REQUEST_LOGS_COLLECTION as NETWORK_REQUEST_LOGS,
         NETWORK_RULES_COLLECTION as NETWORK_RULES, REQUEST_LOGS_COLLECTION as REQUEST_LOGS,
     },
     ui::{components, icons},
@@ -16,7 +15,6 @@ use crate::{
 pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
     let tab = msg.query("tab");
     let active_tab = match tab {
-        "outbound" => "outbound",
         "rules" => "rules",
         _ => "inbound",
     };
@@ -36,12 +34,6 @@ pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
                 hx-target="#content"
                 hx-push-url="true"
             { (icons::arrow_down_left()) " Inbound" }
-            a .tab .(if active_tab == "outbound" { "active" } else { "" })
-                href="/b/admin/settings/network?tab=outbound"
-                hx-get="/b/admin/settings/network?tab=outbound"
-                hx-target="#content"
-                hx-push-url="true"
-            { (icons::arrow_up_right()) " Outbound" }
         }
 
         @if active_tab == "rules" {
@@ -57,8 +49,6 @@ pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
         div #network-tab-content {
             @if active_tab == "inbound" {
                 (network_inbound_tab(ctx, msg).await)
-            } @else if active_tab == "outbound" {
-                (network_outbound_tab(ctx, msg).await)
             } @else {
                 // rules tab still renders content but with banner above
                 (network_rules_tab(ctx, msg).await)
@@ -267,225 +257,6 @@ pub async fn network_inbound_detail(ctx: &dyn Context, msg: &Message) -> OutputS
             div style="text-align:center;padding:8px" {
                 button .btn .btn-secondary .btn-sm
                     hx-get={"/b/admin/network/detail/inbound?method=" (method) "&path=" (path) "&offset=" (next_offset)}
-                    hx-target="closest div"
-                    hx-swap="outerHTML"
-                { "Load more" }
-            }
-        }
-    };
-    crate::ui::html_response(markup)
-}
-
-async fn network_outbound_tab(ctx: &dyn Context, msg: &Message) -> Markup {
-    let search = msg.query("search").to_string();
-
-    let (where_clause, args) = if search.is_empty() {
-        (String::new(), vec![])
-    } else {
-        (
-            " WHERE url LIKE ?1".to_string(),
-            vec![serde_json::json!(format!("%{search}%"))],
-        )
-    };
-
-    // Uses SUM(CASE WHEN...) which is too complex for the grouped query builder.
-    let summary = db::query_raw(
-        ctx,
-        &format!(
-            "SELECT method, url, source_block, COUNT(*) as cnt, \
-             CAST(AVG(duration_ms) AS INTEGER) as avg_ms, \
-             SUM(CASE WHEN error_message != '' THEN 1 ELSE 0 END) as errors, \
-             MAX(created_at) as last_seen \
-             FROM {NETWORK_REQUEST_LOGS}{where_clause} \
-             GROUP BY method, url ORDER BY cnt DESC LIMIT 50"
-        ),
-        &args,
-    )
-    .await
-    .unwrap_or_default();
-
-    html! {
-        div .filter-bar {
-            (components::search_input_with_value("search", "Search by URL...", "/b/admin/settings/network?tab=outbound", "#content", &search))
-        }
-
-        style { (maud::PreEscaped("
-            .expand-row { cursor: pointer; }
-            .expand-row:hover { background: var(--bg-secondary, #f8fafc); }
-            .detail-rows td { background: var(--bg-secondary, #f8fafc); font-size: 12px; }
-            .detail-rows[hidden] { display: none; }
-        ")) }
-
-        div .table-container {
-            table .table {
-                thead {
-                    tr {
-                        th style="width:30px" { "" }
-                        th { "Method" }
-                        th { "URL" }
-                        th { "Block" }
-                        th { "Requests" }
-                        th { "Avg Duration" }
-                        th { "Errors" }
-                        th { "Last Seen" }
-                    }
-                }
-                tbody {
-                    @if summary.is_empty() {
-                        tr {
-                            td colspan="8" .text-center .text-muted style="padding: 2rem;" { "No outbound requests yet" }
-                        }
-                    }
-                    @for (i, row) in summary.iter().enumerate() {
-                        @let method = row.data.get("method").and_then(|v| v.as_str()).unwrap_or("");
-                        @let url = row.data.get("url").and_then(|v| v.as_str()).unwrap_or("");
-                        @let source_block = row.data.get("source_block").and_then(|v| v.as_str()).unwrap_or("");
-                        @let cnt = row.data.get("cnt").and_then(|v| v.as_i64()).unwrap_or(0);
-                        @let avg_ms = row.data.get("avg_ms").and_then(|v| v.as_i64()).unwrap_or(0);
-                        @let errors = row.data.get("errors").and_then(|v| v.as_i64()).unwrap_or(0);
-                        @let last_seen = row.data.get("last_seen").and_then(|v| v.as_str()).unwrap_or("");
-                        @let row_id = format!("outbound-{i}");
-                        @let encoded_url = url.replace('&', "%26");
-                        @let detail_url = format!("/b/admin/network/detail/outbound?method={method}&url={encoded_url}");
-                        tr .expand-row
-                            onclick={"toggleDetail('" (row_id) "','" (detail_url) "')"}
-                        {
-                            td .text-muted { (icons::chevron_right()) }
-                            td .text-sm .font-medium { (method.to_uppercase()) }
-                            td .text-sm style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=(url) { (url) }
-                            td .text-sm {
-                                @if !source_block.is_empty() {
-                                    span .badge .badge-info { (source_block) }
-                                }
-                            }
-                            td .text-sm {
-                                span .badge .badge-info { (cnt) }
-                            }
-                            td .text-muted .text-sm { (avg_ms) "ms" }
-                            td .text-sm {
-                                @if errors > 0 {
-                                    span .badge .badge-danger { (errors) }
-                                } @else {
-                                    span .text-muted { "0" }
-                                }
-                            }
-                            td .text-muted .text-sm { (last_seen.get(..19).unwrap_or(last_seen)) }
-                        }
-                        tr .detail-rows hidden {
-                            td colspan="8" style="padding:0" {
-                                div id=(row_id) {}
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Htmx fragment: individual requests for a given outbound URL.
-pub async fn network_outbound_detail(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let method = msg.query("method").to_string();
-    let url = msg.query("url").to_string();
-    let offset: i64 = msg.query("offset").parse().unwrap_or(0);
-    let limit: i64 = 20;
-
-    let (sql, vals) = query::build_select_columns(
-        NETWORK_REQUEST_LOGS,
-        &[
-            "status_code",
-            "duration_ms",
-            "source_block",
-            "error_message",
-            "created_at",
-        ],
-        &ListOptions {
-            filters: vec![
-                Filter {
-                    field: "method".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!(&method),
-                },
-                Filter {
-                    field: "url".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!(&url),
-                },
-            ],
-            sort: vec![SortField {
-                field: "created_at".into(),
-                desc: true,
-            }],
-            limit: limit + 1,
-            offset,
-            ..Default::default()
-        },
-        None,
-        Backend::Sqlite,
-    );
-    let rows = db::query_raw(ctx, &sql, &sea_values_to_json(vals))
-        .await
-        .unwrap_or_default();
-
-    let has_more = rows.len() as i64 > limit;
-    let display_rows = if has_more {
-        &rows[..limit as usize]
-    } else {
-        &rows
-    };
-    let encoded_url = url.replace('&', "%26");
-
-    let markup = html! {
-        table .table style="margin:0" {
-            thead {
-                tr {
-                    th { "Status" }
-                    th { "Block" }
-                    th { "Duration" }
-                    th { "Error" }
-                    th { "Time" }
-                }
-            }
-            tbody {
-                @for record in display_rows {
-                    @let status_code = record.data.get("status_code").and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))).unwrap_or(0);
-                    @let duration = record.data.get("duration_ms").and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))).unwrap_or(0);
-                    @let source_block = record.data.get("source_block").and_then(|v| v.as_str()).unwrap_or("");
-                    @let error_msg = record.data.get("error_message").and_then(|v| v.as_str()).unwrap_or("");
-                    @let created = record.data.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
-                    tr {
-                        td {
-                            @if !error_msg.is_empty() {
-                                span .badge .badge-danger {
-                                    @if status_code > 0 { (status_code) } @else { "ERR" }
-                                }
-                            } @else if status_code >= 400 {
-                                span .badge .badge-warning { (status_code) }
-                            } @else if status_code > 0 {
-                                span .badge .badge-success { (status_code) }
-                            } @else {
-                                span .badge .badge-muted { "\u{2014}" }
-                            }
-                        }
-                        td {
-                            @if !source_block.is_empty() {
-                                span .badge .badge-info { (source_block) }
-                            }
-                        }
-                        td .text-muted { (duration) "ms" }
-                        td .text-muted style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=(error_msg) {
-                            (error_msg)
-                        }
-                        td .text-muted { (created.get(..19).unwrap_or(created)) }
-                    }
-                }
-            }
-        }
-        @if has_more {
-            @let next_offset = offset + limit;
-            div style="text-align:center;padding:8px" {
-                button .btn .btn-secondary .btn-sm
-                    hx-get={"/b/admin/network/detail/outbound?method=" (method) "&url=" (encoded_url) "&offset=" (next_offset)}
                     hx-target="closest div"
                     hx-swap="outerHTML"
                 { "Load more" }

--- a/crates/solobase-core/src/blocks/network.rs
+++ b/crates/solobase-core/src/blocks/network.rs
@@ -1,21 +1,16 @@
 //! Solobase network block wrapper.
 //!
-//! Wraps the wafer-core `NetworkBlock` to add outbound request logging.
-//! Network access control is enforced by WRAP grants in `call_block()`
-//! before the message reaches this handler.
+//! Wraps the wafer-core `NetworkBlock` to buffer the response stream so
+//! callers receive a complete, re-emittable event sequence. Network access
+//! control is enforced by WRAP grants in `call_block()` before the message
+//! reaches this handler.
 
 use std::sync::Arc;
 
 use futures::StreamExt;
-use wafer_block::{
-    codec,
-    stream::StreamEvent,
-    wire::network::{Request as NetRequest, ResponseHeader as NetResponseHeader},
-};
-use wafer_core::{clients::database as db, interfaces::network::service::NetworkService};
+use wafer_block::stream::StreamEvent;
+use wafer_core::interfaces::network::service::NetworkService;
 use wafer_run::{block::Block, context::Context, types::*, BlockInfo, InputStream, OutputStream};
-
-use super::helpers::{json_map, now_millis};
 
 /// A network block that logs outbound requests.
 pub struct SolobaseNetworkBlock {
@@ -30,16 +25,6 @@ impl SolobaseNetworkBlock {
     }
 }
 
-/// Parse the request payload (a MessagePack-encoded `wire::network::Request`)
-/// to extract method + url for logging. Decode failures fall back to
-/// `UNKNOWN`/empty so logging never blocks the actual request.
-fn parse_request_info(body: &[u8]) -> (String, String) {
-    match codec::decode::<NetRequest>(body) {
-        Ok(req) => (req.method.to_uppercase(), req.url),
-        Err(_) => ("UNKNOWN".into(), String::new()),
-    }
-}
-
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for SolobaseNetworkBlock {
@@ -48,66 +33,28 @@ impl Block for SolobaseNetworkBlock {
     }
 
     async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        let source_block = ctx.caller_id().unwrap_or("unknown").to_string();
         let body = input.collect_to_bytes().await;
-        let (method, url) = parse_request_info(&body);
 
         // Network access control is enforced by WRAP in call_block() before
-        // reaching this handler. This block only handles logging + execution.
+        // reaching this handler.
 
         // Dispatch to the wrapped wafer-core network block. The response is a
         // two-frame stream: a `wire::network::ResponseHeader` chunk followed
         // by zero-or-more body chunks. We must preserve frame boundaries when
         // forwarding — `collect_buffered` would concatenate header + body and
         // break the downstream `buffered_header_and_body` decoder.
-        let start = now_millis();
         let inner_out = self
             .inner
             .handle(ctx, msg, InputStream::from_bytes(body))
             .await;
 
-        // Drain the inner stream into a buffer of events so we can both log
-        // (via the decoded header's `status_code`) and forward verbatim.
+        // Drain the inner stream into a buffer of events so we can forward
+        // them verbatim, preserving all frame boundaries.
         let mut events: Vec<StreamEvent> = Vec::new();
         let mut inner = inner_out;
         while let Some(evt) = inner.next().await {
             events.push(evt);
         }
-        let duration_ms = (now_millis() - start) as i64;
-
-        // Pick out the status_code from the first Chunk (the header frame).
-        let mut status_code: i64 = 0;
-        let mut error_message = String::new();
-        for evt in &events {
-            match evt {
-                StreamEvent::Chunk(bytes) => {
-                    if let Ok(header) = codec::decode::<NetResponseHeader>(bytes) {
-                        status_code = header.status_code as i64;
-                    }
-                    break;
-                }
-                StreamEvent::Error(e) => {
-                    error_message = e.message.clone();
-                    break;
-                }
-                _ => continue,
-            }
-        }
-
-        // Log the request (best-effort, don't fail the actual request)
-        let _ = db::create(
-            ctx,
-            crate::blocks::admin::NETWORK_REQUEST_LOGS_COLLECTION,
-            json_map(serde_json::json!({
-                "source_block": source_block,
-                "method": method,
-                "url": url,
-                "status_code": status_code,
-                "duration_ms": duration_ms,
-                "error_message": error_message,
-            })),
-        )
-        .await;
 
         // Re-emit the captured events to the caller, preserving frame
         // boundaries so the typed network client can decode header + body.

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config_vars;
 pub mod crypto;
 pub mod features;
 pub mod flows;
+pub mod migrations;
 pub mod pipeline;
 pub mod routing;
 pub mod ui;

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -46,7 +46,25 @@ pub fn generate_initial_schema(collections: &[CollectionSchema]) -> String {
     if collections.is_empty() {
         return String::new();
     }
-    todo!("Task 5 will implement non-empty path")
+    let mut out = String::new();
+    for s in collections {
+        out.push_str(&render_create_table(s));
+        out.push_str(";\n\n");
+    }
+    for s in collections {
+        for idx in &s.indexes {
+            out.push_str(&render_create_index(&s.name, idx));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn render_create_index(table: &str, idx: &IndexSchema) -> String {
+    let cols = idx.fields.join("__");
+    let unique = if idx.unique { "UNIQUE " } else { "" };
+    let cols_csv = idx.fields.join(", ");
+    format!("CREATE {unique}INDEX IF NOT EXISTS idx_{table}__{cols} ON {table} ({cols_csv});")
 }
 
 #[cfg(test)]
@@ -56,6 +74,22 @@ mod tests {
     #[test]
     fn empty_input_produces_empty_string() {
         assert_eq!(generate_initial_schema(&[]), "");
+    }
+
+    #[test]
+    fn generate_initial_schema_emits_all_tables_and_indexes() {
+        let widgets = CollectionSchema::new("suppers_ai__demo__widgets").field("name", "text");
+        let things = CollectionSchema::new("suppers_ai__demo__things")
+            .field("widget_id", "text")
+            .index(&["widget_id"]);
+        let sql = generate_initial_schema(&[widgets, things]);
+        assert!(sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__demo__widgets"));
+        assert!(sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__demo__things"));
+        assert!(sql.contains(
+            "CREATE INDEX IF NOT EXISTS idx_suppers_ai__demo__things__widget_id \
+             ON suppers_ai__demo__things (widget_id);"
+        ));
+        assert!(sql.ends_with(";\n"));
     }
 
     #[test]

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -1,0 +1,31 @@
+//! Generate SQLite DDL from CollectionSchema declarations.
+//!
+//! `solobase build --target cloudflare` walks `all_block_infos()` and feeds
+//! their collections into `generate_initial_schema()` to produce a single
+//! migration SQL file consumed by `wrangler d1 migrations apply`.
+
+use wafer_block::types::{CollectionSchema, IndexSchema};
+
+/// Render a single CREATE TABLE statement (without trailing semicolon).
+pub fn render_create_table(schema: &CollectionSchema) -> String {
+    todo!("Task 2")
+}
+
+/// Render the full initial schema migration: CREATE TABLE for each collection,
+/// followed by CREATE INDEX statements, separated by blank lines.
+pub fn generate_initial_schema(collections: &[CollectionSchema]) -> String {
+    if collections.is_empty() {
+        return String::new();
+    }
+    todo!("Task 5 will implement non-empty path")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_produces_empty_string() {
+        assert_eq!(generate_initial_schema(&[]), "");
+    }
+}

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -6,6 +6,31 @@
 
 use wafer_block::types::{CollectionSchema, IndexSchema};
 
+/// Hand-authored migration SQL that can't be derived from `CollectionSchema`.
+///
+/// Auth declares its schema through the `service_blocks::auth::AuthBlock`,
+/// whose `info()` method does not declare any `CollectionSchema` — so the
+/// auto-generator can't reach those tables. They live as hand-authored SQL
+/// shipped at `blocks/auth/migrations/*.sqlite.sql` and embedded here at
+/// compile time.
+///
+/// Returned as `(filename, content)` pairs. The build script writes them
+/// alongside the auto-generated `0001_initial_schema.sql`. Filenames begin
+/// at `0002_` so `wrangler d1 migrations apply` runs them after the
+/// auto-generated initial schema.
+pub fn extra_migrations() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "0002_auth_schema.sql",
+            include_str!("blocks/auth/migrations/001_auth_schema.sqlite.sql"),
+        ),
+        (
+            "0003_reserved_orgs.sql",
+            include_str!("blocks/auth/migrations/002_reserved_orgs.sqlite.sql"),
+        ),
+    ]
+}
+
 /// Render a single CREATE TABLE statement (without trailing semicolon).
 pub fn render_create_table(schema: &CollectionSchema) -> String {
     let mut col_lines = vec!["    id TEXT PRIMARY KEY".to_string()];

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -59,6 +59,27 @@ mod tests {
     }
 
     #[test]
+    fn render_create_table_unique_and_typed_fields() {
+        let schema = CollectionSchema::new("suppers_ai__demo__items")
+            .field_unique("slug", "text")
+            .field("count", "int")
+            .field("ratio", "real")
+            .field("payload", "blob");
+        let sql = render_create_table(&schema);
+        let expected = "\
+CREATE TABLE IF NOT EXISTS suppers_ai__demo__items (
+    id TEXT PRIMARY KEY,
+    slug TEXT UNIQUE,
+    count INTEGER,
+    ratio REAL,
+    payload BLOB,
+    created_at TEXT,
+    updated_at TEXT
+)";
+        assert_eq!(sql, expected);
+    }
+
+    #[test]
     fn render_create_table_simple_text_fields() {
         let schema = CollectionSchema::new("suppers_ai__demo__widgets")
             .field("name", "text")

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -59,6 +59,24 @@ mod tests {
     }
 
     #[test]
+    fn render_create_table_skips_explicit_id_field() {
+        let schema = CollectionSchema::new("suppers_ai__demo__rows")
+            .field("id", "text")
+            .field("label", "text")
+            .field("created_at", "text")
+            .field("updated_at", "text");
+        let sql = render_create_table(&schema);
+        let expected = "\
+CREATE TABLE IF NOT EXISTS suppers_ai__demo__rows (
+    id TEXT PRIMARY KEY,
+    label TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)";
+        assert_eq!(sql, expected);
+    }
+
+    #[test]
     fn render_create_table_unique_and_typed_fields() {
         let schema = CollectionSchema::new("suppers_ai__demo__items")
             .field_unique("slug", "text")

--- a/crates/solobase-core/src/migrations.rs
+++ b/crates/solobase-core/src/migrations.rs
@@ -8,7 +8,36 @@ use wafer_block::types::{CollectionSchema, IndexSchema};
 
 /// Render a single CREATE TABLE statement (without trailing semicolon).
 pub fn render_create_table(schema: &CollectionSchema) -> String {
-    todo!("Task 2")
+    let mut col_lines = vec!["    id TEXT PRIMARY KEY".to_string()];
+    for f in &schema.fields {
+        if matches!(f.name.as_str(), "id" | "created_at" | "updated_at") {
+            continue; // emitted by the boilerplate
+        }
+        let mut line = format!("    {} {}", f.name, sql_type(&f.field_type));
+        if f.unique {
+            line.push_str(" UNIQUE");
+        }
+        col_lines.push(line);
+    }
+    col_lines.push("    created_at TEXT".to_string());
+    col_lines.push("    updated_at TEXT".to_string());
+    format!(
+        "CREATE TABLE IF NOT EXISTS {} (\n{}\n)",
+        schema.name,
+        col_lines.join(",\n")
+    )
+}
+
+/// Map CollectionSchema field_type strings to SQLite column types.
+/// All non-text types fall back to TEXT — solobase historically stores
+/// everything as text and parses on read.
+fn sql_type(field_type: &str) -> &'static str {
+    match field_type {
+        "int" | "integer" | "i64" | "i32" => "INTEGER",
+        "real" | "f64" | "f32" => "REAL",
+        "blob" | "bytes" => "BLOB",
+        _ => "TEXT",
+    }
 }
 
 /// Render the full initial schema migration: CREATE TABLE for each collection,
@@ -27,5 +56,22 @@ mod tests {
     #[test]
     fn empty_input_produces_empty_string() {
         assert_eq!(generate_initial_schema(&[]), "");
+    }
+
+    #[test]
+    fn render_create_table_simple_text_fields() {
+        let schema = CollectionSchema::new("suppers_ai__demo__widgets")
+            .field("name", "text")
+            .field("color", "text");
+        let sql = render_create_table(&schema);
+        let expected = "\
+CREATE TABLE IF NOT EXISTS suppers_ai__demo__widgets (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    color TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)";
+        assert_eq!(sql, expected);
     }
 }

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -103,6 +103,15 @@ pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
     let out_dir = repo_root.join("target/solobase-cloudflare");
     let wrangler_toml = out_dir.join("wrangler.toml");
 
+    // Apply D1 migrations BEFORE pushing the worker bundle. The new code
+    // expects tables to exist (no more lazy ensure_table()), so migrations
+    // must land first.
+    let migrations_dir = out_dir.join("migrations");
+    if migrations_dir.is_dir() {
+        cf_deploy::d1_migrate_remote(&cfg.d1.database_name, &wrangler_toml)?;
+        println!("-> D1 migrations applied to {}", cfg.d1.database_name);
+    }
+
     cf_deploy::wrangler_deploy(&wrangler_toml)?;
 
     let assets_root = out_dir.join("assets");
@@ -111,11 +120,6 @@ pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
         "-> uploaded {} R2 objects to bucket {}",
         n, cfg.r2.bucket_name
     );
-
-    if repo_root.join("migrations").is_dir() {
-        cf_deploy::d1_migrate_remote(&cfg.d1.database_name, &wrangler_toml)?;
-        println!("-> D1 migrations applied to {}", cfg.d1.database_name);
-    }
 
     println!();
     println!("deploy complete");

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -33,9 +33,18 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
         .collect();
     let sql = solobase_core::migrations::generate_initial_schema(&collections);
     std::fs::write(migrations_dir.join("0001_initial_schema.sql"), &sql)?;
+
+    // Hand-authored migrations for blocks whose schema isn't declared via
+    // CollectionSchema (e.g. wafer-core's AuthBlock). Embedded at compile
+    // time; written alongside the auto-generated initial schema.
+    for (name, content) in solobase_core::migrations::extra_migrations() {
+        std::fs::write(migrations_dir.join(name), content)?;
+    }
+
+    let migration_count = std::fs::read_dir(&migrations_dir)?.count();
     println!(
-        "-> wrote {} bytes of migrations to {}",
-        sql.len(),
+        "-> wrote {} migration files to {}",
+        migration_count,
         migrations_dir.display()
     );
 

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -21,6 +21,24 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     let wrangler_path = wrangler::generate(&cfg, repo_root, &out_dir)?;
     println!("-> {}", wrangler_path.display());
 
+    // Generate D1 migrations from registered blocks' CollectionSchema.
+    // Wrangler picks these up via `migrations_dir` in wrangler.toml when
+    // `wrangler d1 migrations apply` runs at deploy time.
+    let migrations_dir = out_dir.join("migrations");
+    std::fs::create_dir_all(&migrations_dir)?;
+    let block_infos = solobase_core::blocks::all_block_infos();
+    let collections: Vec<_> = block_infos
+        .iter()
+        .flat_map(|b| b.collections.iter().cloned())
+        .collect();
+    let sql = solobase_core::migrations::generate_initial_schema(&collections);
+    std::fs::write(migrations_dir.join("0001_initial_schema.sql"), &sql)?;
+    println!(
+        "-> wrote {} bytes of migrations to {}",
+        sql.len(),
+        migrations_dir.display()
+    );
+
     cf_build::run(repo_root, release)?;
 
     let report = assets::stage(repo_root, &out_dir)?;

--- a/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
@@ -96,6 +96,7 @@ fn base_toml(cfg: &CloudflareConfig) -> toml::Value {
         "database_id".into(),
         Value::String(cfg.d1.database_id.clone()),
     );
+    d1_entry.insert("migrations_dir".into(), Value::String("migrations".into()));
     root.insert(
         "d1_databases".into(),
         Value::Array(vec![Value::Table(d1_entry)]),


### PR DESCRIPTION
## Summary
- Adds `solobase_core::migrations` — generates SQLite DDL from `CollectionSchema` declarations (5 unit tests).
- `solobase build --target cloudflare` now writes 3 migration files to `target/solobase-cloudflare/migrations/`:
  - `0001_initial_schema.sql` — auto-generated from `all_block_infos()` (31 tables across admin, files, products, llm, messages, userportal, legalpages).
  - `0002_auth_schema.sql` — hand-authored auth schema, embedded via `include_str!` (8 tables: users, sessions, tokens, etc.). `AuthBlock::info()` declares no `CollectionSchema` so auto-gen can't reach those tables.
  - `0003_reserved_orgs.sql` — auth seed data.
- Generated `wrangler.toml` now sets `migrations_dir = "migrations"`.
- `solobase deploy --target cloudflare` applies migrations BEFORE pushing the worker (was: after).
- **Cached `ensure_table` per-isolate** instead of dropping it: `static OnceLock<Mutex<HashMap<String, HashSet<String>>>>` tracks known column sets per table. First insert per (isolate, table) runs `CREATE TABLE IF NOT EXISTS` + `PRAGMA table_info`; subsequent inserts skip both. Combined with deploy-time migrations, the hot path runs zero schema work.
- Drops `network_request_logs` writer + collection declaration entirely (admin/pages/network.rs lost an outbound-tab + detail handler).

This is **PR2 of a four-PR sequence** to drop wafer-site D1 traffic from ~415 queries/request to ≈1 write per request. Stacks on PR1 #113 (now merged); this PR replaces the auto-closed #114 after PR1 squash-merged.

Spec: `workspace/docs/superpowers/specs/2026-05-09-d1-query-amplification-fix-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-09-d1-amplification-pr2-migrations.md`

## Design deviation from plan

The plan said "drop `ensure_table` entirely" assuming all writable tables would be in our generated migrations. Recon found that some blocks (e.g. `vector`) write to tables but declare no `CollectionSchema` — dropping `ensure_table` would 500 those writes. Switched to caching `ensure_table` per-isolate, which gets us the same hot-path perf while keeping correctness for non-declared blocks.

## Verification (from prior PR #114)

Deployed to wafer.run. `wrangler d1 migrations list wafer-site-prod --remote` shows 3 migrations applied. D1 jumped from 18 → 42 tables. `wrangler tail` on 8 sequential requests showed clean output: bare GET status line per request, zero `CREATE TABLE` / `PRAGMA` / `network_request_log` chatter. All 200s.

## Test plan
- [x] `cargo test -p solobase-core --lib migrations::` — 5 passing
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown`
- [x] `cargo +nightly fmt -- --check`
- [x] Generated SQL applies cleanly to local sqlite (38 tables, no syntax errors)
- [x] `wrangler d1 migrations apply` succeeds against wafer-site-prod (idempotent on re-run)
- [x] Production smoke: 8/8 200 responses
- [x] Tail confirms hot path is silent (no schema chatter)

## Replaces
Replaces #114 which auto-closed when its base branch (`perf/d1-config-cache`, PR #113) was deleted on squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)