### PR TITLE
perf(userportal): drop per-request block_settings D1 read (D1 PR3b)

### DIFF
--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -164,6 +164,13 @@ where
             env_vars.insert(key.to_string(), secret.to_string());
         }
     }
+    // Fan-out block_settings into the config snapshot so consumer blocks
+    // (e.g. userportal) can read enablement state via `ctx.config_get`
+    // without re-querying the `block_settings` D1 table per request.
+    env_vars.insert(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY.to_string(),
+        snapshot.1.to_config_json(),
+    );
 
     // 3. Construct remaining 5 services.
     let bucket: Arc<dyn StorageService> = make_r2_storage_service(&env, runner::R2_BINDING)

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -170,17 +170,14 @@ impl UserPortalBlock {
     }
 
     async fn handle_config(&self, ctx: &dyn Context) -> OutputStream {
-        let block_rows = db::list_all(ctx, crate::blocks::admin::BLOCK_SETTINGS_COLLECTION, vec![])
-            .await
-            .unwrap_or_default();
+        let settings = ctx
+            .config_get(crate::features::BLOCK_SETTINGS_CONFIG_KEY)
+            .map(crate::features::BlockSettings::from_config_json)
+            .unwrap_or_else(|| crate::features::BlockSettings::from_map(Default::default()));
 
         let is_enabled = |name: &str| -> bool {
-            block_rows
-                .iter()
-                .find(|r| r.data.get("block_name").and_then(|v| v.as_str()) == Some(name))
-                .and_then(|r| r.data.get("enabled").and_then(|v| v.as_i64()))
-                .map(|v| v != 0)
-                .unwrap_or(true)
+            use crate::features::FeatureConfig;
+            settings.is_block_enabled(name)
         };
 
         let config_val = serde_json::json!({

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -5,6 +5,16 @@
 
 use std::collections::HashMap;
 
+/// Synthetic config key carrying the block_settings JSON map.
+///
+/// At boot, loaders fan-out the loaded `BlockSettings` into the wafer config
+/// snapshot under this key (in addition to the existing `FeatureConfig` Arc
+/// handed to `SolobaseRouterBlock`). Blocks that need to query enablement
+/// state without re-reading D1 read this key via `ctx.config_get` and parse
+/// the JSON. Double-underscore brackets mark the key as internal — it is
+/// never set via env var or the variables table.
+pub const BLOCK_SETTINGS_CONFIG_KEY: &str = "__SOLOBASE_BLOCK_SETTINGS_JSON__";
+
 /// Trait for querying which solobase blocks are enabled.
 pub trait FeatureConfig: wafer_run::MaybeSend + wafer_run::MaybeSync {
     /// Check if a block is enabled by its full name (e.g., "suppers-ai/products").
@@ -27,6 +37,21 @@ impl BlockSettings {
     pub fn is_enabled(&self, short_name: &str) -> bool {
         let full = format!("suppers-ai/{short_name}");
         self.enabled.get(&full).copied().unwrap_or(true)
+    }
+
+    /// Serialize the enabled map to a JSON string for transport through the
+    /// wafer config snapshot under [`BLOCK_SETTINGS_CONFIG_KEY`]. Empty map
+    /// serializes to `"{}"`.
+    pub fn to_config_json(&self) -> String {
+        serde_json::to_string(&self.enabled).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Parse a `BlockSettings` from the JSON shape produced by
+    /// [`Self::to_config_json`]. Falls back to an empty map on parse error so
+    /// `is_block_enabled` retains "default enabled" semantics.
+    pub fn from_config_json(json: &str) -> Self {
+        let map = serde_json::from_str(json).unwrap_or_default();
+        Self::from_map(map)
     }
 }
 

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -49,6 +49,13 @@ pub async fn initialize() -> Result<(), JsValue> {
     for (key, value) in &vars {
         config_svc.set(key, value);
     }
+    // Fan-out block_settings into the config snapshot so consumer blocks
+    // (e.g. userportal) can read enablement state via `ctx.config_get`
+    // without re-querying the `block_settings` browser-DB table per request.
+    config_svc.set(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
+        &features.to_config_json(),
+    );
 
     let browser_llm: Arc<dyn wafer_core::interfaces::llm::service::LlmService> =
         Arc::new(solobase_browser::llm::BrowserLlmService::new());

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -56,6 +56,13 @@ pub async fn run() -> anyhow::Result<()> {
     for (key, value) in &vars {
         config_service.set(key, value);
     }
+    // Fan-out block_settings into the config snapshot so consumer blocks
+    // (e.g. userportal) can read enablement state via `ctx.config_get`
+    // without re-querying the `block_settings` SQLite table per request.
+    config_service.set(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
+        &features.to_config_json(),
+    );
 
     let (mut wafer, storage_block) = SolobaseBuilder::new()
         .database(solobase_native::make_sqlite_database_service(


### PR DESCRIPTION
## Summary
- Drops the per-request `db::list_all(BLOCK_SETTINGS_COLLECTION)` in `userportal::handle_config`. The same data is already loaded once at boot — block code just couldn't reach it through `&dyn Context`.
- Fan-out the loaded `BlockSettings` into the existing wafer config snapshot under a synthetic key (`__SOLOBASE_BLOCK_SETTINGS_JSON__`). userportal reads via `ctx.config_get` + JSON parse and reuses `FeatureConfig::is_block_enabled`.
- Touches 3 loaders (native `cli/server.rs`, browser `solobase-web/lib.rs`, Cloudflare `solobase-cloudflare/lib.rs`) so the synth key is populated everywhere the block_settings table is read.

**Per-render impact on `/b/userportal/config`:** 1 D1 read → 0.

## Why not a wafer-run cross-repo change
The prior handoff suggested adding `is_block_enabled` on `wafer-block::Context` (default impl `true`) and implementing on `RuntimeContext` reading from "the block_settings it already holds". Recon shows `RuntimeContext` does **not** hold block_settings — that's purely a solobase concern wired into `SolobaseRouterBlock`. Wafer-run has no feature-gate concept, so a producer-side change would be polluting wafer-run with solobase semantics. Solving it via the existing config_get / per-isolate cache (already in place from PR1) keeps the change in solobase, reuses the cache, and adds no new wafer-run API.

## Test plan
- [x] `cargo test -p solobase-core --lib` — 556 passed
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- [x] `cargo check -p solobase-web --target wasm32-unknown-unknown` — clean
- [x] `cargo build -p solobase` — clean
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — exit 0 (warnings only, all pre-existing)
- [x] `cargo +nightly fmt --all -- --check` — clean

Refs: docs/superpowers/specs/2026-05-09-d1-query-amplification-fix-design.md
Follows: #113, #115, #120 (PR1 / PR2 / PR3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)