### PR TITLE
fix(security): products SEC-054, SEC-059, SEC-063 (regression restored)

### DIFF
--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -271,6 +271,21 @@ async fn handle_update_quota(ctx: &dyn Context, msg: &Message, input: InputStrea
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
+    // SEC-059: whitelist accepted quota fields — never forward arbitrary
+    // caller-controlled keys to `db::upsert`. Reject anything outside the
+    // known quota schema.
+    const ALLOWED_QUOTA_FIELDS: &[&str] = &[
+        "max_storage_bytes",
+        "max_file_size_bytes",
+        "max_files_per_bucket",
+        "reset_period_days",
+    ];
+    for key in body.keys() {
+        if !ALLOWED_QUOTA_FIELDS.contains(&key.as_str()) {
+            return err_bad_request(&format!("Unknown quota field: {key}"));
+        }
+    }
+
     let mut data = body;
     data.insert(
         "user_id".to_string(),

--- a/crates/solobase-core/src/blocks/products/pricing.rs
+++ b/crates/solobase-core/src/blocks/products/pricing.rs
@@ -44,6 +44,9 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
             .get("base_price")
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
+        if let Err(e) = validate_price(base_price) {
+            return err_bad_request(&e);
+        }
         let total = base_price * body.quantity as f64;
         return ok_json(&serde_json::json!({
             "unit_price": base_price,
@@ -68,6 +71,9 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
         Ok(p) => p,
         Err(e) => return err_bad_request(&format!("Formula evaluation error: {e}")),
     };
+    if let Err(e) = validate_price(unit_price) {
+        return err_bad_request(&e);
+    }
 
     // Check conditions
     let conditions = template.data.get("conditions");
@@ -88,6 +94,9 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
     } else {
         unit_price
     };
+    if let Err(e) = validate_price(final_price) {
+        return err_bad_request(&e);
+    }
 
     let total = final_price * body.quantity as f64;
 
@@ -99,6 +108,31 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
         "formula": formula,
         "variables_used": body.variables
     }))
+}
+
+/// Minimum acceptable price for a product (in display currency units).
+/// Anything below this is treated as an attempt at price manipulation or a
+/// formula bug, not a legitimate sale.
+pub const MIN_PRICE: f64 = 0.01;
+
+/// Validate an evaluated unit/final price.
+///
+/// Rejects NaN, non-finite values, and any price <= 0.0. Enforces a minimum
+/// of `MIN_PRICE` (1 cent). Returns a human-readable error suitable for
+/// `err_bad_request`.
+pub fn validate_price(price: f64) -> Result<(), String> {
+    if !price.is_finite() {
+        return Err("Invalid price: not a finite number".to_string());
+    }
+    if price <= 0.0 {
+        return Err("Invalid price: must be greater than zero".to_string());
+    }
+    if price < MIN_PRICE {
+        return Err(format!(
+            "Invalid price: must be at least {MIN_PRICE} (got {price})"
+        ));
+    }
+    Ok(())
 }
 
 /// Evaluate a simple pricing formula.

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -128,10 +128,11 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
                 .unwrap_or(0.0)
         };
 
-        // Reject negative or zero unit prices (prevent price manipulation via variables)
-        if unit_price < 0.0 {
+        // Reject non-positive / sub-minimum unit prices (prevent price manipulation
+        // via variables or zero-priced freebies sneaking past).
+        if let Err(e) = super::pricing::validate_price(unit_price) {
             return err_bad_request(&format!(
-                "Invalid price for product {}: price cannot be negative",
+                "Invalid price for product {}: {e}",
                 item.product_id
             ));
         }

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -224,11 +224,18 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
         );
         let revert_args = sea_values_to_json(revert_vals);
         let _ = db::exec_raw(ctx, &revert_sql, &revert_args).await;
+        // SEC-054: log full Stripe response server-side for diagnostics,
+        // but never forward Stripe's response body to the client — it can
+        // leak account configuration, API keys in error messages, internal
+        // resource IDs, etc.
         let err_body = String::from_utf8_lossy(&resp.body);
-        return err_internal(&format!(
-            "Stripe error ({}): {}",
-            resp.status_code, err_body
-        ));
+        tracing::error!(
+            status = resp.status_code,
+            body = %err_body,
+            purchase_id = %body.purchase_id,
+            "Stripe checkout session creation failed"
+        );
+        return err_internal("Payment processing error");
     }
 
     let session: serde_json::Value = match serde_json::from_slice(&resp.body) {

--- a/crates/solobase-core/src/blocks/products/tests/pricing_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/pricing_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::mock_context::*;
-use crate::blocks::products::pricing::evaluate_formula;
+use crate::blocks::products::pricing::{evaluate_formula, validate_price, MIN_PRICE};
 
 // ============================================================
 // Basic arithmetic
@@ -447,4 +447,55 @@ async fn calculate_price_with_conditions() {
     let out2 = pricing::handle_calculate(&ctx, input2).await;
     let body2 = output_to_json(out2).await;
     assert!((body2["unit_price"].as_f64().unwrap() - 8.0).abs() < 0.01);
+}
+
+// ============================================================
+// SEC-063: validate_price guard (regression test)
+// ============================================================
+
+#[test]
+fn validate_price_rejects_negative() {
+    let err = validate_price(-1.0).unwrap_err();
+    assert!(err.contains("greater than zero"), "got: {err}");
+}
+
+#[test]
+fn validate_price_rejects_zero() {
+    let err = validate_price(0.0).unwrap_err();
+    assert!(err.contains("greater than zero"), "got: {err}");
+}
+
+#[test]
+fn validate_price_rejects_negative_zero() {
+    let err = validate_price(-0.0).unwrap_err();
+    assert!(err.contains("greater than zero"), "got: {err}");
+}
+
+#[test]
+fn validate_price_rejects_below_minimum() {
+    let err = validate_price(0.005).unwrap_err();
+    assert!(err.contains("at least"), "got: {err}");
+}
+
+#[test]
+fn validate_price_accepts_minimum() {
+    assert!(validate_price(MIN_PRICE).is_ok());
+}
+
+#[test]
+fn validate_price_accepts_normal() {
+    assert!(validate_price(9.99).is_ok());
+    assert!(validate_price(1_000_000.0).is_ok());
+}
+
+#[test]
+fn validate_price_rejects_nan() {
+    let err = validate_price(f64::NAN).unwrap_err();
+    assert!(err.contains("finite"), "got: {err}");
+}
+
+#[test]
+fn validate_price_rejects_infinity() {
+    let err = validate_price(f64::INFINITY).unwrap_err();
+    assert!(err.contains("finite"), "got: {err}");
 }


### PR DESCRIPTION
## Summary

Restores a regressed price guard and tightens two other MEDIUM findings in the products surface.

- **SEC-063 (MEDIUM, REGRESSED)** `products/pricing.rs:67-89` — a refactor between 2026-04-10 and today deleted the `unit_price < 0.0` guard entirely, so negative and zero prices were silently accepted. Restored and tightened: new `validate_price()` helper rejects `<= 0.0`, non-finite, and anything below `MIN_PRICE = 0.01`. Applied to both `unit_price` and `final_price` in `handle_calculate`, the direct base-price path, and the `purchase.rs` line-item price check (which previously only rejected `< 0.0`).
- **SEC-054 (MEDIUM)** `products/stripe.rs:227-231` — `err_internal(&format!("Stripe error ({}): {}", ...))` forwarded Stripe's raw response body to the client (leaks account configuration, internal IDs, key fragments in error messages). Now logs full response server-side via `tracing::error!` and returns generic `err_internal("Payment processing error")` to the client.
- **SEC-059 (MEDIUM)** `files/cloud.rs:259-295` `handle_update_quota` — `HashMap<String, serde_json::Value>` body was forwarded straight to `db::upsert`. Added a whitelist of accepted quota fields (`max_storage_bytes`, `max_file_size_bytes`, `max_files_per_bucket`, `reset_period_days`) and rejects any key outside it.

See `docs/security-review-2026-04-10.md` §6 for current-code evidence.

## Test plan

- [x] `cargo build -p solobase-core` clean
- [x] `cargo test -p solobase-core --lib` — 567 passed (added 8 tests for `validate_price`)
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)