### PR TITLE
feat(solobase-browser): export loadEngine/unloadEngine from t2i-engine.js

### DIFF
--- a/crates/solobase-browser/assets/t2i-engine.js
+++ b/crates/solobase-browser/assets/t2i-engine.js
@@ -154,4 +154,46 @@ navigator.serviceWorker.addEventListener('message', (event) => {
     }
 });
 
+// ---------------------------------------------------------------------------
+// Page-direct load API (ESM exports).
+//
+// Mirrors `webllm-engine.js::{loadEngine,unloadEngine}`. Page-side consumers
+// (e.g. the gizza-ai model picker) import these to drive the transformers.js
+// pipeline directly in the window without bouncing through the service-worker
+// bridge. Required because Chrome's FetchEvent.respondWith() lifetime cap
+// kills SW-routed model downloads on cold (~500 MB) loads.
+//
+// `_pipe` / `_pipeModel` are the same module-scoped state used by the SW
+// generate path's `handleGenerateStream` above. ESM modules are singletons
+// within a realm, so `import { loadEngine } from '/t2i-engine.js'` from
+// another script in the same window shares this state.
+// ---------------------------------------------------------------------------
+export async function loadEngine(modelId, onProgress) {
+    const { pipeline } = await loadTransformers();
+    if (_pipeModel === modelId && _pipe) {
+        return; // already loaded
+    }
+    if (_pipe) {
+        try { await _pipe.dispose?.(); } catch (_e) {}
+        _pipe = null;
+        _pipeModel = null;
+    }
+    _pipe = await pipeline('text-to-image', modelId, {
+        device: 'webgpu',
+        progress_callback: (report) => {
+            if (typeof onProgress === 'function') {
+                onProgress(String(report?.status ?? report?.file ?? ''));
+            }
+        },
+    });
+    _pipeModel = modelId;
+}
+
+export async function unloadEngine() {
+    if (!_pipe) return;
+    try { await _pipe.dispose?.(); } catch (_e) {}
+    _pipe = null;
+    _pipeModel = null;
+}
+
 console.log('t2i-engine.js loaded');


### PR DESCRIPTION
## Summary

- Add ESM exports `loadEngine(modelId, onProgress)` and `unloadEngine()` to `t2i-engine.js`, parallel to `webllm-engine.js`.

## Why

Follow-up to #132. The gizza-ai model picker loads chat models page-direct by importing `loadEngine` from `/webllm-engine.js` — this avoids Chrome's FetchEvent.respondWith() lifetime cap that would otherwise kill cold SW-routed model downloads. The T2I picker entry needs the same affordance: page-direct `loadEngine` import + invocation, so the ~500 MB SD-Turbo download isn't constrained by SW lifecycle.

The new exports share module-scoped state (`_pipe`, `_pipeModel`) with the existing SW-routed generate handler, so a model loaded page-direct is also usable by subsequent generate calls without re-instantiation.

## Test plan

- [x] `cargo test -p solobase-browser --lib assets::` — asset bundle tests pass.
- [x] `cargo build -p solobase-browser` — clean.
- [ ] CI
- [ ] Used end-to-end in gizza-ai PR-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)