### PR TITLE
feat(solobase): BrowserImageService + image route block + builder wiring

### DIFF
--- a/crates/solobase-browser/assets/index.html.tmpl
+++ b/crates/solobase-browser/assets/index.html.tmpl
@@ -30,5 +30,6 @@
     <script src="/loader.js"></script>
     <script type="module" src="/webllm-engine.js"></script>
     <script type="module" src="/embed-engine.js"></script>
+    <script type="module" src="/t2i-engine.js"></script>
 </body>
 </html>

--- a/crates/solobase-browser/assets/sw.js.tmpl
+++ b/crates/solobase-browser/assets/sw.js.tmpl
@@ -110,6 +110,15 @@ self.addEventListener('message', (event) => {
         }
         return;
     }
+
+    // Image bridge: route all image-* replies (one-shot responses and stream
+    // frames) from the page to bridge.js's handler.
+    if (typeof msg.type === 'string' && msg.type.startsWith('image-')) {
+        if (typeof globalThis.__solobaseCompleteImageMessage === 'function') {
+            globalThis.__solobaseCompleteImageMessage(msg);
+        }
+        return;
+    }
 });
 
 // ---------------------------------------------------------------------------
@@ -136,6 +145,7 @@ self.addEventListener('fetch', (event) => {
         url.pathname === '/asset-manifest.json' ||
         url.pathname === '/webllm-engine.js' ||
         url.pathname === '/embed-engine.js' ||
+        url.pathname === '/t2i-engine.js' ||
         url.pathname.startsWith('__WASM_JS_PREFIX__') ||
         url.pathname.startsWith('/snippets/') ||
         url.pathname.startsWith('/vendor/') ||

--- a/crates/solobase-browser/assets/t2i-engine.js
+++ b/crates/solobase-browser/assets/t2i-engine.js
@@ -1,0 +1,157 @@
+// t2i-engine.js — page-side text-to-image engine.
+//
+// Runs in the window (WebGPU is window-only). Driven by SW postMessages from
+// bridge.js's `image*` family. Structurally parallel to webllm-engine.js.
+//
+// SW → Page request shapes (see bridge.js for the producing side):
+//   { type: 'image-load-request',          id, modelId }
+//   { type: 'image-unload-request',        id }
+//   { type: 'image-generate-stream-request', id, body }   // body = JSON ImageRequest
+//   { type: 'image-stream-cancel',         id }
+//
+// Page → SW reply shapes:
+//   { type: 'image-load-response',   id, error? }
+//   { type: 'image-unload-response', id, error? }
+//   { type: 'image-stream-frame',    id, kind, payload? }
+//     `kind` ∈ {'progress','done','error'}.
+//
+// The @huggingface/transformers import is lazy: a top-level import would
+// download a multi-MB ESM bundle on every page load, even for pages that
+// never touch image generation. Defer until first use.
+
+let _Pipeline = null;
+async function loadTransformers() {
+    if (_Pipeline) return _Pipeline;
+    const mod = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.0');
+    _Pipeline = mod;
+    return _Pipeline;
+}
+
+let _pipe = null;
+let _pipeModel = null;
+const _activeStreams = new Map(); // id -> AbortController
+
+async function swPost(payload) {
+    const reg = await navigator.serviceWorker.ready;
+    reg.active?.postMessage(payload);
+}
+
+async function swStreamFrame(id, kind, payload) {
+    await swPost({ type: 'image-stream-frame', id, kind, payload });
+}
+
+async function handleLoadEngine(msg) {
+    try {
+        const { pipeline } = await loadTransformers();
+        if (_pipeModel === msg.modelId && _pipe) {
+            await swPost({ type: 'image-load-response', id: msg.id });
+            return;
+        }
+        if (_pipe) {
+            try { await _pipe.dispose?.(); } catch (_e) {}
+            _pipe = null;
+            _pipeModel = null;
+        }
+        _pipe = await pipeline('text-to-image', msg.modelId, { device: 'webgpu' });
+        _pipeModel = msg.modelId;
+        await swPost({ type: 'image-load-response', id: msg.id });
+    } catch (e) {
+        await swPost({ type: 'image-load-response', id: msg.id, error: String(e) });
+    }
+}
+
+async function handleUnloadEngine(msg) {
+    try {
+        if (_pipe) {
+            try { await _pipe.dispose?.(); } catch (_e) {}
+            _pipe = null;
+            _pipeModel = null;
+        }
+        await swPost({ type: 'image-unload-response', id: msg.id });
+    } catch (e) {
+        await swPost({ type: 'image-unload-response', id: msg.id, error: String(e) });
+    }
+}
+
+async function handleGenerateStream(msg) {
+    if (!_pipe) {
+        await swStreamFrame(msg.id, 'error', 'model not loaded; call load_model first');
+        return;
+    }
+    const ac = new AbortController();
+    _activeStreams.set(msg.id, ac);
+    try {
+        const req = JSON.parse(msg.body);
+        const params = req.params || {};
+        const result = await _pipe(req.prompt, {
+            num_inference_steps: params.steps ?? 1,
+            guidance_scale: params.guidance_scale ?? 0.0,
+            width: params.width ?? 512,
+            height: params.height ?? 512,
+            negative_prompt: params.negative_prompt,
+            seed: params.seed,
+        });
+        if (ac.signal.aborted) {
+            await swStreamFrame(msg.id, 'error', 'cancelled');
+            return;
+        }
+        const pngBytes = await rawImageToPng(result);
+        const data = uint8ToBase64(pngBytes);
+        await swStreamFrame(msg.id, 'done', { data, mime_type: 'image/png' });
+    } catch (e) {
+        await swStreamFrame(msg.id, 'error', String(e?.message ?? e));
+    } finally {
+        _activeStreams.delete(msg.id);
+    }
+}
+
+function handleCancel(msg) {
+    const ac = _activeStreams.get(msg.id);
+    if (ac) ac.abort();
+}
+
+async function rawImageToPng(rawImage) {
+    // transformers.js v3 returns a RawImage. Convert via OffscreenCanvas → PNG.
+    // RawImage may be RGB (3 ch) or RGBA (4 ch); normalize to RGBA for canvas.
+    const { width, height, data, channels } = rawImage;
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    const imgData = ctx.createImageData(width, height);
+    if (channels === 4) {
+        imgData.data.set(data);
+    } else if (channels === 3) {
+        for (let i = 0, j = 0; i < width * height; i++, j += 3) {
+            imgData.data[i * 4] = data[j];
+            imgData.data[i * 4 + 1] = data[j + 1];
+            imgData.data[i * 4 + 2] = data[j + 2];
+            imgData.data[i * 4 + 3] = 255;
+        }
+    } else {
+        throw new Error(`unsupported channel count: ${channels}`);
+    }
+    ctx.putImageData(imgData, 0, 0);
+    const blob = await canvas.convertToBlob({ type: 'image/png' });
+    return new Uint8Array(await blob.arrayBuffer());
+}
+
+function uint8ToBase64(u8) {
+    let binary = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < u8.length; i += chunk) {
+        binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk));
+    }
+    return btoa(binary);
+}
+
+navigator.serviceWorker.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (!msg || !msg.type) return;
+    switch (msg.type) {
+        case 'image-load-request':             handleLoadEngine(msg); break;
+        case 'image-unload-request':           handleUnloadEngine(msg); break;
+        case 'image-generate-stream-request':  handleGenerateStream(msg); break;
+        case 'image-stream-cancel':            handleCancel(msg); break;
+    }
+});
+
+console.log('t2i-engine.js loaded');

--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -463,6 +463,146 @@ export function _completeLlmMessage(msg) {
 
 globalThis.__solobaseCompleteLlmMessage = _completeLlmMessage;
 
+// ─── Image (SW → page postMessage bridge) ───────────────────────────────────
+//
+// Mirrors the LLM bridge. One-shot operations (`imageLoadEngine`,
+// `imageUnloadEngine`) use `_pendingImageRequests`. Streamed generation
+// (`imageStartGenerate` + `imageNextFrame`) shares `_activeImageStreams` with
+// a page→SW frame envelope:
+//   { type: 'image-stream-frame', id, kind: 'progress'|'done'|'error', payload? }
+
+const _pendingImageRequests = new Map(); // id -> { resolve, reject }
+const _activeImageStreams   = new Map(); // id -> { push, closeOk, closeErr, queue, waiters }
+
+function _mkImageId(prefix) {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function _registerImageStream(id) {
+    const queue = [];
+    const waiters = [];
+    const push = (frame) => {
+        if (waiters.length > 0) waiters.shift()(frame);
+        else queue.push(frame);
+    };
+    _activeImageStreams.set(id, {
+        push,
+        closeOk: (payload) => push({ kind: 'done', payload }),
+        closeErr: (err) => push({ kind: 'error', payload: err }),
+        queue,
+        waiters,
+    });
+}
+
+/**
+ * Load the page-side T2I engine for `modelId`. Resolves when the model is
+ * fully loaded onto the WebGPU device. One-shot.
+ * @param {string} modelId
+ * @returns {Promise<void>}
+ */
+export async function imageLoadEngine(modelId) {
+    const id = _mkImageId('image-load');
+    const replyPromise = new Promise((resolve, reject) => {
+        _pendingImageRequests.set(id, { resolve, reject });
+    });
+    await _postToWindowClient({ type: 'image-load-request', id, modelId });
+    return await replyPromise;
+}
+
+/**
+ * Unload the page-side T2I engine. One-shot.
+ * @returns {Promise<void>}
+ */
+export async function imageUnloadEngine() {
+    const id = _mkImageId('image-unload');
+    const replyPromise = new Promise((resolve, reject) => {
+        _pendingImageRequests.set(id, { resolve, reject });
+    });
+    await _postToWindowClient({ type: 'image-unload-request', id });
+    return await replyPromise;
+}
+
+/**
+ * Start a streamed image generation. Returns a request id; pump with
+ * `imageNextFrame`. Frames are `{kind:'progress',payload}` (rare on SD-Turbo)
+ * then a terminal `{kind:'done', payload:{data:<base64>, mime_type}}` or
+ * `{kind:'error', payload:<string>}`.
+ * @param {string} bodyJson - JSON-encoded ImageRequest
+ * @returns {Promise<string>} request id
+ */
+export async function imageStartGenerate(bodyJson) {
+    const id = _mkImageId('image-gen');
+    _registerImageStream(id);
+    await _postToWindowClient({ type: 'image-generate-stream-request', id, body: bodyJson });
+    return id;
+}
+
+/**
+ * Pull the next frame from an image generation. Blocks until a frame arrives.
+ * After a terminal frame the stream entry is removed.
+ * @param {string} id
+ * @returns {Promise<string>} JSON-encoded frame
+ */
+export async function imageNextFrame(id) {
+    const stream = _activeImageStreams.get(id);
+    if (!stream) {
+        return JSON.stringify({ kind: 'error', payload: 'unknown request id' });
+    }
+    let frame;
+    if (stream.queue.length > 0) {
+        frame = stream.queue.shift();
+    } else {
+        frame = await new Promise((resolve) => stream.waiters.push(resolve));
+    }
+    if (frame.kind === 'done' || frame.kind === 'error') {
+        _activeImageStreams.delete(id);
+    }
+    return JSON.stringify(frame);
+}
+
+/**
+ * Cancel an in-flight image generation.
+ * @param {string} id
+ */
+export async function imageCancelStream(id) {
+    const stream = _activeImageStreams.get(id);
+    if (stream) {
+        stream.closeErr('cancelled');
+        _activeImageStreams.delete(id);
+    }
+    await _postToWindowClient({ type: 'image-stream-cancel', id });
+}
+
+/**
+ * Called by sw.js when a page image reply arrives. Routes to the pending
+ * one-shot or active stream by id.
+ *
+ * Page → SW message shapes:
+ *   { type: 'image-load-response',   id, error? }                      (one-shot)
+ *   { type: 'image-unload-response', id, error? }                      (one-shot)
+ *   { type: 'image-stream-frame',    id, kind, payload? }              (streams)
+ *     `kind` ∈ {'progress','done','error'}; payload shape varies by kind.
+ */
+export function _completeImageMessage(msg) {
+    if (msg.type === 'image-load-response' || msg.type === 'image-unload-response') {
+        const pending = _pendingImageRequests.get(msg.id);
+        if (!pending) return;
+        _pendingImageRequests.delete(msg.id);
+        if (msg.error) pending.reject(new Error(msg.error));
+        else pending.resolve();
+        return;
+    }
+    if (msg.type === 'image-stream-frame') {
+        const stream = _activeImageStreams.get(msg.id);
+        if (!stream) return;
+        if (msg.kind === 'done') stream.closeOk(msg.payload);
+        else if (msg.kind === 'error') stream.closeErr(msg.payload ?? 'unknown error');
+        else stream.push({ kind: msg.kind, payload: msg.payload });
+    }
+}
+
+globalThis.__solobaseCompleteImageMessage = _completeImageMessage;
+
 // ─── Embed (SW → page postMessage bridge) ───────────────────────────────────
 //
 // Mirrors the LLM bridge pattern: correlation-id keyed postMessage to a window

--- a/crates/solobase-browser/src/assets.rs
+++ b/crates/solobase-browser/src/assets.rs
@@ -54,6 +54,10 @@ const ASSETS: &[Asset] = &[
         path: "embed-engine.js",
         bytes: include_bytes!("../assets/embed-engine.js"),
     },
+    Asset {
+        path: "t2i-engine.js",
+        bytes: include_bytes!("../assets/t2i-engine.js"),
+    },
 ];
 
 #[cfg(test)]
@@ -70,6 +74,7 @@ mod tests {
         assert!(paths.contains(&"vendor/sql-wasm.wasm"));
         assert!(paths.contains(&"webllm-engine.js"));
         assert!(paths.contains(&"embed-engine.js"));
+        assert!(paths.contains(&"t2i-engine.js"));
     }
 
     #[test]

--- a/crates/solobase-browser/src/bridge.rs
+++ b/crates/solobase-browser/src/bridge.rs
@@ -111,6 +111,33 @@ extern "C" {
     #[wasm_bindgen(js_name = llmCancelStream, catch)]
     pub async fn llm_cancel_stream(stream_id: &str) -> Result<JsValue, JsValue>;
 
+    // ─── Image bridge ─────────────────────────────────────────────────────────
+
+    /// Load the page-side T2I engine for `model_id`. One-shot — resolves when
+    /// the model is fully loaded onto the WebGPU device.
+    #[wasm_bindgen(js_name = imageLoadEngine, catch)]
+    pub async fn image_load_engine(model_id: &str) -> Result<JsValue, JsValue>;
+
+    /// Unload the page-side T2I engine.
+    #[wasm_bindgen(js_name = imageUnloadEngine, catch)]
+    pub async fn image_unload_engine() -> Result<JsValue, JsValue>;
+
+    /// Start an image generation. Returns the request id as a JS string. Pump
+    /// frames with `imageNextFrame`.
+    #[wasm_bindgen(js_name = imageStartGenerate, catch)]
+    pub async fn image_start_generate(body_json: &str) -> Result<JsValue, JsValue>;
+
+    /// Pull the next frame from an image generation. Frame JSON:
+    ///   `{kind:'progress', payload:{stage, bytes_downloaded?, bytes_total?}}` |
+    ///   `{kind:'done', payload:{data:<base64>, mime_type}}` |
+    ///   `{kind:'error', payload:<string>}`.
+    #[wasm_bindgen(js_name = imageNextFrame, catch)]
+    pub async fn image_next_frame(request_id: &str) -> Result<JsValue, JsValue>;
+
+    /// Cancel an in-flight generation.
+    #[wasm_bindgen(js_name = imageCancelStream, catch)]
+    pub async fn image_cancel_stream(request_id: &str) -> Result<JsValue, JsValue>;
+
     // ─── Embed bridge ─────────────────────────────────────────────────────────
 
     /// Embed `texts` using the page-resident Transformers.js pipeline for

--- a/crates/solobase-browser/src/image/bridge.rs
+++ b/crates/solobase-browser/src/image/bridge.rs
@@ -1,1 +1,114 @@
-//! Rust shim over the SW↔page image bridge. Fleshed out in plan task 2.2.
+//! Rust-side wrapper over the SW↔page image postMessage bridge.
+//!
+//! Glue around the `image*` functions in `js/bridge.js`. Turns the async
+//! postMessage exchanges into typed Rust calls. Not testable in native —
+//! exercised via the `BrowserImageService` integration and the browser smoke
+//! test.
+
+use base64ct::{Base64, Encoding};
+use wafer_core::interfaces::image::service::ImageError;
+
+use crate::bridge::{
+    image_cancel_stream, image_load_engine, image_next_frame, image_start_generate,
+    image_unload_engine,
+};
+
+fn js_err(e: wasm_bindgen::JsValue) -> ImageError {
+    ImageError::BackendError(format!(
+        "image bridge: {}",
+        e.as_string().unwrap_or_else(|| format!("{e:?}"))
+    ))
+}
+
+pub async fn load_engine(model_id: &str) -> Result<(), ImageError> {
+    image_load_engine(model_id)
+        .await
+        .map(|_| ())
+        .map_err(js_err)
+}
+
+pub async fn unload_engine() -> Result<(), ImageError> {
+    image_unload_engine().await.map(|_| ()).map_err(js_err)
+}
+
+pub async fn start_generate(body_json: &str) -> Result<String, ImageError> {
+    let v = image_start_generate(body_json).await.map_err(js_err)?;
+    v.as_string()
+        .ok_or_else(|| ImageError::BackendError("image bridge: request id not a string".into()))
+}
+
+pub enum Frame {
+    Progress {
+        stage: String,
+        bytes_downloaded: Option<u64>,
+        bytes_total: Option<u64>,
+    },
+    Done {
+        bytes: Vec<u8>,
+        mime_type: String,
+    },
+    Error(String),
+}
+
+pub async fn next_frame(request_id: &str) -> Result<Frame, ImageError> {
+    let v = image_next_frame(request_id).await.map_err(js_err)?;
+    let s = v
+        .as_string()
+        .ok_or_else(|| ImageError::BackendError("image bridge: frame not a string".into()))?;
+    let frame: serde_json::Value = serde_json::from_str(&s)
+        .map_err(|e| ImageError::BackendError(format!("image bridge: frame parse: {e}")))?;
+    let kind = frame.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let payload = frame.get("payload");
+    match kind {
+        "progress" => {
+            let stage = payload
+                .and_then(|p| p.get("stage"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let bytes_downloaded = payload
+                .and_then(|p| p.get("bytes_downloaded"))
+                .and_then(|v| v.as_u64());
+            let bytes_total = payload
+                .and_then(|p| p.get("bytes_total"))
+                .and_then(|v| v.as_u64());
+            Ok(Frame::Progress {
+                stage,
+                bytes_downloaded,
+                bytes_total,
+            })
+        }
+        "done" => {
+            let data_b64 = payload
+                .and_then(|p| p.get("data"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    ImageError::BackendError("image bridge: done frame missing data".into())
+                })?;
+            let bytes = Base64::decode_vec(data_b64)
+                .map_err(|e| ImageError::BackendError(format!("image bridge: base64: {e}")))?;
+            let mime_type = payload
+                .and_then(|p| p.get("mime_type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("image/png")
+                .to_string();
+            Ok(Frame::Done { bytes, mime_type })
+        }
+        "error" => Ok(Frame::Error(
+            payload
+                .and_then(|p| p.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+        )),
+        other => Err(ImageError::BackendError(format!(
+            "image bridge: unknown frame kind '{other}'"
+        ))),
+    }
+}
+
+pub async fn cancel_stream(request_id: &str) -> Result<(), ImageError> {
+    image_cancel_stream(request_id)
+        .await
+        .map(|_| ())
+        .map_err(js_err)
+}

--- a/crates/solobase-browser/src/image/bridge.rs
+++ b/crates/solobase-browser/src/image/bridge.rs
@@ -1,0 +1,1 @@
+//! Rust shim over the SW↔page image bridge. Fleshed out in plan task 2.2.

--- a/crates/solobase-browser/src/image/catalog.rs
+++ b/crates/solobase-browser/src/image/catalog.rs
@@ -40,9 +40,8 @@ fn sd_turbo_caps() -> ModelCapabilities {
 }
 
 fn default_models() -> Vec<ModelInfo> {
-    let mut sd_turbo = ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)");
-    sd_turbo.capabilities = sd_turbo_caps();
-    vec![sd_turbo]
+    vec![ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)")
+        .with_capabilities(sd_turbo_caps())]
 }
 
 #[cfg(test)]

--- a/crates/solobase-browser/src/image/catalog.rs
+++ b/crates/solobase-browser/src/image/catalog.rs
@@ -1,0 +1,61 @@
+//! Default image-model catalog for the browser backend.
+
+use wafer_core::interfaces::image::service::{ModelCapabilities, ModelInfo};
+
+pub const BACKEND_ID: &str = "transformers-image";
+
+#[derive(Debug, Clone)]
+pub struct ModelCatalog {
+    models: Vec<ModelInfo>,
+}
+
+impl ModelCatalog {
+    pub fn new(models: Vec<ModelInfo>) -> Self {
+        Self { models }
+    }
+
+    pub fn models(&self) -> &[ModelInfo] {
+        &self.models
+    }
+}
+
+impl Default for ModelCatalog {
+    fn default() -> Self {
+        Self::new(default_models())
+    }
+}
+
+pub fn default_catalog() -> ModelCatalog {
+    ModelCatalog::default()
+}
+
+fn sd_turbo_caps() -> ModelCapabilities {
+    // `ModelCapabilities` is `#[non_exhaustive]`; construct via Default + field assignment.
+    let mut c = ModelCapabilities::default();
+    c.max_width = Some(512);
+    c.max_height = Some(512);
+    c.supports_negative_prompt = true;
+    c.max_steps = Some(4);
+    c
+}
+
+fn default_models() -> Vec<ModelInfo> {
+    let mut sd_turbo = ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)");
+    sd_turbo.capabilities = sd_turbo_caps();
+    vec![sd_turbo]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_catalog_has_sd_turbo() {
+        let cat = default_catalog();
+        assert_eq!(cat.models().len(), 1);
+        assert_eq!(cat.models()[0].model_id, "Xenova/sd-turbo");
+        assert_eq!(cat.models()[0].backend_id, BACKEND_ID);
+        assert_eq!(cat.models()[0].capabilities.max_width, Some(512));
+        assert!(cat.models()[0].capabilities.supports_negative_prompt);
+    }
+}

--- a/crates/solobase-browser/src/image/catalog.rs
+++ b/crates/solobase-browser/src/image/catalog.rs
@@ -40,8 +40,10 @@ fn sd_turbo_caps() -> ModelCapabilities {
 }
 
 fn default_models() -> Vec<ModelInfo> {
-    vec![ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)")
-        .with_capabilities(sd_turbo_caps())]
+    vec![
+        ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)")
+            .with_capabilities(sd_turbo_caps()),
+    ]
 }
 
 #[cfg(test)]

--- a/crates/solobase-browser/src/image/mod.rs
+++ b/crates/solobase-browser/src/image/mod.rs
@@ -1,0 +1,13 @@
+//! Browser image service — `ImageService` impl driving transformers.js
+//! pipelines via a SW↔page postMessage bridge. Parallel in shape to
+//! `crate::llm`.
+
+#[cfg(target_arch = "wasm32")]
+pub mod bridge;
+pub mod catalog;
+#[cfg(target_arch = "wasm32")]
+pub mod service;
+
+pub use catalog::{default_catalog, ModelCatalog};
+#[cfg(target_arch = "wasm32")]
+pub use service::BrowserImageService;

--- a/crates/solobase-browser/src/image/mod.rs
+++ b/crates/solobase-browser/src/image/mod.rs
@@ -9,5 +9,3 @@ pub mod catalog;
 pub mod service;
 
 pub use catalog::{default_catalog, ModelCatalog};
-#[cfg(target_arch = "wasm32")]
-pub use service::BrowserImageService;

--- a/crates/solobase-browser/src/image/mod.rs
+++ b/crates/solobase-browser/src/image/mod.rs
@@ -9,3 +9,5 @@ pub mod catalog;
 pub mod service;
 
 pub use catalog::{default_catalog, ModelCatalog};
+#[cfg(target_arch = "wasm32")]
+pub use service::BrowserImageService;

--- a/crates/solobase-browser/src/image/service.rs
+++ b/crates/solobase-browser/src/image/service.rs
@@ -1,1 +1,147 @@
-//! BrowserImageService — fleshed out in plan task 2.3.
+//! `BrowserImageService` — `wafer_core::ImageService` impl backed by
+//! `@huggingface/transformers.js` running in the page via the SW↔page
+//! postMessage bridge.
+//!
+//! Single-engine — transformers.js keeps one pipeline in memory at a time.
+//! Model loading is one-shot (no intermediate progress events surfaced yet);
+//! generation is streamed (progress / done / error frames) over the same
+//! SW↔page bridge pattern as the LLM service.
+
+use futures::{channel::mpsc, sink::SinkExt, stream::BoxStream};
+use tokio_util::sync::CancellationToken;
+use wafer_core::interfaces::image::service::{
+    GeneratedImage, ImageError, ImageRequest, ImageResponse, ImageService, LoadProgress, ModelInfo,
+    ModelStatus,
+};
+
+use crate::image::{
+    bridge::{self, Frame},
+    catalog::{default_catalog, ModelCatalog, BACKEND_ID},
+};
+
+pub struct BrowserImageService {
+    catalog: ModelCatalog,
+}
+
+impl BrowserImageService {
+    pub fn new() -> Self {
+        Self {
+            catalog: default_catalog(),
+        }
+    }
+
+    pub fn with_catalog(catalog: ModelCatalog) -> Self {
+        Self { catalog }
+    }
+}
+
+impl Default for BrowserImageService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ImageService for BrowserImageService {
+    async fn generate(
+        &self,
+        req: ImageRequest,
+        cancel: CancellationToken,
+    ) -> Result<ImageResponse, ImageError> {
+        if !self.claims_backend(&req.backend_id) {
+            return Err(ImageError::InvalidRequest(format!(
+                "backend '{}' not claimed by {BACKEND_ID}",
+                req.backend_id
+            )));
+        }
+
+        let body = serde_json::to_string(&req)
+            .map_err(|e| ImageError::BackendError(format!("encode request: {e}")))?;
+        let request_id = bridge::start_generate(&body).await?;
+
+        loop {
+            if cancel.is_cancelled() {
+                let _ = bridge::cancel_stream(&request_id).await;
+                return Err(ImageError::Cancelled);
+            }
+            match bridge::next_frame(&request_id).await? {
+                Frame::Progress { .. } => {
+                    // Generate progress is rapid on SD-Turbo (≤4 steps).
+                    // Use load_model() if you want load-time progress.
+                    continue;
+                }
+                Frame::Done { bytes, mime_type } => {
+                    return Ok(ImageResponse::new(vec![GeneratedImage::new(bytes, mime_type)]));
+                }
+                Frame::Error(msg) => {
+                    return Err(ImageError::BackendError(format!("transformers: {msg}")));
+                }
+            }
+        }
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ImageError> {
+        Ok(self.catalog.models().to_vec())
+    }
+
+    async fn status(&self, backend_id: &str, _model_id: &str) -> Result<ModelStatus, ImageError> {
+        if backend_id != BACKEND_ID {
+            return Err(ImageError::InvalidRequest(format!(
+                "backend '{backend_id}' not claimed by {BACKEND_ID}"
+            )));
+        }
+        // Page-direct engine state isn't visible from the SW. Match the
+        // BrowserLlmService policy: return Unloaded; UI tracks real state
+        // via the load_model stream.
+        Ok(ModelStatus::unloaded())
+    }
+
+    fn load_model(
+        &self,
+        backend_id: &str,
+        model_id: &str,
+        cancel: CancellationToken,
+    ) -> BoxStream<'static, Result<LoadProgress, ImageError>> {
+        if backend_id != BACKEND_ID {
+            let id = backend_id.to_string();
+            return Box::pin(futures::stream::once(async move {
+                Err(ImageError::InvalidRequest(format!(
+                    "backend '{id}' not claimed by {BACKEND_ID}"
+                )))
+            }));
+        }
+        let model = model_id.to_string();
+        let (mut tx, rx) = mpsc::channel::<Result<LoadProgress, ImageError>>(8);
+        wasm_bindgen_futures::spawn_local(async move {
+            if cancel.is_cancelled() {
+                let _ = tx.send(Err(ImageError::Cancelled)).await;
+                return;
+            }
+            // Page-side loadEngine is one round-trip. Intermediate download
+            // progress is not exposed yet; emit a single terminal "ready"
+            // frame so the UI can flip out of the loading state.
+            match bridge::load_engine(&model).await {
+                Ok(()) => {
+                    let _ = tx.send(Ok(LoadProgress::new("ready"))).await;
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(e)).await;
+                }
+            }
+        });
+        Box::pin(rx)
+    }
+
+    async fn unload_model(&self, backend_id: &str, _model_id: &str) -> Result<(), ImageError> {
+        if backend_id != BACKEND_ID {
+            return Err(ImageError::InvalidRequest(format!(
+                "backend '{backend_id}' not claimed by {BACKEND_ID}"
+            )));
+        }
+        bridge::unload_engine().await
+    }
+
+    fn claims_backend(&self, backend_id: &str) -> bool {
+        backend_id == BACKEND_ID
+    }
+}

--- a/crates/solobase-browser/src/image/service.rs
+++ b/crates/solobase-browser/src/image/service.rs
@@ -1,0 +1,1 @@
+//! BrowserImageService — fleshed out in plan task 2.3.

--- a/crates/solobase-browser/src/image/service.rs
+++ b/crates/solobase-browser/src/image/service.rs
@@ -71,7 +71,9 @@ impl ImageService for BrowserImageService {
                     continue;
                 }
                 Frame::Done { bytes, mime_type } => {
-                    return Ok(ImageResponse::new(vec![GeneratedImage::new(bytes, mime_type)]));
+                    return Ok(ImageResponse::new(vec![GeneratedImage::new(
+                        bytes, mime_type,
+                    )]));
                 }
                 Frame::Error(msg) => {
                     return Err(ImageError::BackendError(format!("transformers: {msg}")));

--- a/crates/solobase-browser/src/lib.rs
+++ b/crates/solobase-browser/src/lib.rs
@@ -19,6 +19,7 @@ pub mod tools;
 // Pure-Rust modules — available on all targets (native + wasm32).
 // openai_codec is pure Rust and tested on native; the rest of `llm` is too
 // (stubs today, real impls later behind wasm32 cfg inside the module).
+pub mod image;
 pub mod llm;
 pub mod vector;
 

--- a/crates/solobase-core/src/blocks/image/mod.rs
+++ b/crates/solobase-core/src/blocks/image/mod.rs
@@ -1,0 +1,81 @@
+//! Image-generation feature block. Exposes:
+//!   POST /b/image/api/generate — returns PNG bytes
+//!   GET  /b/image/api/models   — aggregated list of registered image models
+//!
+//! Delegates to the runtime's `wafer-run/image` service block via the typed
+//! native client at `wafer_core::clients::image`. The actual generation
+//! backend is `BrowserImageService` in solobase-browser (transformers.js +
+//! SD-Turbo on WebGPU); native deployments register zero image services and
+//! the block 4xx's accordingly.
+
+pub mod routes;
+
+use wafer_run::{
+    block::{Block, BlockInfo},
+    context::Context,
+    types::*,
+    AuthLevel, InputStream, OutputStream,
+};
+
+use crate::{blocks::helpers::err_not_found, ui};
+
+pub struct ImageBlock;
+
+impl ImageBlock {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ImageBlock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl Block for ImageBlock {
+    fn info(&self) -> BlockInfo {
+        BlockInfo::new(
+            "suppers-ai/image",
+            "0.0.1",
+            "http-handler@v1",
+            "Text-to-image surface — routes to the wafer-run/image service block.",
+        )
+        .instance_mode(InstanceMode::Singleton)
+        .requires(vec!["wafer-run/image".into()])
+        .category(wafer_run::BlockCategory::Feature)
+        .description(
+            "Text-to-image surface. Forwards prompts to the runtime image \
+             service router; the configured backend (e.g. BrowserImageService \
+             with transformers.js + SD-Turbo) renders and returns PNG bytes.",
+        )
+        .endpoints(vec![
+            BlockEndpoint::post("/b/image/api/generate")
+                .summary("Generate an image from a prompt")
+                .auth(AuthLevel::Authenticated),
+            BlockEndpoint::get("/b/image/api/models")
+                .summary("List available image models (aggregated across backends)")
+                .auth(AuthLevel::Authenticated),
+        ])
+        .can_disable(true)
+        .default_enabled(true)
+    }
+
+    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
+        let user_id = msg.user_id().to_string();
+        if user_id.is_empty() {
+            return ui::forbidden_response(&msg);
+        }
+
+        match (msg.action(), msg.path()) {
+            ("create", "/b/image/api/generate") => routes::handle_generate(ctx, input).await,
+            ("retrieve", "/b/image/api/models") => routes::handle_list_models(ctx).await,
+            _ => err_not_found("not found"),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+::wafer_run::register_static_block!("suppers-ai/image", ImageBlock);

--- a/crates/solobase-core/src/blocks/image/routes.rs
+++ b/crates/solobase-core/src/blocks/image/routes.rs
@@ -1,0 +1,93 @@
+//! HTTP routes for the image block.
+//!
+//! Forwards POST /b/image/api/generate to the runtime image router via the
+//! typed native client. PNG bytes flow back as binary; failures map to a
+//! structured JSON error envelope with an HTTP status appropriate to the
+//! `ErrorCode`.
+
+use serde::Deserialize;
+use wafer_block::context::Context;
+use wafer_block::WaferError;
+use wafer_core::clients::image::{self as image_client, ImageParams, ImageRequest};
+use wafer_run::OutputStream;
+
+use crate::blocks::helpers::{err_bad_request, err_internal, ok_json, ResponseBuilder};
+use wafer_run::InputStream;
+
+#[derive(Debug, Deserialize)]
+struct GenerateBody {
+    backend_id: String,
+    model: String,
+    prompt: String,
+    #[serde(default)]
+    params: Option<ImageParams>,
+}
+
+pub async fn handle_generate(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    let raw = input.collect_to_bytes().await;
+    let body: GenerateBody = match serde_json::from_slice(&raw) {
+        Ok(b) => b,
+        Err(e) => return err_bad_request(&format!("invalid json: {e}")),
+    };
+    if body.prompt.trim().is_empty() {
+        return err_bad_request("missing or empty prompt");
+    }
+    if body.backend_id.trim().is_empty() {
+        return err_bad_request("missing backend_id");
+    }
+    if body.model.trim().is_empty() {
+        return err_bad_request("missing model");
+    }
+
+    let req = ImageRequest {
+        backend_id: body.backend_id,
+        model: body.model,
+        prompt: body.prompt,
+        params: body.params.unwrap_or_default(),
+        extra: serde_json::Value::Null,
+    };
+
+    match image_client::generate(ctx, &req).await {
+        Ok(resp) => {
+            let Some(img) = resp.images.into_iter().next() else {
+                return err_internal("image service returned no image");
+            };
+            ResponseBuilder::new()
+                .status(200)
+                .set_header("Cache-Control", "no-store")
+                .body(img.bytes, &img.mime_type)
+        }
+        Err(e) => wafer_err_to_http(e),
+    }
+}
+
+pub async fn handle_list_models(ctx: &dyn Context) -> OutputStream {
+    match image_client::list_models(ctx).await {
+        Ok(models) => ok_json(&serde_json::json!({ "models": models })),
+        Err(e) => wafer_err_to_http(e),
+    }
+}
+
+fn wafer_err_to_http(e: WaferError) -> OutputStream {
+    use wafer_block::ErrorCode;
+    let status = match e.code {
+        ErrorCode::InvalidArgument => 400,
+        ErrorCode::NotFound => 404,
+        ErrorCode::Unimplemented => 501,
+        ErrorCode::Cancelled => 499,
+        ErrorCode::Unavailable => 503,
+        ErrorCode::PermissionDenied => 403,
+        ErrorCode::Unauthenticated => 401,
+        _ => 502,
+    };
+    let body = serde_json::to_vec(&serde_json::json!({
+        "error": {
+            "code": format!("{:?}", e.code),
+            "message": e.message,
+        }
+    }))
+    .unwrap_or_else(|_| Vec::new());
+    ResponseBuilder::new()
+        .status(status)
+        .body(body, "application/json")
+}

--- a/crates/solobase-core/src/blocks/image/routes.rs
+++ b/crates/solobase-core/src/blocks/image/routes.rs
@@ -6,13 +6,11 @@
 //! `ErrorCode`.
 
 use serde::Deserialize;
-use wafer_block::context::Context;
-use wafer_block::WaferError;
+use wafer_block::{context::Context, WaferError};
 use wafer_core::clients::image::{self as image_client, ImageParams, ImageRequest};
-use wafer_run::OutputStream;
+use wafer_run::{InputStream, OutputStream};
 
 use crate::blocks::helpers::{err_bad_request, err_internal, ok_json, ResponseBuilder};
-use wafer_run::InputStream;
 
 #[derive(Debug, Deserialize)]
 struct GenerateBody {

--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -8,6 +8,7 @@ pub mod errors;
 pub mod fastembed;
 pub mod files;
 pub mod helpers;
+pub mod image;
 pub mod legalpages;
 #[cfg(feature = "llm")]
 pub mod llm;
@@ -76,6 +77,7 @@ pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
         auth_ui::AuthUiBlock::default().info(),
         email::EmailBlock::new().info(),
         files::FilesBlock::new().info(),
+        image::ImageBlock::new().info(),
         legalpages::LegalPagesBlock::new().info(),
         messages::MessagesBlock::new().info(),
         products::ProductsBlock::new().info(),
@@ -166,6 +168,7 @@ pub fn register_all_static_blocks(
     )?;
     wafer.register_block("suppers-ai/email", Arc::new(email::EmailBlock::new()))?;
     wafer.register_block("suppers-ai/files", Arc::new(files::FilesBlock::new()))?;
+    wafer.register_block("suppers-ai/image", Arc::new(image::ImageBlock::new()))?;
     wafer.register_block(
         "suppers-ai/legalpages",
         Arc::new(legalpages::LegalPagesBlock::new()),

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -18,8 +18,8 @@ use wafer_block_security_headers as _;
 use wafer_block_web as _;
 use wafer_core::interfaces::{
     config::service::ConfigService, crypto::service::CryptoService,
-    database::service::DatabaseService, image::service::ImageService,
-    llm::service::LlmService, logger::service::LoggerService, network::service::NetworkService,
+    database::service::DatabaseService, image::service::ImageService, llm::service::LlmService,
+    logger::service::LoggerService, network::service::NetworkService,
     storage::service::StorageService,
 };
 use wafer_run::{block::Block, RuntimeError, Wafer};

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -18,8 +18,9 @@ use wafer_block_security_headers as _;
 use wafer_block_web as _;
 use wafer_core::interfaces::{
     config::service::ConfigService, crypto::service::CryptoService,
-    database::service::DatabaseService, llm::service::LlmService, logger::service::LoggerService,
-    network::service::NetworkService, storage::service::StorageService,
+    database::service::DatabaseService, image::service::ImageService,
+    llm::service::LlmService, logger::service::LoggerService, network::service::NetworkService,
+    storage::service::StorageService,
 };
 use wafer_run::{block::Block, RuntimeError, Wafer};
 
@@ -47,6 +48,12 @@ pub struct SolobaseBuilder {
     /// providers (OpenAI/Anthropic/etc.) take precedence over any backend
     /// added here for overlapping `backend_id`s.
     extra_llm_services: Vec<(String, Arc<dyn LlmService>)>,
+    /// Additional `ImageService` backends to register on the
+    /// `MultiBackendImageService` router backing `wafer-run/image`. Same
+    /// shape and order semantics as `extra_llm_services`. No built-in
+    /// provider on native — the prototype's only backend is
+    /// `BrowserImageService` from `solobase-web`.
+    extra_image_services: Vec<(String, Arc<dyn ImageService>)>,
     /// Routes registered by downstream projects via `add_route`. Checked
     /// after built-in `ROUTES` — built-ins always win on prefix collision.
     extra_routes: Vec<ExtraRoute>,
@@ -86,6 +93,7 @@ impl SolobaseBuilder {
             block_configs: Vec::new(),
             extra_blocks: Vec::new(),
             extra_llm_services: Vec::new(),
+            extra_image_services: Vec::new(),
             extra_routes: Vec::new(),
             sqlite_db_path: None,
             extra_vector_service: None,
@@ -151,6 +159,19 @@ impl SolobaseBuilder {
     /// it just contains only the backends passed in via this setter.
     pub fn llm_service(mut self, label: impl Into<String>, service: Arc<dyn LlmService>) -> Self {
         self.extra_llm_services.push((label.into(), service));
+        self
+    }
+
+    /// Register an additional `ImageService` backend on the router backing
+    /// `wafer-run/image`. Mirrors `llm_service` — `label` is for tracing,
+    /// dispatch is by `claims_backend`. Order semantics: first
+    /// `claims_backend` match wins.
+    pub fn image_service(
+        mut self,
+        label: impl Into<String>,
+        service: Arc<dyn ImageService>,
+    ) -> Self {
+        self.extra_image_services.push((label.into(), service));
         self
     }
 
@@ -290,6 +311,18 @@ impl SolobaseBuilder {
         }
 
         wafer_core::service_blocks::llm::register_with(&mut wafer, Arc::new(llm_router))?;
+
+        // 4a-bis. Build the image router and register the service block
+        // backing `wafer-run/image`. Mirrors the LLM path above — no built-in
+        // native provider for the prototype; backends are populated entirely
+        // from `.image_service(...)` entries (typically a `BrowserImageService`
+        // from `solobase-web`).
+        let mut image_router =
+            wafer_core::interfaces::image::router::MultiBackendImageService::new();
+        for (label, svc) in self.extra_image_services {
+            image_router.register(label, svc);
+        }
+        wafer_core::service_blocks::image::register_with(&mut wafer, Arc::new(image_router))?;
 
         // 4b. Register the `wafer-run/vector` runtime block when the
         // `native-embedding` feature is on. `suppers-ai/vector` declares

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -60,6 +60,9 @@ pub async fn initialize() -> Result<(), JsValue> {
     let browser_llm: Arc<dyn wafer_core::interfaces::llm::service::LlmService> =
         Arc::new(solobase_browser::llm::BrowserLlmService::new());
 
+    let browser_image: Arc<dyn wafer_core::interfaces::image::service::ImageService> =
+        Arc::new(solobase_browser::image::BrowserImageService::new());
+
     let browser_vector: Arc<dyn wafer_core::interfaces::vector::service::VectorService> =
         Arc::new(solobase_browser::vector::BrowserVectorService::new());
 
@@ -80,6 +83,7 @@ pub async fn initialize() -> Result<(), JsValue> {
         .network(solobase_browser::make_network_service())
         .logger(solobase_browser::make_console_logger())
         .llm_service("browser", browser_llm)
+        .image_service("browser", browser_image)
         .vector_service(browser_vector)
         .embedding_service(browser_embedding)
         .block_settings(features)


### PR DESCRIPTION
## Summary

Consumer side of the gizza-ai T2I prototype. wafer-run #50 + #51 (producer + small `with_capabilities`/`new` follow-up) shipped to main; this PR wires it through the solobase stack.

- `BrowserImageService` in `solobase-browser/src/image/` — `wafer_core::ImageService` impl driving `@huggingface/transformers.js` + SD-Turbo on WebGPU via a SW↔page postMessage bridge. Parallel in shape to `BrowserLlmService`.
- New `image_*` wasm-bindgen externs in `solobase-browser/src/bridge.rs` and JS counterparts in `js/bridge.js` (one-shot load/unload + streamed generate frames).
- `t2i-engine.js` page-side ESM asset bundled into solobase-browser assets and loaded by `index.html.tmpl`. sw.js route + bypass list extended for `/t2i-engine.js`.
- New `suppers-ai/image` feature block in solobase-core exposing `POST /b/image/api/generate` (binary PNG) and `GET /b/image/api/models` (aggregated `ModelInfo` list). Block auto-registers on native via `register_static_block!` and on wasm32 via `register_all_static_blocks`.
- `SolobaseBuilder::image_service(label, svc)` + `MultiBackendImageService` router registration in `build()`.
- `solobase-web/src/lib.rs` registers `BrowserImageService` under the `"browser"` label.

## Why

Browser-side text-to-image surface in gizza.ai. The agent-side UI lands in a follow-up PR on the gizza-ai repo (PR-3 of the three-PR plan). Acceptance criterion for the prototype: open gizza → Image tab → pick SD-Turbo → Load → Draw → see PNG. Spec: `docs/superpowers/specs/2026-05-12-gizza-ai-t2i-prototype-design.md`. Plan: `docs/superpowers/plans/2026-05-12-gizza-ai-t2i-prototype.md`.

## Notes

- `ModelStatus` returns `Unloaded` for any backend_id check from the SW side — page-direct engine state isn't visible there (same constraint as `BrowserLlmService`). The UI tracks real state via the `load_model` stream.
- `load_model` doesn't yet surface intermediate download-progress frames from transformers.js. A single terminal `ready`/`error` frame is emitted today. Follow-up work can plug the transformers.js `progress_callback` into the SW→page frame stream.
- Native deployments register zero image services and the block returns 502 on `/generate` accordingly — the prototype is browser-only.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare`
- [x] `cargo build -p solobase-web --target wasm32-unknown-unknown`
- [ ] Browser smoke (manual): POST /b/image/api/generate returns PNG — covered end-to-end by gizza-ai PR-3
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)