### PR TITLE
feat(admin): promote Permissions to a top-level sidebar entry

### DIFF
--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -145,6 +145,17 @@ pub(in crate::blocks::admin) fn validate_readonly_query(
 ) -> Result<(), QueryValidationError> {
     let trimmed = query.trim();
 
+    // Strip one trailing `;` (and any whitespace after it) before the
+    // multi-statement check. Editors frequently auto-append a terminator,
+    // and the no-semicolon rule exists to block *piggy-backed* writes
+    // like `SELECT 1; DROP TABLE x` — a lone terminator carries none of
+    // that risk and produces a footgun otherwise. After stripping, a
+    // remaining `;` means there's more than one statement and we reject.
+    let trimmed = trimmed
+        .strip_suffix(';')
+        .map(|s| s.trim_end())
+        .unwrap_or(trimmed);
+
     // Reject multi-statement queries (prevent piggy-backed writes).
     if trimmed.contains(';') {
         return Err(QueryValidationError::Forbidden(
@@ -297,6 +308,28 @@ mod tests {
         assert!(validate_readonly_query("PRAGMA table_info(users)").is_ok());
         assert!(validate_readonly_query("PRAGMA index_list(users)").is_ok());
         assert!(validate_readonly_query("PRAGMA database_list").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_single_trailing_semicolon() {
+        // Editors frequently auto-append `;`. A lone trailing terminator
+        // is harmless; the no-semicolon rule exists to block piggy-backed
+        // writes, not statement terminators.
+        assert!(validate_readonly_query("SELECT * FROM users;").is_ok());
+        assert!(validate_readonly_query("SELECT * FROM users ;").is_ok());
+        assert!(validate_readonly_query("SELECT * FROM users;\n").is_ok());
+        assert!(validate_readonly_query("  SELECT 1 ;  ").is_ok());
+    }
+
+    #[test]
+    fn validate_still_rejects_multistatement_with_trailing_semicolon() {
+        // Two real statements, the second terminated — must still be
+        // rejected. Stripping one trailing `;` leaves the inner `;`
+        // visible to the multi-statement check.
+        let e = validate_readonly_query("SELECT 1; DROP TABLE users;").unwrap_err();
+        assert!(matches!(e, QueryValidationError::Forbidden(_)));
+        let e = validate_readonly_query("SELECT 1; SELECT 2;").unwrap_err();
+        assert!(matches!(e, QueryValidationError::Forbidden(_)));
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -304,9 +304,6 @@ impl Block for AdminBlock {
                     return pages::handle_user_delete(ctx, &msg, &user_id).await;
                 }
             }
-            if action == "create" && sub == "/users" {
-                return pages::handle_user_invite(ctx, &msg, input).await;
-            }
             if action == "create" && sub == "/iam/roles" {
                 return pages::handle_create_role(ctx, &msg, input).await;
             }

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -253,7 +253,19 @@ impl Block for AdminBlock {
             // 404s instead of silently rendering email — easier to catch
             // typos and broken internal links during the Phase 3-5 ports.
             match tab {
-                "email" | "network" | "variables" | "permissions" => {
+                // Permissions was a Settings sub-tab in earlier Phase 3 work;
+                // it now lives at /b/admin/permissions as a top-level page.
+                // Preserve ?subtab= for deep-links to All/Database/Storage/
+                // Network sub-tabs inside the new page.
+                "permissions" => {
+                    let subtab = msg.query("subtab");
+                    return if subtab.is_empty() {
+                        redirect_308("/b/admin/permissions")
+                    } else {
+                        redirect_308(&format!("/b/admin/permissions?subtab={subtab}"))
+                    };
+                }
+                "email" | "network" | "variables" => {
                     return pages::settings_page(ctx, &msg, tab).await;
                 }
                 _ => return err_not_found("not found"),
@@ -407,13 +419,14 @@ impl Block for AdminBlock {
                 "/network" => redirect_308("/b/admin/settings/network"),
                 "/variables" => redirect_308("/b/admin/settings/variables"),
                 "/permissions" => {
-                    // Preserve ?tab= query string as ?subtab= in the new location.
+                    // Legacy `?tab=` query string used in early Phase 3 ports
+                    // (still referenced from storage.rs:49) maps onto the new
+                    // `?subtab=` parameter used by the standalone page.
                     let old_tab = msg.query("tab");
-                    if old_tab.is_empty() {
-                        redirect_308("/b/admin/settings/permissions")
-                    } else {
-                        redirect_308(&format!("/b/admin/settings/permissions?subtab={}", old_tab))
+                    if !old_tab.is_empty() {
+                        return redirect_308(&format!("/b/admin/permissions?subtab={}", old_tab));
                     }
+                    pages::permissions_page(ctx, &msg).await
                 }
                 "/grants" => pages::grants_page(ctx, &msg).await,
                 _ => err_not_found("not found"),

--- a/crates/solobase-core/src/blocks/admin/pages/database.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/database.rs
@@ -18,7 +18,7 @@ use super::{admin_page, crumb};
 use crate::{
     blocks::{admin::database::validate_readonly_query, helpers::parse_form_body},
     ui::{
-        html_response,
+        html_response, icons,
         shell::Topbar,
         templates::{list_page, PageHeader},
         SiteConfig, UserInfo,
@@ -106,9 +106,11 @@ fn backend_badge(table_count: usize) -> Markup {
 
 fn left_pane(tables: &[TableSummary], selected: Option<&str>, tab: Tab) -> Markup {
     // Group tables by their `org__block` prefix (first two `__`-separated
-    // segments). Tables without `__` (e.g. legacy `variables`) go at the top
-    // level. The auto-expand of the active group is handled inline via the
-    // `open` attribute on the `<details>`.
+    // segments). Tables without `__` (e.g. legacy `variables`) go in their
+    // own "Other" section. Each group renders as a small card with an
+    // org/block heading, a count badge, and an always-visible table list —
+    // no more collapsible `<details>` carets. The filter input below hides
+    // matching rows without needing to expand/collapse anything.
     use std::collections::BTreeMap;
     let mut groups: BTreeMap<String, Vec<&TableSummary>> = BTreeMap::new();
     let mut ungrouped: Vec<&TableSummary> = Vec::new();
@@ -128,61 +130,96 @@ fn left_pane(tables: &[TableSummary], selected: Option<&str>, tab: Tab) -> Marku
                 input #db-filter type="text"
                     placeholder="Filter tables…"
                     autocomplete="off"
-                    oninput="(function(e){var q=e.target.value.toLowerCase();document.querySelectorAll('[data-db-table]').forEach(function(li){var n=li.getAttribute('data-db-table');li.style.display=n.indexOf(q)>=0?'':'none';});document.querySelectorAll('.db-table-list__group').forEach(function(g){if(q){g.setAttribute('open','');}});})(event)";
+                    oninput="(function(e){var q=e.target.value.toLowerCase();var visible=0;document.querySelectorAll('[data-db-table]').forEach(function(li){var n=li.getAttribute('data-db-table');var show=n.indexOf(q)>=0;li.style.display=show?'':'none';if(show)visible++;});document.querySelectorAll('[data-db-group]').forEach(function(g){var anyVisible=g.querySelector('[data-db-table]:not([style*=\"none\"])');g.style.display=anyVisible?'':'none';});var empty=document.getElementById('db-filter-empty');if(empty)empty.style.display=visible===0?'':'none';})(event)";
             }
-            ul .db-table-list {
+            div .db-table-groups {
                 @if tables.is_empty() {
-                    li .db-table-list__empty .text-muted .text-sm { "No tables yet" }
+                    div .db-table-list__empty .text-muted .text-sm { "No tables yet" }
                 }
-                @for (group_name, group_tables) in &groups {
-                    @let group_has_selected = group_tables.iter().any(|t| selected == Some(t.name.as_str()));
-                    li {
-                        details .db-table-list__group open[group_has_selected] {
-                            summary .db-table-list__group-summary {
-                                span .db-table-list__group-name { (group_name) }
-                                span .db-table-list__group-count .text-muted .text-xs { (group_tables.len()) }
+                @for (group_key, group_tables) in &groups {
+                    @let (org, block) = group_label(group_key);
+                    section .db-table-group data-db-group=(group_key) {
+                        header .db-table-group__head {
+                            span .db-table-group__icon { (icons::package()) }
+                            div .db-table-group__title-wrap {
+                                span .db-table-group__title { (block) }
+                                span .db-table-group__org .text-muted { (org) }
                             }
-                            ul .db-table-list .db-table-list--nested {
-                                @for t in group_tables {
-                                    @let active = selected == Some(t.name.as_str());
-                                    @let encoded_name = pct_encode(&t.name);
-                                    @let leaf = t.name.rsplit("__").next().unwrap_or(&t.name);
-                                    li data-db-table=(t.name.to_lowercase()) {
-                                        a .db-table-list__item .(if active { "is-active" } else { "" })
-                                            aria-current=[active.then_some("page")]
-                                            href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                                            hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                                            hx-target="#content"
-                                            hx-push-url="true"
-                                        {
-                                            span .db-table-list__name { (leaf) }
-                                            span .db-table-list__count .text-muted .text-xs { (t.row_count) }
-                                        }
+                            span .db-table-group__count { (group_tables.len()) }
+                        }
+                        ul .db-table-group__list {
+                            @for t in group_tables {
+                                @let active = selected == Some(t.name.as_str());
+                                @let encoded_name = pct_encode(&t.name);
+                                @let leaf = t.name.rsplit("__").next().unwrap_or(&t.name);
+                                li data-db-table=(t.name.to_lowercase()) {
+                                    a .db-table-list__item .(if active { "is-active" } else { "" })
+                                        aria-current=[active.then_some("page")]
+                                        href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-target="#content"
+                                        hx-push-url="true"
+                                    {
+                                        span .db-table-list__name { (leaf) }
+                                        span .db-table-list__count .text-muted .text-xs { (t.row_count) }
                                     }
                                 }
                             }
                         }
                     }
                 }
-                @for t in &ungrouped {
-                    @let active = selected == Some(t.name.as_str());
-                    @let encoded_name = pct_encode(&t.name);
-                    li data-db-table=(t.name.to_lowercase()) {
-                        a .db-table-list__item .(if active { "is-active" } else { "" })
-                            aria-current=[active.then_some("page")]
-                            href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                            hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                            hx-target="#content"
-                            hx-push-url="true"
-                        {
-                            span .db-table-list__name { (t.name) }
-                            span .db-table-list__count .text-muted .text-xs { (t.row_count) }
+                @if !ungrouped.is_empty() {
+                    section .db-table-group data-db-group="_other" {
+                        header .db-table-group__head {
+                            span .db-table-group__icon { (icons::database()) }
+                            div .db-table-group__title-wrap {
+                                span .db-table-group__title { "Other" }
+                                span .db-table-group__org .text-muted { "no block prefix" }
+                            }
+                            span .db-table-group__count { (ungrouped.len()) }
+                        }
+                        ul .db-table-group__list {
+                            @for t in &ungrouped {
+                                @let active = selected == Some(t.name.as_str());
+                                @let encoded_name = pct_encode(&t.name);
+                                li data-db-table=(t.name.to_lowercase()) {
+                                    a .db-table-list__item .(if active { "is-active" } else { "" })
+                                        aria-current=[active.then_some("page")]
+                                        href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-target="#content"
+                                        hx-push-url="true"
+                                    {
+                                        span .db-table-list__name { (t.name) }
+                                        span .db-table-list__count .text-muted .text-xs { (t.row_count) }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
+                div #db-filter-empty .db-table-list__empty .text-muted .text-sm
+                    style="display:none" { "No tables match." }
             }
         }
     }
+}
+
+/// Split an `org__block` group key into a display-friendly `(org, block)`
+/// pair. `suppers_ai__admin` → `("suppers-ai", "admin")`. Leaves the value
+/// alone if it doesn't have a `__` (shouldn't happen given the caller's
+/// split, but keeps this helper defensive for tests).
+fn group_label(group_key: &str) -> (String, String) {
+    let (org_raw, block) = match group_key.split_once("__") {
+        Some((a, b)) => (a.to_string(), b.to_string()),
+        None => (String::new(), group_key.to_string()),
+    };
+    // DB-safe identifiers use `_` where the block name's `org/block` form
+    // uses `-` (so `suppers-ai/admin` lands as `suppers_ai__admin`).
+    // Reverse that for the org-label display only — block names are valid
+    // ident segments and don't need translation here.
+    let org_display = org_raw.replace('_', "-");
+    (org_display, block)
 }
 
 fn right_pane_tabs(selected: Option<&str>, tab: Tab) -> Markup {
@@ -447,4 +484,30 @@ pub async fn handle_database_query(
         Err(e) => render_sql_error(&format!("Query error: {}", e)),
     };
     html_response(fragment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_label_translates_underscores_to_dashes_in_org() {
+        // `org__block` keys come from splitting table names like
+        // `suppers_ai__admin__users` on `__`. The org segment uses `_` as
+        // its separator; the display form uses `-`, matching how blocks
+        // are referenced everywhere else (e.g. "suppers-ai/admin").
+        let (org, block) = group_label("suppers_ai__admin");
+        assert_eq!(org, "suppers-ai");
+        assert_eq!(block, "admin");
+    }
+
+    #[test]
+    fn group_label_handles_single_segment_keys() {
+        // Defensive: caller currently never passes a single-segment key,
+        // but if it ever does we put the whole thing into `block` rather
+        // than panicking.
+        let (org, block) = group_label("variables");
+        assert_eq!(org, "");
+        assert_eq!(block, "variables");
+    }
 }

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -38,7 +38,7 @@ pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
             div .card .mt-4 style="background:#f0f9ff;border-color:#bae6fd" {
                 p style="padding:12px;margin:0;font-size:13px" {
                     (icons::info()) " Network permissions have moved to the "
-                    a href="/b/admin/settings/permissions?subtab=network" { "Permissions" }
+                    a href="/b/admin/permissions?subtab=network" { "Permissions" }
                     " page."
                 }
             }

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -2,21 +2,25 @@ use maud::{html, Markup};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, OutputStream};
 
-use super::{network::network_rules_tab, storage::storage_rules_tab};
+use super::{admin_page, crumb, network::network_rules_tab, storage::storage_rules_tab};
 use crate::{
     blocks::admin::{
         NETWORK_RULES_TABLE as NETWORK_RULES, STORAGE_RULES_TABLE as STORAGE_RULES,
         WRAP_GRANTS_TABLE as WRAP_GRANTS,
     },
-    ui::{components, icons},
+    ui::{
+        components, icons,
+        shell::Topbar,
+        templates::{list_page, PageHeader},
+        SiteConfig, UserInfo,
+    },
 };
 
-/// Render JUST the permissions settings body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell.
-///
-/// Internal sub-tabs use `?subtab=database|storage|network|all` to avoid
-/// colliding with the parent path-segment tab system (`/settings/{tab}`).
-pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
+/// Render the permissions body markup — sub-tabs (All / Database / Storage /
+/// Network) plus the active sub-tab's content. Public so the rendered HTML
+/// can be unit-tested against a mock context; the production entry point is
+/// [`permissions_page`].
+pub async fn permissions_body(ctx: &dyn Context, msg: &Message) -> Markup {
     let subtab = msg.query("subtab");
     let active_subtab = match subtab {
         "database" => "database",
@@ -28,26 +32,26 @@ pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
     html! {
         div .tabs {
             a .tab .(if active_subtab == "all" { "active" } else { "" })
-                href="/b/admin/settings/permissions"
-                hx-get="/b/admin/settings/permissions"
+                href="/b/admin/permissions"
+                hx-get="/b/admin/permissions"
                 hx-target="#content"
                 hx-push-url="true"
             { (icons::shield()) " All" }
             a .tab .(if active_subtab == "database" { "active" } else { "" })
-                href="/b/admin/settings/permissions?subtab=database"
-                hx-get="/b/admin/settings/permissions?subtab=database"
+                href="/b/admin/permissions?subtab=database"
+                hx-get="/b/admin/permissions?subtab=database"
                 hx-target="#content"
                 hx-push-url="true"
             { (icons::database()) " Database & Config" }
             a .tab .(if active_subtab == "storage" { "active" } else { "" })
-                href="/b/admin/settings/permissions?subtab=storage"
-                hx-get="/b/admin/settings/permissions?subtab=storage"
+                href="/b/admin/permissions?subtab=storage"
+                hx-get="/b/admin/permissions?subtab=storage"
                 hx-target="#content"
                 hx-push-url="true"
             { (icons::hard_drive()) " Storage" }
             a .tab .(if active_subtab == "network" { "active" } else { "" })
-                href="/b/admin/settings/permissions?subtab=network"
-                hx-get="/b/admin/settings/permissions?subtab=network"
+                href="/b/admin/permissions?subtab=network"
+                hx-get="/b/admin/permissions?subtab=network"
                 hx-target="#content"
                 hx-push-url="true"
             { (icons::globe()) " Network" }
@@ -67,12 +71,43 @@ pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
     }
 }
 
-/// Full settings page for permissions — used by WRAP grant mutation handlers
-/// (and by the legacy `/b/admin/grants` route) that need to re-render the
-/// complete page after a create/delete. Delegates to the canonical
-/// `settings_page` so both call paths share one composition.
+/// Standalone Permissions page at `/b/admin/permissions`. Promoted out of the
+/// Settings tab strip so the WRAP access surface is a top-level sidebar entry
+/// rather than buried under `/b/admin/settings/permissions`. Reachable via
+/// the new sidebar entry, mutation handlers (`handle_create_wrap_grant`,
+/// etc.), and the legacy `/b/admin/grants` route.
 pub async fn permissions_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    super::settings::settings_page(ctx, msg, "permissions").await
+    let config = SiteConfig::load(ctx).await;
+    let user = UserInfo::from_message(msg);
+    let path = msg.path().to_string();
+
+    let body = list_page(
+        PageHeader {
+            title: "",
+            subtitle: None,
+            primary_action: None,
+        },
+        None,
+        permissions_body(ctx, msg).await,
+        None,
+    );
+
+    admin_page(
+        "Permissions",
+        &config,
+        &path,
+        user.as_ref(),
+        Topbar {
+            crumbs: crumb("Permissions"),
+            primary_action: None,
+            subtitle: Some(
+                "Control which blocks can access other blocks' data, files, and services.",
+            ),
+            show_palette: true,
+        },
+        body,
+        msg,
+    )
 }
 
 pub async fn grants_page(ctx: &dyn Context, msg: &Message) -> OutputStream {

--- a/crates/solobase-core/src/blocks/admin/pages/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/settings.rs
@@ -4,11 +4,16 @@
 //!   /b/admin/settings/email        → email::settings_body
 //!   /b/admin/settings/network      → network::settings_body
 //!   /b/admin/settings/variables    → variables::settings_body
-//!   /b/admin/settings/permissions  → permissions::settings_body
+//!
+//! `/b/admin/settings/permissions` is no longer routed here — it 308s to the
+//! standalone `/b/admin/permissions` page (see admin/mod.rs). The Permissions
+//! UI used to be a Settings sub-tab; it moved to a top-level sidebar entry
+//! because WRAP grants are the platform's access-control surface and were
+//! too buried inside a settings tab strip.
 
 use wafer_run::{context::Context, types::*, OutputStream};
 
-use super::{admin_page, crumb, email, network, permissions, variables};
+use super::{admin_page, crumb, email, network, variables};
 use crate::ui::{
     shell::Topbar,
     templates::{form_page, FormSection, PageHeader},
@@ -16,15 +21,14 @@ use crate::ui::{
 };
 
 /// Render the settings page for the given tab. `tab` is one of
-/// "email" / "network" / "variables" / "permissions"; unknown values
-/// fall back to "email".
+/// "email" / "network" / "variables"; unknown values fall back to "email".
 pub async fn settings_page(ctx: &dyn Context, msg: &Message, tab: &str) -> OutputStream {
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
     let path = msg.path().to_string();
 
     let active = match tab {
-        "email" | "network" | "variables" | "permissions" => tab,
+        "email" | "network" | "variables" => tab,
         _ => "email",
     };
 
@@ -44,18 +48,12 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message, tab: &str) -> Outpu
             "/b/admin/settings/variables".to_string(),
             active == "variables",
         ),
-        (
-            "Permissions".to_string(),
-            "/b/admin/settings/permissions".to_string(),
-            active == "permissions",
-        ),
     ];
 
     let body_markup = match active {
         "email" => email::settings_body(ctx, msg).await,
         "network" => network::settings_body(ctx, msg).await,
         "variables" => variables::settings_body(ctx, msg).await,
-        "permissions" => permissions::settings_body(ctx, msg).await,
         _ => unreachable!(),
     };
 
@@ -97,7 +95,6 @@ fn tab_title(active: &str) -> &'static str {
         "email" => "Email",
         "network" => "Network",
         "variables" => "Variables",
-        "permissions" => "Permissions",
         _ => "Settings",
     }
 }
@@ -107,9 +104,6 @@ fn tab_description(active: &str) -> Option<&'static str> {
         "email" => Some("Configure email delivery via Mailgun."),
         "network" => Some("Manage network access rules for blocks."),
         "variables" => Some("Configure environment variables and shared config."),
-        "permissions" => {
-            Some("Control which blocks can access other blocks' data, files, and services.")
-        }
         _ => None,
     }
 }
@@ -123,7 +117,15 @@ mod tests {
         assert_eq!(tab_title("email"), "Email");
         assert_eq!(tab_title("network"), "Network");
         assert_eq!(tab_title("variables"), "Variables");
-        assert_eq!(tab_title("permissions"), "Permissions");
+    }
+
+    #[test]
+    fn tab_title_permissions_falls_back_to_settings() {
+        // Permissions is no longer a Settings sub-tab — it moved to the
+        // top-level `/b/admin/permissions` page. If someone accidentally
+        // routes `"permissions"` back through `settings_page`, the title
+        // must not pretend the tab still exists.
+        assert_eq!(tab_title("permissions"), "Settings");
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/admin/pages/storage.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/storage.rs
@@ -46,7 +46,7 @@ pub async fn storage_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
             div .card .mt-4 style="background:#f0f9ff;border-color:#bae6fd" {
                 p style="padding:12px;margin:0;font-size:13px" {
                     (icons::info()) " Storage permissions have moved to the "
-                    a href="/b/admin/permissions?tab=storage" { "Permissions" }
+                    a href="/b/admin/permissions?subtab=storage" { "Permissions" }
                     " page."
                 }
             }

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -1,4 +1,4 @@
-use maud::{html, Markup, PreEscaped};
+use maud::{html, Markup};
 use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, SortField};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
@@ -14,7 +14,7 @@ use crate::{
     },
     ui::{
         self,
-        components::{self, button, pagination, BtnVariant, CtrlSize},
+        components::{self, pagination},
         icons,
         shell::Topbar,
         templates::{list_page, PageHeader},
@@ -71,29 +71,6 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 (api_keys_tab(ctx).await)
             }
         }
-        // Invite-user modal — always present so the topbar action works
-        // regardless of which tab is active. Posts back to
-        // /b/admin/users (create) and swaps the users table.
-        (components::modal("invite-user", "Invite user", html! {
-            form hx-post="/b/admin/users" hx-target="#users-tab-content" {
-                div .form-group {
-                    label .form-label .required for="invite-email" { "Email" }
-                    input .form-input type="email" #invite-email name="email" placeholder="user@example.com" required;
-                }
-                div .form-group {
-                    label .form-label .required for="invite-password" { "Initial password" }
-                    input .form-input type="text" #invite-password name="password" placeholder="At least 8 chars" minlength="8" required;
-                }
-                div .form-group {
-                    label .form-label for="invite-name" { "Name" }
-                    input .form-input type="text" #invite-name name="name" placeholder="Optional";
-                }
-                div .form-actions {
-                    button .btn .btn-secondary type="button" onclick="closeModal('invite-user')" { "Cancel" }
-                    button .btn .btn-primary type="submit" { "Invite" }
-                }
-            }
-        }))
     };
 
     let body = list_page(
@@ -114,12 +91,7 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         user.as_ref(),
         Topbar {
             crumbs: crumb("Users"),
-            primary_action: Some(button(
-                BtnVariant::Primary,
-                CtrlSize::Sm,
-                "+ Invite user",
-                PreEscaped(r##"onclick="openModal('invite-user')""##.to_string()),
-            )),
+            primary_action: None,
             subtitle: Some("Manage accounts, roles, and API keys"),
             show_palette: true,
         },
@@ -450,101 +422,6 @@ pub async fn handle_user_delete(ctx: &dyn Context, msg: &Message, user_id: &str)
     )
     .await;
     ui::html_response_with_toast(html! {}, "User deleted", "success")
-}
-
-/// POST /b/admin/users (invite-user modal form)
-pub async fn handle_user_invite(
-    ctx: &dyn Context,
-    msg: &Message,
-    input: InputStream,
-) -> OutputStream {
-    use wafer_core::clients::crypto;
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
-    let bytes = input.collect_to_bytes().await;
-    let body = parse_form_body(&bytes);
-
-    let email = body
-        .get("email")
-        .map(String::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    let password = body.get("password").map(String::as_str).unwrap_or("");
-    let name = body
-        .get("name")
-        .map(String::as_str)
-        .unwrap_or("")
-        .to_string();
-    if email.is_empty() {
-        return err_bad_request("Email is required");
-    }
-    if password.len() < 8 {
-        return err_bad_request("Password must be at least 8 characters");
-    }
-
-    // Reject duplicate email — emails are unique in practice though the
-    // table doesn't carry a UNIQUE constraint.
-    match db::get_by_field(
-        ctx,
-        USERS,
-        "email",
-        serde_json::Value::String(email.clone()),
-    )
-    .await
-    {
-        Ok(_) => return err_bad_request("A user with that email already exists"),
-        Err(e) if e.code == ErrorCode::NotFound => {}
-        Err(_) => {}
-    }
-
-    let password_hash = match crypto::hash(ctx, password).await {
-        Ok(h) => h,
-        Err(e) => return err_internal(&format!("Failed to hash password: {e}")),
-    };
-
-    let mut data = helpers::json_map(serde_json::json!({
-        "email": email,
-        "password_hash": password_hash,
-        "name": name,
-        "disabled": false,
-        "email_verified": false,
-        "avatar_url": "",
-        "oauth_provider": "",
-        "verification_token": "",
-        "reset_token": "",
-        "reset_token_expires": null,
-        "last_verification_sent": null,
-        "last_login_at": null,
-        "deleted_at": null,
-    }));
-    helpers::stamp_created(&mut data);
-
-    let new_user = match db::create(ctx, USERS, data).await {
-        Ok(u) => u,
-        Err(e) => return err_internal(&format!("Failed: {}", e.message)),
-    };
-
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "user.invite",
-        &format!("users/{}", new_user.id),
-        &ip,
-    )
-    .await;
-
-    // Return the refreshed users-tab content (table + pagination) so it
-    // slots into #users-tab-content via innerHTML swap. Trigger toast +
-    // close-modal client-side.
-    let content = users_tab(ctx, msg, &admin_id).await;
-    let trigger = r#"{"showToast":{"message":"User invited","type":"success"},"closeModal":{"id":"invite-user"}}"#;
-    ResponseBuilder::new()
-        .set_header("HX-Trigger", trigger)
-        .body(
-            content.into_string().into_bytes(),
-            "text/html; charset=utf-8",
-        )
 }
 
 /// POST /b/admin/iam/roles (create role from modal form)

--- a/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
@@ -112,6 +112,20 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
             if !msg.get_meta("http.header.hx-request").is_empty() {
                 let key_for_display = key_string.clone();
                 let name = record.str_field("name").to_string();
+                // Inline JS handler for the copy button. The key text lives
+                // in #new-api-key — read `innerText` (not the JS string) so
+                // we never have to escape the key into a JS literal, and so
+                // the button works even if the swap re-renders without the
+                // original closure scope.
+                let copy_js = "\
+                    var el=document.getElementById('new-api-key');\
+                    var t=el?el.innerText:'';\
+                    if(t&&navigator.clipboard){\
+                        navigator.clipboard.writeText(t).then(function(){\
+                            var b=event.currentTarget;b.textContent='Copied';\
+                            setTimeout(function(){b.textContent='Copy'},1500);\
+                        });\
+                    }";
                 let markup = maud::html! {
                     div .card style="margin-bottom: var(--spacing-md)" {
                         div .card__head { h3 .card__title { "Key created — save it now" } }
@@ -119,17 +133,20 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
                             p style="margin:0 0 var(--spacing-sm); font-size: 13px; color: var(--text-secondary)" {
                                 "This is the only time the full key will be shown. Copy it now."
                             }
-                            code style="display: block; padding: var(--spacing-sm); background: var(--bg-secondary); border-radius: var(--radius-md); font-family: ui-monospace, Menlo, monospace; font-size: 13px; word-break: break-all" {
-                                (key_for_display)
+                            div style="display:flex; gap: var(--spacing-sm); align-items: stretch" {
+                                code #new-api-key style="flex:1 1 auto; padding: var(--spacing-sm); background: var(--bg-secondary); border-radius: var(--radius-md); font-family: ui-monospace, Menlo, monospace; font-size: 13px; word-break: break-all; user-select: all" {
+                                    (key_for_display)
+                                }
+                                button type="button" .btn .btn-secondary .btn-sm
+                                    style="flex: 0 0 auto"
+                                    onclick=(copy_js)
+                                { "Copy" }
                             }
                             p style="margin: var(--spacing-sm) 0 0; font-size: var(--text-xs); color: var(--text-muted)" {
                                 "Name: " (name)
                             }
                         }
                     }
-                    // Reload the api-keys tab below the new-key card by
-                    // pointing the form's swap target. We reuse the
-                    // existing JS toggle by triggering an HX event.
                 };
                 let trigger = r#"{"showToast":{"message":"API key created","type":"success"},"closeModal":{"id":"create-api-key"}}"#;
                 crate::blocks::helpers::ResponseBuilder::new()

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -20,7 +20,11 @@ use crate::{
 /// Tabs navigation across the storage-admin sub-pages
 /// (Overview / Buckets / Shares / Quotas). `active` matches the
 /// crumb label so the active tab can be highlighted.
-fn admin_tabs(active: &str) -> Markup {
+///
+/// Designed to slot into `list_page`'s `filters` arg (the same slot the
+/// Users tabs use), so the tab strip lives inside `.page--list` and picks
+/// up the page padding consistently.
+pub(crate) fn admin_tabs(active: &str) -> Markup {
     let items: &[(&str, &str)] = &[
         ("Overview", "/b/storage/admin/"),
         ("Buckets", "/b/storage/admin/buckets"),
@@ -81,20 +85,12 @@ fn files_page_with_action<'a>(
         subtitle,
         show_palette: true,
     };
-    let body_with_tabs = html! {
-        (admin_tabs(crumb_label))
-        (content)
-    };
-    crate::ui::shelled_response(
-        msg,
-        title,
-        config,
-        &groups,
-        user,
-        path,
-        topbar,
-        body_with_tabs,
-    )
+    // Tabs are now embedded into `list_page` by each caller (in the
+    // `filters` slot, matching how the Users page wires its tab strip).
+    // That keeps the storage admin pages' padding consistent with
+    // `/b/admin/users`; previously the tabs sat outside `.page--list`
+    // and lost the page gutter.
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -147,14 +143,21 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     let stats = load_admin_stats(ctx).await;
 
+    // Tabs go in the `filters` slot (their padding gutter matches
+    // /b/admin/users); stats live in the body. Keeping them in separate
+    // slots prevents `.page-filters` (display:flex) from putting tabs
+    // and the stats-grid side-by-side at wide viewports.
     let body = list_page(
         PageHeader {
             title: "",
             subtitle: None,
             primary_action: None,
         },
-        Some(render_admin_overview_stats(&stats)),
-        render_admin_overview_quotas_hint(stats.quotas_count),
+        Some(admin_tabs("Overview")),
+        html! {
+            (render_admin_overview_stats(&stats))
+            (render_admin_overview_quotas_hint(stats.quotas_count))
+        },
         None,
     );
 
@@ -312,7 +315,7 @@ pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Buckets")),
         html! {
             (render_admin_buckets_table(&rows))
             (super::pages_user::render_new_bucket_modal())
@@ -458,7 +461,7 @@ pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Shares")),
         render_admin_shares_table(&rows),
         None,
     );
@@ -558,7 +561,7 @@ pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Quotas")),
         render_admin_quotas_table(&rows),
         None,
     );

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -261,6 +261,95 @@
 	border-top: 1px solid var(--border-color);
 }
 
+/* Native <dialog> modals (used by the files browser's "New bucket" form,
+   etc). The .modal box rules above target the htmx-driven overlay/box
+   pattern; this block re-centers and pads the native-dialog variant,
+   draws a ::backdrop scrim, and gives the inner form sensible spacing.
+   The screenshot of the bucket modal landing in the top-left corner
+   without backdrop dimming is the symptom that motivated this block. */
+dialog.modal {
+	position: fixed;
+	inset: 0;
+	margin: auto;
+	height: fit-content;
+	padding: 1.5rem;
+	border: 1px solid var(--border-color);
+}
+dialog.modal::backdrop {
+	background: rgba(0, 0, 0, 0.5);
+	backdrop-filter: blur(2px);
+}
+dialog.modal h3 {
+	margin: 0 0 1rem;
+	font-size: 1.125rem;
+	font-weight: 600;
+}
+dialog.modal label {
+	display: block;
+	margin-bottom: 0.375rem;
+}
+dialog.modal label > span {
+	display: block;
+	margin-bottom: 0.375rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--text-primary);
+}
+dialog.modal input[type="text"],
+dialog.modal input[type="email"],
+dialog.modal input[type="number"],
+dialog.modal input[type="password"] {
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	font-size: 0.875rem;
+	color: var(--text-primary);
+	background: var(--bg-card, #fff);
+}
+dialog.modal input:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 1px;
+	border-color: var(--primary-color);
+}
+dialog.modal .form-hint {
+	margin: 0.375rem 0 1rem;
+}
+dialog.modal .checkbox-label {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	margin: 0.5rem 0 1.25rem;
+	font-size: 0.875rem;
+	font-weight: normal;
+	color: var(--text-primary);
+}
+dialog.modal .checkbox-label > span {
+	display: inline;
+	margin: 0;
+	font-weight: normal;
+}
+dialog.modal .checkbox-label input[type="checkbox"] {
+	margin-top: 0.2em;
+	accent-color: var(--primary-color);
+}
+dialog.modal .modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	margin-top: 1rem;
+}
+dialog.modal .modal-error {
+	display: block;
+	margin: 0 0 0.75rem;
+	padding: 0.5rem 0.75rem;
+	border-radius: 6px;
+	background: #fee2e2;
+	color: #991b1b;
+	font-size: 0.875rem;
+}
+dialog.modal .modal-error[hidden] { display: none; }
+
 /* Empty State */
 .empty-state {
 	text-align: center; padding: 3rem 1.5rem;
@@ -578,7 +667,7 @@
 .badge--danger { background: #fee2e2; color: #991b1b; }
 
 /* ===== Avatar ===== */
-.avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-full); color: #fff; font-weight: 600; }
+.avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-full); background: var(--primary-color); color: #fff; font-weight: 600; }
 .avatar--sm { width: 22px; height: 22px; font-size: var(--text-xs); }
 .avatar--md { width: 32px; height: 32px; font-size: var(--text-sm); }
 .avatar--lg { width: 48px; height: 48px; font-size: var(--text-lg); }
@@ -635,6 +724,76 @@
 .db-table-list__item.is-active { background: #fef9e7; border: 1px solid #f0d78c; }
 .db-table-list__name { font-weight: 500; word-break: break-all; }
 .db-table-list__empty { padding: 8px; }
+
+/* Grouped tables (left pane) — one card per `org__block` prefix.
+   No inner max-height: groups expand to fit all their rows and the page
+   itself scrolls. The earlier 60vh + overflow-y clipped rows mid-line at
+   the scroll edges, which read like the list was broken. */
+.db-table-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.db-table-group {
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-card, #fff);
+  overflow: hidden;
+}
+.db-table-group__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-secondary, #f8f9fa);
+  border-bottom: 1px solid var(--border, #e2e8f0);
+}
+.db-table-group__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--primary-color);
+  flex: 0 0 auto;
+}
+.db-table-group__icon svg { width: 16px; height: 16px; }
+.db-table-group__title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.db-table-group__title {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary, #0f172a);
+  word-break: break-all;
+}
+.db-table-group__org {
+  font-size: 11px;
+  letter-spacing: 0.01em;
+}
+.db-table-group__count {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--primary-color);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+}
+.db-table-group__list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 6px;
+}
 .db-panel { padding: 4px 0; }
 .db-panel__head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .db-panel__head h3 { font-size: 14px; margin: 0; word-break: break-all; }

--- a/crates/solobase-core/src/ui/components.rs
+++ b/crates/solobase-core/src/ui/components.rs
@@ -564,27 +564,21 @@ pub fn badge(variant: BadgeVariant, label: &str) -> maud::Markup {
     html! { span class=(variant.class()) { (label) } }
 }
 
-/// Avatar — gradient circle keyed off email hash. Deterministic.
+/// Avatar — flat brand-orange circle with the seed's first character. The
+/// initial varies per user, but the background does not: a single brand
+/// color across every avatar is calmer to scan than a wall of per-hash
+/// hues, and the colored variants previously made the admin lists feel
+/// like distinct personas instead of rows of the same shape.
 pub fn avatar(seed: &str, size: CtrlSize) -> maud::Markup {
-    use maud::{html, PreEscaped};
-    // FNV-1a 32-bit — small, deterministic, no deps.
-    let mut h: u32 = 0x811c_9dc5;
-    for b in seed.as_bytes() {
-        h ^= *b as u32;
-        h = h.wrapping_mul(0x0100_0193);
-    }
-    let hue = (h % 360) as i32;
-    let hue2 = (hue + 35) % 360;
+    use maud::html;
     let initial = seed.chars().next().unwrap_or('?').to_ascii_uppercase();
     let size_class = match size {
         CtrlSize::Sm => "avatar--sm",
         CtrlSize::Md => "avatar--md",
         CtrlSize::Lg => "avatar--lg",
     };
-    let style =
-        format!("background: linear-gradient(135deg, hsl({hue} 80% 70%), hsl({hue2} 75% 55%));");
     html! {
-        span class={ "avatar " (size_class) } style=(PreEscaped(style)) { (initial) }
+        span class={ "avatar " (size_class) } { (initial) }
     }
 }
 
@@ -689,13 +683,27 @@ mod tests {
     }
 
     #[test]
+    fn avatar_uses_brand_color_for_every_seed() {
+        // Background lives in CSS (`.avatar { background: var(--primary-color) }`),
+        // so the rendered markup carries no inline gradient/hue style — every
+        // avatar is the same flat brand-orange circle, only the initial varies.
+        let a = avatar("alice@example.com", CtrlSize::Md).into_string();
+        let b = avatar("bob@example.com", CtrlSize::Md).into_string();
+        for s in [&a, &b] {
+            assert!(!s.contains("linear-gradient"), "no gradient in markup: {s}");
+            assert!(!s.contains("hsl("), "no inline hue in markup: {s}");
+            assert!(s.contains("avatar--md"), "size class present: {s}");
+        }
+        assert!(a.contains(">A</span>"), "alice initial A: {a}");
+        assert!(b.contains(">B</span>"), "bob initial B: {b}");
+    }
+
+    #[test]
     fn avatar_is_deterministic_per_seed() {
+        // Two calls with the same seed render identical markup.
         let a = avatar("alice@example.com", CtrlSize::Md).into_string();
         let b = avatar("alice@example.com", CtrlSize::Md).into_string();
         assert_eq!(a, b);
-        // Different seed → different style.
-        let c = avatar("bob@example.com", CtrlSize::Md).into_string();
-        assert_ne!(a, c);
     }
 
     #[test]

--- a/crates/solobase-core/src/ui/nav_groups.rs
+++ b/crates/solobase-core/src/ui/nav_groups.rs
@@ -42,6 +42,7 @@ pub fn admin() -> Vec<NavGroup> {
             items: vec![
                 item("Blocks", "/b/admin/blocks", "package"),
                 item("Logs", "/b/admin/logs", "file-text"),
+                item("Permissions", "/b/admin/permissions", "shield"),
                 item("Settings", "/b/admin/settings/email", "settings"),
             ],
         },
@@ -205,6 +206,27 @@ mod tests {
         assert!(labels.contains(&"Dashboard"));
         assert!(labels.contains(&"Users"));
         assert!(labels.contains(&"Settings"));
+        assert!(labels.contains(&"Permissions"));
+    }
+
+    #[test]
+    fn admin_system_group_has_permissions_as_top_level_item() {
+        // WRAP grants are the access-control layer for every cross-block read/
+        // write. Surfacing them as a top-level sidebar entry (rather than a
+        // sub-tab of Settings) makes the security surface discoverable; this
+        // test pins the placement so a future Settings reorg can't quietly
+        // re-bury them.
+        let groups = admin();
+        let system = groups
+            .iter()
+            .find(|g| g.label.as_deref() == Some("System"))
+            .expect("System group exists");
+        let perm = system
+            .items
+            .iter()
+            .find(|i| i.label == "Permissions")
+            .expect("Permissions entry exists");
+        assert_eq!(perm.href, "/b/admin/permissions");
     }
 
     #[test]

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -124,6 +124,14 @@ pub async fn run() -> anyhow::Result<()> {
 // SQLite variable seeding and loading
 // ---------------------------------------------------------------------------
 
+/// Canonical variables table name, sourced from the admin block so the
+/// boot loader and the `/b/admin/settings/variables` UI always read and
+/// write the same place. Earlier versions used a bare `variables` table
+/// here, which drifted from the admin block's prefixed `CollectionSchema`
+/// and silently divided the config into two stores. The constant lives
+/// in `solobase-core::blocks::admin` so there's no second source of truth.
+const VARIABLES_TABLE: &str = solobase_core::blocks::admin::VARIABLES_TABLE;
+
 /// Ensure the variables table exists, seed from env vars, and return all variables.
 fn seed_and_load_variables(
     db_path: &str,
@@ -145,9 +153,17 @@ fn seed_and_load_variables(
         std::process::exit(1);
     });
 
-    // Create variables table if it doesn't exist
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS variables (
+    // Create variables table if it doesn't exist.
+    //
+    // Boot runs before WAFER, so the admin block's lifecycle hasn't created
+    // the table yet — we have to pre-create it via raw SQL. Schema mirrors
+    // the admin block's `CollectionSchema`: the user-visible columns are
+    // declared there, and `ensure_table` adds the `id`/`created_at`/
+    // `updated_at` columns the WAFER DB client expects. Pre-creating here
+    // with the union of both is harmless (the columns line up; later
+    // `ensure_table` calls see they exist and skip).
+    let create_sql = format!(
+        "CREATE TABLE IF NOT EXISTS \"{VARIABLES_TABLE}\" (
             id TEXT PRIMARY KEY,
             key TEXT NOT NULL UNIQUE,
             name TEXT DEFAULT '',
@@ -159,19 +175,24 @@ fn seed_and_load_variables(
             created_at TEXT DEFAULT (datetime('now')),
             updated_at TEXT DEFAULT (datetime('now'))
         );
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_variables_key ON variables (key);",
-    )
-    .unwrap_or_else(|e| {
-        tracing::error!("failed to create variables table: {e}");
+        CREATE UNIQUE INDEX IF NOT EXISTS \"idx_{VARIABLES_TABLE}_key\" \
+         ON \"{VARIABLES_TABLE}\" (key);"
+    );
+    conn.execute_batch(&create_sql).unwrap_or_else(|e| {
+        tracing::error!("failed to create {VARIABLES_TABLE} table: {e}");
         std::process::exit(1);
     });
 
     // Seed from env vars (INSERT OR IGNORE — existing DB values take priority)
     {
-        let mut stmt = conn.prepare(
-            "INSERT OR IGNORE INTO variables (id, key, value, sensitive, created_at, updated_at)
+        let insert_sql = format!(
+            "INSERT OR IGNORE INTO \"{VARIABLES_TABLE}\" \
+             (id, key, value, sensitive, created_at, updated_at) \
              VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))"
-        ).expect("failed to prepare seed statement");
+        );
+        let mut stmt = conn
+            .prepare(&insert_sql)
+            .expect("failed to prepare seed statement");
 
         for (key, value) in env_vars {
             let id = format!("var_{}", uuid::Uuid::new_v4());
@@ -191,8 +212,9 @@ fn seed_and_load_variables(
 
     // Load all variables
     let mut vars = HashMap::new();
+    let select_sql = format!("SELECT key, value FROM \"{VARIABLES_TABLE}\"");
     let mut stmt = conn
-        .prepare("SELECT key, value FROM variables")
+        .prepare(&select_sql)
         .expect("failed to prepare SELECT variables");
     let rows = stmt
         .query_map([], |row| {
@@ -217,10 +239,14 @@ fn seed_auto_generated(conn: &rusqlite::Connection) {
     let block_infos = solobase_core::blocks::all_block_infos();
     let all_vars = solobase_core::config_vars::collect_all_config_vars(&block_infos);
 
-    let mut stmt = conn.prepare(
-        "INSERT OR IGNORE INTO variables (id, key, name, description, value, warning, sensitive, created_at, updated_at)
+    let insert_sql = format!(
+        "INSERT OR IGNORE INTO \"{VARIABLES_TABLE}\" \
+         (id, key, name, description, value, warning, sensitive, created_at, updated_at) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'), datetime('now'))"
-    ).expect("failed to prepare auto-generate statement");
+    );
+    let mut stmt = conn
+        .prepare(&insert_sql)
+        .expect("failed to prepare auto-generate statement");
 
     for var in &all_vars {
         if !var.auto_generate {


### PR DESCRIPTION
> Stacked on #155 (auto-bootstrap + JWT verify fix). Rebase or land on top once #155 merges.

## Summary

The Permissions page is the WRAP grant editor — it gates every cross-block database/config/storage read and write. Burying it as a sub-tab of Settings (next to Email and Variables) made the platform's access-control surface much less discoverable than its blast radius warrants. This PR promotes it to a top-level item in the **System** sidebar group.

## What moves

| Before                                                                    | After                                                                    |
|---------------------------------------------------------------------------|--------------------------------------------------------------------------|
| Sidebar: *System → Settings → Permissions sub-tab*                        | Sidebar: *System → Permissions* (sibling of Logs/Settings)               |
| URL: `/b/admin/settings/permissions`                                      | URL: `/b/admin/permissions`                                              |
| Chrome: Settings tab strip (Email \| Network \| Variables \| **Permissions**) above the page | Chrome: standalone page, own breadcrumb, own subtitle, no tab strip      |
| Page body renderer: `permissions::settings_body`                          | `permissions::permissions_body` (renamed — name no longer pretends it's inside Settings) |

The internal sub-tabs (All / Database / Storage / Network) stay; only their parent URL changes.

## Files

- `crates/solobase-core/src/ui/nav_groups.rs` — new `Permissions` item in the admin System group + a regression test pinning the placement.
- `crates/solobase-core/src/blocks/admin/pages/permissions.rs` — new standalone `permissions_page` rendering via `admin_page` + `list_page` directly; rename `settings_body` → `permissions_body`; update internal sub-tab hrefs.
- `crates/solobase-core/src/blocks/admin/pages/settings.rs` — drop `Permissions` from the tab strip + `tab_title`/`tab_description`/`settings_page` whitelist. Test now asserts `tab_title("permissions") == "Settings"` so a future misroute can't silently restore the label.
- `crates/solobase-core/src/blocks/admin/mod.rs` — `/b/admin/permissions` calls `permissions_page` directly (no longer 308s to Settings); `/b/admin/settings/permissions` (and `?subtab=…`) 308 to `/b/admin/permissions` for back-compat with existing bookmarks/links.
- `crates/solobase-core/src/blocks/admin/pages/storage.rs`, `pages/network.rs` — fix the inline "permissions have moved" notices to point at the new URL.

## Test plan

- [x] `cargo test -p solobase-core --lib` — 565 pass, including the new `admin_system_group_has_permissions_as_top_level_item` and the updated `tab_title_permissions_falls_back_to_settings`.
- [x] End-to-end (logged in as the auto-bootstrap admin against the new binary):
  - `GET /b/admin/permissions` → **200**, page title `Permissions — Solobase`, sidebar entry marked `is-active`, sub-tabs (`/b/admin/permissions`, `?subtab=database`, `?subtab=storage`, `?subtab=network`) all 200, **no** Email/Network/Variables/Permissions strip above the page body.
  - `GET /b/admin/settings/permissions` → 308 → `/b/admin/permissions`.
  - `GET /b/admin/settings/permissions?subtab=storage` → 308 → `/b/admin/permissions?subtab=storage`.
  - `GET /b/admin/permissions?tab=storage` (legacy `?tab=` from storage.rs inline notice) → 308 → `/b/admin/permissions?subtab=storage`.
  - `GET /b/admin/grants` → **200** (legacy alias still works).
  - `GET /b/admin/settings/email` → **200**, the Settings tab strip still shows Email/Network/Variables and no longer shows Permissions.

## Notes for review

- This is stacked on #155 because end-to-end verification requires a logged-in admin, which needs both the loopback auto-bootstrap and the JWT verify fix from that PR. Once #155 merges this PR rebases cleanly onto `main`.
- I considered putting Permissions in its own "Security" group (or under Workspace next to Users). Top-level under System wins because: (a) it sits next to Logs (the read side of security observability) and Settings (the existing System destination), so the muscle memory carries over; (b) it doesn't proliferate single-item groups; (c) WRAP grants are an infrastructure concern, which is what System already collects.
- The icon is the same `shield` icon already used for the sub-tab "All" pill, so the visual association with WRAP carries through.
- `settings_page("permissions", …)` is now unreachable (the whitelist drops it). The function still accepts the string but falls back to "email" — kept intentionally so a stray internal caller can't 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
