### PR TITLE
perf(files): migrate sort-dependent db::list callsites to db::list_sorted

### DIFF
--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -119,25 +119,26 @@ use crate::ui::{
 /// If this gets hot, fold into a single aggregate query via
 /// `wafer-sql-utils::aggregate` (do **not** use raw SQL — CLAUDE.md).
 pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<BucketRow> {
-    use wafer_core::clients::database::{Filter, FilterOp, ListOptions, SortField};
+    use wafer_core::clients::database::{Filter, FilterOp, SortField};
 
     use super::{BUCKETS_COLLECTION, OBJECTS_COLLECTION};
 
-    let opts = ListOptions {
-        filters: vec![Filter {
+    let recs = match db::list_sorted(
+        ctx,
+        BUCKETS_COLLECTION,
+        vec![Filter {
             field: "created_by".into(),
             operator: FilterOp::Equal,
             value: serde_json::Value::String(user_id.into()),
         }],
-        sort: vec![SortField {
+        vec![SortField {
             field: "name".into(),
             desc: false,
         }],
-        ..Default::default()
-    };
-
-    let recs = match db::list(ctx, BUCKETS_COLLECTION, &opts).await {
-        Ok(rl) => rl.records,
+    )
+    .await
+    {
+        Ok(records) => records,
         Err(e) => {
             tracing::warn!(error = %e, "files bucket list failed");
             Vec::new()
@@ -691,24 +692,25 @@ pub fn render_shares_table(rows: &[ShareRow]) -> Markup {
 }
 
 async fn list_shares_for_user(ctx: &dyn Context, user_id: &str) -> Vec<ShareRow> {
-    use wafer_core::clients::database::{Filter, FilterOp, ListOptions, SortField};
+    use wafer_core::clients::database::{Filter, FilterOp, SortField};
 
     use super::SHARES_COLLECTION;
-    let opts = ListOptions {
-        filters: vec![Filter {
+    match db::list_sorted(
+        ctx,
+        SHARES_COLLECTION,
+        vec![Filter {
             field: "created_by".into(),
             operator: FilterOp::Equal,
             value: serde_json::Value::String(user_id.into()),
         }],
-        sort: vec![SortField {
+        vec![SortField {
             field: "created_at".into(),
             desc: true,
         }],
-        ..Default::default()
-    };
-    match db::list(ctx, SHARES_COLLECTION, &opts).await {
-        Ok(rl) => rl
-            .records
+    )
+    .await
+    {
+        Ok(records) => records
             .into_iter()
             .map(|r| ShareRow {
                 token: r


### PR DESCRIPTION
## Summary

Migrates two `db::list` callsites in the files block (user-facing pages) onto `db::list_sorted`, dropping the `SELECT COUNT(*)` round-trip per call.

Depends on wafer-run #48 + solobase #128.

## Audit

| file:line | classification | reason |
|---|---|---|
| `files/pages_user.rs:121` (`list_buckets_for_user`) | **MIGRATE** | sort=`name` asc, default limit, reads only `.records` |
| `files/pages_user.rs:694` (`list_shares_for_user`) | **MIGRATE** | sort=`created_at` desc, default limit, reads only `.records` |
| `files/pages_user.rs:455` (`list_objects_in_bucket`) | KEEP | sort=`key` asc, **`limit: 1000`** is a deliberate UI render cap (S3-style page size). Widening to `list_sorted`'s 10K ceiling would 10× the bucket-listing payload + DOM cost for users with large buckets. |
| `files/pages_admin.rs:308` (`buckets`) | KEEP (small explicit limit) | `limit: 100` |
| `files/pages_admin.rs:446` (`shares`) | KEEP (small explicit limit) | `limit: 100` |
| `files/pages_admin.rs:567` (`quotas`) | KEEP (small explicit limit) | `limit: 100` |
| `files/pages_admin.rs:178/195/203/211/219` (`load_admin_stats`) | KEEP (count widget) | consumes `.total_count` — `db::count` migration belongs to follow-up A |
| `files/storage.rs:478` (`handle_search`) | KEEP (wire shape + pagination) | `ok_json(&result)` + offset |
| `files/storage.rs:501` (`handle_recent`) | KEEP (wire shape + small limit) | `ok_json(&result)` + `limit: 20` |
| `files/cloud.rs:54` (`handle_list_shares`) | KEEP (wire shape) | `ok_json(&result)` |
| `files/cloud.rs:212` (`handle_admin_list_shares`) | KEEP (wire shape + pagination) | `ok_json(&result)` + offset |
| `files/cloud.rs:242` (`handle_access_logs`) | KEEP (wire shape + pagination) | `ok_json(&result)` + offset |
| `files/cloud.rs:253` (`handle_admin_quotas`) | KEEP (wire shape, empty sort) | `ok_json(&result)`, empty `sort: vec![]` |

## Test plan

- [x] `cargo test --workspace --exclude solobase --exclude solobase-cloudflare --exclude solobase-web` green (excluding `solobase` for the build.rs wasm-artifact dependency, matching PR #130's pattern).
- [x] `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` clean.
- [x] `cargo build -p solobase-web --target wasm32-unknown-unknown` clean.

## Notes

Wire-shape audit (PR4 #124 regression class) checked on all 7 `ok_json(&result)` callsites in the files dir — none migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)