### PR TITLE
perf(admin+misc): D1 PR4-admin-misc — db::list → db::list_all

### DIFF
--- a/crates/solobase-core/src/blocks/admin/iam.rs
+++ b/crates/solobase-core/src/blocks/admin/iam.rs
@@ -151,12 +151,16 @@ async fn handle_delete_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn handle_list_permissions(ctx: &dyn Context) -> OutputStream {
-    let opts = ListOptions {
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, PERMISSIONS_COLLECTION, &opts).await {
-        Ok(result) => ok_json(&result),
+    match db::list_all(ctx, PERMISSIONS_COLLECTION, vec![]).await {
+        Ok(records) => {
+            let total_count = records.len() as i64;
+            ok_json(&db::RecordList {
+                records,
+                total_count,
+                page: 1,
+                page_size: total_count,
+            })
+        }
         Err(e) => err_internal(&format!("Database error: {e}")),
     }
 }
@@ -208,13 +212,16 @@ async fn handle_list_user_roles(ctx: &dyn Context, msg: &Message) -> OutputStrea
             value: serde_json::Value::String(user_id),
         });
     }
-    let opts = ListOptions {
-        filters,
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, USER_ROLES_COLLECTION, &opts).await {
-        Ok(result) => ok_json(&result),
+    match db::list_all(ctx, USER_ROLES_COLLECTION, filters).await {
+        Ok(records) => {
+            let total_count = records.len() as i64;
+            ok_json(&db::RecordList {
+                records,
+                total_count,
+                page: 1,
+                page_size: total_count,
+            })
+        }
         Err(e) => err_internal(&format!("Database error: {e}")),
     }
 }

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -192,17 +192,14 @@ async fn users_table(records: &[db::Record], ctx: &dyn Context, current_user_id:
     let mut user_roles: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
     for record in records {
-        let roles_opts = ListOptions {
-            filters: vec![Filter {
-                field: "user_id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(record.id.clone()),
-            }],
-            ..Default::default()
-        };
-        let roles: Vec<String> = match db::list(ctx, USER_ROLES_COLLECTION, &roles_opts).await {
-            Ok(r) => r
-                .records
+        let role_filters = vec![Filter {
+            field: "user_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(record.id.clone()),
+        }];
+        let roles: Vec<String> = match db::list_all(ctx, USER_ROLES_COLLECTION, role_filters).await
+        {
+            Ok(records) => records
                 .iter()
                 .map(|rec| rec.str_field("role").to_string())
                 .filter(|s| !s.is_empty())
@@ -299,17 +296,13 @@ async fn user_row_fragment(ctx: &dyn Context, user_id: &str) -> Markup {
         Err(_) => return html! {},
     };
 
-    let roles_opts = ListOptions {
-        filters: vec![Filter {
-            field: "user_id".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.to_string()),
-        }],
-        ..Default::default()
-    };
-    let roles: Vec<String> = match db::list(ctx, USER_ROLES_COLLECTION, &roles_opts).await {
-        Ok(r) => r
-            .records
+    let role_filters = vec![Filter {
+        field: "user_id".into(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String(user_id.to_string()),
+    }];
+    let roles: Vec<String> = match db::list_all(ctx, USER_ROLES_COLLECTION, role_filters).await {
+        Ok(records) => records
             .iter()
             .map(|rec| rec.str_field("role").to_string())
             .filter(|s| !s.is_empty())
@@ -471,24 +464,17 @@ pub async fn handle_user_invite(
 
     // Reject duplicate email — emails are unique in practice though the
     // table doesn't carry a UNIQUE constraint.
-    let existing = db::list(
+    match db::get_by_field(
         ctx,
         USERS,
-        &ListOptions {
-            filters: vec![Filter {
-                field: "email".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(email.clone()),
-            }],
-            limit: 1,
-            ..Default::default()
-        },
+        "email",
+        serde_json::Value::String(email.clone()),
     )
-    .await;
-    if let Ok(list) = existing {
-        if !list.records.is_empty() {
-            return err_bad_request("A user with that email already exists");
-        }
+    .await
+    {
+        Ok(_) => return err_bad_request("A user with that email already exists"),
+        Err(e) if e.code == ErrorCode::NotFound => {}
+        Err(_) => {}
     }
 
     let password_hash = match crypto::hash(ctx, password).await {

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -1,5 +1,5 @@
 use maud::{html, Markup};
-use wafer_core::clients::database::{self as db, ListOptions};
+use wafer_core::clients::database::{self as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{
@@ -94,15 +94,11 @@ async fn variables_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
 /// "All Variables" tab -- flat table of all config variables from the DB.
 async fn config_all_tab(ctx: &dyn Context) -> Markup {
-    let opts = ListOptions {
-        limit: 200,
-        ..Default::default()
-    };
-    let settings = db::list(ctx, VARIABLES, &opts).await;
+    let settings = db::list_all(ctx, VARIABLES, vec![]).await;
 
     html! {
         @match &settings {
-            Ok(list) => {
+            Ok(records) => {
                 div .table-container {
                     table .table {
                         thead {
@@ -114,7 +110,7 @@ async fn config_all_tab(ctx: &dyn Context) -> Markup {
                             }
                         }
                         tbody {
-                            @for record in &list.records {
+                            @for record in records {
                                 @let key = record.str_field("key");
                                 @let value = record.str_field("value");
                                 @let description = record.str_field("description");

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use wafer_core::clients::{database as db, database::ListOptions};
+use wafer_core::clients::database as db;
 use wafer_run::{
     context::Context,
     types::{self, *},
@@ -99,14 +99,9 @@ fn validate_url_value(value: &str) -> Result<(), String> {
 }
 
 async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
-    let opts = ListOptions {
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, COLLECTION, &opts).await {
-        Ok(result) => {
-            let vars: Vec<_> = result
-                .records
+    match db::list_all(ctx, COLLECTION, vec![]).await {
+        Ok(records) => {
+            let vars: Vec<_> = records
                 .iter()
                 .map(|record| {
                     let key = record.str_field("key").to_string();
@@ -139,15 +134,11 @@ async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
 }
 
 async fn handle_list(ctx: &dyn Context) -> OutputStream {
-    let opts = ListOptions {
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, COLLECTION, &opts).await {
-        Ok(result) => {
+    match db::list_all(ctx, COLLECTION, vec![]).await {
+        Ok(records) => {
             // Convert to key-value map, masking sensitive values
             let mut settings = HashMap::new();
-            for record in &result.records {
+            for record in &records {
                 let key = record.str_field("key");
                 let is_sensitive = record.i64_field("sensitive") == 1;
                 let value = if is_sensitive {

--- a/crates/solobase-core/src/blocks/admin/users.rs
+++ b/crates/solobase-core/src/blocks/admin/users.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use wafer_core::clients::{
     database as db,
-    database::{Filter, FilterOp, ListOptions, SortField},
+    database::{Filter, FilterOp, SortField},
 };
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
@@ -62,18 +62,14 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
             // Strip password hashes and enrich with roles
             for record in &mut result.records {
                 record.data.remove("password_hash");
-                let roles_opts = ListOptions {
-                    filters: vec![Filter {
-                        field: "user_id".to_string(),
-                        operator: FilterOp::Equal,
-                        value: serde_json::Value::String(record.id.clone()),
-                    }],
-                    ..Default::default()
-                };
+                let role_filters = vec![Filter {
+                    field: "user_id".to_string(),
+                    operator: FilterOp::Equal,
+                    value: serde_json::Value::String(record.id.clone()),
+                }];
                 let roles: Vec<String> =
-                    match db::list(ctx, USER_ROLES_COLLECTION, &roles_opts).await {
-                        Ok(r) => r
-                            .records
+                    match db::list_all(ctx, USER_ROLES_COLLECTION, role_filters).await {
+                        Ok(records) => records
                             .iter()
                             .map(|rec| rec.str_field("role").to_string())
                             .filter(|s| !s.is_empty())
@@ -109,23 +105,20 @@ async fn get_user(ctx: &dyn Context, id: &str) -> OutputStream {
         Ok(mut record) => {
             record.data.remove("password_hash");
             // Get roles
-            let roles_opts = ListOptions {
-                filters: vec![Filter {
-                    field: "user_id".to_string(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::Value::String(id.to_string()),
-                }],
-                ..Default::default()
-            };
-            let roles: Vec<String> = match db::list(ctx, USER_ROLES_COLLECTION, &roles_opts).await {
-                Ok(r) => r
-                    .records
-                    .iter()
-                    .map(|rec| rec.str_field("role").to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect(),
-                Err(_) => Vec::new(),
-            };
+            let role_filters = vec![Filter {
+                field: "user_id".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(id.to_string()),
+            }];
+            let roles: Vec<String> =
+                match db::list_all(ctx, USER_ROLES_COLLECTION, role_filters).await {
+                    Ok(records) => records
+                        .iter()
+                        .map(|rec| rec.str_field("role").to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect(),
+                    Err(_) => Vec::new(),
+                };
             let mut resp = serde_json::to_value(&record).unwrap_or_default();
             if let Some(obj) = resp.as_object_mut() {
                 obj.insert("roles".to_string(), serde_json::json!(roles));


### PR DESCRIPTION
## Summary
Migrates 7 db::list callsites in **admin/** to db::list_all, plus 1 to db::get_by_field. Drops unconditional SELECT COUNT(*) for callers that only consume .records.

Migrations (7 list_all + 1 get_by_field):
- admin/iam.rs:158, 216 (permissions + user-roles list — JSON shape preserved via synthetic RecordList)
- admin/users.rs:74, 120 (role enrichment in list + get)
- admin/settings.rs:106, 146 (handle_list_full + handle_list)
- admin/pages/variables.rs:101 (config_all_tab)
- admin/pages/users.rs:203, 310 (role lookups in users_table + user_row_fragment)
- admin/pages/users.rs:474 (duplicate-email guard → get_by_field)

KEEPs (sort/offset/paginated):
- admin/iam.rs:54 (sort: name)
- admin/custom_tables.rs:174 (paginated + sort)
- admin/pages/users.rs:622, 708 (sort + limit:100 — standalone tabs but sort guard wins)
- legalpages/mod.rs:93, 183 (sort)
- legalpages/pages.rs:78, 105, 686 (sort)
- userportal/mod.rs:270 (sort)

### Open Q resolutions (from plan)
- **admin/custom_tables.rs:174** — KEEP: uses pagination_params (page_size + offset) and sort created_at desc; ships full RecordList to admin SQL-explorer UI.
- **admin/pages/users.rs:622, 708** — KEEP both: although they're standalone tabs (Roles, API Keys) and not paginated, both have non-default sort (`name asc`, `created_at desc`) which db::list_all does not accept. Sort guard from matrix wins.

Part of the D1 amplification fix series. Follows #113, #115, #120, #121.

Plan: docs/superpowers/plans/2026-05-12-d1-amplification-pr4-list-all-migration.md

## Test plan
- [x] cargo test -p solobase-core --lib — 556 passed
- [x] cargo check -p solobase-cloudflare --target wasm32-unknown-unknown
- [x] cargo +nightly fmt --all -- --check
- [x] clippy clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)