### PR TITLE
chore(auth-ui): drop std::env::var fallback in pages::get

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
@@ -41,32 +41,16 @@ pub(super) async fn load_variables(ctx: &dyn Context) -> HashMap<String, String>
     settings
 }
 
-// Lookup precedence: DB > env > default. See `get` below.
-/// Lookup precedence for shared / block-scoped settings:
-///
-/// 1. Admin-managed value persisted in the variables table (`settings` map).
-/// 2. Process environment variable of the same name — lets `.env` bootstrap
-///    a fresh deployment (e.g. `SOLOBASE_SHARED__ALLOW_SIGNUP=false`)
-///    before any admin has touched the UI.
-/// 3. Hardcoded `default`.
-///
-/// The fallback uses a `Box::leak`-free pattern: we cache the env lookup
-/// in a thread-local so the borrow can outlive the closure. Simpler:
-/// rebind via `String::leak` — but we want a clean borrow lifetime, so the
-/// signature returns `Cow<'a, str>`. Callers compare with `==` or pass the
-/// result through `to_string()`, which both work transparently.
+/// Lookup a shared / block-scoped setting from the variables table, falling
+/// back to `default` when the key is absent. The variables table is the
+/// single source of truth — process env is only read at first cold-start by
+/// `admin::settings::seed_admin_variables` to populate this table.
 pub(super) fn get<'a>(
     settings: &'a HashMap<String, String>,
     key: &str,
     default: &'a str,
-) -> std::borrow::Cow<'a, str> {
-    if let Some(v) = settings.get(key) {
-        return std::borrow::Cow::Borrowed(v.as_str());
-    }
-    if let Ok(v) = std::env::var(key) {
-        return std::borrow::Cow::Owned(v);
-    }
-    std::borrow::Cow::Borrowed(default)
+) -> &'a str {
+    settings.get(key).map(String::as_str).unwrap_or(default)
 }
 
 /// Build SiteConfig from the variables settings map.
@@ -108,11 +92,11 @@ pub(super) fn site_config(settings: &HashMap<String, String>) -> SiteConfig {
 /// - `SUPPERS_AI__AUTH_UI__OAUTH_<PROVIDER>_CLIENT_ID`
 /// - `SUPPERS_AI__AUTH_UI__OAUTH_<PROVIDER>_CLIENT_SECRET`
 /// - `SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI` (single URI, provider-agnostic;
-///    the provider is encoded in the signed `state` JWT)
+///   the provider is encoded in the signed `state` JWT)
 ///
 /// These match what `oauth.rs` actually reads when building the auth_url.
-/// On cloudflare the values come from D1 via `load_variables`; on native
-/// they fall through to process env via `get()`.
+/// Values come from the variables table via `load_variables` on both
+/// native (sqlite) and cloudflare (D1).
 pub(super) fn oauth_provider_configured(
     settings: &HashMap<String, String>,
     provider: &str,


### PR DESCRIPTION
## Summary
- `auth_ui::pages::get` previously fell back to `std::env::var(key)` when the variables table didn't have a key. That fallback was dead on Cloudflare (workers have no process env), bypassed the config service on native, and contradicted the CLAUDE.md "no magic / single representation" rule.
- Removed the env::var branch. Function now collapses from `Cow<'a, str>` to `&'a str` since both remaining branches are borrows. All 5 callsites already used `.to_string()` / `.is_empty()` / `.split()`, all of which work transparently on `&str`.
- Bootstrap from process env still happens (intentionally, dev-only) via `admin::settings::seed_admin_variables` at first cold-start — that path is the documented seed point.
- Doc-comment fixups: removed misleading "On cloudflare/native they fall through to env" wording, fixed pre-existing clippy doc-list overindent on `oauth_provider_configured`.

Closes the `std::env::var` audit follow-up from the [solobase-cloudflare-target-active](https://github.com/suppers-ai/solobase) memory. The remaining `std::env::var` site (`admin/settings.rs:372`) is the intentional seed-from-env bootstrap and is left in place.

## Test plan
- [x] `cargo check -p solobase-core`
- [x] `cargo test -p solobase-core --lib` — 552 passing
- [x] `cargo +nightly fmt -- --check` on touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)