### PR TITLE
feat(files): explicit SQL migration files at block Init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,6 +5904,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5925,6 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5937,6 +5939,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5947,6 +5950,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5966,6 +5970,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5975,6 +5980,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5990,6 +5996,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6001,6 +6008,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6011,6 +6019,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde",
@@ -6022,6 +6031,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6031,6 +6041,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6045,6 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6062,6 +6074,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6071,6 +6084,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6081,6 +6095,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6095,6 +6110,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6105,6 +6121,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6121,6 +6138,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6132,6 +6150,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6148,6 +6167,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "serde",
  "serde_json",
@@ -6157,6 +6177,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6185,6 +6206,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,7 +5904,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5925,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5939,7 +5937,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5950,7 +5947,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5970,7 +5966,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5980,7 +5975,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5996,7 +5990,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6008,7 +6001,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6019,7 +6011,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde",
@@ -6031,7 +6022,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6041,7 +6031,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6056,7 +6045,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6074,7 +6062,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6084,7 +6071,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6095,7 +6081,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6110,7 +6095,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6121,7 +6105,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6138,7 +6121,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6150,7 +6132,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6167,7 +6148,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "serde",
  "serde_json",
@@ -6177,7 +6157,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6206,7 +6185,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bfdfba4fa4499300617ba8cf999c42bc09666049"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/files/migrations/001_initial_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/files/migrations/001_initial_schema.postgres.sql
@@ -1,0 +1,85 @@
+-- Initial files schema (Postgres parity — untested).
+-- Solobase deploys SQLite/D1 today; this file is included for parity with
+-- the auth-migrations pattern. Validate before enabling Postgres for files.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__buckets (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    public       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by   TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_buckets_created_by
+    ON suppers_ai__files__buckets (created_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__objects (
+    id            TEXT PRIMARY KEY,
+    bucket        TEXT NOT NULL,
+    key           TEXT NOT NULL,
+    size          BIGINT NOT NULL DEFAULT 0,
+    content_type  TEXT NOT NULL DEFAULT 'application/octet-stream',
+    status        TEXT NOT NULL DEFAULT 'complete',
+    uploaded_by   TEXT NOT NULL DEFAULT '',
+    uploaded_at   TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_objects_bucket_key
+    ON suppers_ai__files__objects (bucket, key);
+CREATE INDEX IF NOT EXISTS idx_objects_uploaded_by
+    ON suppers_ai__files__objects (uploaded_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__views (
+    id          TEXT PRIMARY KEY,
+    bucket      TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    user_id     TEXT NOT NULL DEFAULT '',
+    viewed_at   TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_views_user_id_viewed_at
+    ON suppers_ai__files__views (user_id, viewed_at);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_shares (
+    id                 TEXT PRIMARY KEY,
+    token              TEXT NOT NULL,
+    bucket             TEXT NOT NULL,
+    key                TEXT NOT NULL,
+    created_by         TEXT NOT NULL DEFAULT '',
+    expires_at         TEXT,
+    access_count       INTEGER NOT NULL DEFAULT 0,
+    max_access_count   INTEGER,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cloud_shares_token
+    ON suppers_ai__files__cloud_shares (token);
+CREATE INDEX IF NOT EXISTS idx_cloud_shares_created_by
+    ON suppers_ai__files__cloud_shares (created_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_access_logs (
+    id           TEXT PRIMARY KEY,
+    share_id     TEXT NOT NULL,
+    accessed_at  TEXT,
+    ip_address   TEXT NOT NULL DEFAULT '',
+    user_agent   TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cloud_access_logs_share_id
+    ON suppers_ai__files__cloud_access_logs (share_id);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_quotas (
+    id                    TEXT PRIMARY KEY,
+    user_id               TEXT NOT NULL,
+    max_storage_bytes     BIGINT NOT NULL DEFAULT 1073741824,
+    max_file_size_bytes   BIGINT NOT NULL DEFAULT 104857600,
+    max_files_per_bucket  INTEGER NOT NULL DEFAULT 10000,
+    reset_period_days     INTEGER NOT NULL DEFAULT 0,
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cloud_quotas_user_id
+    ON suppers_ai__files__cloud_quotas (user_id);

--- a/crates/solobase-core/src/blocks/files/migrations/001_initial_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/files/migrations/001_initial_schema.sqlite.sql
@@ -1,0 +1,84 @@
+-- Initial files schema. Run at block Init via db::ddl.
+-- Idempotent — every statement uses IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__buckets (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    public       INTEGER NOT NULL DEFAULT 0,
+    created_by   TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_buckets_created_by
+    ON suppers_ai__files__buckets (created_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__objects (
+    id            TEXT PRIMARY KEY,
+    bucket        TEXT NOT NULL,
+    key           TEXT NOT NULL,
+    size          INTEGER NOT NULL DEFAULT 0,
+    content_type  TEXT NOT NULL DEFAULT 'application/octet-stream',
+    status        TEXT NOT NULL DEFAULT 'complete',
+    uploaded_by   TEXT NOT NULL DEFAULT '',
+    uploaded_at   TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_objects_bucket_key
+    ON suppers_ai__files__objects (bucket, key);
+CREATE INDEX IF NOT EXISTS idx_objects_uploaded_by
+    ON suppers_ai__files__objects (uploaded_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__views (
+    id          TEXT PRIMARY KEY,
+    bucket      TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    user_id     TEXT NOT NULL DEFAULT '',
+    viewed_at   TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_views_user_id_viewed_at
+    ON suppers_ai__files__views (user_id, viewed_at);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_shares (
+    id                 TEXT PRIMARY KEY,
+    token              TEXT NOT NULL,
+    bucket             TEXT NOT NULL,
+    key                TEXT NOT NULL,
+    created_by         TEXT NOT NULL DEFAULT '',
+    expires_at         TEXT,
+    access_count       INTEGER NOT NULL DEFAULT 0,
+    max_access_count   INTEGER,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cloud_shares_token
+    ON suppers_ai__files__cloud_shares (token);
+CREATE INDEX IF NOT EXISTS idx_cloud_shares_created_by
+    ON suppers_ai__files__cloud_shares (created_by);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_access_logs (
+    id           TEXT PRIMARY KEY,
+    share_id     TEXT NOT NULL,
+    accessed_at  TEXT,
+    ip_address   TEXT NOT NULL DEFAULT '',
+    user_agent   TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cloud_access_logs_share_id
+    ON suppers_ai__files__cloud_access_logs (share_id);
+
+CREATE TABLE IF NOT EXISTS suppers_ai__files__cloud_quotas (
+    id                    TEXT PRIMARY KEY,
+    user_id               TEXT NOT NULL,
+    max_storage_bytes     INTEGER NOT NULL DEFAULT 1073741824,
+    max_file_size_bytes   INTEGER NOT NULL DEFAULT 104857600,
+    max_files_per_bucket  INTEGER NOT NULL DEFAULT 10000,
+    reset_period_days     INTEGER NOT NULL DEFAULT 0,
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cloud_quotas_user_id
+    ON suppers_ai__files__cloud_quotas (user_id);

--- a/crates/solobase-core/src/blocks/files/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/files/migrations/mod.rs
@@ -1,0 +1,164 @@
+//! Files block migrations. Applied from the block's `Init` lifecycle.
+//!
+//! SQL files are embedded with `include_str!`. Backend selection reads the
+//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
+//! Falls back to `sqlite` when the config block is not registered — the same
+//! default solobase-native applies.
+//!
+//! Statements are executed one-by-one through `wafer-run/database`'s typed
+//! `db::ddl` message contract — the WRAP-aware path that lets any
+//! attributable caller run `CREATE TABLE` / `CREATE INDEX` / `DROP TABLE`
+//! against its own (`{org}__{block}__*`) tables without an admin grant. The
+//! parser splits on bare `;` outside of `--` line comments. Embedded `;`
+//! inside string literals is NOT supported — the canonical migration files
+//! don't use any.
+
+use wafer_core::clients::{config, database as db};
+use wafer_run::context::Context;
+
+const SQL_001_SQLITE: &str = include_str!("001_initial_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_initial_schema.postgres.sql");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Sqlite,
+    Postgres,
+}
+
+async fn backend(ctx: &dyn Context) -> Backend {
+    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
+    match raw.to_ascii_lowercase().as_str() {
+        "postgres" => Backend::Postgres,
+        _ => Backend::Sqlite,
+    }
+}
+
+/// Apply all files migrations in order. Idempotent: every `CREATE TABLE` /
+/// `CREATE INDEX` uses `IF NOT EXISTS`.
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let b = backend(ctx).await;
+    apply_script(
+        ctx,
+        match b {
+            Backend::Sqlite => SQL_001_SQLITE,
+            Backend::Postgres => SQL_001_POSTGRES,
+        },
+    )
+    .await
+    .map_err(|e| format!("migration 001: {e}"))?;
+    Ok(())
+}
+
+/// Execute each statement in `sql` via `db::ddl`.
+async fn apply_script(ctx: &dyn Context, sql: &str) -> Result<(), String> {
+    for stmt in split_statements(sql) {
+        if !has_executable_content(&stmt) {
+            continue;
+        }
+        let trimmed = stmt.trim();
+        db::ddl(ctx, trimmed)
+            .await
+            .map_err(|e| format!("ddl failed on `{trimmed}`: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Split `sql` on `;` outside `--` line comments.
+fn split_statements(sql: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_line_comment = false;
+    for ch in sql.chars() {
+        if in_line_comment {
+            current.push(ch);
+            if ch == '\n' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if ch == '-' && current.ends_with('-') {
+            in_line_comment = true;
+            current.push(ch);
+            continue;
+        }
+        if ch == ';' {
+            out.push(std::mem::take(&mut current));
+            continue;
+        }
+        current.push(ch);
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Returns true if `stmt` contains at least one non-blank, non-comment line.
+fn has_executable_content(stmt: &str) -> bool {
+    stmt.lines().any(|line| {
+        let l = line.trim();
+        !l.is_empty() && !l.starts_with("--")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_executable_content, split_statements};
+
+    #[test]
+    fn empty_chunk_has_no_executable_content() {
+        assert!(!has_executable_content(""));
+        assert!(!has_executable_content("   \n  "));
+    }
+
+    #[test]
+    fn comment_only_chunk_is_skipped() {
+        assert!(!has_executable_content("-- one\n-- two\n"));
+    }
+
+    #[test]
+    fn ddl_with_leading_comment_is_executed() {
+        assert!(has_executable_content(
+            "-- header\nCREATE TABLE foo (id TEXT)"
+        ));
+    }
+
+    #[test]
+    fn split_ignores_semicolons_inside_line_comments() {
+        let sql = "-- Placeholder; text\nSELECT 1;";
+        let parts = split_statements(sql);
+        assert_eq!(parts.len(), 1);
+        assert!(parts[0].contains("SELECT 1"));
+    }
+
+    #[test]
+    fn split_handles_multiple_statements() {
+        let sql = "DROP TABLE foo;\nCREATE TABLE bar (id TEXT);\n";
+        let count = split_statements(sql)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn sql_files_split_into_expected_chunks() {
+        let sqlite_count = split_statements(super::SQL_001_SQLITE)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            sqlite_count, 14,
+            "sqlite migration: expected 14 statements, got {sqlite_count}"
+        );
+
+        let postgres_count = split_statements(super::SQL_001_POSTGRES)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            postgres_count, 14,
+            "postgres migration: expected 14 statements, got {postgres_count}"
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -1,4 +1,5 @@
 mod cloud;
+mod migrations;
 pub(crate) mod models;
 mod pages_admin;
 pub(crate) mod pages_user;
@@ -244,9 +245,17 @@ impl Block for FilesBlock {
 
     async fn lifecycle(
         &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
+        ctx: &dyn Context,
+        event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
+        if matches!(event.event_type, LifecycleType::Init) {
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("files migrations: {e}"),
+                )
+            })?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- New \`crates/solobase-core/src/blocks/files/migrations/\` directory mirroring auth + registry patterns.
- \`001_initial_schema.{sqlite,postgres}.sql\` — canonical schema for all 6 files-block tables with proper column types + 8 indexes.
- \`migrations/mod.rs\` — backend dispatch + statement splitter + 6 unit tests (asserts 14 statements per .sql file).
- Wired into \`FilesBlock::lifecycle\` for the \`LifecycleType::Init\` event.

Second block ported off \`ensure_table()\` auto-create (registry was first — site #23). Tracked under the \`ensure-table-removal-in-progress\` memory.

## Indexes materialized

| Table | Indexes |
|---|---|
| buckets | INDEX(created_by) |
| objects | UNIQUE(bucket, key) [upgraded from INDEX(bucket)], INDEX(uploaded_by) |
| views | INDEX(user_id, viewed_at) |
| cloud_shares | UNIQUE(token) [upgraded from INDEX(token)], INDEX(created_by) |
| cloud_access_logs | INDEX(share_id) |
| cloud_quotas | UNIQUE(user_id) |

8 indexes total — 4 from existing CollectionSchema + 4 audit-and-add additions for query patterns identified in storage.rs / pages_user.rs / cloud.rs.

## Deploy plan
Per the \`active-development-can-wipe-prod-db\` memory:

1. Merge this PR.
2. Drop the 6 files tables on wafer-site-prod:
   \`\`\`bash
   for t in buckets objects views cloud_shares cloud_access_logs cloud_quotas; do
     wrangler d1 execute wafer-site-prod --remote --command "DROP TABLE IF EXISTS suppers_ai__files__\$t"
   done
   \`\`\`
3. Redeploy via the standard wafer-run prod-deploy runbook.
4. Trigger Init by hitting any wafer.run route.
5. Verify the 8 indexes via \`wrangler d1 execute wafer-site-prod --remote --command "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name LIKE 'suppers_ai__files__%' AND name NOT LIKE 'sqlite_autoindex%'"\`.
6. Spot-check via \`EXPLAIN QUERY PLAN\` on a (bucket, key) lookup — should use \`idx_objects_bucket_key\`.

## Test plan
- [x] \`cargo check -p solobase-core\` clean
- [x] \`cargo test -p solobase-core --lib\` 556 → 562 (6 new migration unit tests)
- [x] \`cargo +nightly fmt --all\` no diff
- [x] \`cargo clippy --all-targets\` no new warnings (119 pre-existing unchanged)
- [ ] CI green
- [ ] Manual post-merge: D1 wipe + redeploy, verify indexes appear

## Risks / open questions
- Postgres migration file is **untested** — solobase deploys SQLite/D1 only.
- \`UNIQUE(bucket, key)\` on OBJECTS rejects duplicates. Pre-deploy check: query for any \`(bucket, key)\` collisions before wiping. Wiping per the deploy plan sidesteps this on prod; CI/dev environments should be checked if duplicates exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)