### PR TITLE
perf(llm): D1 PR4-llm — db::list → db::list_all

### DIFF
--- a/crates/solobase-core/src/blocks/llm/migrations.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations.rs
@@ -22,7 +22,7 @@
 
 use std::collections::HashMap;
 
-use wafer_core::clients::database::{self as db, ListOptions, Record};
+use wafer_core::clients::database::{self as db, Record};
 use wafer_run::{context::Context, types::ErrorCode};
 
 use super::{
@@ -124,7 +124,7 @@ pub(super) async fn migrate_legacy_providers(
     // Step 1: read the legacy table. NotFound (table doesn't exist) = already
     // migrated — return cleanly. All other errors bubble up to the caller.
     // audit-allow: legacy-block-table — `provider-llm` was renamed to `llm`; the old block no longer registers, so no grant can exist. Probe is one-shot and swallows NotFound on the steady-state path.
-    let legacy = match db::list(ctx, LEGACY_COLLECTION, &ListOptions::default()).await {
+    let legacy_records = match db::list_all(ctx, LEGACY_COLLECTION, vec![]).await {
         Ok(r) => r,
         Err(e) if e.code == ErrorCode::NotFound => {
             // Already migrated or never needed — common path on every subsequent
@@ -137,7 +137,7 @@ pub(super) async fn migrate_legacy_providers(
         }
     };
 
-    if legacy.records.is_empty() {
+    if legacy_records.is_empty() {
         // Empty legacy table — nothing to copy, but we still drop it so the
         // next boot takes the short-circuit path above.
         drop_legacy_table(ctx).await;
@@ -146,12 +146,12 @@ pub(super) async fn migrate_legacy_providers(
 
     tracing::info!(
         "migrating {} legacy provider row(s) from {LEGACY_COLLECTION} → {PROVIDERS_COLLECTION}",
-        legacy.records.len()
+        legacy_records.len()
     );
 
     let mut migrated = 0usize;
     let mut skipped = 0usize;
-    for record in &legacy.records {
+    for record in &legacy_records {
         match migrate_one(ctx, record).await {
             MigrateOutcome::Inserted => migrated += 1,
             MigrateOutcome::Skipped => skipped += 1,
@@ -228,12 +228,8 @@ async fn drop_legacy_table(ctx: &dyn Context) {
 /// Mirrors `routes::reload_provider_service` but is intentionally duplicated
 /// here to keep the migration self-contained (no cross-module coupling).
 async fn reload_service(ctx: &dyn Context, provider_svc: &ProviderLlmService) {
-    let opts = ListOptions {
-        limit: 200,
-        ..Default::default()
-    };
-    let records = match db::list(ctx, PROVIDERS_COLLECTION, &opts).await {
-        Ok(r) => r.records,
+    let records = match db::list_all(ctx, PROVIDERS_COLLECTION, vec![]).await {
+        Ok(r) => r,
         Err(e) => {
             tracing::warn!("post-migration reload list failed: {e}");
             return;

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -7,10 +7,7 @@ pub mod ui;
 
 use std::sync::Arc;
 
-use wafer_core::clients::{
-    config, database as db,
-    database::{Filter, FilterOp, ListOptions},
-};
+use wafer_core::clients::{config, database as db};
 use wafer_run::{
     block::{Block, BlockInfo},
     context::Context,
@@ -191,18 +188,17 @@ impl LlmBlock {
         ctx: &dyn Context,
         thread_id: &str,
     ) -> Option<std::collections::HashMap<String, serde_json::Value>> {
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "thread_id".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(thread_id.to_string()),
-            }],
-            limit: 1,
-            ..Default::default()
-        };
-        let result = db::list(ctx, SETTINGS_COLLECTION, &opts).await.ok()?;
-        let record = result.records.into_iter().next()?;
-        Some(record.data)
+        match db::get_by_field(
+            ctx,
+            SETTINGS_COLLECTION,
+            "thread_id",
+            serde_json::Value::String(thread_id.to_string()),
+        )
+        .await
+        {
+            Ok(record) => Some(record.data),
+            Err(_) => None,
+        }
     }
 
     /// Get the first enabled provider ID from the provider-llm block DB.
@@ -212,25 +208,9 @@ impl LlmBlock {
     /// against `suppers_ai__llm__providers` via `routes::resolve_backend_id`.
     #[allow(dead_code)]
     pub(super) async fn get_default_provider_id(&self, ctx: &dyn Context) -> String {
-        use wafer_core::clients::database::{Filter, FilterOp, ListOptions};
-
         const PROVIDERS_COLLECTION: &str = "suppers_ai__provider_llm__providers";
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "enabled".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(1),
-            }],
-            limit: 1,
-            ..Default::default()
-        };
-        match db::list(ctx, PROVIDERS_COLLECTION, &opts).await {
-            Ok(r) => r
-                .records
-                .into_iter()
-                .next()
-                .map(|rec| rec.id)
-                .unwrap_or_default(),
+        match db::get_by_field(ctx, PROVIDERS_COLLECTION, "enabled", serde_json::json!(1)).await {
+            Ok(rec) => rec.id,
             Err(_) => String::new(),
         }
     }
@@ -269,31 +249,30 @@ impl LlmBlock {
 
             if let Some(mut data) = existing {
                 // Update existing record — find record ID
-                let opts = ListOptions {
-                    filters: vec![Filter {
-                        field: "thread_id".to_string(),
-                        operator: FilterOp::Equal,
-                        value: serde_json::Value::String(thread_id.clone()),
-                    }],
-                    limit: 1,
-                    ..Default::default()
-                };
-                let result = match db::list(ctx, SETTINGS_COLLECTION, &opts).await {
+                let record = match db::get_by_field(
+                    ctx,
+                    SETTINGS_COLLECTION,
+                    "thread_id",
+                    serde_json::Value::String(thread_id.clone()),
+                )
+                .await
+                {
                     Ok(r) => r,
+                    Err(e) if e.code == ErrorCode::NotFound => {
+                        return err_internal("Thread setting vanished between read and update")
+                    }
                     Err(e) => return err_internal(&format!("Database error: {e}")),
                 };
-                if let Some(record) = result.records.into_iter().next() {
-                    if let Some(pb) = body.provider_block {
-                        data.insert("provider_block".to_string(), serde_json::json!(pb));
-                    }
-                    if let Some(m) = body.model {
-                        data.insert("model".to_string(), serde_json::json!(m));
-                    }
-                    helpers::stamp_updated(&mut data);
-                    match db::update(ctx, SETTINGS_COLLECTION, &record.id, data).await {
-                        Ok(r) => return ok_json(&r),
-                        Err(e) => return err_internal(&format!("Database error: {e}")),
-                    }
+                if let Some(pb) = body.provider_block {
+                    data.insert("provider_block".to_string(), serde_json::json!(pb));
+                }
+                if let Some(m) = body.model {
+                    data.insert("model".to_string(), serde_json::json!(m));
+                }
+                helpers::stamp_updated(&mut data);
+                match db::update(ctx, SETTINGS_COLLECTION, &record.id, data).await {
+                    Ok(r) => return ok_json(&r),
+                    Err(e) => return err_internal(&format!("Database error: {e}")),
                 }
             } else {
                 // Create new per-thread setting

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -403,14 +403,9 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let default_model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
 
     // Load per-thread overrides
-    let overrides_opts = ListOptions {
-        limit: 100,
-        ..Default::default()
-    };
-    let overrides = match db::list(ctx, SETTINGS_COLLECTION, &overrides_opts).await {
-        Ok(r) => r.records,
-        Err(_) => vec![],
-    };
+    let overrides: Vec<db::Record> = db::list_all(ctx, SETTINGS_COLLECTION, vec![])
+        .await
+        .unwrap_or_default();
 
     let content = html! {
         (components::page_header(

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -113,15 +113,11 @@ async fn resolve_backend_id(
         return Ok(provider_block.to_string());
     }
 
-    let opts = db::ListOptions {
-        limit: 100,
-        ..Default::default()
-    };
-    let result = db::list(ctx, PROVIDERS_COLLECTION, &opts)
+    let records = db::list_all(ctx, PROVIDERS_COLLECTION, vec![])
         .await
         .map_err(|_| "provider lookup failed")?;
 
-    for record in result.records {
+    for record in records {
         if let Ok(cfg) = row_to_config(&record) {
             if cfg.enabled {
                 return Ok(cfg.name);
@@ -388,15 +384,11 @@ pub(super) async fn reload_provider_service(
     block: &LlmBlock,
     ctx: &dyn Context,
 ) -> Result<(), String> {
-    let opts = db::ListOptions {
-        limit: 200,
-        ..Default::default()
-    };
-    let result = db::list(ctx, PROVIDERS_COLLECTION, &opts)
+    let records = db::list_all(ctx, PROVIDERS_COLLECTION, vec![])
         .await
         .map_err(|e| format!("provider reload list failed: {e}"))?;
-    let mut configs: Vec<ProviderConfig> = Vec::with_capacity(result.records.len());
-    for rec in &result.records {
+    let mut configs: Vec<ProviderConfig> = Vec::with_capacity(records.len());
+    for rec in &records {
         match row_to_config(rec) {
             Ok(cfg) if cfg.enabled => configs.push(cfg),
             Ok(_) => {} // disabled — skip
@@ -423,16 +415,11 @@ pub(super) async fn list_providers(
     if !helpers::is_admin(msg) {
         return err_forbidden("admin role required");
     }
-    let opts = db::ListOptions {
-        limit: 200,
-        ..Default::default()
-    };
-    let result = match db::list(ctx, PROVIDERS_COLLECTION, &opts).await {
+    let records = match db::list_all(ctx, PROVIDERS_COLLECTION, vec![]).await {
         Ok(r) => r,
         Err(e) => return err_internal(&format!("Database error: {e}")),
     };
-    let providers: Vec<serde_json::Value> = result
-        .records
+    let providers: Vec<serde_json::Value> = records
         .iter()
         .filter_map(|rec| {
             row_to_config(rec)

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -16,7 +16,7 @@
 //! function directly (tests, future router changes).
 
 use maud::{html, Markup};
-use wafer_core::clients::{database as db, database::ListOptions};
+use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use super::{
@@ -84,14 +84,9 @@ pub(super) async fn providers_page(
 
     // Load all provider rows (both enabled and disabled) — the admin UI
     // wants the full picture, not just the in-flight set.
-    let opts = ListOptions {
-        limit: 200,
-        ..Default::default()
-    };
     let configs: Vec<(String, ProviderConfig)> =
-        match db::list(ctx, PROVIDERS_COLLECTION, &opts).await {
-            Ok(r) => r
-                .records
+        match db::list_all(ctx, PROVIDERS_COLLECTION, vec![]).await {
+            Ok(records) => records
                 .into_iter()
                 .filter_map(|rec| row_to_config(&rec).ok().map(|cfg| (rec.id, cfg)))
                 .collect(),


### PR DESCRIPTION
## Summary
Migrates 8 db::list callsites in the **llm/** directory to db::list_all (5) or db::get_by_field (3). Drops the unconditional SELECT COUNT(*) for callers that only consume .records.

- list_all: migrations.rs (legacy read + reload_service), ui.rs (providers_page), routes.rs (resolve_backend_id, reload_provider_service, list_providers), pages.rs (settings overrides).
- get_by_field: mod.rs (get_thread_setting, get_default_provider_id, handle_post_config existing-record lookup) — all limit:1 single-Equal-filter patterns.
- KEPT on db::list: pages.rs threads sidebar (sort:updated_at desc) + chat entries (sort:created_at asc) — sort guard from the plan matrix.

Part of the D1 amplification fix series. Follows #113, #115, #120, #121.

Plan: docs/superpowers/plans/2026-05-12-d1-amplification-pr4-list-all-migration.md

## Test plan
- [x] cargo test -p solobase-core --lib (556 pass, baseline match)
- [x] cargo check -p solobase-cloudflare --target wasm32-unknown-unknown
- [x] cargo +nightly fmt --all -- --check
- [x] clippy clean for llm/ (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)