### PR TITLE
chore(auth): refresh stale doc comments after Plan A2 wiring

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -107,16 +107,16 @@ pub(crate) mod helpers {
     }
 
     /// Resolve user roles, idempotently granting `admin` if the user's email
-    /// matches the configured `SUPPERS_AI__AUTH__ADMIN_EMAIL` and they don't
-    /// already have it.
+    /// matches the configured `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL`
+    /// and they don't already have it.
     ///
     /// This closes a real footgun: roles are normally only assigned at signup,
-    /// so changing `ADMIN_EMAIL` after a user already exists never elevates
-    /// them. With this helper, every login re-checks the rule and grants admin
-    /// once when appropriate.
+    /// so changing the configured admin email after a user already exists
+    /// never elevates them. With this helper, every login re-checks the rule
+    /// and grants admin once when appropriate.
     ///
     /// Intentionally **upgrade-only**: never removes a role, never demotes.
-    /// Unsetting `ADMIN_EMAIL` does not revoke admin from anyone — that has
+    /// Unsetting the admin email does not revoke admin from anyone — that has
     /// to be done explicitly via the admin UI / DB. Removing roles silently
     /// on login would be an availability foot-gun (one typo in env locks
     /// everyone out).

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -287,13 +287,10 @@ mod tests_phase_4 {
         }
     }
 
-    /// Seed a user using the live (TEXT-everything) convention via
-    /// `db::create`, matching how `seed_admin_user` writes rows in
-    /// production. This sidesteps the migration's NOT NULL on
-    /// `display_name`/`role` so the test can use the unwired-migration
-    /// schema while still mirroring production.
+    /// Seed a user row directly via SQL so the test can pin a deterministic
+    /// `user_id` — `db::create` would generate one. The row provides every
+    /// NOT NULL column required by the auth migration.
     async fn seed_user(ctx: &TestContext, user_id: &str) {
-        // Use exec_raw so we can pin the id (db::create would generate one).
         db::exec_raw(
             ctx,
             "INSERT INTO suppers_ai__auth__users (id, email, display_name, role, created_at, updated_at) \


### PR DESCRIPTION
## Summary
Two doc-only fixes the Plan A2 PRs missed:

- **`auth/mod.rs::ensure_admin_role`** — comment named the pre-A2 `SUPPERS_AI__AUTH__ADMIN_EMAIL`; the function actually reads `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL` at line 131.
- **`repo/sessions.rs::tests_phase_4::seed_user`** — referenced the removed `seed_admin_user` and an "unwired-migration schema" rationale that no longer applies (`TestContext::with_auth` runs `migrations::apply`). Replaced with the actual reason: pin a deterministic `user_id` via raw SQL.

Closes the doc-side residue from Phase 5d Item J.

## Test plan
- [x] `cargo check -p solobase-core --tests`
- No code-path changes — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)