### PR TITLE
perf(auth): migrate sort-dependent db::list callsites to db::list_sorted

### DIFF
--- a/crates/solobase-core/src/blocks/auth/repo/orgs.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/orgs.rs
@@ -85,23 +85,22 @@ pub async fn find_by_name(ctx: &dyn Context, name: &str) -> Result<Option<OrgRow
 /// Return all orgs owned by `user_id`, ordered by `created_at` ASC for
 /// stable rendering. Empty Vec if the user owns none.
 pub async fn list_for_user(ctx: &dyn Context, user_id: &str) -> Result<Vec<OrgRow>, OrgsRepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
+    let records = db::list_sorted(
+        ctx,
+        TABLE,
+        vec![db::Filter {
             field: "owner_user_id".into(),
             operator: db::FilterOp::Equal,
             value: json!(user_id),
         }],
-        sort: vec![db::SortField {
+        vec![db::SortField {
             field: "created_at".into(),
             desc: false,
         }],
-        limit: 1000,
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| OrgsRepoError::Db(format!("orgs list_for_user: {e}")))?;
-    res.records.iter().map(|r| row_from_map(&r.data)).collect()
+    )
+    .await
+    .map_err(|e| OrgsRepoError::Db(format!("orgs list_for_user: {e}")))?;
+    records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 /// Payload for [`upsert_claimed`]. Borrowed fields — caller keeps ownership.

--- a/crates/solobase-core/src/blocks/auth/repo/pats.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/pats.rs
@@ -112,23 +112,22 @@ pub async fn insert(ctx: &dyn Context, new: NewPat) -> Result<(), RepoError> {
 /// top". `token_hash` is returned on the row but API callers are expected to
 /// strip it before serialising to the client.
 pub async fn list_for_user(ctx: &dyn Context, user_id: &str) -> Result<Vec<PatRow>, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
+    let records = db::list_sorted(
+        ctx,
+        TABLE,
+        vec![db::Filter {
             field: "user_id".into(),
             operator: db::FilterOp::Equal,
             value: json!(user_id),
         }],
-        sort: vec![db::SortField {
+        vec![db::SortField {
             field: "created_at".into(),
             desc: true,
         }],
-        limit: 1000,
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| RepoError::Db(format!("pat list: {e}")))?;
-    res.records.iter().map(|r| row_from_map(&r.data)).collect()
+    )
+    .await
+    .map_err(|e| RepoError::Db(format!("pat list: {e}")))?;
+    records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 pub async fn find_by_token_hash(

--- a/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/provider_links.rs
@@ -143,22 +143,22 @@ pub async fn list_for_user(
     ctx: &dyn Context,
     user_id: &str,
 ) -> Result<Vec<ProviderLink>, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
+    let records = db::list_sorted(
+        ctx,
+        TABLE,
+        vec![db::Filter {
             field: "user_id".into(),
             operator: db::FilterOp::Equal,
             value: json!(user_id),
         }],
-        sort: vec![db::SortField {
+        vec![db::SortField {
             field: "linked_at".into(),
             desc: false,
         }],
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| RepoError::Db(format!("provider_links list_for_user: {e}")))?;
-    res.records.iter().map(|r| row_from_map(&r.data)).collect()
+    )
+    .await
+    .map_err(|e| RepoError::Db(format!("provider_links list_for_user: {e}")))?;
+    records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -221,22 +221,22 @@ pub async fn delete_expired(ctx: &dyn Context, cutoff: &str) -> Result<u64, Repo
 /// Return all active sessions for `user_id`, ordered by `last_used_at` DESC
 /// so the most recently active session sorts first.
 pub async fn list_for_user(ctx: &dyn Context, user_id: &str) -> Result<Vec<SessionRow>, RepoError> {
-    let opts = db::ListOptions {
-        filters: vec![db::Filter {
+    let records = db::list_sorted(
+        ctx,
+        TABLE,
+        vec![db::Filter {
             field: "user_id".into(),
             operator: db::FilterOp::Equal,
             value: json!(user_id),
         }],
-        sort: vec![db::SortField {
+        vec![db::SortField {
             field: "last_used_at".into(),
             desc: true,
         }],
-        ..Default::default()
-    };
-    let res = db::list(ctx, TABLE, &opts)
-        .await
-        .map_err(|e| RepoError::Db(format!("session list_for_user: {e}")))?;
-    res.records.iter().map(|r| row_from_map(&r.data)).collect()
+    )
+    .await
+    .map_err(|e| RepoError::Db(format!("session list_for_user: {e}")))?;
+    records.iter().map(|r| row_from_map(&r.data)).collect()
 }
 
 /// Delete a session row, but only if it belongs to `user_id`. Returns 0 if


### PR DESCRIPTION
## Summary

Migrates sort-dependent `db::list` callsites in the auth block from bare `db::list` onto `db::list_sorted`, dropping the `SELECT COUNT(*)` round-trip per call.

Depends on wafer-run #48 + solobase #128.

## Audit

| file:line | classification | reason |
|---|---|---|
| `auth/repo/sessions.rs:236` (`list_for_user`) | MIGRATE | `user_id` filter + `last_used_at DESC` sort, no offset, default limit, consumer reads `res.records` only. |
| `auth/repo/orgs.rs:101` (`list_for_user`) | MIGRATE | `owner_user_id` filter + `created_at ASC` sort, no offset, `limit: 1000`, consumer reads `res.records` only. |
| `auth/repo/pats.rs:128` (`list_for_user`) | MIGRATE | `user_id` filter + `created_at DESC` sort, no offset, `limit: 1000`, consumer reads `res.records` only. |
| `auth/repo/provider_links.rs:158` (`list_for_user`) | MIGRATE | `user_id` filter + `linked_at ASC` sort, no offset, default limit, consumer reads `res.records` only. |

All 4 callsites in scope migrate cleanly — none consume `.total_count`, none return `RecordList` envelopes on the wire.

## Test plan

- [x] `cargo build -p solobase-core` clean.
- [x] `cargo test -p solobase-core auth::repo` — 24 tests passed (includes `list_for_user_returns_only_caller_sessions`, `list_for_user_returns_only_caller_links`).
- [x] `cargo test --workspace --exclude solobase-cloudflare --exclude solobase-web` green.
- [x] `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` clean.
- [x] `cargo build -p solobase-web --release --target wasm32-unknown-unknown` clean.
- [x] Each migration committed individually for line-by-line review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)