### PR TITLE
feat(solobase-browser): export unloadEngine for page-direct cache priming

### DIFF
--- a/crates/solobase-browser/assets/webllm-engine.js
+++ b/crates/solobase-browser/assets/webllm-engine.js
@@ -125,6 +125,16 @@ export async function loadEngine(modelId, onProgress) {
     _engineModel = modelId;
 }
 
+// Page-direct unload — releases GPU memory but leaves IndexedDB-cached
+// weights intact. Used by the picker's "Download" action: load → unload
+// caches the model without keeping it as the active engine.
+export async function unloadEngine() {
+    if (!_engine) return;
+    try { await _engine.unload(); } catch (_e) {}
+    _engine = null;
+    _engineModel = null;
+}
+
 navigator.serviceWorker.addEventListener('message', (event) => {
     const msg = event.data;
     if (!msg || !msg.type) return;

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -236,6 +236,7 @@ async fn handle_access_logs(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }],
         limit: page_size as i64,
         offset: ((page - 1) * page_size) as i64,
+        skip_count: false,
     };
 
     match db::list(ctx, ACCESS_LOGS_COLLECTION, &opts).await {

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -472,6 +472,7 @@ async fn handle_search(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }],
         limit: page_size as i64,
         offset: offset as i64,
+        skip_count: false,
     };
 
     match db::list(ctx, OBJECTS_META_COLLECTION, &opts).await {

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -179,6 +179,7 @@ impl LegalPagesBlock {
             }],
             limit: page_size as i64,
             offset: offset as i64,
+            skip_count: false,
         };
         match db::list(ctx, COLLECTION, &opts).await {
             Ok(result) => ok_json(&result),

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -105,6 +105,7 @@ pub async fn list_contexts(
         }],
         limit: params.page_size,
         offset: params.offset,
+        skip_count: false,
     };
 
     db::list(ctx, CONTEXTS_COLLECTION, &opts)
@@ -234,6 +235,7 @@ pub async fn list_entries(
         }],
         limit: params.page_size,
         offset: params.offset,
+        skip_count: false,
     };
 
     db::list(ctx, ENTRIES_COLLECTION, &opts)


### PR DESCRIPTION
## Summary
- Adds an `unloadEngine()` ESM export to `crates/solobase-browser/assets/webllm-engine.js` that releases GPU resources but preserves the IndexedDB-cached model weights.
- Pairs with the existing `loadEngine()` so consumers can do a load-then-unload roundtrip to prime the cache without keeping the model active.

## Why
Picker consumers (gizza-ai's "Download" row action — see follow-up gizza-ai PR) need to bring a model into the local cache without making it the active chat engine. WebLLM doesn't expose a separate "fetch weights only" API, so the load-then-unload pattern is the standard workaround. Without an `unloadEngine` export, callers can't release the GPU after the prime.

## Test plan
- [ ] Visual: open gizza-ai (companion PR), click brain → Download button on a row → progress runs → status flips to "Cached" without changing the active chat session.
- [ ] Existing chat path (SW-routed `llm-chat-stream-request`) still uses the same module-scoped `_engine` — no behavioral change for inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)