### PR TITLE
feat(vector): contextual retrieval via document-level LLM summary

### DIFF
--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -45,6 +45,25 @@ const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
 const DEFAULT_MODEL_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_MODEL";
 pub(super) const DEFAULT_PROVIDER: &str = "suppers-ai/provider-llm";
 
+/// Read the cross-block default LLM target — the `(provider_block, model)`
+/// pair other blocks (e.g. vector contextual retrieval) should use when they
+/// have no caller-supplied preference.
+///
+/// Returns `None` when no model is configured. The provider falls back to
+/// [`DEFAULT_PROVIDER`] if its env var is unset, but the model has no built-in
+/// default — operators must set `SUPPERS_AI__LLM__DEFAULT_MODEL` for a target
+/// to be available. Callers should treat `None` as "no LLM configured" and
+/// take a degraded path (skip the LLM step, return an error, etc.).
+pub(crate) async fn default_target(ctx: &dyn Context) -> Option<(String, String)> {
+    let provider = config::get_default(ctx, DEFAULT_PROVIDER_VAR, DEFAULT_PROVIDER).await;
+    let model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
+    if model.is_empty() || provider.is_empty() {
+        None
+    } else {
+        Some((provider, model))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Inter-block call helpers
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/vector/ingestion.rs
+++ b/crates/solobase-core/src/blocks/vector/ingestion.rs
@@ -2,19 +2,27 @@
 //!
 //! This module provides the building blocks used by the `POST
 //! /b/vector/api/ingest` route to split a document into embedding-sized
-//! chunks and (eventually) prepend per-chunk context summaries via an LLM.
+//! chunks and (optionally) prepend a short LLM-generated context summary
+//! to each chunk before embedding.
 //!
 //! The chunker is intentionally simple: we whitespace-split as a token
-//! proxy, which is close enough for bge-m3 / MiniLM at this granularity.
-//! A real tokenizer would drift by a handful of tokens per chunk but
-//! costs a dependency + runtime work that buys us nothing at ingest time.
+//! proxy. `vector/pages.rs::handle_ingest` ratio-adjusts the threshold by
+//! the embedder's BPE token count when available, so the whitespace
+//! approximation only sets the chunk shape, not its real BPE budget.
 //!
-//! `add_context` is a stub right now — it returns the chunks unchanged.
-//! Hooking it up to an LLM lives in a follow-up task; wiring the call
-//! into the ingest route today means the route doesn't have to change
-//! when that lands.
+//! `add_context` runs one LLM call per ingest (not per chunk — that would
+//! be N round-trips per document) to produce a document-level context
+//! summary, then prepends that summary to every chunk. This is a
+//! simplification of Anthropic's per-chunk contextual retrieval recipe
+//! and trades some precision for one wire call instead of N.
 
+use wafer_block::wire::llm::{
+    ChatContent, ChatMessage, ChatRequest, ChatRole, ChunkDelta,
+};
+use wafer_core::clients::llm;
 use wafer_run::{context::Context, types::WaferError};
+
+use crate::blocks::llm as llm_block;
 
 /// Approximate max tokens per chunk. We use whitespace-split as a proxy
 /// for tokenization — close enough for bge-m3 / MiniLM at this
@@ -64,25 +72,87 @@ pub fn chunk(text: &str, chunk_tokens: usize, overlap_ratio: f32) -> Vec<String>
     out
 }
 
-/// Prepend a context summary to each chunk using an LLM.
+/// Prepend a short LLM-generated context summary to each chunk.
 ///
-/// This is a scaffold: today it just returns the chunks unchanged so the
-/// ingest route can call into it without a surface-area change when the
-/// real LLM integration lands. `document` is the full source document
-/// (so a future implementation can ask the LLM to summarize each chunk
-/// in the context of the whole), `chunks` is the output of `chunk()`.
+/// Cost model: one LLM call per ingest (not per chunk). The call sees the
+/// full `document` and is asked for a 1–2 sentence summary; that single
+/// summary is prepended to every chunk. This is cheaper than the
+/// per-chunk Anthropic Contextual Retrieval recipe (which makes N LLM
+/// calls per document) at the cost of less per-chunk specificity.
+///
+/// Degrades silently — `chunks` is returned unchanged — when:
+///   * no LLM is configured (`SUPPERS_AI__LLM__DEFAULT_MODEL` empty),
+///   * the chat call errors (block not registered, transport failure, …),
+///   * the LLM returns no text (empty stream).
+///
+/// The ingest must not fail because the contextual step couldn't run; the
+/// raw chunks are still useful for retrieval.
 pub async fn add_context(
     ctx: &dyn Context,
     document: &str,
     chunks: Vec<String>,
 ) -> Result<Vec<String>, WaferError> {
-    // Explicitly discard the unused args to make the "stub for now"
-    // intent visible — rather than leaving `_ctx`/`_document` in the
-    // signature, which would mask future compiler warnings once those
-    // args start being used.
-    let _ = (ctx, document);
-    Ok(chunks)
+    if chunks.is_empty() {
+        return Ok(chunks);
+    }
+    let Some((provider, model)) = llm_block::default_target(ctx).await else {
+        tracing::debug!("contextual retrieval skipped: no default LLM model configured");
+        return Ok(chunks);
+    };
+
+    let request = ChatRequest {
+        backend_id: provider,
+        model,
+        messages: vec![
+            ChatMessage {
+                role: ChatRole::System,
+                content: ChatContent::Text(CONTEXTUAL_SYSTEM_PROMPT.into()),
+                tool_call_id: None,
+                tool_calls: Vec::new(),
+            },
+            ChatMessage {
+                role: ChatRole::User,
+                content: ChatContent::Text(document.into()),
+                tool_call_id: None,
+                tool_calls: Vec::new(),
+            },
+        ],
+        params: Default::default(),
+        tools: Vec::new(),
+        extra: serde_json::Value::Null,
+    };
+
+    let response_chunks = match llm::chat(ctx, &request).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, "contextual retrieval LLM call failed; skipping");
+            return Ok(chunks);
+        }
+    };
+
+    let mut context = String::new();
+    for chunk in response_chunks {
+        if let ChunkDelta::Text(t) = chunk.delta {
+            context.push_str(&t);
+        }
+    }
+    let context = context.trim();
+    if context.is_empty() {
+        return Ok(chunks);
+    }
+
+    Ok(chunks
+        .into_iter()
+        .map(|c| format!("{context}\n\n{c}"))
+        .collect())
 }
+
+const CONTEXTUAL_SYSTEM_PROMPT: &str = "\
+You are summarizing a document so retrieval excerpts from it are easier to \
+understand out of context. Return one or two short sentences describing what \
+the document is about and who or what it concerns. Do not preface with \
+\"This document\" or \"Summary:\" — write the description plainly. No \
+markdown, no bullet points, no quotes around the answer.";
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/vector/ingestion.rs
+++ b/crates/solobase-core/src/blocks/vector/ingestion.rs
@@ -16,12 +16,17 @@
 //! simplification of Anthropic's per-chunk contextual retrieval recipe
 //! and trades some precision for one wire call instead of N.
 
-use wafer_block::wire::llm::{
-    ChatContent, ChatMessage, ChatRequest, ChatRole, ChunkDelta,
-};
+// `blocks::llm` is feature-gated (`reqwest/stream` it pulls in for the SSE
+// provider conflicts with `worker`'s `wasm-streams` on wasm32). When the
+// feature is off we degrade silently — same fallback path as "no LLM
+// configured at runtime".
+#[cfg(feature = "llm")]
+use wafer_block::wire::llm::{ChatContent, ChatMessage, ChatRequest, ChatRole, ChunkDelta};
+#[cfg(feature = "llm")]
 use wafer_core::clients::llm;
 use wafer_run::{context::Context, types::WaferError};
 
+#[cfg(feature = "llm")]
 use crate::blocks::llm as llm_block;
 
 /// Approximate max tokens per chunk. We use whitespace-split as a proxy
@@ -87,6 +92,19 @@ pub fn chunk(text: &str, chunk_tokens: usize, overlap_ratio: f32) -> Vec<String>
 ///
 /// The ingest must not fail because the contextual step couldn't run; the
 /// raw chunks are still useful for retrieval.
+#[cfg(not(feature = "llm"))]
+pub async fn add_context(
+    ctx: &dyn Context,
+    document: &str,
+    chunks: Vec<String>,
+) -> Result<Vec<String>, WaferError> {
+    // wasm32 / no-LLM build: degrade silently — same fallback path as the
+    // `llm` feature build takes when no provider is configured.
+    let _ = (ctx, document);
+    Ok(chunks)
+}
+
+#[cfg(feature = "llm")]
 pub async fn add_context(
     ctx: &dyn Context,
     document: &str,
@@ -147,6 +165,7 @@ pub async fn add_context(
         .collect())
 }
 
+#[cfg(feature = "llm")]
 const CONTEXTUAL_SYSTEM_PROMPT: &str = "\
 You are summarizing a document so retrieval excerpts from it are easier to \
 understand out of context. Return one or two short sentences describing what \


### PR DESCRIPTION

handle_ingest already calls ingestion::add_context whenever the ingest
request sets `contextual: true`. Previously add_context was a stub
returning the chunks unchanged; this wires it to the LLM.

Design: one LLM call per ingest (not per chunk). The call sees the full
document and is asked for a one-or-two-sentence summary; that single
summary is prepended to every chunk before embedding. Cheaper than the
per-chunk Anthropic Contextual Retrieval recipe (which makes N calls
per document) at the cost of per-chunk specificity. Plan §1a settled
the closure refactor as YAGNI for the same reason — both layers favour
one wire call per document over N.

Degrades silently — chunks returned unchanged — on:
  - `SUPPERS_AI__LLM__DEFAULT_MODEL` not set (no LLM configured)
  - chat call error (block not registered, transport failure, …)
  - empty LLM response

Ingest must not fail because the contextual step couldn't run; the raw
chunks are still useful for retrieval.

Lifts the cross-block "what's the configured LLM target" lookup into
a new `blocks::llm::default_target(ctx) -> Option<(provider, model)>`
helper so vector/ingestion.rs doesn't reach for the env-var names
directly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes the §1b TODO in workspace/VECTOR_IMPLEMENTATION_PLAN.md.