### PR TITLE
fix(security): gate CORS wildcard on discovery endpoints (SEC-073)

### DIFF
--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -5,7 +5,7 @@
 
 use futures::StreamExt;
 use wafer_block::stream::StreamEvent;
-use wafer_core::clients::database as db;
+use wafer_core::clients::{config as config_client, database as db};
 use wafer_run::{
     block::BlockInfo, context::Context, meta::*, streams::output::TerminalNotResponse, types::*,
     InputStream, OutputStream,
@@ -51,10 +51,23 @@ pub async fn handle_request(
             wafer_core::discovery::generate_agent_card(block_infos, project_name, "", &server_url)
         };
 
-        return ResponseBuilder::new()
-            .set_header("Cache-Control", "public, max-age=3600")
-            .set_header("Access-Control-Allow-Origin", "*")
-            .json(&body);
+        // [SEC-073] Only emit `Access-Control-Allow-Origin: *` in dev. These
+        // endpoints are intentionally public-discovery (no auth, anyone can
+        // GET them), but advertising `*` to every cross-origin caller in
+        // production lets unauthenticated browser code at any site map the
+        // whole solobase API surface — useful reconnaissance for a targeted
+        // attack. In prod we just omit the header; non-browser clients
+        // (curl, the agent runtime, server-side fetchers) don't care about
+        // CORS so they still see the body.
+        let environment =
+            config_client::get_default(ctx, "SOLOBASE_SHARED__ENVIRONMENT", "development").await;
+        let is_dev = environment.eq_ignore_ascii_case("development");
+
+        let mut resp = ResponseBuilder::new().set_header("Cache-Control", "public, max-age=3600");
+        if is_dev {
+            resp = resp.set_header("Access-Control-Allow-Origin", "*");
+        }
+        return resp.json(&body);
     }
 
     // 1. Strip /api prefix from resource path


### PR DESCRIPTION
## Summary

`pipeline.rs` previously set `Access-Control-Allow-Origin: *` unconditionally on the discovery endpoints (`/openapi.json` and `/.well-known/agent.json`). Even though those endpoints are intentionally public, advertising a wildcard CORS header to every cross-origin caller in production lets unauthenticated browser code at any third-party site enumerate the full solobase API surface — useful reconnaissance ahead of a targeted attack.

This PR reads `SOLOBASE_SHARED__ENVIRONMENT` (matches the existing convention used by `build_auth_cookie` for the `Secure` cookie flag) and only emits the wildcard when the value is `development`. In production the header is simply omitted; non-browser clients (curl, the agent runtime, server-side fetchers) don't enforce CORS so they still receive the body unchanged.

Cites SEC-073 from `docs/security-review-2026-04-10.md` §6.

## Test plan

- [x] `cargo build -p solobase-core`
- [x] `cargo test -p solobase-core` — 620 tests pass
- [x] `cargo +nightly fmt --all`
- [ ] Manual: `curl -i -H 'Origin: https://evil.com' https://wafer.run/.well-known/agent.json` — confirm no `Access-Control-Allow-Origin` header in prod response
- [ ] Manual: same request against a dev instance — confirm `Access-Control-Allow-Origin: *` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)