### PR TITLE
feat(solobase-browser): swap t2i-engine to Janus-Pro-1B (autoregressive T2I via transformers.js)

### DIFF
--- a/crates/solobase-browser/assets/t2i-engine.js
+++ b/crates/solobase-browser/assets/t2i-engine.js
@@ -28,7 +28,9 @@
 let _transformers = null;
 async function loadTransformers() {
     if (_transformers) return _transformers;
-    _transformers = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.0');
+    // Janus-Pro requires MultiModalityCausalLM, which was added in 3.7.x.
+    // Pin to 3.7.1 (the version HF's official janus-pro-webgpu example uses).
+    _transformers = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.7.1');
     return _transformers;
 }
 

--- a/crates/solobase-browser/assets/t2i-engine.js
+++ b/crates/solobase-browser/assets/t2i-engine.js
@@ -1,7 +1,16 @@
 // t2i-engine.js — page-side text-to-image engine.
 //
 // Runs in the window (WebGPU is window-only). Driven by SW postMessages from
-// bridge.js's `image*` family. Structurally parallel to webllm-engine.js.
+// bridge.js's `image*` family, OR called page-direct via ESM exports (mirrors
+// webllm-engine.js).
+//
+// Engine: Janus-Pro-1B (DeepSeek's unified multimodal model). HF's official
+// blessed path for in-browser T2I via transformers.js — there is no
+// `pipeline('text-to-image')` abstraction in transformers.js (the
+// `pipeline('text-to-image', ...)` call throws "Unsupported pipeline"). Janus
+// is autoregressive (token-stream → 384×384 image) rather than a diffusion
+// pipeline. Reference impl:
+// github.com/huggingface/transformers.js-examples/tree/main/janus-pro-webgpu
 //
 // SW → Page request shapes (see bridge.js for the producing side):
 //   { type: 'image-load-request',          id, modelId }
@@ -13,22 +22,31 @@
 //   { type: 'image-load-response',   id, error? }
 //   { type: 'image-unload-response', id, error? }
 //   { type: 'image-stream-frame',    id, kind, payload? }
-//     `kind` ∈ {'progress','done','error'}.
-//
-// The @huggingface/transformers import is lazy: a top-level import would
-// download a multi-MB ESM bundle on every page load, even for pages that
-// never touch image generation. Defer until first use.
+//     `kind` ∈ {'progress','done','error'}. Progress frames carry
+//     `{ stage, count?, total? }` during autoregressive token generation.
 
-let _Pipeline = null;
+let _transformers = null;
 async function loadTransformers() {
-    if (_Pipeline) return _Pipeline;
-    const mod = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.0');
-    _Pipeline = mod;
-    return _Pipeline;
+    if (_transformers) return _transformers;
+    _transformers = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.0');
+    return _transformers;
 }
 
-let _pipe = null;
-let _pipeModel = null;
+let _fp16Supported = null;
+async function detectFp16() {
+    if (_fp16Supported !== null) return _fp16Supported;
+    try {
+        const adapter = await navigator.gpu?.requestAdapter();
+        _fp16Supported = !!adapter?.features?.has('shader-f16');
+    } catch (_e) {
+        _fp16Supported = false;
+    }
+    return _fp16Supported;
+}
+
+let _processor = null;
+let _model = null;
+let _modelId = null;
 const _activeStreams = new Map(); // id -> AbortController
 
 async function swPost(payload) {
@@ -40,41 +58,119 @@ async function swStreamFrame(id, kind, payload) {
     await swPost({ type: 'image-stream-frame', id, kind, payload });
 }
 
+async function ensureLoaded(modelId, onProgress) {
+    if (_processor && _model && _modelId === modelId) return;
+    if (_model) {
+        try { await _model.dispose?.(); } catch (_e) {}
+        _model = null;
+        _processor = null;
+        _modelId = null;
+    }
+    const { AutoProcessor, MultiModalityCausalLM } = await loadTransformers();
+    const fp16 = await detectFp16();
+    const dtype = fp16
+        ? {
+              prepare_inputs_embeds: 'q4',
+              language_model: 'q4f16',
+              lm_head: 'fp16',
+              gen_head: 'fp16',
+              gen_img_embeds: 'fp16',
+              image_decode: 'fp32',
+          }
+        : {
+              prepare_inputs_embeds: 'fp32',
+              language_model: 'q4',
+              lm_head: 'fp32',
+              gen_head: 'fp32',
+              gen_img_embeds: 'fp32',
+              image_decode: 'fp32',
+          };
+    const device = {
+        // `prepare_inputs_embeds` runs on wasm in HF's reference example —
+        // there's an open WebGPU bug for that subgraph. Match their choice.
+        prepare_inputs_embeds: 'wasm',
+        language_model: 'webgpu',
+        lm_head: 'webgpu',
+        gen_head: 'webgpu',
+        gen_img_embeds: 'webgpu',
+        image_decode: 'webgpu',
+    };
+    const progress_callback = onProgress
+        ? (report) => {
+              onProgress(String(report?.status ?? report?.file ?? ''));
+          }
+        : undefined;
+    [_processor, _model] = await Promise.all([
+        AutoProcessor.from_pretrained(modelId, { progress_callback }),
+        MultiModalityCausalLM.from_pretrained(modelId, { dtype, device, progress_callback }),
+    ]);
+    _modelId = modelId;
+}
+
 async function handleLoadEngine(msg) {
     try {
-        const { pipeline } = await loadTransformers();
-        if (_pipeModel === msg.modelId && _pipe) {
-            await swPost({ type: 'image-load-response', id: msg.id });
-            return;
-        }
-        if (_pipe) {
-            try { await _pipe.dispose?.(); } catch (_e) {}
-            _pipe = null;
-            _pipeModel = null;
-        }
-        _pipe = await pipeline('text-to-image', msg.modelId, { device: 'webgpu' });
-        _pipeModel = msg.modelId;
+        await ensureLoaded(msg.modelId);
         await swPost({ type: 'image-load-response', id: msg.id });
     } catch (e) {
-        await swPost({ type: 'image-load-response', id: msg.id, error: String(e) });
+        await swPost({ type: 'image-load-response', id: msg.id, error: String(e?.message ?? e) });
     }
 }
 
 async function handleUnloadEngine(msg) {
     try {
-        if (_pipe) {
-            try { await _pipe.dispose?.(); } catch (_e) {}
-            _pipe = null;
-            _pipeModel = null;
+        if (_model) {
+            try { await _model.dispose?.(); } catch (_e) {}
         }
+        _processor = null;
+        _model = null;
+        _modelId = null;
         await swPost({ type: 'image-unload-response', id: msg.id });
     } catch (e) {
         await swPost({ type: 'image-unload-response', id: msg.id, error: String(e) });
     }
 }
 
+// Internal helper used by both SW-routed and ESM-direct generate paths.
+async function generateOnce(prompt, { onProgress, signal } = {}) {
+    if (!_processor || !_model) {
+        throw new Error('model not loaded; call loadEngine first');
+    }
+    const { BaseStreamer } = await loadTransformers();
+    const conversation = [{ role: '<|User|>', content: prompt }];
+    const inputs = await _processor(conversation, { chat_template: 'text_to_image' });
+
+    const num_image_tokens = _processor.num_image_tokens;
+    class ProgressStreamer extends BaseStreamer {
+        constructor() { super(); this.count = null; this.start = null; }
+        put(_value) {
+            if (this.count === null) { this.count = 0; this.start = performance.now(); return; }
+            this.count++;
+            onProgress?.({
+                stage: 'generate',
+                count: this.count,
+                total: num_image_tokens,
+                progress: this.count / num_image_tokens,
+                time_ms: performance.now() - this.start,
+            });
+        }
+        end() {}
+    }
+    const streamer = new ProgressStreamer();
+
+    const outputs = await _model.generate_images({
+        ...inputs,
+        min_new_tokens: num_image_tokens,
+        max_new_tokens: num_image_tokens,
+        do_sample: true,
+        streamer,
+    });
+    if (signal?.aborted) throw new Error('cancelled');
+    const blob = await outputs[0].toBlob();
+    return new Uint8Array(await blob.arrayBuffer());
+}
+
 async function handleGenerateStream(msg) {
-    if (!_pipe) {
+    if (!_processor || !_model) {
         await swStreamFrame(msg.id, 'error', 'model not loaded; call load_model first');
         return;
     }
@@ -82,20 +178,14 @@ async function handleGenerateStream(msg) {
     _activeStreams.set(msg.id, ac);
     try {
         const req = JSON.parse(msg.body);
-        const params = req.params || {};
-        const result = await _pipe(req.prompt, {
-            num_inference_steps: params.steps ?? 1,
-            guidance_scale: params.guidance_scale ?? 0.0,
-            width: params.width ?? 512,
-            height: params.height ?? 512,
-            negative_prompt: params.negative_prompt,
-            seed: params.seed,
+        const pngBytes = await generateOnce(req.prompt, {
+            signal: ac.signal,
+            onProgress: (p) => { swStreamFrame(msg.id, 'progress', p); },
         });
         if (ac.signal.aborted) {
             await swStreamFrame(msg.id, 'error', 'cancelled');
             return;
         }
-        const pngBytes = await rawImageToPng(result);
         const data = uint8ToBase64(pngBytes);
         await swStreamFrame(msg.id, 'done', { data, mime_type: 'image/png' });
     } catch (e) {
@@ -108,30 +198,6 @@ async function handleGenerateStream(msg) {
 function handleCancel(msg) {
     const ac = _activeStreams.get(msg.id);
     if (ac) ac.abort();
-}
-
-async function rawImageToPng(rawImage) {
-    // transformers.js v3 returns a RawImage. Convert via OffscreenCanvas → PNG.
-    // RawImage may be RGB (3 ch) or RGBA (4 ch); normalize to RGBA for canvas.
-    const { width, height, data, channels } = rawImage;
-    const canvas = new OffscreenCanvas(width, height);
-    const ctx = canvas.getContext('2d');
-    const imgData = ctx.createImageData(width, height);
-    if (channels === 4) {
-        imgData.data.set(data);
-    } else if (channels === 3) {
-        for (let i = 0, j = 0; i < width * height; i++, j += 3) {
-            imgData.data[i * 4] = data[j];
-            imgData.data[i * 4 + 1] = data[j + 1];
-            imgData.data[i * 4 + 2] = data[j + 2];
-            imgData.data[i * 4 + 3] = 255;
-        }
-    } else {
-        throw new Error(`unsupported channel count: ${channels}`);
-    }
-    ctx.putImageData(imgData, 0, 0);
-    const blob = await canvas.convertToBlob({ type: 'image/png' });
-    return new Uint8Array(await blob.arrayBuffer());
 }
 
 function uint8ToBase64(u8) {
@@ -155,45 +221,35 @@ navigator.serviceWorker.addEventListener('message', (event) => {
 });
 
 // ---------------------------------------------------------------------------
-// Page-direct load API (ESM exports).
+// Page-direct API (ESM exports).
 //
 // Mirrors `webllm-engine.js::{loadEngine,unloadEngine}`. Page-side consumers
-// (e.g. the gizza-ai model picker) import these to drive the transformers.js
-// pipeline directly in the window without bouncing through the service-worker
-// bridge. Required because Chrome's FetchEvent.respondWith() lifetime cap
-// kills SW-routed model downloads on cold (~500 MB) loads.
-//
-// `_pipe` / `_pipeModel` are the same module-scoped state used by the SW
-// generate path's `handleGenerateStream` above. ESM modules are singletons
-// within a realm, so `import { loadEngine } from '/t2i-engine.js'` from
-// another script in the same window shares this state.
+// (e.g. the gizza-ai image composer) import these to drive Janus-Pro directly
+// in the window without bouncing through the service-worker bridge. Required
+// because Chrome's FetchEvent.respondWith() lifetime cap kills SW-routed
+// model downloads on cold loads (Janus-Pro is ~700 MB - 1.5 GB depending on
+// quantization).
 // ---------------------------------------------------------------------------
 export async function loadEngine(modelId, onProgress) {
-    const { pipeline } = await loadTransformers();
-    if (_pipeModel === modelId && _pipe) {
-        return; // already loaded
-    }
-    if (_pipe) {
-        try { await _pipe.dispose?.(); } catch (_e) {}
-        _pipe = null;
-        _pipeModel = null;
-    }
-    _pipe = await pipeline('text-to-image', modelId, {
-        device: 'webgpu',
-        progress_callback: (report) => {
-            if (typeof onProgress === 'function') {
-                onProgress(String(report?.status ?? report?.file ?? ''));
-            }
-        },
-    });
-    _pipeModel = modelId;
+    await ensureLoaded(modelId, onProgress);
 }
 
 export async function unloadEngine() {
-    if (!_pipe) return;
-    try { await _pipe.dispose?.(); } catch (_e) {}
-    _pipe = null;
-    _pipeModel = null;
+    if (_model) {
+        try { await _model.dispose?.(); } catch (_e) {}
+    }
+    _processor = null;
+    _model = null;
+    _modelId = null;
 }
 
-console.log('t2i-engine.js loaded');
+// Page-direct one-shot generate. Returns the PNG bytes as a Uint8Array.
+// Same engine state (_processor / _model) as the SW-routed path.
+export async function generateImage(prompt, opts = {}) {
+    if (!_processor || !_model) {
+        throw new Error('model not loaded; call loadEngine first');
+    }
+    return await generateOnce(prompt, opts);
+}
+
+console.log('t2i-engine.js loaded (Janus-Pro)');

--- a/crates/solobase-browser/src/image/catalog.rs
+++ b/crates/solobase-browser/src/image/catalog.rs
@@ -29,21 +29,28 @@ pub fn default_catalog() -> ModelCatalog {
     ModelCatalog::default()
 }
 
-fn sd_turbo_caps() -> ModelCapabilities {
+fn janus_pro_caps() -> ModelCapabilities {
     // `ModelCapabilities` is `#[non_exhaustive]`; construct via Default + field assignment.
+    // Janus-Pro is autoregressive (not diffusion). Output is 384×384; `steps`
+    // / `guidance_scale` / `negative_prompt` are ignored by the engine. The
+    // capability flags here describe what the UI should expose; we set
+    // `supports_negative_prompt = false` and leave `max_steps = None` because
+    // those knobs don't apply to the autoregressive token loop.
     let mut c = ModelCapabilities::default();
-    c.max_width = Some(512);
-    c.max_height = Some(512);
-    c.supports_negative_prompt = true;
-    c.max_steps = Some(4);
+    c.max_width = Some(384);
+    c.max_height = Some(384);
+    c.supports_negative_prompt = false;
+    c.max_steps = None;
     c
 }
 
 fn default_models() -> Vec<ModelInfo> {
-    vec![
-        ModelInfo::new(BACKEND_ID, "Xenova/sd-turbo", "SD-Turbo (≈500 MB)")
-            .with_capabilities(sd_turbo_caps()),
-    ]
+    vec![ModelInfo::new(
+        BACKEND_ID,
+        "onnx-community/Janus-Pro-1B-ONNX",
+        "Janus-Pro 1B (≈700 MB – 1.5 GB)",
+    )
+    .with_capabilities(janus_pro_caps())]
 }
 
 #[cfg(test)]
@@ -51,12 +58,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_catalog_has_sd_turbo() {
+    fn default_catalog_has_janus_pro() {
         let cat = default_catalog();
         assert_eq!(cat.models().len(), 1);
-        assert_eq!(cat.models()[0].model_id, "Xenova/sd-turbo");
+        assert_eq!(cat.models()[0].model_id, "onnx-community/Janus-Pro-1B-ONNX");
         assert_eq!(cat.models()[0].backend_id, BACKEND_ID);
-        assert_eq!(cat.models()[0].capabilities.max_width, Some(512));
-        assert!(cat.models()[0].capabilities.supports_negative_prompt);
+        assert_eq!(cat.models()[0].capabilities.max_width, Some(384));
+        // Janus is autoregressive: no negative prompt, no step count.
+        assert!(!cat.models()[0].capabilities.supports_negative_prompt);
+        assert_eq!(cat.models()[0].capabilities.max_steps, None);
     }
 }


### PR DESCRIPTION
## Summary

Replace the broken \`pipeline('text-to-image', ...)\` call in \`t2i-engine.js\` with HF's blessed in-browser T2I path: **Janus-Pro-1B** (DeepSeek's unified multimodal model) driven via \`AutoProcessor\` + \`MultiModalityCausalLM.generate_images\` on \`@huggingface/transformers@3.7.1\`.

- Catalog model id: \`Xenova/sd-turbo\` → \`onnx-community/Janus-Pro-1B-ONNX\`.
- Capabilities updated: 384×384 output; \`supports_negative_prompt = false\`; \`max_steps = None\` (autoregressive token loop, not diffusion).
- transformers.js pin bumped from 3.0.0 → 3.7.1 (the version HF's official \`janus-pro-webgpu\` example uses; \`MultiModalityCausalLM\` was added there).
- 6 ONNX subgraphs loaded on WebGPU (\`prepare_inputs_embeds\` on WASM per HF's open WebGPU bug); FP16 fast path if WebGPU advertises \`shader-f16\`, else FP32/Q4 mixed dtype.

## Why

The previous wiring used \`pipeline('text-to-image', modelId, ...)\`. transformers.js — **even at the latest v4.2** — does not implement a \`text-to-image\` pipeline. Clicking Draw on PR #45 immediately threw:

> Unsupported pipeline: text-to-image. Must be one of [text-classification, ..., image-to-image, ...]

Janus-Pro is HF's officially-blessed browser T2I path. Reference impl: \`huggingface/transformers.js-examples/janus-pro-webgpu\`. Working public demo: \`huggingface.co/spaces/webml-community/janus-pro-webgpu\`.

\`@aislamov/diffusers.js\` and \`mlc-ai/web-stable-diffusion\` were evaluated and rejected: diffusers.js is 3-year-old and effectively unmaintained (demo domain offline); MLC's web-SD is not published on npm.

## Architecture notes

- 6 ONNX sessions share module-scoped state (\`_processor\` + \`_model\`). Both the SW-routed path (used by \`POST /b/image/api/generate\`) and the page-direct ESM exports use the same state.
- \`ProgressStreamer\` fires one progress frame per emitted image token (Janus emits 576 image tokens for a 384×384 output). SW-routed callers receive these as \`{ kind: 'progress', payload: { count, total, progress, time_ms } }\` frames; page-direct callers can pass \`onProgress\` to \`generateImage()\`.

## Hardware requirements (smoke testing)

This change requires either:
- A WebGPU adapter that advertises \`shader-f16\` (most NVIDIA Pascal+ / AMD RDNA / Apple Silicon) — fits Janus-Pro at FP16 inside WebGPU's 1 GB \`maxStorageBufferBindingSize\`, OR
- Enough device memory + relaxed WebGPU limits for the FP32 fallback (not generally available).

Headless Chromium and many integrated GPUs lack \`shader-f16\`; on those, generation will trap inside ORT-WASM with an allocation error. Local Playwright smoke from this branch confirmed: all 6 model subgraphs download cleanly and WebGPU session creation succeeds, then the FP32 fallback path runs out of headroom inside generation. Manual smoke on real hardware (discrete GPU) is the remaining gate.

## Test plan

- [x] \`cargo +nightly fmt\` — clean.
- [x] \`cargo test -p solobase-browser --lib image::\` — catalog test updated and passes.
- [x] \`cargo install --path crates/solobase --force\` — rebuilds the CLI's embedded \`static_assets()\` so \`solobase build\` writes the new \`t2i-engine.js\` to \`pkg/\`.
- [x] Playwright smoke (headless Chromium): plumbing works end-to-end through model download + ORT session creation; FP32 fallback traps on shader-f16-less adapter (expected).
- [ ] CI
- [ ] Manual smoke on a machine with \`shader-f16\` WebGPU — confirm PNG comes back.

## Follow-up

- The gizza-ai picker currently has \`IMAGE_MODEL_ID = 'Xenova/sd-turbo'\` hardcoded; needs a one-line bump + \`solobase-pin.txt\` bump in a small gizza-ai PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)