### PR TITLE
perf(widgets): db::count for 9 dashboard widgets + db::sum for total size

### DIFF
--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -112,21 +112,16 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
 
     // Total users
-    let user_count = db::list(
+    let user_count = db::count(
         ctx,
         USERS,
-        &ListOptions {
-            filters: vec![Filter {
-                field: "deleted_at".into(),
-                operator: FilterOp::IsNull,
-                value: serde_json::Value::Null,
-            }],
-            limit: 1,
-            ..Default::default()
-        },
+        &[Filter {
+            field: "deleted_at".into(),
+            operator: FilterOp::IsNull,
+            value: serde_json::Value::Null,
+        }],
     )
     .await
-    .map(|r| r.total_count)
     .unwrap_or(0);
 
     // New users today

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -171,72 +171,47 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn load_admin_stats(ctx: &dyn Context) -> AdminStats {
-    let one = ListOptions {
-        limit: 1,
-        ..Default::default()
-    };
-    let buckets = match db::list(ctx, BUCKETS_COLLECTION, &one).await {
-        Ok(r) => r.total_count,
-        Err(e) => {
+    let buckets = db::count(ctx, BUCKETS_COLLECTION, &[])
+        .await
+        .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: bucket count failed");
             0
-        }
-    };
+        });
 
-    let complete_only = ListOptions {
-        filters: vec![Filter {
-            field: "status".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String("complete".into()),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let files = match db::list(ctx, OBJECTS_COLLECTION, &complete_only).await {
-        Ok(r) => r.total_count,
-        Err(e) => {
+    let complete_filter = [Filter {
+        field: "status".into(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String("complete".into()),
+    }];
+
+    let files = db::count(ctx, OBJECTS_COLLECTION, &complete_filter)
+        .await
+        .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: files count failed");
             0
-        }
-    };
+        });
 
-    let shares = match db::list(ctx, SHARES_COLLECTION, &one).await {
-        Ok(r) => r.total_count,
-        Err(e) => {
+    let shares = db::count(ctx, SHARES_COLLECTION, &[])
+        .await
+        .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: shares count failed");
             0
-        }
-    };
+        });
 
-    let quotas_count = match db::list(ctx, QUOTAS_COLLECTION, &one).await {
-        Ok(r) => r.total_count,
-        Err(e) => {
+    let quotas_count = db::count(ctx, QUOTAS_COLLECTION, &[])
+        .await
+        .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: quotas count failed");
             0
-        }
-    };
+        });
 
-    let total_size_bytes: i64 = match db::list(
-        ctx,
-        OBJECTS_COLLECTION,
-        &ListOptions {
-            filters: vec![Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String("complete".into()),
-            }],
-            limit: 10000,
-            ..Default::default()
-        },
-    )
-    .await
-    {
-        Ok(r) => r.records.iter().map(|rec| rec.i64_field("size")).sum(),
-        Err(e) => {
+    let total_size_bytes = db::sum(ctx, OBJECTS_COLLECTION, "size", &complete_filter)
+        .await
+        .map(|s| s as i64)
+        .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: total size sum failed");
             0
-        }
-    };
+        });
 
     AdminStats {
         buckets,

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -46,27 +46,10 @@ fn products_page<'a>(
 pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
-    let one = ListOptions {
-        limit: 1,
-        ..Default::default()
-    };
-
-    let products_count = db::list(ctx, PRODUCTS_COLLECTION, &one)
-        .await
-        .map(|r| r.total_count)
-        .unwrap_or(0);
-    let groups_count = db::list(ctx, GROUPS_COLLECTION, &one)
-        .await
-        .map(|r| r.total_count)
-        .unwrap_or(0);
-    let purchases_count = db::list(ctx, PURCHASES_COLLECTION, &one)
-        .await
-        .map(|r| r.total_count)
-        .unwrap_or(0);
-    let pricing_count = db::list(ctx, PRICING_COLLECTION, &one)
-        .await
-        .map(|r| r.total_count)
-        .unwrap_or(0);
+    let products_count = db::count(ctx, PRODUCTS_COLLECTION, &[]).await.unwrap_or(0);
+    let groups_count = db::count(ctx, GROUPS_COLLECTION, &[]).await.unwrap_or(0);
+    let purchases_count = db::count(ctx, PURCHASES_COLLECTION, &[]).await.unwrap_or(0);
+    let pricing_count = db::count(ctx, PRICING_COLLECTION, &[]).await.unwrap_or(0);
 
     let content = html! {
         (components::page_header("Products Overview", Some("Product catalog statistics"), None))


### PR DESCRIPTION
## Summary
- 9 widget callsites migrated from `db::list(limit=1).total_count` to `db::count(.., &filters)` — saves a SELECT * round-trip per widget.
- Storage-admin total-size widget migrated from `db::list(limit=10000) + sum-in-Rust` to `db::sum(.., "size", &filters)` — removes the 10K row clamp (correctness fix beyond perf).

Closes the documented follow-up A on D1 amplification.

## Test plan
- [x] \`cargo check -p solobase-core\` clean
- [x] \`cargo test -p solobase-core --lib\` no new failures (556 → 556)
- [x] \`cargo +nightly fmt --all\` no diff
- [x] \`cargo clippy -p solobase-core --all-targets\` no new warnings (160 pre-existing, unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)