### PR TITLE
perf(files): D1 PR4-files — db::list → db::list_all

### DIFF
--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -86,24 +86,20 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
     let is_admin = helpers::is_admin(&msg);
     if !is_admin {
         let user_id = msg.user_id();
-        let opts = wafer_core::clients::database::ListOptions {
-            filters: vec![
-                wafer_core::clients::database::Filter {
-                    field: "name".to_string(),
-                    operator: wafer_core::clients::database::FilterOp::Equal,
-                    value: serde_json::Value::String(body.bucket.clone()),
-                },
-                wafer_core::clients::database::Filter {
-                    field: "created_by".to_string(),
-                    operator: wafer_core::clients::database::FilterOp::Equal,
-                    value: serde_json::Value::String(user_id.to_string()),
-                },
-            ],
-            limit: 1,
-            ..Default::default()
-        };
-        let owns_bucket = match db::list(ctx, BUCKETS_COLLECTION, &opts).await {
-            Ok(result) => !result.records.is_empty(),
+        let filters = vec![
+            wafer_core::clients::database::Filter {
+                field: "name".to_string(),
+                operator: wafer_core::clients::database::FilterOp::Equal,
+                value: serde_json::Value::String(body.bucket.clone()),
+            },
+            wafer_core::clients::database::Filter {
+                field: "created_by".to_string(),
+                operator: wafer_core::clients::database::FilterOp::Equal,
+                value: serde_json::Value::String(user_id.to_string()),
+            },
+        ];
+        let owns_bucket = match db::list_all(ctx, BUCKETS_COLLECTION, filters).await {
+            Ok(records) => !records.is_empty(),
             _ => false,
         };
         if !owns_bucket {

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -428,27 +428,24 @@ pub fn render_breadcrumbs(bucket: &str, current_prefix: &str) -> Markup {
 }
 
 async fn user_owns_bucket(ctx: &dyn Context, user_id: &str, bucket: &str) -> bool {
-    use wafer_core::clients::database::{Filter, FilterOp, ListOptions};
+    use wafer_core::clients::database::{Filter, FilterOp};
 
     use super::BUCKETS_COLLECTION;
 
-    let opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "name".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(bucket.into()),
-            },
-            Filter {
-                field: "created_by".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(user_id.into()),
-            },
-        ],
-        ..Default::default()
-    };
-    match db::list(ctx, BUCKETS_COLLECTION, &opts).await {
-        Ok(rl) => !rl.records.is_empty(),
+    let filters = vec![
+        Filter {
+            field: "name".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(bucket.into()),
+        },
+        Filter {
+            field: "created_by".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.into()),
+        },
+    ];
+    match db::list_all(ctx, BUCKETS_COLLECTION, filters).await {
+        Ok(records) => !records.is_empty(),
         Err(e) => {
             tracing::warn!(error = %e, bucket = %bucket, "bucket-ownership check failed");
             false
@@ -761,30 +758,28 @@ async fn list_shares_for_user(ctx: &dyn Context, user_id: &str) -> Vec<ShareRow>
 }
 
 async fn load_quota_info(ctx: &dyn Context, user_id: &str) -> QuotaInfo {
-    use wafer_core::clients::database::{Filter, FilterOp, ListOptions};
+    use wafer_core::clients::database::{Filter, FilterOp};
+    use wafer_run::types::ErrorCode;
 
     use super::{OBJECTS_COLLECTION, QUOTAS_COLLECTION};
 
-    let limit_opts = ListOptions {
-        filters: vec![Filter {
-            field: "user_id".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.into()),
-        }],
-        ..Default::default()
-    };
-    let limit = match db::list(ctx, QUOTAS_COLLECTION, &limit_opts).await {
-        Ok(rl) => rl
-            .records
-            .into_iter()
-            .next()
-            .and_then(|r| {
-                r.data.get("max_storage_bytes").and_then(|v| {
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
+    let limit = match db::get_by_field(
+        ctx,
+        QUOTAS_COLLECTION,
+        "user_id",
+        serde_json::Value::String(user_id.into()),
+    )
+    .await
+    {
+        Ok(r) => r
+            .data
+            .get("max_storage_bytes")
+            .and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
             })
             .unwrap_or(1_073_741_824),
+        Err(e) if e.code == ErrorCode::NotFound => 1_073_741_824,
         Err(e) => {
             tracing::warn!(error = %e, "quota lookup failed");
             1_073_741_824

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -81,24 +81,20 @@ async fn is_bucket_access_denied(ctx: &dyn Context, msg: &Message, bucket: &str)
     }
 
     let user_id = msg.user_id();
-    let opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "name".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(bucket.to_string()),
-            },
-            Filter {
-                field: "created_by".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(user_id.to_string()),
-            },
-        ],
-        limit: 1,
-        ..Default::default()
-    };
-    match db::list(ctx, BUCKETS_COLLECTION, &opts).await {
-        Ok(result) if !result.records.is_empty() => false,
+    let filters = vec![
+        Filter {
+            field: "name".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(bucket.to_string()),
+        },
+        Filter {
+            field: "created_by".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        },
+    ];
+    match db::list_all(ctx, BUCKETS_COLLECTION, filters).await {
+        Ok(records) if !records.is_empty() => false,
         _ => true, // denied
     }
 }
@@ -124,19 +120,14 @@ async fn handle_list_buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
             Err(e) => err_internal(&format!("Storage error: {e}")),
         }
     } else {
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "created_by".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(user_id.to_string()),
-            }],
-            limit: 1000,
-            ..Default::default()
-        };
-        match db::list(ctx, BUCKETS_COLLECTION, &opts).await {
-            Ok(result) => {
-                let names: Vec<&str> = result
-                    .records
+        let filters = vec![Filter {
+            field: "created_by".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        }];
+        match db::list_all(ctx, BUCKETS_COLLECTION, filters).await {
+            Ok(records) => {
+                let names: Vec<&str> = records
                     .iter()
                     .filter_map(|r| r.data.get("name").and_then(|v| v.as_str()))
                     .collect();


### PR DESCRIPTION
## Summary
Migrates 5 `db::list` callsites in the **files/** block to `db::list_all` (4) or `db::get_by_field` (1). Drops the unconditional `SELECT COUNT(*)` for callers that only consume `.records` (existence checks + a bounded-fetch + "take first" lookup).

Concretely:
- `cloud.rs` ~105 (bucket-ownership check): `list` → `list_all`
- `storage.rs` ~100 (is_bucket_access_denied): `list` → `list_all`
- `storage.rs` ~136 (handle_list_buckets non-admin, rebuilds JSON manually): `list` → `list_all`
- `pages_user.rs` ~450 (user_owns_bucket): `list` → `list_all`
- `pages_user.rs` ~776 (load_quota_info single-record lookup): `list` → `get_by_field` (with `NotFound` fallback to the default quota)

The remaining 12 files/ callsites stay on `db::list` per the plan matrix:
- **Sort-dependent renders** (losing `ORDER BY` would visibly break the SSR table or JSON-API order): `cloud.rs` ~54/~216/~245, `storage.rs` ~486/~509, `pages_user.rs` ~139/~478/~712, `pages_admin.rs` ~308/~446/~567.
- **Response-shape preservation**: `cloud.rs` ~256 emits `ok_json(&result)` (the full `RecordList`); migrating would change the JSON wire shape from object to bare array.
- **Dashboard counts on `pages_admin.rs` ~178/195/203/211/219** are explicit KEEPs pending the `PR4-followup` `db::count()` builder.

Part of the D1 amplification fix series. Follows #113, #115, #120, #121.

Plan: `docs/superpowers/plans/2026-05-12-d1-amplification-pr4-list-all-migration.md`

## Test plan
- [x] `cargo test -p solobase-core --lib` — 556 passed, 0 failed (same as baseline)
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy -p solobase-core --lib` — no new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)