### PR TITLE
perf(products+misc): migrate sort-dependent db::list callsites to db::list_sorted

### DIFF
--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -5,7 +5,7 @@
 //! prefixed storage name (e.g. `"suppers_ai__vector__docs"`) at the block
 //! boundary — no magic mapping elsewhere in the stack.
 
-use wafer_core::clients::database::{self as db, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, SortField};
 use wafer_run::{
     context::Context,
     types::{ErrorCode, WaferError},
@@ -147,18 +147,19 @@ async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> 
 /// collections, so `db::list` gives us `Ok(empty)` rather than an
 /// error. Same for `db::count` against the per-index meta table.
 pub async fn list_index_rows(ctx: &dyn Context) -> Result<Vec<IndexRow>, WaferError> {
-    let opts = ListOptions {
-        limit: 1000,
-        sort: vec![SortField {
+    let records = db::list_sorted(
+        ctx,
+        "suppers_ai__vector__registry",
+        vec![],
+        vec![SortField {
             field: "prefixed_name".to_string(),
             desc: false,
         }],
-        ..Default::default()
-    };
-    let result = db::list(ctx, "suppers_ai__vector__registry", &opts).await?;
+    )
+    .await?;
 
-    let mut rows = Vec::with_capacity(result.records.len());
-    for rec in result.records {
+    let mut rows = Vec::with_capacity(records.len());
+    for rec in records {
         if let Some(row) = map_index_row(ctx, &rec).await {
             rows.push(row);
         }


### PR DESCRIPTION
## Summary

Migrates sort-dependent `db::list` callsites in products/messages/vector/userportal/legalpages onto `db::list_sorted`, dropping the `SELECT COUNT(*)` round-trip per call.

Depends on wafer-run #48 + solobase #128.

## Audit

| file:line | classification | reason |
|---|---|---|
| products/handlers.rs:650 (user_list_groups) | KEEP (wire shape) | `ok_json(&result)` where result: RecordList — PR4 #124 class |
| products/variables.rs:41 | KEEP (wire shape) | `ok_json(&result)` where result: RecordList |
| products/pages.rs:54 (overview/products_count) | KEEP (total_count) | consumes `r.total_count` |
| products/pages.rs:58 (overview/groups_count) | KEEP (total_count) | consumes `r.total_count` |
| products/pages.rs:62 (overview/purchases_count) | KEEP (total_count) | consumes `r.total_count` |
| products/pages.rs:66 (overview/pricing_count) | KEEP (total_count) | consumes `r.total_count` |
| products/pages.rs:205 (groups page) | KEEP (small explicit limit) | limit: 100 < 1000 |
| products/pages.rs:263 (pricing page) | KEEP (small explicit limit) | limit: 100 < 1000 |
| messages/service.rs:111 (list_contexts) | KEEP (real pagination) | offset + page_size, returns RecordList incl. total_count |
| messages/service.rs:241 (list_entries) | KEEP (real pagination) | offset + page_size, returns RecordList incl. total_count |
| vector/service.rs:158 (list_index_rows) | **MIGRATE** | sort by prefixed_name, no offset, reads only `.records`, returns `Vec<IndexRow>` |
| userportal/mod.rs:270 (load_buttons) | KEEP (small explicit limit) | limit: 50 < 1000 |
| legalpages/mod.rs:93 (handle_public) | KEEP (small explicit limit) | limit: 1 |
| legalpages/mod.rs:184 (handle_admin_list) | KEEP (wire shape + pagination) | offset/page_size + `ok_json(&result)` |
| legalpages/pages.rs:78 (find_current_doc draft) | KEEP (small explicit limit) | limit: 1 |
| legalpages/pages.rs:105 (find_current_doc published) | KEEP (small explicit limit) | limit: 1 |
| legalpages/pages.rs:686 (next_version lookup) | KEEP (small explicit limit) | limit: 1 |

1 migration, 16 kept.

## Test plan

- [x] `cargo test --workspace --exclude solobase --exclude solobase-cloudflare --exclude solobase-web` green (solobase bin excluded because it requires a pre-built solobase-web wasm artifact).
- [x] `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` clean.
- [x] `cargo build -p solobase-browser --target wasm32-unknown-unknown` clean.
- [x] `products/handlers.rs` audited for `ok_json(&result: RecordList)` regression (PR4 #124 class) — found 2 wire-shape callsites in products dir; both KEPT.

Generated with Claude Code