### PR TITLE
perf(products+misc): D1 PR4-products-misc — db::list → db::list_all

### DIFF
--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -818,12 +818,8 @@ async fn handle_user_group_products(ctx: &dyn Context, msg: &Message) -> OutputS
 
 // User-accessible group templates (read-only)
 async fn handle_user_list_group_templates(ctx: &dyn Context, _msg: &Message) -> OutputStream {
-    let opts = ListOptions {
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, super::GROUP_TEMPLATES_COLLECTION, &opts).await {
-        Ok(result) => ok_json(&result),
+    match db::list_all(ctx, super::GROUP_TEMPLATES_COLLECTION, vec![]).await {
+        Ok(records) => ok_json(&records),
         Err(e) => err_internal(&format!("Database error: {e}")),
     }
 }

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -275,17 +275,11 @@ impl Block for ProductsBlock {
         if event.event_type == LifecycleType::Init {
             // Seed default templates if they don't exist — these are required by FK constraints
             // on the groups and products tables.
-            use db::ListOptions;
             use wafer_core::clients::database as db;
 
-            let check_opts = ListOptions {
-                limit: 1,
-                ..Default::default()
-            };
-
             // Default group template
-            match db::list(ctx, GROUP_TEMPLATES_COLLECTION, &check_opts).await {
-                Ok(list) if list.records.is_empty() => {
+            match db::list_all(ctx, GROUP_TEMPLATES_COLLECTION, vec![]).await {
+                Ok(records) if records.is_empty() => {
                     let mut data = std::collections::HashMap::new();
                     data.insert(
                         "name".to_string(),
@@ -305,8 +299,8 @@ impl Block for ProductsBlock {
             }
 
             // Default product template
-            match db::list(ctx, PRODUCT_TEMPLATES_COLLECTION, &check_opts).await {
-                Ok(list) if list.records.is_empty() => {
+            match db::list_all(ctx, PRODUCT_TEMPLATES_COLLECTION, vec![]).await {
+                Ok(records) if records.is_empty() => {
                     let mut data = std::collections::HashMap::new();
                     data.insert(
                         "name".to_string(),

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use wafer_core::clients::{
     database as db,
-    database::{Filter, FilterOp, ListOptions, SortField},
+    database::{Filter, FilterOp, SortField},
 };
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use wafer_sql_utils::{value::sea_values_to_json, Backend};
@@ -307,17 +307,13 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Get line items
-    let items_opts = ListOptions {
-        filters: vec![Filter {
-            field: "purchase_id".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(id.to_string()),
-        }],
-        ..Default::default()
-    };
-    let line_items = db::list(ctx, LINE_ITEMS_COLLECTION, &items_opts)
+    let items_filters = vec![Filter {
+        field: "purchase_id".to_string(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String(id.to_string()),
+    }];
+    let line_items = db::list_all(ctx, LINE_ITEMS_COLLECTION, items_filters)
         .await
-        .map(|r| r.records)
         .unwrap_or_default();
 
     ok_json(&serde_json::json!({

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -5,7 +5,7 @@
 //! prefixed storage name (e.g. `"suppers_ai__vector__docs"`) at the block
 //! boundary — no magic mapping elsewhere in the stack.
 
-use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, ListOptions, SortField};
 use wafer_run::{
     context::Context,
     types::{ErrorCode, WaferError},
@@ -172,18 +172,17 @@ pub async fn get_index_row(
     ctx: &dyn Context,
     storage_name: &str,
 ) -> Result<Option<IndexRow>, WaferError> {
-    let opts = ListOptions {
-        filters: vec![Filter {
-            field: "prefixed_name".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(storage_name.to_string()),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let result = db::list(ctx, "suppers_ai__vector__registry", &opts).await?;
-    let Some(rec) = result.records.into_iter().next() else {
-        return Ok(None);
+    let rec = match db::get_by_field(
+        ctx,
+        "suppers_ai__vector__registry",
+        "prefixed_name",
+        serde_json::Value::String(storage_name.to_string()),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) if e.code == ErrorCode::NotFound => return Ok(None),
+        Err(e) => return Err(e),
     };
     Ok(map_index_row(ctx, &rec).await)
 }


### PR DESCRIPTION
## Summary
Migrates 5 db::list callsites in **products/** (excluding pages.rs) and **vector/service.rs** to db::list_all / db::get_by_field. Drops unconditional SELECT COUNT(*) for callers that only consume .records.

Per the migration matrix, all sort/offset-bearing callsites are KEPT (messages/service.rs paginated history+entries, products/variables.rs, products/handlers.rs handle_user_list_groups, vector/service.rs list_index_rows).

Callsite tally:
- list_all (4): products/purchase.rs:318, products/handlers.rs:825 (group-templates endpoint — response shape changes from RecordList JSON to plain array; no in-tree consumer), products/mod.rs:287 + 308 (init "is table empty?" check)
- get_by_field (1): vector/service.rs:184 (get_index_row by prefixed_name)
- KEEP (5): products/variables.rs:41, products/handlers.rs:650, messages/service.rs:110 + 239, vector/service.rs:158

Part of the D1 amplification fix series. Follows #113, #115, #120, #121.

Plan: docs/superpowers/plans/2026-05-12-d1-amplification-pr4-list-all-migration.md

## Test plan
- [x] cargo test -p solobase-core --lib (556 pass)
- [x] cargo check -p solobase-cloudflare --target wasm32-unknown-unknown
- [x] cargo +nightly fmt --all -- --check
- [x] cargo clippy -p solobase-core --lib (clean; pre-existing PI-approximation lint in pricing_tests is unrelated)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>