### PR TITLE
chore: sync Cargo.lock — add hex to solobase-core deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4746,6 +4746,7 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.2.17",
+ "hex",
  "hkdf",
  "hmac",
  "js-sys",


### PR DESCRIPTION
## Summary
`solobase-core/Cargo.toml` has declared `hex = { workspace = true }` since PR #143 — `migration_helper.rs:174` uses `hex::encode` for SHA256 hashes — but the lockfile was never regenerated. Catching up now.

## Test plan
- [x] No code change; cargo-lock-only delta
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)