### PR TITLE
perf(auth): D1 PR4-auth — db::list → db::list_all

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -32,7 +32,7 @@ use std::{collections::HashMap, time::Duration};
 
 use wafer_core::clients::{
     config as config_client, crypto,
-    database::{self as db, Filter, FilterOp, ListOptions},
+    database::{self as db, Filter, FilterOp},
 };
 
 use super::helpers::{hex_encode, json_map};
@@ -86,16 +86,13 @@ pub(crate) mod helpers {
                 roles.push(inline.to_string());
             }
         }
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "user_id".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(user_id.to_string()),
-            }],
-            ..Default::default()
-        };
-        if let Ok(r) = db::list(ctx, USER_ROLES_COLLECTION, &opts).await {
-            for rec in &r.records {
+        let filters = vec![Filter {
+            field: "user_id".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        }];
+        if let Ok(records) = db::list_all(ctx, USER_ROLES_COLLECTION, filters).await {
+            for rec in &records {
                 if let Some(role) = rec.data.get("role").and_then(|v| v.as_str()) {
                     if !roles.iter().any(|r| r == role) {
                         roles.push(role.to_string());

--- a/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
@@ -58,26 +58,22 @@ fn hex_encode(bytes: &[u8]) -> String {
 pub async fn is_valid(ctx: &dyn Context, token_hash: &[u8]) -> Result<bool, RepoError> {
     let now = now_iso();
     let hex = hex_encode(token_hash);
-    let opts = db::ListOptions {
-        filters: vec![
-            db::Filter {
-                field: "token_hash".into(),
-                operator: db::FilterOp::Equal,
-                value: json!(hex),
-            },
-            db::Filter {
-                field: "expires_at".into(),
-                operator: db::FilterOp::GreaterEqual,
-                value: json!(now),
-            },
-        ],
-        limit: 1,
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
+    let filters = vec![
+        db::Filter {
+            field: "token_hash".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(hex),
+        },
+        db::Filter {
+            field: "expires_at".into(),
+            operator: db::FilterOp::GreaterEqual,
+            value: json!(now),
+        },
+    ];
+    let records = db::list_all(ctx, TABLE, filters)
         .await
         .map_err(|e| RepoError::Db(format!("bootstrap_tokens lookup: {e}")))?;
-    Ok(!res.records.is_empty())
+    Ok(!records.is_empty())
 }
 
 /// Delete every row whose `token_hash` matches `token_hash`. Used by the
@@ -89,18 +85,15 @@ pub async fn is_valid(ctx: &dyn Context, token_hash: &[u8]) -> Result<bool, Repo
 /// removes all of them so subsequent `is_valid` calls return false.
 pub async fn delete_by_hash(ctx: &dyn Context, token_hash: &[u8]) -> Result<(), RepoError> {
     let hex = hex_encode(token_hash);
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
-            field: "token_hash".into(),
-            operator: db::FilterOp::Equal,
-            value: json!(hex),
-        }],
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
+    let filters = vec![db::Filter {
+        field: "token_hash".into(),
+        operator: db::FilterOp::Equal,
+        value: json!(hex),
+    }];
+    let records = db::list_all(ctx, TABLE, filters)
         .await
         .map_err(|e| RepoError::Db(format!("bootstrap_tokens lookup for delete: {e}")))?;
-    for record in res.records {
+    for record in records {
         db::delete(ctx, TABLE, &record.id)
             .await
             .map_err(|e| RepoError::Db(format!("bootstrap_tokens delete: {e}")))?;

--- a/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
@@ -78,27 +78,23 @@ pub async fn update_password(
     user_id: &str,
     new_hash: &str,
 ) -> Result<(), RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
-            field: "user_id".into(),
-            operator: db::FilterOp::Equal,
-            value: serde_json::json!(user_id),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let existing = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| RepoError::Db(format!("local_credentials lookup: {e}")))?;
-    if existing.records.is_empty() {
-        insert(ctx, user_id, new_hash, false).await
-    } else {
-        let mut data: HashMap<String, Value> = HashMap::new();
-        data.insert("password_hash".into(), json!(new_hash));
-        db::update_by_filters(ctx, TABLE, opts.filters, data)
-            .await
-            .map_err(|e| RepoError::Db(format!("local_credentials update_password: {e}")))?;
-        Ok(())
+    use wafer_block::ErrorCode;
+    let filters = vec![db::Filter {
+        field: "user_id".into(),
+        operator: db::FilterOp::Equal,
+        value: serde_json::json!(user_id),
+    }];
+    match db::get_by_field(ctx, TABLE, "user_id", json!(user_id)).await {
+        Ok(_) => {
+            let mut data: HashMap<String, Value> = HashMap::new();
+            data.insert("password_hash".into(), json!(new_hash));
+            db::update_by_filters(ctx, TABLE, filters, data)
+                .await
+                .map_err(|e| RepoError::Db(format!("local_credentials update_password: {e}")))?;
+            Ok(())
+        }
+        Err(e) if e.code == ErrorCode::NOT_FOUND => insert(ctx, user_id, new_hash, false).await,
+        Err(e) => Err(RepoError::Db(format!("local_credentials lookup: {e}"))),
     }
 }
 

--- a/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
@@ -73,12 +73,7 @@ pub async fn upsert(ctx: &dyn Context, new: NewLink<'_>) -> Result<(), RepoError
             value: json!(new.provider_ref),
         },
     ];
-    let opts = db::ListOptions {
-        filters: filters.clone(),
-        limit: 1,
-        ..Default::default()
-    };
-    let existing = db::list(ctx, TABLE, &opts)
+    let existing = db::list_all(ctx, TABLE, filters.clone())
         .await
         .map_err(|e| RepoError::Db(format!("provider_links upsert lookup: {e}")))?;
 
@@ -88,7 +83,7 @@ pub async fn upsert(ctx: &dyn Context, new: NewLink<'_>) -> Result<(), RepoError
     data.insert("access_token".into(), json!(new.access_token));
     data.insert("linked_at".into(), json!(now));
 
-    if existing.records.is_empty() {
+    if existing.is_empty() {
         // Insert: include the natural-key columns + a fresh synthetic id.
         let id = uuid::Uuid::now_v7().to_string();
         data.insert("id".into(), json!(id));
@@ -113,26 +108,22 @@ pub async fn find_by_provider_ref(
     provider: &str,
     provider_ref: &str,
 ) -> Result<Option<ProviderLink>, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![
-            db::Filter {
-                field: "provider".into(),
-                operator: db::FilterOp::Equal,
-                value: json!(provider),
-            },
-            db::Filter {
-                field: "provider_ref".into(),
-                operator: db::FilterOp::Equal,
-                value: json!(provider_ref),
-            },
-        ],
-        limit: 1,
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
+    let filters = vec![
+        db::Filter {
+            field: "provider".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(provider),
+        },
+        db::Filter {
+            field: "provider_ref".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(provider_ref),
+        },
+    ];
+    let records = db::list_all(ctx, TABLE, filters)
         .await
         .map_err(|e| RepoError::Db(format!("provider_links find: {e}")))?;
-    match res.records.first() {
+    match records.first() {
         Some(r) => Ok(Some(row_from_map(&r.data)?)),
         None => Ok(None),
     }

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -151,19 +151,12 @@ async fn find_record_by_hash(
     ctx: &dyn Context,
     hash: &[u8],
 ) -> Result<Option<wafer_core::clients::database::Record>, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
-            field: "token_hash".into(),
-            operator: db::FilterOp::Equal,
-            value: json!(hex_encode(hash)),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| RepoError::Db(format!("session lookup: {e}")))?;
-    Ok(res.records.into_iter().next())
+    use wafer_block::ErrorCode;
+    match db::get_by_field(ctx, TABLE, "token_hash", json!(hex_encode(hash))).await {
+        Ok(rec) => Ok(Some(rec)),
+        Err(e) if e.code == ErrorCode::NOT_FOUND => Ok(None),
+        Err(e) => Err(RepoError::Db(format!("session lookup: {e}"))),
+    }
 }
 
 pub async fn find_by_token_hash(
@@ -208,19 +201,16 @@ pub async fn delete_by_token_hash(ctx: &dyn Context, hash: &[u8]) -> Result<u64,
 /// `cutoff` is compared as an ISO-8601 string; rows store timestamps in the
 /// same text format (see [`now_iso`]).
 pub async fn delete_expired(ctx: &dyn Context, cutoff: &str) -> Result<u64, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
-            field: "expires_at".into(),
-            operator: db::FilterOp::LessThan,
-            value: json!(cutoff),
-        }],
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
+    let filters = vec![db::Filter {
+        field: "expires_at".into(),
+        operator: db::FilterOp::LessThan,
+        value: json!(cutoff),
+    }];
+    let records = db::list_all(ctx, TABLE, filters)
         .await
         .map_err(|e| RepoError::Db(format!("delete expired list: {e}")))?;
     let mut deleted = 0u64;
-    for record in res.records {
+    for record in records {
         if db::delete(ctx, TABLE, &record.id).await.is_ok() {
             deleted += 1;
         }

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -430,11 +430,11 @@ mod tests {
             .expect("init applies migrations and runs bootstrap");
 
         // Migrations applied → users table exists and is queryable.
-        let rows = db::list(&*ctx, users::TABLE, &db::ListOptions::default())
+        let rows = db::list_all(&*ctx, users::TABLE, vec![])
             .await
             .expect("users table exists after init");
         // No bootstrap admin env vars → bootstrap no-ops, table stays empty.
-        assert_eq!(rows.records.len(), 0);
+        assert_eq!(rows.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
@@ -50,19 +50,16 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     }
 
     // Validate refresh token exists in DB (prevents use of revoked tokens)
-    let token_filter = wafer_core::clients::database::Filter {
-        field: "token".to_string(),
-        operator: wafer_core::clients::database::FilterOp::Equal,
-        value: serde_json::Value::String(body.refresh_token.clone()),
-    };
-    let token_opts = wafer_core::clients::database::ListOptions {
-        filters: vec![token_filter],
-        limit: 1,
-        ..Default::default()
-    };
-    match db::list(ctx, TOKENS_COLLECTION, &token_opts).await {
-        Ok(result) if !result.records.is_empty() => {} // Token exists — proceed
-        _ => return error_response(ErrorCode::InvalidToken, "Refresh token has been revoked"),
+    match db::get_by_field(
+        ctx,
+        TOKENS_COLLECTION,
+        "token",
+        serde_json::Value::String(body.refresh_token.clone()),
+    )
+    .await
+    {
+        Ok(_) => {} // Token exists — proceed
+        Err(_) => return error_response(ErrorCode::InvalidToken, "Refresh token has been revoked"),
     }
 
     // Get user and verify account is still active


### PR DESCRIPTION
## Summary
Migrates 8 `db::list` callsites in the **auth** + **auth_ui/api** directories — 6 to `db::list_all`, 2 to `db::get_by_field` (single-filter limit:1 patterns). Drops the unconditional `SELECT COUNT(*)` for callers that only consume `.records`.

Part of the D1 amplification fix series. Follows #113, #115, #120, #121.

### Migrations
- `bootstrap_tokens.rs` — `is_valid` + `delete_by_hash` → `list_all`
- `local_credentials.rs` — `update_password` lookup → `get_by_field`
- `provider_links.rs` — `upsert` lookup + `find_by_provider_ref` → `list_all`
- `sessions.rs` — `find_record_by_hash` → `get_by_field`; `delete_expired` → `list_all`
- `auth/mod.rs` — `USER_ROLES_COLLECTION` lookup → `list_all`
- `auth/service.rs` — test-only `init` assert → `list_all`
- `auth_ui/api/refresh.rs` — refresh-token existence check → `get_by_field`

### KEEP (sort/offset present — paginated or serialises total_count)
- `orgs.rs::list_for_user`, `pats.rs::list_for_user`, `provider_links.rs::list_for_user`, `sessions.rs::list_for_user` — all have explicit `sort`
- `auth_ui/api/api_keys.rs::handle_list` — has `sort` and serialises the full `RecordList` to consumers (including `total_count`)

Plan: `docs/superpowers/plans/2026-05-12-d1-amplification-pr4-list-all-migration.md`

## Test plan
- [x] `cargo test -p solobase-core --lib` — 556 passed (matches baseline)
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown`
- [x] `cargo +nightly fmt --all -- --check`
- [x] No new clippy errors vs baseline (pre-existing PI-approximation error in `vector` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)