### PR TITLE
perf(d1+browser): skip COUNT round-trip when skip_count is set

### DIFF
--- a/crates/solobase-browser/src/database.rs
+++ b/crates/solobase-browser/src/database.rs
@@ -350,22 +350,29 @@ impl DatabaseService for BrowserDatabaseService {
 
         let (where_clause, filter_params) = build_where(&opts.filters);
 
-        // COUNT
-        let count_sql = format!(
-            "SELECT COUNT(*) as cnt FROM {} {}",
-            quote_ident(&table),
-            where_clause
-        );
         let params_json = params_to_json(&filter_params);
-        let count_json = bridge::db_query_raw(&count_sql, &params_json)
-            .map_err(|e| DatabaseError::Internal(format!("sql exec: {:?}", e)))?;
-        let count_rows: Vec<serde_json::Value> =
-            serde_json::from_str(&count_json).unwrap_or_default();
-        let total_count: i64 = count_rows
-            .first()
-            .and_then(|r| r.get("cnt"))
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
+
+        // Count total — skipped when caller passed skip_count: true.
+        let total_count: Option<i64> = if opts.skip_count {
+            None
+        } else {
+            let count_sql = format!(
+                "SELECT COUNT(*) as cnt FROM {} {}",
+                quote_ident(&table),
+                where_clause
+            );
+            let count_json = bridge::db_query_raw(&count_sql, &params_json)
+                .map_err(|e| DatabaseError::Internal(format!("sql exec: {:?}", e)))?;
+            let count_rows: Vec<serde_json::Value> =
+                serde_json::from_str(&count_json).unwrap_or_default();
+            Some(
+                count_rows
+                    .first()
+                    .and_then(|r| r.get("cnt"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0),
+            )
+        };
 
         // SELECT
         let mut select_sql = format!("SELECT * FROM {} {}", quote_ident(&table), where_clause);
@@ -399,6 +406,7 @@ impl DatabaseService for BrowserDatabaseService {
             1
         };
 
+        let total_count = total_count.unwrap_or(records.len() as i64);
         Ok(RecordList {
             records,
             total_count,

--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -194,24 +194,30 @@ impl DatabaseService for D1DatabaseService {
         let (where_sql, params) = build_where_clause(&opts.filters);
         let limit_for_empty = if opts.limit > 0 { opts.limit } else { 100 };
 
-        // Count query
-        let count_sql = format!("SELECT COUNT(*) as cnt FROM {} WHERE {}", table, where_sql);
-        let count_stmt = self.db.prepare(&count_sql).bind(&params).map_err(db_err)?;
-        let count_row = match count_stmt.first::<serde_json::Value>(None).await {
-            Ok(row) => row,
-            Err(e) if is_no_such_table(&e.to_string()) => {
-                return Ok(RecordList {
-                    records: Vec::new(),
-                    total_count: 0,
-                    page: 1,
-                    page_size: limit_for_empty,
-                });
-            }
-            Err(e) => return Err(db_err(e)),
+        // Count total — skipped when caller passed skip_count: true.
+        let total_count: Option<i64> = if opts.skip_count {
+            None
+        } else {
+            let count_sql = format!("SELECT COUNT(*) as cnt FROM {} WHERE {}", table, where_sql);
+            let count_stmt = self.db.prepare(&count_sql).bind(&params).map_err(db_err)?;
+            let count_row = match count_stmt.first::<serde_json::Value>(None).await {
+                Ok(row) => row,
+                Err(e) if is_no_such_table(&e.to_string()) => {
+                    return Ok(RecordList {
+                        records: Vec::new(),
+                        total_count: 0,
+                        page: 1,
+                        page_size: limit_for_empty,
+                    });
+                }
+                Err(e) => return Err(db_err(e)),
+            };
+            Some(
+                count_row
+                    .and_then(|v| v.get("cnt").and_then(|c| c.as_i64()))
+                    .unwrap_or(0),
+            )
         };
-        let total_count = count_row
-            .and_then(|v| v.get("cnt").and_then(|c| c.as_i64()))
-            .unwrap_or(0);
 
         // Data query
         let mut sql = format!("SELECT * FROM {} WHERE {}", table, where_sql);
@@ -236,7 +242,18 @@ impl DatabaseService for D1DatabaseService {
         sql.push_str(&format!(" LIMIT {} OFFSET {}", limit, opts.offset));
 
         let stmt = self.db.prepare(&sql).bind(&params).map_err(db_err)?;
-        let results = stmt.all().await.map_err(db_err)?;
+        let results = match stmt.all().await {
+            Ok(r) => r,
+            Err(e) if is_no_such_table(&e.to_string()) => {
+                return Ok(RecordList {
+                    records: Vec::new(),
+                    total_count: total_count.unwrap_or(0),
+                    page: 1,
+                    page_size: limit_for_empty,
+                });
+            }
+            Err(e) => return Err(db_err(e)),
+        };
         let rows: Vec<serde_json::Value> = results.results().map_err(db_err)?;
 
         let page = if limit > 0 {
@@ -245,8 +262,10 @@ impl DatabaseService for D1DatabaseService {
             1
         };
 
+        let records: Vec<Record> = rows.into_iter().map(json_to_record).collect();
+        let total_count = total_count.unwrap_or(records.len() as i64);
         Ok(RecordList {
-            records: rows.into_iter().map(json_to_record).collect(),
+            records,
             total_count,
             page,
             page_size: limit,


### PR DESCRIPTION
## Summary

- D1 backend (`solobase-cloudflare`) short-circuits the `SELECT COUNT(*)` query when `ListOptions.skip_count` is true.
- sql.js backend (`solobase-browser`) mirrors the same short-circuit.
- After this deploys, every existing `db::list_all` caller in production stops paying the COUNT round-trip — this is where the D1 read-amplification savings PR4 promised actually land.

Depends on wafer-run PR α (#48, merged 2026-05-12 at `7c0d3a7`) — pulled in via Cargo.lock bump.

PR α added a required field `skip_count: bool` to `ListOptions`; 5 pre-existing solobase-core `ListOptions { ... }` literals were missing `..Default::default()` and the first commit in this PR adds it so they default to `skip_count: false` (current behavior). The β2-β6 migration PRs will replace those callsites with `db::list_sorted` where applicable.

Background: spec `docs/superpowers/specs/2026-05-12-d1-list-skip-count-and-list-sorted-design.md` (workspace meta-repo).

## Test plan

- [x] `cargo build --workspace --exclude solobase-cloudflare --exclude solobase-web` green.
- [x] `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` green.
- [x] `cargo build -p solobase-browser --target wasm32-unknown-unknown` green.
- [x] `cargo test --workspace --exclude solobase-cloudflare --exclude solobase-web` green.
- [ ] After merge + deploy, watch D1 reads. β1 is what realizes the savings PR3b/PR4 anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)