### PR TITLE
perf(auth_ui): drop redundant page-level config reads (D1 PR3)

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
@@ -15,15 +15,10 @@ use crate::{
 };
 
 pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let logo_url = db::get_by_field(
-        ctx,
-        crate::blocks::admin::VARIABLES_COLLECTION,
-        "key",
-        serde_json::Value::String("SOLOBASE_SHARED__AUTH_LOGO_URL".into()),
-    )
-    .await
-    .map(|r| r.str_field("value").to_string())
-    .unwrap_or_default();
+    let logo_url = ctx
+        .config_get("SOLOBASE_SHARED__AUTH_LOGO_URL")
+        .unwrap_or("")
+        .to_string();
 
     // Token comes from query param or body
     let token = {

--- a/crates/solobase-core/src/blocks/auth_ui/pages/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/bootstrap.rs
@@ -10,15 +10,14 @@
 use maud::html;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
-use super::{load_variables, site_config};
+use super::site_config;
 use crate::{
     blocks::auth::brand_panel,
     ui::{self, templates::auth_split},
 };
 
 pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let settings = load_variables(ctx).await;
-    let config = site_config(&settings);
+    let config = site_config(ctx);
     let app_name = &config.app_name;
     let logo_url = &config.logo_url;
 

--- a/crates/solobase-core/src/blocks/auth_ui/pages/change_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/change_password.rs
@@ -3,15 +3,14 @@
 use maud::{html, PreEscaped};
 use wafer_run::{context::Context, types::Message, OutputStream};
 
-use super::{load_variables, pw_field, pw_toggle_js, site_config};
+use super::{pw_field, pw_toggle_js, site_config};
 use crate::{
     blocks::auth::brand_panel,
     ui::{self, templates::auth_split},
 };
 
 pub async fn handle(ctx: &dyn Context, _msg: &Message) -> OutputStream {
-    let settings = load_variables(ctx).await;
-    let config = site_config(&settings);
+    let config = site_config(ctx);
     let app_name = &config.app_name;
     let logo_url = &config.logo_url;
 

--- a/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
@@ -14,9 +14,7 @@ use crate::{
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let config = site_config(ctx);
-    let app_name = ctx
-        .config_get("SOLOBASE_SHARED__APP_NAME")
-        .unwrap_or("Solobase");
+    let app_name = &config.app_name;
     let allow_signup = ctx
         .config_get("SOLOBASE_SHARED__ALLOW_SIGNUP")
         .unwrap_or("true")

--- a/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
@@ -4,8 +4,8 @@ use maud::{html, PreEscaped};
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use super::{
-    get, load_variables, login_script, oauth_button_script, oauth_provider_configured,
-    oauth_provider_icon, oauth_provider_label, pw_field, pw_toggle_js, site_config,
+    login_script, oauth_button_script, oauth_provider_configured, oauth_provider_icon,
+    oauth_provider_label, pw_field, pw_toggle_js, site_config,
 };
 use crate::{
     blocks::auth::brand_panel,
@@ -13,10 +13,14 @@ use crate::{
 };
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let settings = load_variables(ctx).await;
-    let config = site_config(&settings);
-    let app_name = get(&settings, "SOLOBASE_SHARED__APP_NAME", "Solobase");
-    let allow_signup = get(&settings, "SOLOBASE_SHARED__ALLOW_SIGNUP", "true") == "true";
+    let config = site_config(ctx);
+    let app_name = ctx
+        .config_get("SOLOBASE_SHARED__APP_NAME")
+        .unwrap_or("Solobase");
+    let allow_signup = ctx
+        .config_get("SOLOBASE_SHARED__ALLOW_SIGNUP")
+        .unwrap_or("true")
+        == "true";
     let raw_redirect = msg.get_meta("req.query.redirect").to_string();
     // Validate redirect — only allow relative paths (prevent open redirect)
     let redirect = if raw_redirect.starts_with('/') && !raw_redirect.starts_with("//") {
@@ -24,12 +28,10 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     } else {
         String::new()
     };
-    let post_login_raw = get(
-        &settings,
-        "SOLOBASE_SHARED__POST_LOGIN_REDIRECT",
-        "/b/admin/",
-    )
-    .to_string();
+    let post_login_raw = ctx
+        .config_get("SOLOBASE_SHARED__POST_LOGIN_REDIRECT")
+        .unwrap_or("/b/admin/")
+        .to_string();
     let post_login = if post_login_raw.starts_with('/') && !post_login_raw.starts_with("//") {
         post_login_raw
     } else {
@@ -47,12 +49,15 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // full credential triple (CLIENT_ID + CLIENT_SECRET + REDIRECT_URL) is
     // present in env. Avoids rendering a "Continue with GitHub" button that
     // would 4xx as soon as it's clicked.
-    let oauth_enabled = get(&settings, "SOLOBASE_SHARED__ENABLE_OAUTH", "false") == "true";
+    let oauth_enabled = ctx
+        .config_get("SOLOBASE_SHARED__ENABLE_OAUTH")
+        .unwrap_or("false")
+        == "true";
     let oauth_providers: Vec<&'static str> = if oauth_enabled {
         ["github", "google", "microsoft"]
             .iter()
             .copied()
-            .filter(|p| oauth_provider_configured(&settings, p))
+            .filter(|p| oauth_provider_configured(ctx, p))
             .collect()
     } else {
         Vec::new()

--- a/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
@@ -69,8 +69,6 @@ pub(super) fn site_config(ctx: &dyn Context) -> SiteConfig {
 ///   the provider is encoded in the signed `state` JWT)
 ///
 /// These match what `oauth.rs` actually reads when building the auth_url.
-/// Values come from the config snapshot via `ctx.config_get` on both native
-/// (sqlite) and cloudflare (D1) targets.
 pub(super) fn oauth_provider_configured(ctx: &dyn Context, provider: &str) -> bool {
     let up = provider.to_ascii_uppercase();
     !ctx.config_get(&format!("SUPPERS_AI__AUTH_UI__OAUTH_{up}_CLIENT_ID"))

--- a/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
@@ -11,78 +11,52 @@ pub mod reset_password;
 pub mod settings;
 pub mod signup;
 
-use std::collections::HashMap;
-
 use maud::{html, Markup};
-use wafer_core::clients::{database as db, database::ListOptions};
 use wafer_run::context::Context;
 
-use crate::{
-    blocks::helpers::RecordExt,
-    ui::{self, SiteConfig},
-};
+use crate::ui::{self, SiteConfig};
 
-/// Read all key-value pairs from the variables table.
-pub(super) async fn load_variables(ctx: &dyn Context) -> HashMap<String, String> {
-    let opts = ListOptions {
-        limit: 100,
-        ..Default::default()
+/// Build SiteConfig directly from `ctx.config_get(...)`.
+///
+/// Values come from the cached config snapshot — on cloudflare, populated
+/// once per isolate by `solobase-cloudflare::config_cache::get_or_load`;
+/// on native, populated at boot by `seed_and_load_variables` in
+/// `solobase::cli::server`. No D1 / SQLite read happens here.
+pub(super) fn site_config(ctx: &dyn Context) -> SiteConfig {
+    let auth_logo = ctx
+        .config_get("SOLOBASE_SHARED__AUTH_LOGO_URL")
+        .unwrap_or("");
+    let logo_url = if auth_logo.is_empty() {
+        ctx.config_get("SOLOBASE_SHARED__LOGO_URL")
+            .unwrap_or("https://solobase.dev/images/logo_long.png")
+    } else {
+        auth_logo
     };
-    let mut settings = HashMap::new();
-    if let Ok(result) = db::list(ctx, crate::blocks::admin::VARIABLES_COLLECTION, &opts).await {
-        for record in &result.records {
-            let key = record.str_field("key").to_string();
-            let value = record.str_field("value").to_string();
-            if !key.is_empty() {
-                settings.insert(key, value);
-            }
-        }
-    }
-    settings
-}
 
-/// Lookup a shared / block-scoped setting from the variables table, falling
-/// back to `default` when the key is absent. The variables table is the
-/// single source of truth — process env is only read at first cold-start by
-/// `admin::settings::seed_admin_variables` to populate this table.
-pub(super) fn get<'a>(
-    settings: &'a HashMap<String, String>,
-    key: &str,
-    default: &'a str,
-) -> &'a str {
-    settings.get(key).map(String::as_str).unwrap_or(default)
-}
+    let embedded_scripts = ctx
+        .config_get("SOLOBASE_SHARED__EMBEDDED_SCRIPTS")
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
 
-/// Build SiteConfig from the variables settings map.
-pub(super) fn site_config(settings: &HashMap<String, String>) -> SiteConfig {
     SiteConfig {
-        app_name: get(settings, "SOLOBASE_SHARED__APP_NAME", "Solobase").to_string(),
-        logo_url: {
-            let auth_logo = get(settings, "SOLOBASE_SHARED__AUTH_LOGO_URL", "");
-            if auth_logo.is_empty() {
-                get(
-                    settings,
-                    "SOLOBASE_SHARED__LOGO_URL",
-                    "https://solobase.dev/images/logo_long.png",
-                )
-                .to_string()
-            } else {
-                auth_logo.to_string()
-            }
-        },
-        logo_icon_url: get(
-            settings,
-            "SOLOBASE_SHARED__LOGO_ICON_URL",
-            "https://solobase.dev/images/logo.png",
-        )
-        .to_string(),
-        favicon_url: get(settings, "SOLOBASE_SHARED__FAVICON_URL", "").to_string(),
-        embedded_scripts: get(settings, "SOLOBASE_SHARED__EMBEDDED_SCRIPTS", "")
-            .split(',')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .collect(),
+        app_name: ctx
+            .config_get("SOLOBASE_SHARED__APP_NAME")
+            .unwrap_or("Solobase")
+            .to_string(),
+        logo_url: logo_url.to_string(),
+        logo_icon_url: ctx
+            .config_get("SOLOBASE_SHARED__LOGO_ICON_URL")
+            .unwrap_or("https://solobase.dev/images/logo.png")
+            .to_string(),
+        favicon_url: ctx
+            .config_get("SOLOBASE_SHARED__FAVICON_URL")
+            .unwrap_or("")
+            .to_string(),
+        embedded_scripts,
     }
 }
 
@@ -95,26 +69,21 @@ pub(super) fn site_config(settings: &HashMap<String, String>) -> SiteConfig {
 ///   the provider is encoded in the signed `state` JWT)
 ///
 /// These match what `oauth.rs` actually reads when building the auth_url.
-/// Values come from the variables table via `load_variables` on both
-/// native (sqlite) and cloudflare (D1).
-pub(super) fn oauth_provider_configured(
-    settings: &HashMap<String, String>,
-    provider: &str,
-) -> bool {
+/// Values come from the config snapshot via `ctx.config_get` on both native
+/// (sqlite) and cloudflare (D1) targets.
+pub(super) fn oauth_provider_configured(ctx: &dyn Context, provider: &str) -> bool {
     let up = provider.to_ascii_uppercase();
-    !get(
-        settings,
-        &format!("SUPPERS_AI__AUTH_UI__OAUTH_{up}_CLIENT_ID"),
-        "",
-    )
-    .is_empty()
-        && !get(
-            settings,
-            &format!("SUPPERS_AI__AUTH_UI__OAUTH_{up}_CLIENT_SECRET"),
-            "",
-        )
+    !ctx.config_get(&format!("SUPPERS_AI__AUTH_UI__OAUTH_{up}_CLIENT_ID"))
+        .unwrap_or("")
         .is_empty()
-        && !get(settings, "SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI", "").is_empty()
+        && !ctx
+            .config_get(&format!("SUPPERS_AI__AUTH_UI__OAUTH_{up}_CLIENT_SECRET"))
+            .unwrap_or("")
+            .is_empty()
+        && !ctx
+            .config_get("SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI")
+            .unwrap_or("")
+            .is_empty()
 }
 
 /// Display label for an OAuth provider button.
@@ -258,5 +227,100 @@ async function handleForgot(){
   showInfo('If that email is registered, a password reset link has been sent.');
 }
 "#
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    #[tokio::test]
+    async fn site_config_reads_from_ctx_config_get_with_defaults() {
+        let ctx = TestContext::new().await;
+        let cfg = site_config(&ctx);
+
+        assert_eq!(cfg.app_name, "Solobase");
+        assert_eq!(cfg.logo_url, "https://solobase.dev/images/logo_long.png");
+        assert_eq!(cfg.logo_icon_url, "https://solobase.dev/images/logo.png");
+        assert!(cfg.favicon_url.is_empty());
+        assert!(cfg.embedded_scripts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn site_config_picks_auth_logo_when_set() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config(
+            "SOLOBASE_SHARED__AUTH_LOGO_URL",
+            "https://example.com/auth.png",
+        );
+        ctx.set_config("SOLOBASE_SHARED__LOGO_URL", "https://example.com/main.png");
+
+        let cfg = site_config(&ctx);
+        assert_eq!(cfg.logo_url, "https://example.com/auth.png");
+    }
+
+    #[tokio::test]
+    async fn site_config_falls_back_to_logo_url_when_auth_logo_empty() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SOLOBASE_SHARED__LOGO_URL", "https://example.com/main.png");
+
+        let cfg = site_config(&ctx);
+        assert_eq!(cfg.logo_url, "https://example.com/main.png");
+    }
+
+    #[tokio::test]
+    async fn site_config_app_name_override() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SOLOBASE_SHARED__APP_NAME", "MyApp");
+
+        let cfg = site_config(&ctx);
+        assert_eq!(cfg.app_name, "MyApp");
+    }
+
+    #[tokio::test]
+    async fn site_config_embedded_scripts_splits_csv() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config(
+            "SOLOBASE_SHARED__EMBEDDED_SCRIPTS",
+            "https://a.example.com/a.js, https://b.example.com/b.js,",
+        );
+
+        let cfg = site_config(&ctx);
+        assert_eq!(
+            cfg.embedded_scripts,
+            vec![
+                "https://a.example.com/a.js".to_string(),
+                "https://b.example.com/b.js".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_provider_configured_requires_all_three_keys() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_ID", "id");
+        ctx.set_config("SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_SECRET", "secret");
+        assert!(
+            !oauth_provider_configured(&ctx, "github"),
+            "should be false without REDIRECT_URI"
+        );
+
+        ctx.set_config(
+            "SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI",
+            "https://example.com/cb",
+        );
+        assert!(
+            oauth_provider_configured(&ctx, "github"),
+            "should be true once all three are set"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_provider_configured_false_when_missing_any_key() {
+        let ctx = TestContext::new().await;
+        assert!(!oauth_provider_configured(&ctx, "github"));
+        assert!(!oauth_provider_configured(&ctx, "google"));
+        assert!(!oauth_provider_configured(&ctx, "microsoft"));
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/pages/reset_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/reset_password.rs
@@ -2,25 +2,15 @@
 //! in Task 5.
 
 use maud::{html, PreEscaped};
-use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
-use crate::{
-    blocks::{auth::brand_panel, helpers::RecordExt},
-    ui,
-    ui::templates::auth_split,
-};
+use crate::{blocks::auth::brand_panel, ui, ui::templates::auth_split};
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let logo_url = db::get_by_field(
-        ctx,
-        crate::blocks::admin::VARIABLES_COLLECTION,
-        "key",
-        serde_json::Value::String("SOLOBASE_SHARED__AUTH_LOGO_URL".into()),
-    )
-    .await
-    .map(|r| r.str_field("value").to_string())
-    .unwrap_or_default();
+    let logo_url = ctx
+        .config_get("SOLOBASE_SHARED__AUTH_LOGO_URL")
+        .unwrap_or("")
+        .to_string();
 
     let token = msg.get_meta("req.query.token").to_string();
     if token.is_empty() {

--- a/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
@@ -11,9 +11,7 @@ use crate::{
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let config = site_config(ctx);
-    let app_name = ctx
-        .config_get("SOLOBASE_SHARED__APP_NAME")
-        .unwrap_or("Solobase");
+    let app_name = &config.app_name;
     let allow_signup = ctx
         .config_get("SOLOBASE_SHARED__ALLOW_SIGNUP")
         .unwrap_or("true")

--- a/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
@@ -3,17 +3,21 @@
 use maud::{html, PreEscaped};
 use wafer_run::{context::Context, types::Message, OutputStream};
 
-use super::{get, load_variables, pw_field, pw_toggle_js, site_config};
+use super::{pw_field, pw_toggle_js, site_config};
 use crate::{
     blocks::auth::brand_panel,
     ui::{self, templates::auth_split},
 };
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let settings = load_variables(ctx).await;
-    let config = site_config(&settings);
-    let app_name = get(&settings, "SOLOBASE_SHARED__APP_NAME", "Solobase");
-    let allow_signup = get(&settings, "SOLOBASE_SHARED__ALLOW_SIGNUP", "true") == "true";
+    let config = site_config(ctx);
+    let app_name = ctx
+        .config_get("SOLOBASE_SHARED__APP_NAME")
+        .unwrap_or("Solobase");
+    let allow_signup = ctx
+        .config_get("SOLOBASE_SHARED__ALLOW_SIGNUP")
+        .unwrap_or("true")
+        == "true";
     let raw_redirect = msg.get_meta("req.query.redirect").to_string();
     // Validate redirect — only allow relative paths (prevent open redirect)
     let redirect = if raw_redirect.starts_with('/') && !raw_redirect.starts_with("//") {

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -34,8 +34,10 @@ use wafer_run::{
 #[derive(Clone)]
 pub struct TestContext {
     database_block: Arc<dyn Block>,
-    /// Placeholder for config values — populated by Task 5 (`with_auth`).
-    pub config: Arc<Mutex<HashMap<String, String>>>,
+    /// Config snapshot used by `config_get`. Immutable after construction so
+    /// `config_get` can return `Option<&str>` without holding a lock.
+    /// Populated via [`with_config`] or [`set_config`].
+    config: Arc<HashMap<String, String>>,
     /// Placeholder for dynamically registered blocks — populated by Task 6.
     pub blocks: Arc<Mutex<HashMap<String, Arc<dyn Block>>>>,
     /// WRAP-enforcement caller identity. `None` = WRAP checks skipped (the
@@ -60,12 +62,30 @@ impl TestContext {
 
         Self {
             database_block,
-            config: Arc::new(Mutex::new(HashMap::new())),
+            config: Arc::new(HashMap::new()),
             blocks: Arc::new(Mutex::new(HashMap::new())),
             caller_id: None,
             wrap_grants: Vec::new(),
             wrap_admin_block: String::new(),
         }
+    }
+
+    /// Replace the config snapshot with `vars`. Builder-style: returns `self`.
+    ///
+    /// Use before the first call that exercises `ctx.config_get(...)`.
+    pub fn with_config(mut self, vars: HashMap<String, String>) -> Self {
+        self.config = Arc::new(vars);
+        self
+    }
+
+    /// Insert a single config entry into the snapshot.
+    ///
+    /// Makes a fresh `Arc<HashMap>` clone on each call — fine for tests,
+    /// where the number of entries is small and mutations happen at setup time.
+    pub fn set_config(&mut self, key: &str, value: &str) {
+        let mut map = (*self.config).clone();
+        map.insert(key.to_string(), value.to_string());
+        self.config = Arc::new(map);
     }
 
     /// Opt the test into WRAP enforcement on `call_block`.
@@ -175,14 +195,8 @@ impl Context for TestContext {
         false
     }
 
-    fn config_get(&self, _key: &str) -> Option<&str> {
-        // TODO(test_support): returning None here is a deliberate stub.
-        // Borrowing a &str out of the Mutex<HashMap> would require holding the
-        // guard for the lifetime of the return value, which the `Context` trait
-        // signature (&self → Option<&str>) does not allow. Task 5 will either
-        // leak a value into a thread-local or switch to a pre-computed snapshot
-        // when `with_auth()` is called.
-        None
+    fn config_get(&self, key: &str) -> Option<&str> {
+        self.config.get(key).map(String::as_str)
     }
 
     fn clone_arc(&self) -> Arc<dyn Context> {

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -36,7 +36,7 @@ pub struct TestContext {
     database_block: Arc<dyn Block>,
     /// Config snapshot used by `config_get`. Immutable after construction so
     /// `config_get` can return `Option<&str>` without holding a lock.
-    /// Populated via [`with_config`] or [`set_config`].
+    /// Populated via [`set_config`].
     config: Arc<HashMap<String, String>>,
     /// Placeholder for dynamically registered blocks — populated by Task 6.
     pub blocks: Arc<Mutex<HashMap<String, Arc<dyn Block>>>>,
@@ -68,14 +68,6 @@ impl TestContext {
             wrap_grants: Vec::new(),
             wrap_admin_block: String::new(),
         }
-    }
-
-    /// Replace the config snapshot with `vars`. Builder-style: returns `self`.
-    ///
-    /// Use before the first call that exercises `ctx.config_get(...)`.
-    pub fn with_config(mut self, vars: HashMap<String, String>) -> Self {
-        self.config = Arc::new(vars);
-        self
     }
 
     /// Insert a single config entry into the snapshot.


### PR DESCRIPTION
## Summary

Third in the D1 query amplification fix series (after #113 + #115).

Replaces every per-render D1 read against `suppers_ai__admin__variables` in the `auth_ui` block with `ctx.config_get(...)` against the already-cached snapshot from PR1's `config_cache`.

- **Anonymous `/b/auth/login` render**: was 2 D1 reads per page (`db::list`'s unconditional COUNT+SELECT against `suppers_ai__admin__variables`); now 0.
- **`/b/auth/api/verify`, `/b/auth/reset-password`**: was 1 D1 read per request for the logo lookup; now 0.

Same cached snapshot the runtime already loads once per isolate — we just stop re-fetching.

## Changes

`auth_ui/pages/mod.rs` — `site_config(ctx)` + `oauth_provider_configured(ctx, provider)` take `&dyn Context`. `load_variables` and the `get(&HashMap, ...)` helper are deleted. 7 new unit tests cover defaults, the `AUTH_LOGO_URL`/`LOGO_URL` fallback, `APP_NAME` override, `EMBEDDED_SCRIPTS` CSV split, and the three-key OAuth gate.

`auth_ui/pages/{bootstrap,change_password,login,signup}.rs` — drop the `load_variables(ctx).await` call. Read individual keys via `ctx.config_get`. `login` and `signup` use `&config.app_name` (single source of truth — no double-fetch).

`auth_ui/api/verify.rs`, `auth_ui/pages/reset_password.rs` — replace `db::get_by_field(VARIABLES_COLLECTION, "key", "SOLOBASE_SHARED__AUTH_LOGO_URL")` with `ctx.config_get(...)`.

`test_support.rs` — fixes a pre-existing TODO: `TestContext::config_get` used to return `None` unconditionally because `config` was wrapped in `Arc<Mutex<HashMap>>` and you can't return `Option<&str>` while holding the guard. Switched to `Arc<HashMap>` (immutable after construction) and added a `set_config(&mut self, key, value)` setter so the new tests can populate config keys.

## Out of scope / follow-ups

- **PR3b — `userportal/mod.rs:173` re-reads `BLOCK_SETTINGS_COLLECTION`** per `/b/userportal/config` request. Same amplification pattern, but `BlockSettings` isn't exposed by the wafer-run `Context` trait. Migrating cleanly needs a new `Context::is_block_enabled(name)` method in wafer-run + plumbing on both targets. Separate cross-repo PR.
- **Admin variable write path doesn't refresh the in-memory snapshot.** On cloudflare, admin edits propagate via the 60s TTL (acceptable per the design spec). On native, an admin variable edit isn't visible until process restart — pre-existing behavior, no regression introduced here. If addressed, it's via `Context::config_set` propagation, separate from this PR.

## Test plan

- [x] `cargo test -p solobase-core` — 615 lib + 7 integration + 1 lockfile, all pass (7 new tests in `blocks::auth_ui::pages::tests`).
- [x] `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` — clean.
- [x] `cargo fmt --all` — clean.
- [x] `cargo clippy -p solobase-core --all-targets` — zero new warnings on touched files; the two `let...else` warnings on `verify.rs` line numbers are pre-existing on `main` (user-lookup matches, unrelated to this PR).
- [x] Audit: `rg "VARIABLES_COLLECTION"` shows zero matches in `auth_ui/`; remaining hits are admin write/management paths + loaders + non-admin `products__variables` table.
- [ ] Deploy + `wrangler tail wafer-site` to confirm 0 D1 reads on `/b/auth/login` warm-isolate hits.

## Refs

- Spec: `docs/superpowers/specs/2026-05-09-d1-query-amplification-fix-design.md`
- Plan: `docs/superpowers/plans/2026-05-11-d1-amplification-pr3-page-config.md`
- Handoff: `docs/superpowers/handoffs/2026-05-09-d1-amplification-pr1-pr2-handoff.md`
- Series: #113 (PR1 config cache), #115 (PR2 migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)