### PR TITLE
fix(security): admin/files quick wins (SEC-052/053/055/058/060/064)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/custom_tables.rs
+++ b/crates/solobase-core/src/blocks/admin/custom_tables.rs
@@ -97,18 +97,17 @@ async fn handle_create_table(ctx: &dyn Context, input: InputStream) -> OutputStr
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    // Sanitize name: keep only [A-Za-z0-9_] from the user-supplied suffix.
-    let table_name = format!(
-        "custom_{}",
-        body.name
-            .replace(|c: char| !c.is_alphanumeric() && c != '_', "")
-    );
+    // SEC-053: use the shared `sanitize_ident` helper so create + drop paths
+    // (and any future identifier-sanitization site) agree on what's allowed.
+    // Inline `replace(|c| !c.is_alphanumeric() && c != '_', "")` was an
+    // out-of-band rule that drifted from the drop path.
+    let table_name = format!("custom_{}", sanitize_ident(&body.name));
 
     // Map a user-supplied SQL-flavoured type string to the builder column
     // helper. Unknown types fall back to TEXT. User columns are nullable
     // by default (matches the previous hand-written DDL).
     fn user_column(name: &str, col_type: &str) -> Column {
-        let safe_name = name.replace(|c: char| !c.is_alphanumeric() && c != '_', "");
+        let safe_name = sanitize_ident(name);
         match col_type.to_uppercase().as_str() {
             "INTEGER" => col_int(&safe_name).null(),
             "REAL" => col_float(&safe_name).null(),

--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -172,6 +172,10 @@ pub(in crate::blocks::admin) fn validate_readonly_query(
         "COMMIT",
         "ROLLBACK",
         "RETURNING",
+        // SEC-052: reject WITH RECURSIVE — unbounded recursive CTEs are a
+        // cheap DoS vector against the admin SQL explorer. A plain
+        // (non-recursive) WITH is still allowed via the first-word check.
+        "RECURSIVE",
     ];
     for keyword in FORBIDDEN_KEYWORDS {
         let upper = query_upper.as_str();
@@ -284,6 +288,17 @@ mod tests {
         assert!(validate_readonly_query("UPDATE users SET x = 1").is_err());
         assert!(validate_readonly_query("DELETE FROM users").is_err());
         assert!(validate_readonly_query("SELECT 1; DROP TABLE users").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_recursive_cte() {
+        // SEC-052: unbounded recursive CTEs are a DoS vector.
+        assert!(validate_readonly_query(
+            "WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x) SELECT * FROM x"
+        )
+        .is_err());
+        // Plain (non-recursive) WITH still works.
+        assert!(validate_readonly_query("WITH x AS (SELECT 1) SELECT * FROM x").is_ok());
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -25,6 +25,17 @@ pub const VARIABLES_TABLE: &str = "suppers_ai__admin__variables";
 
 const MASKED_VALUE: &str = "********";
 
+/// SEC-060: unified sensitive-key check used by both `handle_list_full` and
+/// `handle_list`. A value is sensitive if the row's `sensitive` flag is 1
+/// OR the key name follows the `_SECRET` / `_KEY` suffix convention. Both
+/// listing endpoints must agree on this — the previous code masked on the
+/// suffix in `list_full` but only on the flag in `list`, so an admin who
+/// forgot to flip the `sensitive` flag on a `*_SECRET` key would have it
+/// leak through the lightweight listing.
+fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
+    sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
+}
+
 pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let action = msg.action();
     let path = msg.path();
@@ -117,9 +128,7 @@ async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
                 .iter()
                 .map(|record| {
                     let key = record.str_field("key").to_string();
-                    let is_sensitive = record.i64_field("sensitive") == 1
-                        || key.ends_with("_SECRET")
-                        || key.ends_with("_KEY");
+                    let is_sensitive = is_sensitive_key(&key, record.i64_field("sensitive"));
                     let is_system = key.starts_with("SOLOBASE_SHARED__");
                     // Mask sensitive values even in the "full" listing
                     let value = if is_sensitive {
@@ -152,7 +161,7 @@ async fn handle_list(ctx: &dyn Context) -> OutputStream {
             let mut settings = HashMap::new();
             for record in &records {
                 let key = record.str_field("key");
-                let is_sensitive = record.i64_field("sensitive") == 1;
+                let is_sensitive = is_sensitive_key(key, record.i64_field("sensitive"));
                 let value = if is_sensitive {
                     serde_json::Value::String(MASKED_VALUE.to_string())
                 } else {

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -32,7 +32,12 @@ pub async fn generate_share_token(
         serde_json::Value::String("share".to_string()),
     );
 
-    crypto::sign(ctx, &claims, Duration::from_secs(365 * 24 * 3600))
+    // SEC-055: share JWT lifetime — 30 days. The previous 1-year default
+    // gave any leaked share URL effectively unbounded validity. Users who
+    // need longer-lived shares can re-share; the typical use case (send
+    // a link, recipient downloads within hours/days) fits well under 30d.
+    const SHARE_TOKEN_TTL: Duration = Duration::from_secs(30 * 24 * 3600);
+    crypto::sign(ctx, &claims, SHARE_TOKEN_TTL)
         .await
         .map_err(|e| err_internal(&format!("Token generation failed: {e}")))
 }

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -107,9 +107,18 @@ async fn is_bucket_access_denied(ctx: &dyn Context, msg: &Message, bucket: &str)
 }
 
 /// Validate a storage key for path traversal attacks.
-/// Rejects keys containing `..`, absolute paths, or null bytes.
+/// Rejects keys containing `..`, absolute paths, null bytes, or backslashes.
+///
+/// SEC-064: backslash is rejected because backends running on Windows-style
+/// paths (or any backend that ever normalises `\` to `/`) would otherwise
+/// allow `..\..\etc\passwd`-style traversal that the `..` check alone would
+/// not catch when the segment separator is `\` instead of `/`.
 fn is_valid_storage_key(key: &str) -> bool {
-    !key.is_empty() && !key.contains("..") && !key.starts_with('/') && !key.contains('\0')
+    !key.is_empty()
+        && !key.contains("..")
+        && !key.starts_with('/')
+        && !key.contains('\0')
+        && !key.contains('\\')
 }
 
 /// Validate a bucket name. Must be non-empty, no path traversal, no slashes.

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -496,7 +496,32 @@ async fn handle_create_button(ctx: &dyn Context, input: InputStream) -> OutputSt
     ui::html_response(render_buttons_table(&buttons))
 }
 
+/// Validate that `id` is safe to interpolate into inline HTML/JS strings
+/// (DOM IDs, `getElementById` arguments, etc.). Rejects anything outside
+/// `[A-Za-z0-9_-]` and any string longer than 64 chars or empty.
+///
+/// Used by SEC-058: the userportal edit-button form inlines the record ID
+/// into a `script` block via `PreEscaped`, so it must not contain quotes,
+/// angle brackets, backslashes, or any other JS-syntax-significant chars.
+fn is_safe_dom_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 async fn handle_edit_button_form(ctx: &dyn Context, id: &str) -> OutputStream {
+    // SEC-058: the modal auto-show script below uses `PreEscaped(format!(...))`
+    // to inject the record ID into inline JS. A record returned from
+    // `db::get` should always have a well-formed ID (UUIDv7), but defensively
+    // reject any caller-supplied path segment that isn't strict
+    // `[a-zA-Z0-9_-]{1,64}` so the JS string interpolation can never be
+    // poisoned even if a future code path looks the record up by a
+    // non-validated identifier.
+    if !is_safe_dom_id(id) {
+        return err_not_found("Button not found");
+    }
     let record = match db::get(ctx, TABLE, id).await {
         Ok(r) => r,
         Err(_) => return err_not_found("Button not found"),


### PR DESCRIPTION
## Summary

Six small admin/files hardening fixes. Each is mechanical and scoped to the cited file. SEC-056 (atomic UPDATE for share access count) is **deferred**: it needs a new builder in `wafer-sql-utils`, which lands in a separate wafer-run PR — see below.

- **SEC-052** `admin/database.rs:143` — admin SQL explorer's `validate_readonly_query` allowed `WITH` but had no `RECURSIVE` filter, leaving an unbounded recursive-CTE DoS vector. Added `RECURSIVE` to `FORBIDDEN_KEYWORDS` (whole-word match). Plain (non-recursive) `WITH` still works.
- **SEC-053** `admin/custom_tables.rs:101` — create-table path used inline `.replace(|c| !c.is_alphanumeric() && c != '_', "")`, the drop path used `sanitize_ident` from `wafer-sql-utils`. Both paths (and the column-name sanitizer) now go through `sanitize_ident`.
- **SEC-055** `files/share.rs:35` — share-link JWT TTL shortened from 1 year to 30 days. A leaked share URL no longer has effectively unbounded validity. No `ConfigVar` was present for this; left as a constant for now.
- **SEC-058** `userportal/mod.rs:547` — `PreEscaped(format!("...getElementById('edit-btn-{id}')..."))` injected an unvalidated path-derived ID into inline JS. Added a defensive `is_safe_dom_id` check (rejects anything outside `[A-Za-z0-9_-]{1,64}`) before the DB lookup; in practice all real IDs are UUIDv7, but a path segment could otherwise carry quotes/`<`/backslash.
- **SEC-060** `admin/settings.rs:120` and `:155` — `list_full` masked on `sensitive == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")`, but `list` masked only on `sensitive == 1`. Both now use a shared `is_sensitive_key(key, flag)` helper, so a `*_SECRET` row with the flag missing still gets masked in both endpoints.
- **SEC-064** `files/storage.rs:111` — `is_valid_storage_key` rejected `..`, `/`, `\0` but not `\`. A backend that ever normalises `\` → `/` would have allowed `..\..\etc\passwd`-style traversal. Added `!key.contains('\\')`.

**SEC-056 deferred — flagged for separate wafer-run PR.** `share.rs:72-100` reads `access_count` then writes `access_count + 1`, a non-atomic increment that can lose updates under concurrent share access. `wafer-sql-utils` exposes no column-expression UPDATE builder (only `build_update_where(data: &[(String, Value)], …)` with literal values); the closest existing helper is `build_rate_limit_upsert`, which has its own column-shape requirements and doesn't match share table semantics. Adding `build_update_where_with_exprs` (or a dedicated `build_increment_field_where`) belongs in a wafer-run PR — landing it inline here would be a cross-repo workaround.

See `docs/security-review-2026-04-10.md` §6 for current-code evidence.

## Test plan

- [x] `cargo build -p solobase-core` clean
- [x] `cargo test -p solobase-core --lib` — 560 passed (added 1 test for `validate_readonly_query` recursive-CTE rejection + existing plain-WITH path)
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)