### PR TITLE
refactor(sql-utils): Phase 5 PR 2 — custom_tables CREATE TABLE via ddl::build_create_table

### DIFF
--- a/crates/solobase-core/src/blocks/admin/custom_tables.rs
+++ b/crates/solobase-core/src/blocks/admin/custom_tables.rs
@@ -71,6 +71,10 @@ async fn handle_list_tables(ctx: &dyn Context) -> OutputStream {
 }
 
 async fn handle_create_table(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    use wafer_core::interfaces::database::service::{
+        col_blob, col_datetime, col_float, col_int, col_text, default_now, pk, Column, Table,
+    };
+
     #[derive(serde::Deserialize)]
     struct Req {
         name: String,
@@ -93,32 +97,39 @@ async fn handle_create_table(ctx: &dyn Context, input: InputStream) -> OutputStr
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    // Sanitize name
+    // Sanitize name: keep only [A-Za-z0-9_] from the user-supplied suffix.
     let table_name = format!(
         "custom_{}",
         body.name
             .replace(|c: char| !c.is_alphanumeric() && c != '_', "")
     );
 
-    let mut col_defs = vec!["id TEXT PRIMARY KEY".to_string()];
-    for col in &body.columns {
-        let safe_name = col
-            .name
-            .replace(|c: char| !c.is_alphanumeric() && c != '_', "");
-        let safe_type = match col.col_type.to_uppercase().as_str() {
-            "TEXT" | "INTEGER" | "REAL" | "BLOB" => col.col_type.to_uppercase(),
-            _ => "TEXT".to_string(),
-        };
-        col_defs.push(format!("\"{}\" {}", safe_name, safe_type));
+    // Map a user-supplied SQL-flavoured type string to the builder column
+    // helper. Unknown types fall back to TEXT. User columns are nullable
+    // by default (matches the previous hand-written DDL).
+    fn user_column(name: &str, col_type: &str) -> Column {
+        let safe_name = name.replace(|c: char| !c.is_alphanumeric() && c != '_', "");
+        match col_type.to_uppercase().as_str() {
+            "INTEGER" => col_int(&safe_name).null(),
+            "REAL" => col_float(&safe_name).null(),
+            "BLOB" => col_blob(&safe_name).null(),
+            _ => col_text(&safe_name).null(),
+        }
     }
-    col_defs.push("created_at TEXT DEFAULT CURRENT_TIMESTAMP".to_string());
-    col_defs.push("updated_at TEXT DEFAULT CURRENT_TIMESTAMP".to_string());
 
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS \"{}\" ({})",
-        table_name,
-        col_defs.join(", ")
-    );
+    let mut table = Table::new(&table_name);
+    table.columns.push(pk("id"));
+    for col in &body.columns {
+        table.columns.push(user_column(&col.name, &col.col_type));
+    }
+    table
+        .columns
+        .push(col_datetime("created_at").def(default_now()));
+    table
+        .columns
+        .push(col_datetime("updated_at").def(default_now()));
+
+    let sql = ddl::build_create_table(&table, Backend::Sqlite);
 
     match db::exec_raw(ctx, &sql, &[]).await {
         Ok(_) => ok_json(&serde_json::json!({"table": table_name, "created": true})),


### PR DESCRIPTION
## Summary

Phase 5 PR 2 from \`workspace/SQL_UTILS_PLAN.md\`. The only hand-written SQL site in \`admin/database.rs\` + \`admin/custom_tables.rs\` was the \`CREATE TABLE\` in \`custom_tables::handle_create_table\`, which built column DDL by \`format!\`-and-concat:

\`\`\`rust
col_defs.push(format!("\"{}\" {}", safe_name, safe_type));
// ...
let sql = format!("CREATE TABLE IF NOT EXISTS \"{}\" ({})", table_name, col_defs.join(", "));
db::exec_raw(ctx, &sql, &[]).await
\`\`\`

Replaced with a \`Table\` built from the wafer-core schema helpers (\`pk\`, \`col_text\`, \`col_int\`, \`col_float\`, \`col_blob\`, \`col_datetime\`) and rendered through \`ddl::build_create_table(&table, Backend::Sqlite)\`.

## Behaviour preserved

- User-supplied columns stay nullable (\`.null()\`) — matches the previous DDL shape that had no \`NOT NULL\`.
- \`created_at\` / \`updated_at\` use \`DEFAULT CURRENT_TIMESTAMP\` via \`col_datetime(...).def(default_now())\` — renders as \`DATETIME DEFAULT CURRENT_TIMESTAMP\` in SQLite (NUMERIC affinity, stores the same TEXT timestamp the previous code did).
- \`id\` stays \`TEXT PRIMARY KEY\` via \`pk("id")\`.
- Type whitelist (\`TEXT\` / \`INTEGER\` / \`REAL\` / \`BLOB\`, unknown → \`TEXT\`) preserved via the local \`user_column()\` helper.

## What's *not* in this PR

The 7 remaining \`exec_raw\` / \`query_raw\` call sites in these two files were already builder-fed:

| Site | Builder |
|------|---------|
| database.rs:28, 47 | \`introspect::build_list_tables\` |
| database.rs:60 | \`introspect::build_table_row_count\` |
| database.rs:91 | \`introspect::build_table_info\` |
| database.rs:257 | **legitimate exception** — admin SQL explorer accepts user-typed read-only queries (\`validate_readonly_query\` gate) |
| custom_tables.rs:60 | \`introspect::build_list_tables_like\` |
| custom_tables.rs:155 | \`ddl::build_drop_table\` |

They stay as transports for builder-generated SQL, matching the plan's stated goal ("zero \`query_raw\` / \`exec_raw\` calls with **hand-written** SQL in block code").

## Verification

- \`cargo check -p solobase-core\` — clean.
- \`cargo test -p solobase-core --lib\` — 562 pass.
- No new wafer-run dependency: this PR uses \`ddl::build_create_table\` and the \`Table\` / column helpers already shipped on \`main\`.

## Test plan

- [ ] CI green.
- [ ] Manual smoke on \`/b/admin/custom-tables\`: create a table with mixed column types, insert/list/update/delete records, drop the table.