### PR TITLE
fix(security): centralize error sanitization (SEC-089)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,10 +6036,12 @@ name = "wafer-block-network"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "wafer-core",
  "wafer-run",

--- a/crates/solobase-core/src/blocks/admin/custom_tables.rs
+++ b/crates/solobase-core/src/blocks/admin/custom_tables.rs
@@ -59,7 +59,7 @@ async fn handle_list_tables(ctx: &dyn Context) -> OutputStream {
     let (sql, args) = introspect::build_list_tables_like("custom_", Backend::Sqlite);
     let tables = match db::query_raw(ctx, &sql, &args).await {
         Ok(t) => t,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     let names: Vec<&str> = tables
@@ -133,7 +133,7 @@ async fn handle_create_table(ctx: &dyn Context, input: InputStream) -> OutputStr
 
     match db::exec_raw(ctx, &sql, &[]).await {
         Ok(_) => ok_json(&serde_json::json!({"table": table_name, "created": true})),
-        Err(e) => err_internal(&format!("Failed to create table: {e}")),
+        Err(e) => err_internal("Failed to create table", e),
     }
 }
 
@@ -154,7 +154,7 @@ async fn handle_drop_table(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let drop_sql = ddl::build_drop_table(&safe_name, Backend::Sqlite);
     match db::exec_raw(ctx, &drop_sql, &[]).await {
         Ok(_) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) => err_internal(&format!("Failed to drop table: {e}")),
+        Err(e) => err_internal("Failed to drop table", e),
     }
 }
 
@@ -184,7 +184,7 @@ async fn handle_list_records(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, &full_name, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -213,7 +213,7 @@ async fn handle_create_record(
 
     match db::create(ctx, &full_name, body).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -248,7 +248,7 @@ async fn handle_update_record(
             if msg_str.contains("not found") || msg_str.contains("Not found") {
                 err_not_found("Record not found")
             } else {
-                err_internal(&format!("Database error: {e}"))
+                err_internal("Database error", e)
             }
         }
     }
@@ -275,7 +275,7 @@ async fn handle_delete_record(ctx: &dyn Context, msg: &Message) -> OutputStream 
             if msg_str.contains("not found") || msg_str.contains("Not found") {
                 err_not_found("Record not found")
             } else {
-                err_internal(&format!("Database error: {e}"))
+                err_internal("Database error", e)
             }
         }
     }

--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -27,7 +27,7 @@ async fn handle_info(ctx: &dyn Context) -> OutputStream {
     let sql = introspect::build_list_tables(Backend::Sqlite);
     let tables = match db::query_raw(ctx, &sql, &[]).await {
         Ok(t) => t,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     let table_names: Vec<&str> = tables
@@ -46,7 +46,7 @@ async fn handle_tables(ctx: &dyn Context) -> OutputStream {
     let sql = introspect::build_list_tables(Backend::Sqlite);
     let tables = match db::query_raw(ctx, &sql, &[]).await {
         Ok(t) => t,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     let mut table_info = Vec::new();
@@ -90,7 +90,7 @@ async fn handle_columns(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let (info_sql, info_args) = introspect::build_table_info(table_name, Backend::Sqlite);
     let columns = match db::query_raw(ctx, &info_sql, &info_args).await {
         Ok(c) => c,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     let col_info: Vec<serde_json::Value> = columns

--- a/crates/solobase-core/src/blocks/admin/iam.rs
+++ b/crates/solobase-core/src/blocks/admin/iam.rs
@@ -61,7 +61,7 @@ async fn handle_list_roles(ctx: &dyn Context) -> OutputStream {
     };
     match db::list(ctx, ROLES_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -86,7 +86,7 @@ async fn handle_create_role(ctx: &dyn Context, input: InputStream) -> OutputStre
     helpers::stamp_created(&mut data);
     match db::create(ctx, ROLES_TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -118,7 +118,7 @@ async fn handle_update_role(ctx: &dyn Context, msg: &Message, input: InputStream
             helpers::stamp_updated(&mut data);
             return match db::update(ctx, ROLES_TABLE, id, data).await {
                 Ok(record) => ok_json(&record),
-                Err(e) => err_internal(&format!("Database error: {e}")),
+                Err(e) => err_internal("Database error", e),
             };
         }
     }
@@ -133,7 +133,7 @@ async fn handle_update_role(ctx: &dyn Context, msg: &Message, input: InputStream
     match db::update(ctx, ROLES_TABLE, id, data).await {
         Ok(record) => ok_json(&record),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Role not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -154,7 +154,7 @@ async fn handle_delete_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match db::delete(ctx, ROLES_TABLE, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Role not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -169,7 +169,7 @@ async fn handle_list_permissions(ctx: &dyn Context) -> OutputStream {
                 page_size: total_count,
             })
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -193,7 +193,7 @@ async fn handle_create_permission(ctx: &dyn Context, input: InputStream) -> Outp
     helpers::stamp_created(&mut data);
     match db::create(ctx, PERMISSIONS_TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -206,7 +206,7 @@ async fn handle_delete_permission(ctx: &dyn Context, msg: &Message) -> OutputStr
     match db::delete(ctx, PERMISSIONS_TABLE, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Permission not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -230,7 +230,7 @@ async fn handle_list_user_roles(ctx: &dyn Context, msg: &Message) -> OutputStrea
                 page_size: total_count,
             })
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -278,7 +278,7 @@ async fn handle_assign_role(ctx: &dyn Context, msg: &Message, input: InputStream
     }));
     match db::create(ctx, USER_ROLES_TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -302,14 +302,14 @@ async fn handle_remove_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
             return err_not_found("User-role assignment not found");
         }
         Err(e) => {
-            return err_internal(&format!("Database error: {e}"));
+            return err_internal("Database error", e);
         }
     }
 
     match db::delete(ctx, USER_ROLES_TABLE, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("User-role assignment not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 

--- a/crates/solobase-core/src/blocks/admin/logs.rs
+++ b/crates/solobase-core/src/blocks/admin/logs.rs
@@ -71,7 +71,7 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -112,7 +112,7 @@ async fn handle_system_logs(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -395,7 +395,7 @@ pub async fn handle_user_disable(ctx: &dyn Context, msg: &Message, user_id: &str
     data.insert("disabled".to_string(), serde_json::json!(true));
     helpers::stamp_updated(&mut data);
     if let Err(e) = db::update(ctx, USERS, user_id, data).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,
@@ -417,7 +417,7 @@ pub async fn handle_user_enable(ctx: &dyn Context, msg: &Message, user_id: &str)
     data.insert("disabled".to_string(), serde_json::json!(false));
     helpers::stamp_updated(&mut data);
     if let Err(e) = db::update(ctx, USERS, user_id, data).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,
@@ -439,7 +439,7 @@ pub async fn handle_user_delete(ctx: &dyn Context, msg: &Message, user_id: &str)
     }
     let ip = msg.remote_addr().to_string();
     if let Err(e) = db::soft_delete(ctx, USERS, user_id).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,
@@ -500,7 +500,7 @@ pub async fn handle_user_invite(
 
     let password_hash = match crypto::hash(ctx, password).await {
         Ok(h) => h,
-        Err(e) => return err_internal(&format!("Failed to hash password: {e}")),
+        Err(e) => return err_internal("Failed to hash password", e),
     };
 
     let mut data = helpers::json_map(serde_json::json!({
@@ -522,7 +522,7 @@ pub async fn handle_user_invite(
 
     let new_user = match db::create(ctx, USERS, data).await {
         Ok(u) => u,
-        Err(e) => return err_internal(&format!("Failed: {}", e.message)),
+        Err(e) => return err_internal("Failed", e.message),
     };
 
     super::super::logs::audit_log(
@@ -575,7 +575,7 @@ pub async fn handle_create_role(
     helpers::stamp_created(&mut data);
 
     if let Err(e) = db::create(ctx, ROLES_TABLE, data).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(ctx, &admin_id, "role.create", &format!("roles/{name}"), &ip)
         .await;
@@ -602,7 +602,7 @@ pub async fn handle_delete_role(ctx: &dyn Context, msg: &Message, role_id: &str)
     }
 
     if let Err(e) = db::delete(ctx, ROLES_TABLE, role_id).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -462,7 +462,7 @@ pub async fn handle_create_variable(
     helpers::stamp_created(&mut data);
 
     if let Err(e) = db::create(ctx, VARIABLES, data).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,
@@ -599,7 +599,7 @@ pub async fn handle_update_variable(
     helpers::stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, VARIABLES, &record.id, data).await {
-        return err_internal(&format!("Failed: {}", e.message));
+        return err_internal("Failed", e.message);
     }
     super::super::logs::audit_log(
         ctx,

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -141,7 +141,7 @@ async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
                 .collect();
             ok_json(&vars)
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -168,7 +168,7 @@ async fn handle_list(ctx: &dyn Context) -> OutputStream {
             }
             ok_json(&settings)
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -201,7 +201,7 @@ async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
             ok_json(&record)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Setting not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -255,7 +255,7 @@ async fn handle_set(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
     .await
     {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -296,7 +296,7 @@ async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
     }));
     match db::create(ctx, VARIABLES_TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -321,7 +321,7 @@ async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
     {
         Ok(record) => match db::delete(ctx, VARIABLES_TABLE, &record.id).await {
             Ok(_) => ok_json(&serde_json::json!({"deleted": key})),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         },
         Err(_) => err_not_found("Setting not found"),
     }

--- a/crates/solobase-core/src/blocks/admin/users.rs
+++ b/crates/solobase-core/src/blocks/admin/users.rs
@@ -82,7 +82,7 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
             }
             ok_json(&result)
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -125,7 +125,7 @@ async fn get_user(ctx: &dyn Context, id: &str) -> OutputStream {
             ok_json(&resp)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("User not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -171,7 +171,7 @@ async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
             ok_json(&record)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("User not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -196,6 +196,6 @@ async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match db::soft_delete(ctx, COLLECTION, id).await {
         Ok(_) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("User not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
@@ -49,7 +49,7 @@ pub async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
             }
             ok_json(&result)
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -80,7 +80,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
     // Generate random key
     let random_bytes = match crypto::random_bytes(ctx, 24).await {
         Ok(b) => b,
-        Err(e) => return err_internal(&format!("Failed to generate key: {e}")),
+        Err(e) => return err_internal("Failed to generate key", e),
     };
     let key_string = format!("sb_{}", hex_encode(&random_bytes));
 
@@ -148,7 +148,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
                 }))
             }
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -175,7 +175,7 @@ pub async fn handle_revoke(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
     match db::update(ctx, API_KEYS_TABLE, id, data).await {
         Ok(_) => ok_json(&serde_json::json!({"message": "API key revoked"})),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -199,6 +199,6 @@ pub async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::delete(ctx, API_KEYS_TABLE, id).await {
         Ok(_) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
@@ -21,7 +21,10 @@ use crate::blocks::{
         repo::{bootstrap_tokens, sessions, users},
         service::hash_token,
     },
-    helpers::{err_bad_request, err_internal, err_unauthorized, parse_form_body, ResponseBuilder},
+    helpers::{
+        err_bad_request, err_internal, err_internal_no_cause, err_unauthorized, parse_form_body,
+        ResponseBuilder,
+    },
 };
 
 pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
@@ -49,7 +52,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     match bootstrap_tokens::is_valid(ctx, &token_hash).await {
         Ok(true) => {}
         Ok(false) => return err_unauthorized("invalid or expired bootstrap token"),
-        Err(e) => return err_internal(&format!("bootstrap_tokens lookup: {e}")),
+        Err(e) => return err_internal("bootstrap_tokens lookup", e),
     }
 
     // 2. Create the admin user via the same code path bootstrap-on-init uses.
@@ -57,7 +60,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     //    `deleted_at`) and the local_credentials row consistent with the
     //    env-var path.
     if let Err(e) = bootstrap::bootstrap_with_email_password(ctx, &email, &password).await {
-        return err_internal(&format!("create admin: {e}"));
+        return err_internal("create admin", e);
     }
 
     // 3. Consume the token row. Best-effort: the admin user already exists,
@@ -73,9 +76,11 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let user = match users::find_by_email(ctx, &email).await {
         Ok(Some(u)) => u,
         Ok(None) => {
-            return err_internal("bootstrap created admin but find_by_email returned no row")
+            return err_internal_no_cause(
+                "bootstrap created admin but find_by_email returned no row",
+            )
         }
-        Err(e) => return err_internal(&format!("users::find_by_email after bootstrap: {e}")),
+        Err(e) => return err_internal("users::find_by_email after bootstrap", e),
     };
 
     // 5. Mint a session — same pattern as auth_ui::api::login::handle.

--- a/crates/solobase-core/src/blocks/auth_ui/api/change_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/change_password.rs
@@ -54,7 +54,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
                 "No password set for this account",
             )
         }
-        Err(e) => return err_internal(&format!("Credential lookup failed: {e}")),
+        Err(e) => return err_internal("Credential lookup failed", e),
     };
 
     if crypto::compare_hash(ctx, &body.current_password, &cred.password_hash)
@@ -69,7 +69,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
 
     let new_hash = match crypto::hash(ctx, &body.new_password).await {
         Ok(h) => h,
-        Err(e) => return err_internal(&format!("Hash failed: {e}")),
+        Err(e) => return err_internal("Hash failed", e),
     };
 
     match local_credentials::update_password(ctx, user_id, &new_hash).await {
@@ -85,6 +85,6 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
             .ok();
             ok_json(&serde_json::json!({"message": "Password changed successfully"}))
         }
-        Err(e) => err_internal(&format!("Update failed: {e}")),
+        Err(e) => err_internal("Update failed", e),
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
@@ -37,7 +37,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Generate reset token (expires in 1 hour)
     let reset_token = match crypto::random_bytes(ctx, 32).await {
         Ok(bytes) => hex_encode(&bytes),
-        Err(e) => return err_internal(&format!("Token generation failed: {e}")),
+        Err(e) => return err_internal("Token generation failed", e),
     };
 
     let expires = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
@@ -48,7 +48,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     crate::blocks::helpers::stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, USERS_TABLE, &user.id, data).await {
-        return err_internal(&format!("Failed to store reset token: {e}"));
+        return err_internal("Failed to store reset token", e);
     }
 
     // Send reset email

--- a/crates/solobase-core/src/blocks/auth_ui/api/me.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/me.rs
@@ -64,6 +64,6 @@ pub async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream)
                 "roles": roles
             }))
         }
-        Err(e) => err_internal(&format!("Update failed: {e}")),
+        Err(e) => err_internal("Update failed", e),
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
@@ -75,12 +75,12 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Hash new password
     let new_hash = match crypto::hash(ctx, &body.new_password).await {
         Ok(h) => h,
-        Err(e) => return err_internal(&format!("Hash failed: {e}")),
+        Err(e) => return err_internal("Hash failed", e),
     };
 
     // Update credential row (typed path, no password_hash on users table).
     if let Err(e) = local_credentials::update_password(ctx, &user.id, &new_hash).await {
-        return err_internal(&format!("Failed to update password: {e}"));
+        return err_internal("Failed to update password", e);
     }
 
     // Clear reset token on the users row.
@@ -91,7 +91,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     crate::blocks::helpers::stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, USERS_TABLE, &user.id, data).await {
-        return err_internal(&format!("Failed to clear reset token: {e}"));
+        return err_internal("Failed to clear reset token", e);
     }
 
     // Revoke all refresh tokens — invalidate any stolen sessions

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -102,7 +102,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Hash password
     let password_hash = match crypto::hash(ctx, &body.password).await {
         Ok(h) => h,
-        Err(e) => return err_internal(&format!("Failed to hash password: {e}")),
+        Err(e) => return err_internal("Failed to hash password", e),
     };
 
     // Check if email verification is required
@@ -114,7 +114,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let verification_token = if require_verification {
         match crypto::random_bytes(ctx, 32).await {
             Ok(bytes) => hex_encode(&bytes),
-            Err(e) => return err_internal(&format!("Failed to generate verification token: {e}")),
+            Err(e) => return err_internal("Failed to generate verification token", e),
         }
     } else {
         String::new()
@@ -147,11 +147,11 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     .await
     {
         Ok(u) => u,
-        Err(e) => return err_internal(&format!("Failed to create user: {e}")),
+        Err(e) => return err_internal("Failed to create user", e),
     };
 
     if let Err(e) = local_credentials::insert(ctx, &user.id, &password_hash, false).await {
-        return err_internal(&format!("Failed to store credentials: {e}"));
+        return err_internal("Failed to store credentials", e);
     }
 
     // Set email_verified and verification_token on the legacy USERS_TABLE row

--- a/crates/solobase-core/src/blocks/auth_ui/api/sync_user.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/sync_user.rs
@@ -51,7 +51,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
             crate::blocks::helpers::stamp_created(&mut data);
             match db::create(ctx, USERS_TABLE, data).await {
                 Ok(u) => u,
-                Err(e) => return err_internal(&format!("Create failed: {e}")),
+                Err(e) => return err_internal("Create failed", e),
             }
         }
     };

--- a/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
@@ -79,7 +79,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
     crate::blocks::helpers::stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, USERS_TABLE, &user.id, data).await {
-        return err_internal(&format!("Failed to verify email: {e}"));
+        return err_internal("Failed to verify email", e);
     }
 
     html_respond(
@@ -138,7 +138,7 @@ pub async fn handle_resend(ctx: &dyn Context, input: InputStream) -> OutputStrea
     // Generate new token
     let new_token = match crypto::random_bytes(ctx, 32).await {
         Ok(bytes) => hex_encode(&bytes),
-        Err(e) => return err_internal(&format!("Token generation failed: {e}")),
+        Err(e) => return err_internal("Token generation failed", e),
     };
 
     let now = crate::blocks::helpers::now_rfc3339();
@@ -149,7 +149,7 @@ pub async fn handle_resend(ctx: &dyn Context, input: InputStream) -> OutputStrea
     crate::blocks::helpers::stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, USERS_TABLE, &user.id, data).await {
-        return err_internal(&format!("Failed to update token: {e}"));
+        return err_internal("Failed to update token", e);
     }
 
     send_verification_email(ctx, &email_lower, &new_token).await;

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -14,7 +14,10 @@ use crate::blocks::{
         repo::{provider_links, users},
         USERS_TABLE,
     },
-    helpers::{err_bad_request, err_forbidden, err_internal, json_map, ResponseBuilder},
+    helpers::{
+        err_bad_request, err_forbidden, err_internal, err_internal_no_cause, json_map,
+        ResponseBuilder,
+    },
 };
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -82,7 +85,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await;
 
     if client_id.is_empty() || client_secret.is_empty() {
-        return err_internal("OAuth provider not fully configured");
+        return err_internal_no_cause("OAuth provider not fully configured");
     }
 
     // Exchange code for token (URL-encode all values, include PKCE verifier)
@@ -117,12 +120,12 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         match network::do_request(ctx, "POST", &token_url, &headers, Some(&token_body_bytes)).await
         {
             Ok(r) => r,
-            Err(e) => return err_internal(&format!("Token exchange failed: {e}")),
+            Err(e) => return err_internal("Token exchange failed", e),
         };
 
     let token_data: serde_json::Value = match serde_json::from_slice(&token_resp.body) {
         Ok(d) => d,
-        Err(_) => return err_internal("Failed to parse token response"),
+        Err(_) => return err_internal_no_cause("Failed to parse token response"),
     };
 
     let access_token_oauth = token_data
@@ -130,7 +133,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         .and_then(|v| v.as_str())
         .unwrap_or("");
     if access_token_oauth.is_empty() {
-        return err_internal("No access token in OAuth response");
+        return err_internal_no_cause("No access token in OAuth response");
     }
 
     // Get user info
@@ -147,7 +150,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
             "https://graph.microsoft.com/v1.0/me".to_string(),
             format!("Bearer {}", access_token_oauth),
         ),
-        _ => return err_internal("Unsupported provider"),
+        _ => return err_internal_no_cause("Unsupported provider"),
     };
 
     let mut info_headers = HashMap::new();
@@ -163,7 +166,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let info_resp = match network::do_request(ctx, "GET", &userinfo_url, &info_headers, None).await
     {
         Ok(r) => r,
-        Err(e) => return err_internal(&format!("User info request failed: {e}")),
+        Err(e) => return err_internal("User info request failed", e),
     };
 
     let user_info: serde_json::Value = match serde_json::from_slice(&info_resp.body) {
@@ -173,10 +176,13 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 .chars()
                 .take(200)
                 .collect();
-            return err_internal(&format!(
-                "Failed to parse user info (status {}, parse: {}, body preview: {})",
-                info_resp.status_code, e, preview
-            ));
+            return err_internal(
+                "Failed to parse OAuth user info",
+                format!(
+                    "status={} parse={} body_preview={}",
+                    info_resp.status_code, e, preview
+                ),
+            );
         }
     };
 
@@ -246,7 +252,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     if email.is_empty() {
-        return err_internal("No email returned by OAuth provider");
+        return err_internal_no_cause("No email returned by OAuth provider");
     }
 
     // Extract the stable provider-side user identifier.
@@ -262,7 +268,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
     if provider_ref.is_empty() {
-        return err_internal("OAuth provider did not return a stable user id");
+        return err_internal_no_cause("OAuth provider did not return a stable user id");
     }
 
     // Stable per-provider handle (GitHub `login`, others fall back to email local-part).
@@ -276,7 +282,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let existing_link =
         match provider_links::find_by_provider_ref(ctx, &provider, &provider_ref).await {
             Ok(l) => l,
-            Err(e) => return err_internal(&format!("provider_links lookup failed: {e}")),
+            Err(e) => return err_internal("provider_links lookup failed", e),
         };
 
     // --- Step 2 / 3: resolve user_id ---
@@ -352,10 +358,10 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
                         }
                         u.id
                     }
-                    Err(e) => return err_internal(&format!("Failed to create user: {e}")),
+                    Err(e) => return err_internal("Failed to create user", e),
                 }
             }
-            Err(e) => return err_internal(&format!("User lookup failed: {e}")),
+            Err(e) => return err_internal("User lookup failed", e),
         }
     };
 

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
@@ -54,7 +54,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // Generate PKCE code verifier and challenge
     let code_verifier = match generate_pkce_verifier() {
         Ok(v) => v,
-        Err(e) => return err_internal(&format!("Failed to generate PKCE verifier: {e}")),
+        Err(e) => return err_internal("Failed to generate PKCE verifier", e),
     };
     let code_challenge = pkce_challenge(&code_verifier);
 
@@ -74,7 +74,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
     let state = match crypto::sign(ctx, &state_claims, Duration::from_secs(600)).await {
         Ok(s) => s,
-        Err(e) => return err_internal(&format!("Failed to generate state: {e}")),
+        Err(e) => return err_internal("Failed to generate state", e),
     };
 
     let auth_url = match provider {

--- a/crates/solobase-core/src/blocks/crud.rs
+++ b/crates/solobase-core/src/blocks/crud.rs
@@ -47,7 +47,7 @@ pub async fn crud_list(
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -69,7 +69,7 @@ pub async fn crud_get(
         Err(e) if e.code == ErrorCode::NotFound => {
             err_not_found(&format!("{not_found_label} not found"))
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -96,7 +96,7 @@ pub async fn crud_create(
 
     match db::create(ctx, collection, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -127,7 +127,7 @@ pub async fn crud_update(
         Err(e) if e.code == ErrorCode::NotFound => {
             err_not_found(&format!("{not_found_label} not found"))
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -149,6 +149,6 @@ pub async fn crud_delete(
         Err(e) if e.code == ErrorCode::NotFound => {
             err_not_found(&format!("{not_found_label} not found"))
         }
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/fastembed.rs
+++ b/crates/solobase-core/src/blocks/fastembed.rs
@@ -98,7 +98,7 @@ impl Block for FastembedBlock {
         let body = input.collect_to_bytes().await;
         let svc = match self.get_service() {
             Ok(s) => s,
-            Err(e) => return err_internal(&e),
+            Err(e) => return err_internal("fastembed service unavailable", e),
         };
         handle_embedding_message(svc, &msg, &body).await
     }

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -53,7 +53,7 @@ async fn handle_list_shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, SHARES_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -159,7 +159,7 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
             "token": token,
             "direct_url": format!("/b/storage/direct/{}", token)
         })),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -185,7 +185,7 @@ async fn handle_delete_share(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match db::delete(ctx, SHARES_TABLE, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Share not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -211,7 +211,7 @@ async fn handle_admin_list_shares(ctx: &dyn Context, msg: &Message) -> OutputStr
     };
     match db::list(ctx, SHARES_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -241,7 +241,7 @@ async fn handle_access_logs(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, ACCESS_LOGS_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -252,7 +252,7 @@ async fn handle_admin_quotas(ctx: &dyn Context, _msg: &Message) -> OutputStream 
     };
     match db::list(ctx, QUOTAS_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -291,6 +291,6 @@ async fn handle_update_quota(ctx: &dyn Context, msg: &Message, input: InputStrea
     .await
     {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -4,7 +4,8 @@ use wafer_core::clients::{crypto, database as db, storage as store};
 use wafer_run::{context::Context, types::*, OutputStream};
 
 use crate::blocks::helpers::{
-    err_bad_request, err_forbidden, err_internal, err_not_found, ResponseBuilder,
+    err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
+    ResponseBuilder,
 };
 
 /// Public share-link table — one row per generated token.
@@ -34,7 +35,7 @@ pub async fn generate_share_token(
 
     crypto::sign(ctx, &claims, Duration::from_secs(365 * 24 * 3600))
         .await
-        .map_err(|e| err_internal(&format!("Token generation failed: {e}")))
+        .map_err(|e| err_internal("Token generation failed", e))
 }
 
 pub async fn handle_direct_access(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -88,7 +89,7 @@ pub async fn handle_direct_access(ctx: &dyn Context, msg: &Message) -> OutputStr
     let key = share.data.get("key").and_then(|v| v.as_str()).unwrap_or("");
 
     if bucket.is_empty() || key.is_empty() {
-        return err_internal("Invalid share data");
+        return err_internal_no_cause("Invalid share data");
     }
 
     // Increment access count
@@ -136,6 +137,6 @@ pub async fn handle_direct_access(ctx: &dyn Context, msg: &Message) -> OutputStr
             .set_header("Cache-Control", "private, max-age=3600")
             .body(data, &info.content_type),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("File not found"),
-        Err(e) => err_internal(&format!("Storage error: {e}")),
+        Err(e) => err_internal("Storage error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -124,7 +124,7 @@ async fn handle_list_buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
     if is_admin {
         match store::list_folders(ctx).await {
             Ok(folders) => ok_json(&serde_json::json!({"buckets": folders})),
-            Err(e) => err_internal(&format!("Storage error: {e}")),
+            Err(e) => err_internal("Storage error", e),
         }
     } else {
         let filters = vec![Filter {
@@ -140,7 +140,7 @@ async fn handle_list_buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
                     .collect();
                 ok_json(&serde_json::json!({"buckets": names}))
             }
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 }
@@ -191,7 +191,7 @@ async fn handle_create_bucket(
             }
             ok_json(&serde_json::json!({"name": body.name, "created": true}))
         }
-        Err(e) => err_internal(&format!("Failed to create bucket: {e}")),
+        Err(e) => err_internal("Failed to create bucket", e),
     }
 }
 
@@ -229,7 +229,7 @@ async fn handle_delete_bucket(ctx: &dyn Context, msg: &Message) -> OutputStream 
             .ok();
             ok_json(&serde_json::json!({"deleted": true}))
         }
-        Err(e) => err_internal(&format!("Failed to delete bucket: {e}")),
+        Err(e) => err_internal("Failed to delete bucket", e),
     }
 }
 
@@ -257,7 +257,7 @@ async fn handle_list_objects(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match store::list(ctx, bucket, &opts).await {
         Ok(list) => ok_json(&list),
-        Err(e) => err_internal(&format!("Storage error: {e}")),
+        Err(e) => err_internal("Storage error", e),
     }
 }
 
@@ -300,7 +300,7 @@ async fn handle_get_object(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match store::get(ctx, bucket, key).await {
         Ok((data, info)) => ResponseBuilder::new().body(data, &info.content_type),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Object not found"),
-        Err(e) => err_internal(&format!("Storage error: {e}")),
+        Err(e) => err_internal("Storage error", e),
     }
 }
 
@@ -370,7 +370,7 @@ async fn handle_upload_object(
 
     let pending_record = match db::create(ctx, OBJECTS_TABLE, pending_data).await {
         Ok(record) => record,
-        Err(e) => return err_internal(&format!("Failed to reserve upload slot: {e}")),
+        Err(e) => return err_internal("Failed to reserve upload slot", e),
     };
 
     match store::put(ctx, bucket, &key, &body_bytes, &content_type).await {
@@ -391,7 +391,7 @@ async fn handle_upload_object(
             if let Err(del_err) = db::delete(ctx, OBJECTS_TABLE, &pending_record.id).await {
                 tracing::warn!("Failed to clean up pending record: {del_err}");
             }
-            err_internal(&format!("Upload failed: {e}"))
+            err_internal("Upload failed", e)
         }
     }
 }
@@ -434,7 +434,7 @@ async fn handle_delete_object(ctx: &dyn Context, msg: &Message) -> OutputStream 
             ok_json(&serde_json::json!({"deleted": true}))
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Object not found"),
-        Err(e) => err_internal(&format!("Delete failed: {e}")),
+        Err(e) => err_internal("Delete failed", e),
     }
 }
 
@@ -476,7 +476,7 @@ async fn handle_search(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, OBJECTS_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Search failed: {e}")),
+        Err(e) => err_internal("Search failed", e),
     }
 }
 
@@ -499,7 +499,7 @@ async fn handle_recent(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, super::VIEWS_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -199,11 +199,7 @@ pub fn ok_json<T: Serialize>(value: &T) -> OutputStream {
                 value: "application/json".to_string(),
             }],
         ),
-        Err(e) => OutputStream::error(WaferError {
-            code: ErrorCode::Internal,
-            message: format!("serialize failed: {}", e),
-            meta: vec![],
-        }),
+        Err(e) => err_internal("response serialization failed", e),
     }
 }
 
@@ -258,12 +254,63 @@ pub fn err_conflict(message: &str) -> OutputStream {
 }
 
 /// Return a 500 Internal Server Error `OutputStream`.
-pub fn err_internal(message: &str) -> OutputStream {
+///
+/// **Do not pass raw error text to the client.** This helper generates a short
+/// correlation ID, logs the full error detail server-side via
+/// [`tracing::error!`], and returns only `"Internal server error (ref: <id>)"`
+/// to the caller. The `context` argument is a short, fixed label (no
+/// interpolated error text) used for log grouping — e.g. `"Database error"`,
+/// `"Storage error"`, `"Failed to update profile"`. The `error` argument is
+/// the underlying error/cause; it is logged but NEVER echoed to the client.
+///
+/// ```ignore
+/// .map_err(|e| err_internal("Database error", e))
+/// ```
+pub fn err_internal<E: std::fmt::Display>(context: &str, error: E) -> OutputStream {
+    let id = correlation_id();
+    tracing::error!(
+        correlation_id = %id,
+        error = %error,
+        context = %context,
+        "internal error",
+    );
     OutputStream::error(WaferError {
         code: ErrorCode::Internal,
-        message: message.to_string(),
+        message: format!("Internal server error (ref: {})", id),
         meta: vec![],
     })
+}
+
+/// 500 Internal Server Error for the rare case where there is no underlying
+/// cause to log (e.g. an internal invariant violation with a static label).
+/// Still logs the context with a correlation ID and returns the sanitized
+/// `"Internal server error (ref: <id>)"` message. Most callers should prefer
+/// [`err_internal`] which captures the underlying error.
+pub fn err_internal_no_cause(context: &str) -> OutputStream {
+    let id = correlation_id();
+    tracing::error!(
+        correlation_id = %id,
+        context = %context,
+        "internal error (no cause)",
+    );
+    OutputStream::error(WaferError {
+        code: ErrorCode::Internal,
+        message: format!("Internal server error (ref: {})", id),
+        meta: vec![],
+    })
+}
+
+/// 8-byte hex correlation ID — short enough to be quotable in support tickets,
+/// random enough to grep logs without collisions.
+fn correlation_id() -> String {
+    let mut buf = [0u8; 8];
+    if getrandom::getrandom(&mut buf).is_err() {
+        // Fall back to timestamp-derived ID; correlation IDs are diagnostic
+        // aids, not security primitives, so a deterministic fallback is fine.
+        let nanos = now_millis();
+        buf.copy_from_slice(&nanos.to_be_bytes());
+    }
+    hex_encode(&buf)
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +370,7 @@ impl ResponseBuilder {
                 });
                 OutputStream::respond_with_meta(body, self.meta)
             }
-            Err(e) => err_internal(&format!("serialize failed: {}", e)),
+            Err(e) => err_internal("response serialization failed", e),
         }
     }
 
@@ -499,6 +546,103 @@ mod tests {
         assert_eq!(
             hash,
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    /// Helper: drain an OutputStream and extract the client-facing error
+    /// message. Panics if the stream did not terminate with an error.
+    fn error_message(stream: OutputStream) -> String {
+        use wafer_run::TerminalNotResponse;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        match rt.block_on(stream.collect_buffered()) {
+            Ok(_) => panic!("expected error terminal, got Complete"),
+            Err(TerminalNotResponse::Error(e)) => e.message,
+            Err(other) => panic!("expected error terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn err_internal_sanitizes_underlying_error() {
+        // A vivid error message with content that MUST NOT reach the client:
+        // SQL fragments, table names, secrets — anything an attacker could
+        // use to fingerprint the backend.
+        let raw = "DB error: no such table: secret_users_table (sqlite code 1)";
+        let stream = err_internal("Database error", raw);
+        let msg = error_message(stream);
+
+        // Client message is the sanitized form.
+        assert!(
+            msg.starts_with("Internal server error (ref: "),
+            "expected sanitized prefix, got {msg:?}"
+        );
+        assert!(msg.ends_with(')'), "expected closing paren, got {msg:?}");
+
+        // Raw error text does NOT leak.
+        assert!(
+            !msg.contains("DB error"),
+            "raw error label leaked into client message: {msg:?}"
+        );
+        assert!(
+            !msg.contains("secret_users_table"),
+            "table name leaked into client message: {msg:?}"
+        );
+        assert!(
+            !msg.contains("sqlite"),
+            "backend name leaked into client message: {msg:?}"
+        );
+        assert!(
+            !msg.contains("Database error"),
+            "context label leaked into client message: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn err_internal_message_contains_ref_id() {
+        let stream = err_internal("Database error", "boom");
+        let msg = error_message(stream);
+
+        // Pull out the ref id and check it's a hex string of the expected
+        // length (8 bytes -> 16 hex chars).
+        let id = msg
+            .strip_prefix("Internal server error (ref: ")
+            .and_then(|s| s.strip_suffix(')'))
+            .expect("message shape");
+        assert_eq!(
+            id.len(),
+            16,
+            "expected 16-char hex correlation id, got {id:?}"
+        );
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit()),
+            "ref id is not hex: {id:?}"
+        );
+    }
+
+    #[test]
+    fn err_internal_ids_are_unique_across_calls() {
+        let a = error_message(err_internal("ctx", "e1"));
+        let b = error_message(err_internal("ctx", "e2"));
+        assert_ne!(
+            a, b,
+            "correlation IDs should differ between independent calls"
+        );
+    }
+
+    #[test]
+    fn err_internal_no_cause_also_sanitizes() {
+        let stream = err_internal_no_cause("Thread setting vanished between read and update");
+        let msg = error_message(stream);
+        assert!(
+            msg.starts_with("Internal server error (ref: "),
+            "expected sanitized prefix, got {msg:?}"
+        );
+        // Even the context label is not echoed.
+        assert!(
+            !msg.contains("Thread setting"),
+            "context label leaked into client message: {msg:?}"
         );
     }
 }

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -94,7 +94,7 @@ impl LegalPagesBlock {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(error = %e, "legalpages: db list failed");
-                return err_internal(&format!("Database error: {e}"));
+                return err_internal("Database error", e);
             }
         };
 
@@ -183,7 +183,7 @@ impl LegalPagesBlock {
         };
         match db::list(ctx, COLLECTION, &opts).await {
             Ok(result) => ok_json(&result),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 
@@ -195,7 +195,7 @@ impl LegalPagesBlock {
         match db::get(ctx, COLLECTION, id).await {
             Ok(record) => ok_json(&record),
             Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 
@@ -229,7 +229,7 @@ impl LegalPagesBlock {
 
         match db::create(ctx, COLLECTION, data).await {
             Ok(record) => ok_json(&record),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 
@@ -256,7 +256,7 @@ impl LegalPagesBlock {
         match db::update(ctx, COLLECTION, id, data).await {
             Ok(record) => ok_json(&record),
             Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 
@@ -270,7 +270,7 @@ impl LegalPagesBlock {
         let doc = match db::get(ctx, COLLECTION, id).await {
             Ok(r) => r,
             Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Document not found"),
-            Err(e) => return err_internal(&format!("Database error: {e}")),
+            Err(e) => return err_internal("Database error", e),
         };
 
         let doc_type = doc
@@ -317,7 +317,7 @@ impl LegalPagesBlock {
 
         match db::update(ctx, COLLECTION, id, data).await {
             Ok(record) => ok_json(&record),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 
@@ -329,7 +329,7 @@ impl LegalPagesBlock {
         match db::delete(ctx, COLLECTION, id).await {
             Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
             Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
-            Err(e) => err_internal(&format!("Database error: {e}")),
+            Err(e) => err_internal("Database error", e),
         }
     }
 

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -17,7 +17,7 @@ use wafer_run::{
 
 use self::{providers::ProviderLlmService, schema::providers_schema};
 use crate::blocks::helpers::{
-    self, err_bad_request, err_internal, err_not_found, json_map, ok_json,
+    self, err_bad_request, err_internal, err_internal_no_cause, err_not_found, json_map, ok_json,
 };
 
 /// LLM feature block. Owns the provider admin UI + chat thread persistence.
@@ -278,9 +278,11 @@ impl LlmBlock {
                 {
                     Ok(r) => r,
                     Err(e) if e.code == ErrorCode::NotFound => {
-                        return err_internal("Thread setting vanished between read and update")
+                        return err_internal_no_cause(
+                            "Thread setting vanished between read and update",
+                        )
                     }
-                    Err(e) => return err_internal(&format!("Database error: {e}")),
+                    Err(e) => return err_internal("Database error", e),
                 };
                 if let Some(pb) = body.provider_block {
                     data.insert("provider_block".to_string(), serde_json::json!(pb));
@@ -291,7 +293,7 @@ impl LlmBlock {
                 helpers::stamp_updated(&mut data);
                 match db::update(ctx, SETTINGS_TABLE, &record.id, data).await {
                     Ok(r) => return ok_json(&r),
-                    Err(e) => return err_internal(&format!("Database error: {e}")),
+                    Err(e) => return err_internal("Database error", e),
                 }
             } else {
                 // Create new per-thread setting
@@ -303,7 +305,7 @@ impl LlmBlock {
                 helpers::stamp_created(&mut data);
                 match db::create(ctx, SETTINGS_TABLE, data).await {
                     Ok(r) => return ok_json(&r),
-                    Err(e) => return err_internal(&format!("Database error: {e}")),
+                    Err(e) => return err_internal("Database error", e),
                 }
             }
         }

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -170,7 +170,7 @@ async fn dispatch_chat(
     //    backend_id (first enabled provider). Non-legacy values pass through.
     let backend_id = match resolve_backend_id(ctx, &provider_block).await {
         Ok(id) => id,
-        Err(e) => return Err(err_internal(e)),
+        Err(e) => return Err(err_internal("resolve_backend_id failed", e)),
     };
 
     // 5. Build the service request and dispatch via the typed client.
@@ -185,7 +185,7 @@ async fn dispatch_chat(
     };
     let stream = match llm_client::chat_stream(ctx, &chat_req).await {
         Ok(s) => s,
-        Err(e) => return Err(err_internal(&format!("llm chat dispatch: {}", e.message))),
+        Err(e) => return Err(err_internal("llm chat dispatch", e.message)),
     };
     Ok((thread_id, stream))
 }
@@ -210,7 +210,7 @@ pub(super) async fn handle_chat(
     while let Some(item) = stream.next().await {
         let chunk = match item {
             Ok(c) => c,
-            Err(e) => return err_internal(&format!("llm service error: {}", e.message)),
+            Err(e) => return err_internal("llm service error", e.message),
         };
         match chunk.delta {
             ChunkDelta::Text(s) => content.push_str(&s),
@@ -417,7 +417,7 @@ pub(super) async fn list_providers(
     }
     let records = match db::list_all(ctx, PROVIDERS_TABLE, vec![]).await {
         Ok(r) => r,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
     let providers: Vec<serde_json::Value> = records
         .iter()
@@ -488,11 +488,11 @@ pub(super) async fn create_provider(
 
     let record = match db::create(ctx, PROVIDERS_TABLE, data).await {
         Ok(r) => r,
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     if let Err(e) = reload_provider_service(block, ctx).await {
-        return err_internal(&e);
+        return err_internal("reload_provider_service failed", e);
     }
 
     ok_json(&provider_to_json(&record.id, &cfg))
@@ -525,11 +525,11 @@ pub(super) async fn update_provider(
         Err(e) if e.code == wafer_run::types::ErrorCode::NotFound => {
             return err_not_found("Provider not found")
         }
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
     let mut cfg = match row_to_config(&existing) {
         Ok(c) => c,
-        Err(e) => return err_internal(&format!("Stored provider row invalid: {e}")),
+        Err(e) => return err_internal("Stored provider row invalid", e),
     };
 
     if let Some(n) = body.name.filter(|s| !s.is_empty()) {
@@ -566,11 +566,11 @@ pub(super) async fn update_provider(
         Err(e) if e.code == wafer_run::types::ErrorCode::NotFound => {
             return err_not_found("Provider not found")
         }
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     if let Err(e) = reload_provider_service(block, ctx).await {
-        return err_internal(&e);
+        return err_internal("reload_provider_service failed", e);
     }
 
     ok_json(&provider_to_json(&record.id, &cfg))
@@ -594,11 +594,11 @@ pub(super) async fn delete_provider(
         Err(e) if e.code == wafer_run::types::ErrorCode::NotFound => {
             return err_not_found("Provider not found")
         }
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     }
 
     if let Err(e) = reload_provider_service(block, ctx).await {
-        return err_internal(&e);
+        return err_internal("reload_provider_service failed", e);
     }
 
     ok_json(&serde_json::json!({ "deleted": true }))
@@ -645,7 +645,7 @@ pub(super) async fn list_models(
 ) -> OutputStream {
     match llm_client::list_models(ctx).await {
         Ok(models) => ok_json(&serde_json::json!({ "models": models })),
-        Err(e) => err_internal(&format!("llm list_models failed: {}", e.message)),
+        Err(e) => err_internal("llm list_models failed", e.message),
     }
 }
 
@@ -666,7 +666,7 @@ pub(super) async fn model_status(
     };
     match llm_client::status(ctx, &req).await {
         Ok(status) => ok_json(&serde_json::json!({ "status": status })),
-        Err(e) => err_internal(&format!("llm status failed: {}", e.message)),
+        Err(e) => err_internal("llm status failed", e.message),
     }
 }
 
@@ -690,7 +690,7 @@ pub(super) async fn load_model(
     };
     let stream = match llm_client::load_model_stream(ctx, &req).await {
         Ok(s) => s,
-        Err(e) => return err_internal(&format!("llm load_model failed: {}", e.message)),
+        Err(e) => return err_internal("llm load_model failed", e.message),
     };
     let _ = msg;
 
@@ -748,7 +748,7 @@ pub(super) async fn unload_model(
     let _ = msg;
     match llm_client::unload_model(ctx, &req).await {
         Ok(()) => ok_json(&serde_json::json!({ "unloaded": true })),
-        Err(e) => err_internal(&format!("llm unload_model failed: {}", e.message)),
+        Err(e) => err_internal("llm unload_model failed", e.message),
     }
 }
 
@@ -775,11 +775,11 @@ pub(super) async fn discover_models(
         Err(e) if e.code == wafer_run::types::ErrorCode::NotFound => {
             return err_not_found("Provider not found")
         }
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
     let mut cfg = match row_to_config(&existing) {
         Ok(c) => c,
-        Err(e) => return err_internal(&format!("Stored provider row invalid: {e}")),
+        Err(e) => return err_internal("Stored provider row invalid", e),
     };
 
     // Make sure the in-memory service knows about this provider — discover
@@ -787,12 +787,12 @@ pub(super) async fn discover_models(
     // started or the row is disabled (and so was excluded from the last
     // configure call).
     if let Err(e) = reload_provider_service(block, ctx).await {
-        return err_internal(&e);
+        return err_internal("reload_provider_service failed", e);
     }
 
     let models = match block.provider_svc.discover_models(&cfg.name).await {
         Ok(m) => m,
-        Err(e) => return err_internal(&format!("discover_models failed: {e:?}")),
+        Err(e) => return err_internal("discover_models failed", format!("{e:?}")),
     };
     let model_ids: Vec<String> = models.iter().map(|m| m.model_id.clone()).collect();
     cfg.models = model_ids.clone();
@@ -800,11 +800,11 @@ pub(super) async fn discover_models(
     let mut data = config_to_row(&cfg);
     helpers::stamp_updated(&mut data);
     if let Err(e) = db::update(ctx, PROVIDERS_TABLE, &id, data).await {
-        return err_internal(&format!("Database error: {e}"));
+        return err_internal("Database error", e);
     }
 
     if let Err(e) = reload_provider_service(block, ctx).await {
-        return err_internal(&e);
+        return err_internal("reload_provider_service failed", e);
     }
 
     ok_json(&serde_json::json!({ "models": model_ids }))

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -90,7 +90,7 @@ pub(super) async fn providers_page(
                 .into_iter()
                 .filter_map(|rec| row_to_config(&rec).ok().map(|cfg| (rec.id, cfg)))
                 .collect(),
-            Err(e) => return err_internal(&format!("Database error: {e}")),
+            Err(e) => return err_internal("Database error", e),
         };
 
     let content = html! {
@@ -365,12 +365,12 @@ pub(super) async fn models_page(
     let buffered = match out.collect_buffered().await {
         Ok(b) => b,
         Err(e) => {
-            return err_internal(&format!("list_models failed: {e:?}"));
+            return err_internal("list_models failed", format!("{e:?}"));
         }
     };
     let envelope: serde_json::Value = match serde_json::from_slice(&buffered.body) {
         Ok(v) => v,
-        Err(e) => return err_internal(&format!("decode models envelope: {e}")),
+        Err(e) => return err_internal("decode models envelope", e),
     };
     let empty_vec: Vec<serde_json::Value> = Vec::new();
     let models: &[serde_json::Value] = envelope

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -199,7 +199,7 @@ pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStre
     let context = match service::get_context(ctx, context_id).await {
         Ok(r) => r,
         Err(e) if e.code == ErrorCode::NotFound => return ui::not_found_response(msg),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     let entries_params = ListEntriesParams {

--- a/crates/solobase-core/src/blocks/messages/rest.rs
+++ b/crates/solobase-core/src/blocks/messages/rest.rs
@@ -59,7 +59,7 @@ pub async fn list_contexts(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
     match service::list_contexts(ctx, &params).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&e),
+        Err(e) => err_internal("list_contexts failed", e),
     }
 }
 
@@ -94,7 +94,7 @@ pub async fn create_context(ctx: &dyn Context, input: InputStream) -> OutputStre
     .await
     {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&e),
+        Err(e) => err_internal("create_context failed", e),
     }
 }
 
@@ -106,7 +106,7 @@ pub async fn get_context(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match service::get_context(ctx, id).await {
         Ok(record) => ok_json(&record),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Context not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -124,7 +124,7 @@ pub async fn update_context(ctx: &dyn Context, msg: &Message, input: InputStream
     match service::update_context(ctx, id, body).await {
         Ok(record) => ok_json(&record),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Context not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -135,7 +135,7 @@ pub async fn delete_context(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
     match service::delete_context(ctx, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) => err_internal(&e),
+        Err(e) => err_internal("delete_context failed", e),
     }
 }
 
@@ -157,7 +157,7 @@ pub async fn list_entries(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
     match service::list_entries(ctx, context_id, &params).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&e),
+        Err(e) => err_internal("list_entries failed", e),
     }
 }
 
@@ -200,7 +200,7 @@ pub async fn add_entry(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
     .await
     {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&e),
+        Err(e) => err_internal("add_entry failed", e),
     }
 }
 
@@ -212,7 +212,7 @@ pub async fn get_entry(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match service::get_entry(ctx, id).await {
         Ok(record) => ok_json(&record),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Entry not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -224,6 +224,6 @@ pub async fn delete_entry(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match service::delete_entry(ctx, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Entry not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -399,7 +399,7 @@ async fn handle_catalog(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -419,7 +419,7 @@ async fn handle_get_product_public(ctx: &dyn Context, msg: &Message) -> OutputSt
             ok_json(&record)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Product not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -477,7 +477,7 @@ async fn handle_user_list_products(ctx: &dyn Context, msg: &Message) -> OutputSt
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -497,7 +497,7 @@ async fn handle_user_get_product(ctx: &dyn Context, msg: &Message) -> OutputStre
             ok_json(&record)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Product not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -552,7 +552,7 @@ async fn handle_user_create_product(
 
     match db::create(ctx, PRODUCTS_TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -579,7 +579,7 @@ async fn handle_user_update_product(
             }
         }
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Product not found"),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     }
 
     let raw = input.collect_to_bytes().await;
@@ -595,7 +595,7 @@ async fn handle_user_update_product(
 
     match db::update(ctx, PRODUCTS_TABLE, &id, body).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -618,12 +618,12 @@ async fn handle_user_delete_product(ctx: &dyn Context, msg: &Message) -> OutputS
             }
         }
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Product not found"),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     }
 
     match db::delete(ctx, PRODUCTS_TABLE, &id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -650,7 +650,7 @@ async fn handle_user_list_groups(ctx: &dyn Context, msg: &Message) -> OutputStre
     };
     match db::list(ctx, GROUPS_TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -670,7 +670,7 @@ async fn handle_user_get_group(ctx: &dyn Context, msg: &Message) -> OutputStream
             ok_json(&record)
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Group not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -700,7 +700,7 @@ async fn handle_user_create_group(
 
     match db::create(ctx, GROUPS_TABLE, body).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -727,7 +727,7 @@ async fn handle_user_update_group(
             }
         }
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Group not found"),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     }
 
     let raw = input.collect_to_bytes().await;
@@ -739,7 +739,7 @@ async fn handle_user_update_group(
 
     match db::update(ctx, GROUPS_TABLE, &id, body).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -762,12 +762,12 @@ async fn handle_user_delete_group(ctx: &dyn Context, msg: &Message) -> OutputStr
             }
         }
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Group not found"),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     }
 
     match db::delete(ctx, GROUPS_TABLE, &id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -813,7 +813,7 @@ async fn handle_user_group_products(ctx: &dyn Context, msg: &Message) -> OutputS
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -821,7 +821,7 @@ async fn handle_user_group_products(ctx: &dyn Context, msg: &Message) -> OutputS
 async fn handle_user_list_group_templates(ctx: &dyn Context, _msg: &Message) -> OutputStream {
     match db::list_all(ctx, GROUP_TEMPLATES_TABLE, vec![]).await {
         Ok(records) => ok_json(&records),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 

--- a/crates/solobase-core/src/blocks/products/pricing.rs
+++ b/crates/solobase-core/src/blocks/products/pricing.rs
@@ -4,7 +4,9 @@ use wafer_core::clients::database as db;
 use wafer_run::{context::Context, InputStream, OutputStream};
 
 use super::PRODUCTS_TABLE;
-use crate::blocks::helpers::{err_bad_request, err_internal, err_not_found, ok_json, RecordExt};
+use crate::blocks::helpers::{
+    err_bad_request, err_internal_no_cause, err_not_found, ok_json, RecordExt,
+};
 
 /// Pricing template table — reusable pricing rule definitions (formulas,
 /// tiers, etc.) referenced by products at calc time.
@@ -55,12 +57,12 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
 
     let template = match db::get(ctx, TABLE, template_id).await {
         Ok(t) => t,
-        Err(_) => return err_internal("Pricing template not found"),
+        Err(_) => return err_internal_no_cause("Pricing template not found"),
     };
 
     let formula = template.str_field("price_formula");
     if formula.is_empty() {
-        return err_internal("Empty pricing formula");
+        return err_internal_no_cause("Empty pricing formula");
     }
 
     // Evaluate formula

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -182,7 +182,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
 
     let purchase = match db::create(ctx, PURCHASES_TABLE, purchase_data).await {
         Ok(p) => p,
-        Err(e) => return err_internal(&format!("Failed to create purchase: {e}")),
+        Err(e) => return err_internal("Failed to create purchase", e),
     };
 
     // Create line items — roll back purchase on failure
@@ -211,7 +211,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
         if let Err(e) = db::create(ctx, LINE_ITEMS_TABLE, item_data).await {
             // Clean up the purchase since line items are incomplete
             let _ = db::delete(ctx, PURCHASES_TABLE, &purchase.id).await;
-            return err_internal(&format!("Failed to create line item: {e}"));
+            return err_internal("Failed to create line item", e);
         }
     }
 
@@ -248,7 +248,7 @@ pub async fn handle_list_user(ctx: &dyn Context, msg: &Message) -> OutputStream 
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -289,7 +289,7 @@ pub async fn handle_list_admin(ctx: &dyn Context, msg: &Message) -> OutputStream
     .await
     {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -303,7 +303,7 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let purchase = match db::get(ctx, PURCHASES_TABLE, id).await {
         Ok(p) => p,
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Purchase not found"),
-        Err(e) => return err_internal(&format!("Database error: {e}")),
+        Err(e) => return err_internal("Database error", e),
     };
 
     // Verify access: user can only view their own, admin can view all
@@ -352,7 +352,7 @@ pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream)
         if e.code == ErrorCode::NotFound {
             return err_not_found("Purchase not found");
         }
-        return err_internal(&format!("Database error: {e}"));
+        return err_internal("Database error", e);
     }
 
     // Atomic status transition: completed → refunded (prevents double-refund race)
@@ -395,6 +395,6 @@ pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream)
     // Fetch the updated record for the response
     match db::get(ctx, PURCHASES_TABLE, &id).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -9,14 +9,14 @@ use wafer_sql_utils::{value::sea_values_to_json, Backend};
 
 use super::{LINE_ITEMS_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
 use crate::blocks::helpers::{
-    err_bad_request, err_forbidden, err_internal, err_not_found, err_unauthorized, hex_encode,
-    ok_json,
+    err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
+    err_unauthorized, hex_encode, ok_json,
 };
 
 pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let stripe_key = match config::get(ctx, "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY").await {
         Ok(k) => k,
-        Err(_) => return err_internal("Stripe is not configured"),
+        Err(_) => return err_internal_no_cause("Stripe is not configured"),
     };
 
     #[derive(serde::Deserialize)]
@@ -194,7 +194,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     .await
     {
         Ok(r) => r,
-        Err(e) => return err_internal(&format!("Stripe API error: {e}")),
+        Err(e) => return err_internal("Stripe API error", e),
     };
 
     if resp.status_code >= 400 {
@@ -225,15 +225,15 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
         let revert_args = sea_values_to_json(revert_vals);
         let _ = db::exec_raw(ctx, &revert_sql, &revert_args).await;
         let err_body = String::from_utf8_lossy(&resp.body);
-        return err_internal(&format!(
-            "Stripe error ({}): {}",
-            resp.status_code, err_body
-        ));
+        return err_internal(
+            "Stripe API error",
+            format!("status={} body={}", resp.status_code, err_body),
+        );
     }
 
     let session: serde_json::Value = match serde_json::from_slice(&resp.body) {
         Ok(d) => d,
-        Err(_) => return err_internal("Failed to parse Stripe response"),
+        Err(_) => return err_internal_no_cause("Failed to parse Stripe response"),
     };
 
     let session_id = session.get("id").and_then(|v| v.as_str()).unwrap_or("");
@@ -268,7 +268,7 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
     let webhook_secret =
         config::get_default(ctx, "SUPPERS_AI__PRODUCTS__STRIPE_WEBHOOK_SECRET", "").await;
     if webhook_secret.is_empty() {
-        return err_internal(
+        return err_internal_no_cause(
             "STRIPE_WEBHOOK_SECRET not configured — webhook processing disabled for security",
         );
     }
@@ -570,7 +570,7 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                     );
                     if let Err(e) = db::update(ctx, PURCHASES_TABLE, &purchase.id, data).await {
                         tracing::error!("Failed to mark purchase as refunded: {e}");
-                        return err_internal(&format!("Failed to update purchase: {e}"));
+                        return err_internal("Failed to update purchase", e);
                     }
                 }
             }

--- a/crates/solobase-core/src/blocks/products/variables.rs
+++ b/crates/solobase-core/src/blocks/products/variables.rs
@@ -43,7 +43,7 @@ pub async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     match db::list(ctx, TABLE, &opts).await {
         Ok(result) => ok_json(&result),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -85,7 +85,7 @@ pub async fn handle_create(ctx: &dyn Context, input: InputStream) -> OutputStrea
 
     match db::create(ctx, TABLE, data).await {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -112,7 +112,7 @@ pub async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream)
     match db::update(ctx, TABLE, &id, body).await {
         Ok(record) => ok_json(&record),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Variable not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -127,6 +127,6 @@ pub async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
     match db::delete(ctx, TABLE, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Variable not found"),
-        Err(e) => err_internal(&format!("Database error: {e}")),
+        Err(e) => err_internal("Database error", e),
     }
 }

--- a/crates/solobase-core/src/blocks/transformers_embed.rs
+++ b/crates/solobase-core/src/blocks/transformers_embed.rs
@@ -53,7 +53,7 @@ impl Block for TransformersEmbedBlock {
             ServiceOp::EMBEDDING_EMBED => {
                 handle_embedding_message(self.service.as_ref(), &msg, &body).await
             }
-            other => err_internal(&format!("unsupported op: {other}")),
+            other => err_internal("unsupported op", other),
         }
     }
 

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -307,7 +307,7 @@ async fn handle_update_profile(
     stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, crate::blocks::auth::USERS_TABLE, &user_id, data).await {
-        return err_internal(&format!("Failed to update profile: {}", e.message));
+        return err_internal("Failed to update profile", e.message);
     }
 
     // Plain form POST → 303 See Other so the browser follows up with a GET
@@ -488,7 +488,7 @@ async fn handle_create_button(ctx: &dyn Context, input: InputStream) -> OutputSt
     super::helpers::stamp_created(&mut data);
 
     if let Err(e) = db::create(ctx, TABLE, data).await {
-        return err_internal(&format!("Failed to create button: {}", e.message));
+        return err_internal("Failed to create button", e.message);
     }
 
     // Re-render buttons table
@@ -581,7 +581,7 @@ async fn handle_update_button(ctx: &dyn Context, input: InputStream, id: &str) -
     stamp_updated(&mut data);
 
     if let Err(e) = db::update(ctx, TABLE, id, data).await {
-        return err_internal(&format!("Failed to update button: {}", e.message));
+        return err_internal("Failed to update button", e.message);
     }
 
     // Re-render buttons table
@@ -591,7 +591,7 @@ async fn handle_update_button(ctx: &dyn Context, input: InputStream, id: &str) -
 
 async fn handle_delete_button(ctx: &dyn Context, id: &str) -> OutputStream {
     if let Err(e) = db::delete(ctx, TABLE, id).await {
-        return err_internal(&format!("Failed to delete button: {}", e.message));
+        return err_internal("Failed to delete button", e.message);
     }
 
     let buttons = load_buttons(ctx).await;

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -52,7 +52,9 @@ use super::{
     ingestion::{self, DEFAULT_CHUNK_TOKENS, DEFAULT_OVERLAP_RATIO},
     service::{self, TABLE_PREFIX},
 };
-use crate::blocks::helpers::{err_bad_request, err_internal, err_not_found, ok_json};
+use crate::blocks::helpers::{
+    err_bad_request, err_internal, err_internal_no_cause, err_not_found, ok_json,
+};
 
 /// Per-index metadata registry table.
 ///
@@ -196,7 +198,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
     };
 
     if let Err(e) = vclient::create_index(ctx, cfg.clone()).await {
-        return err_internal(&format!("create_index failed: {e}"));
+        return err_internal("create_index failed", e);
     }
 
     // Record the index in the registry so queries against it can look up
@@ -206,7 +208,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
     // can retry create (idempotent at the registry level via OR REPLACE
     // and harmless at vclient level because the index already exists).
     if let Err(e) = ensure_registry(ctx).await {
-        return err_internal(&format!("registry init failed: {e}"));
+        return err_internal("registry init failed", e);
     }
     let (sql, vals) = upsert::build_upsert(
         REGISTRY_TABLE,
@@ -224,7 +226,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
         Backend::Sqlite,
     );
     if let Err(e) = db::exec_raw(ctx, &sql, &sea_values_to_json(vals)).await {
-        return err_internal(&format!("registry write failed: {e}"));
+        return err_internal("registry write failed", e);
     }
 
     // htmx callers (the admin modal) want HTML back so the swap renders
@@ -233,7 +235,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
     if !msg.get_meta("http.header.hx-request").is_empty() {
         let body_html = match super::pages_ui::render_index_list_fragment(ctx).await {
             Ok(m) => m,
-            Err(e) => return err_internal(&format!("Failed to refresh: {e}")),
+            Err(e) => return err_internal("Failed to refresh", e),
         };
         let trigger = r#"{"showToast":{"message":"Index created","type":"success"},"closeModal":{"id":"create-vector-index"}}"#;
         return crate::blocks::helpers::ResponseBuilder::new()
@@ -265,7 +267,7 @@ async fn ensure_registry(ctx: &dyn Context) -> Result<(), WaferError> {
 async fn list_indexes(ctx: &dyn Context) -> OutputStream {
     match discover_indexes(ctx).await {
         Ok(indexes) => ok_json(&serde_json::json!({ "indexes": indexes })),
-        Err(e) => err_internal(&format!("list indexes failed: {e}")),
+        Err(e) => err_internal("list indexes failed", e),
     }
 }
 
@@ -333,7 +335,7 @@ async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
         Err(e) if e.code == ErrorCode::NotFound => {
             err_not_found(&format!("index not found: {name}"))
         }
-        Err(e) => err_internal(&format!("delete_index failed: {e}")),
+        Err(e) => err_internal("delete_index failed", e),
     }
 }
 
@@ -385,7 +387,7 @@ async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStream {
             err_not_found(&format!("index not found: {}", body.index))
         }
         Err(e) if e.code == ErrorCode::InvalidArgument => err_bad_request(&e.message),
-        Err(e) => err_internal(&format!("upsert failed: {e}")),
+        Err(e) => err_internal("upsert failed", e),
     }
 }
 
@@ -411,7 +413,7 @@ async fn delete_single(ctx: &dyn Context, msg: &Message) -> OutputStream {
         Err(e) if e.code == ErrorCode::NotFound => {
             err_not_found(&format!("index not found: {index}"))
         }
-        Err(e) => err_internal(&format!("delete failed: {e}")),
+        Err(e) => err_internal("delete failed", e),
     }
 }
 
@@ -440,7 +442,7 @@ fn extract_index_and_id(msg: &Message) -> (&str, &str) {
 async fn stats(ctx: &dyn Context) -> OutputStream {
     let indexes = match discover_indexes(ctx).await {
         Ok(v) => v,
-        Err(e) => return err_internal(&format!("stats failed: {e}")),
+        Err(e) => return err_internal("stats failed", e),
     };
 
     let mut out: Vec<serde_json::Value> = Vec::with_capacity(indexes.len());
@@ -503,7 +505,7 @@ async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // registry table existed.
     let (model_id, keyword_search) = match load_index_metadata(ctx, &prefixed).await {
         Ok(m) => m,
-        Err(e) => return err_internal(&format!("load index metadata failed: {e}")),
+        Err(e) => return err_internal("load index metadata failed", e),
     };
 
     // Default mode reflects the index's declared capabilities. An index
@@ -525,9 +527,9 @@ async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
             match vclient::embed(ctx, block, vec![text.to_string()]).await {
                 Ok((_, _, mut vectors)) => match vectors.pop() {
                     Some(v) => v,
-                    None => return err_internal("embedding block returned no vectors"),
+                    None => return err_internal_no_cause("embedding block returned no vectors"),
                 },
-                Err(e) => return err_internal(&format!("embed failed: {e}")),
+                Err(e) => return err_internal("embed failed", e),
             }
         }
         _ => return err_bad_request("either 'text' or 'vector' is required"),
@@ -561,7 +563,7 @@ async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
             err_not_found(&format!("index not found: {}", body.index))
         }
         Err(e) if e.code == ErrorCode::InvalidArgument => err_bad_request(&e.message),
-        Err(e) => err_internal(&format!("query failed: {e}")),
+        Err(e) => err_internal("query failed", e),
     }
 }
 
@@ -706,7 +708,7 @@ async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // query route does.
     let (model_id, _keyword_search) = match load_index_metadata(ctx, &prefixed).await {
         Ok(m) => m,
-        Err(e) => return err_internal(&format!("load index metadata failed: {e}")),
+        Err(e) => return err_internal("load index metadata failed", e),
     };
 
     // Re-ingestion safety: wipe any chunks we previously wrote for this
@@ -733,7 +735,7 @@ async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
             .collect();
         if !prior_ids.is_empty() {
             if let Err(e) = vclient::delete(ctx, &prefixed, prior_ids).await {
-                return err_internal(&format!("failed to clear prior chunks: {e}"));
+                return err_internal("failed to clear prior chunks", e);
             }
         }
     }
@@ -769,7 +771,7 @@ async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
     if body.contextual {
         match ingestion::add_context(ctx, &body.text, chunks).await {
             Ok(c) => chunks = c,
-            Err(e) => return err_internal(&format!("add_context failed: {e}")),
+            Err(e) => return err_internal("add_context failed", e),
         }
     }
     if chunks.is_empty() {
@@ -781,17 +783,16 @@ async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let (_model_name, _dims, vectors) =
         match vclient::embed(ctx, embedding_block, chunks.clone()).await {
             Ok(tuple) => tuple,
-            Err(e) => return err_internal(&format!("embed failed: {e}")),
+            Err(e) => return err_internal("embed failed", e),
         };
 
     if vectors.len() != chunks.len() {
         // Sanity check — embedding block violated its contract. Surface
         // the mismatch instead of silently upserting a truncated set.
-        return err_internal(&format!(
-            "embedding returned {} vectors for {} chunks",
-            vectors.len(),
-            chunks.len()
-        ));
+        return err_internal(
+            "embedding/chunk count mismatch",
+            format!("vectors={} chunks={}", vectors.len(), chunks.len()),
+        );
     }
 
     // Build VectorEntry list. Ids are `{document_id}:{i}` so re-ingestion
@@ -821,7 +822,7 @@ async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
             err_not_found(&format!("index not found: {}", body.index))
         }
         Err(e) if e.code == ErrorCode::InvalidArgument => err_bad_request(&e.message),
-        Err(e) => err_internal(&format!("upsert failed: {e}")),
+        Err(e) => err_internal("upsert failed", e),
     }
 }
 
@@ -867,6 +868,6 @@ async fn embed(ctx: &dyn Context, input: InputStream) -> OutputStream {
             vectors,
         }),
         Err(e) if e.code == ErrorCode::InvalidArgument => err_bad_request(&e.message),
-        Err(e) => err_internal(&format!("embed failed: {e}")),
+        Err(e) => err_internal("embed failed", e),
     }
 }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -276,7 +276,7 @@ pub fn server_error_response(msg: &wafer_run::types::Message) -> wafer_run::Outp
             ("Go home", "/"),
         )
     } else {
-        crate::blocks::helpers::err_internal("internal server error")
+        crate::blocks::helpers::err_internal_no_cause("internal server error")
     }
 }
 


### PR DESCRIPTION
## Summary

- Stop echoing raw DB/storage/crypto error messages to clients. \`err_internal\` now takes \`(context: &str, error: impl Display)\`, generates a short hex correlation ID, logs the full detail server-side via \`tracing::error!\`, and returns \`\"Internal server error (ref: <id>)\"\` to the caller.
- Added \`err_internal_no_cause(context)\` for the rare invariant-violation case where there is no underlying error to log; still sanitizes the client message.
- Migrated **208 \`err_internal\` callsites + 18 \`err_internal_no_cause\` callsites** across **40 files** in \`solobase-core\` (the review listed 40+ as examples — this PR covers the full sweep).

## Migrated callsite groups

- \`blocks/crud.rs\`, \`blocks/userportal\`
- \`blocks/products/{purchase,handlers,stripe,variables,pricing}.rs\`
- \`blocks/files/{cloud,share,storage}.rs\`
- \`blocks/admin/{custom_tables,database,iam,logs,settings,users,pages/*}.rs\`
- \`blocks/auth_ui/{api/*,oauth/*}.rs\`
- \`blocks/llm/{mod,routes,ui}.rs\`
- \`blocks/vector/pages.rs\`
- \`blocks/messages/{pages,rest}.rs\`
- \`blocks/{legalpages,fastembed,transformers_embed}.rs\`
- \`ui/mod.rs\`

## Sister helpers — audited, left as-is

- \`err_bad_request\` — typical pattern is \`format!(\"Invalid body: {e}\")\` where \`e\` is a serde parse error. Echoes caller-supplied input validation, no backend secrets. Safe.
- \`err_not_found\` / \`err_forbidden\` / \`err_unauthorized\` / \`err_conflict\` — no raw-error formatting found. Only \`format!(\"X not found: {id}\")\` with caller-supplied identifiers, which the caller already knows. Safe.
- \`admin/database.rs\` \`err_bad_request(\"Query error: {e}\")\` — admin SQL explorer (documented exception in CLAUDE.md), echoes by design.

## Test plan

- [x] \`cargo build -p solobase-core\` clean (no warnings)
- [x] \`cargo test -p solobase-core\` — all 624 existing tests pass, plus 4 new tests covering: client message does NOT leak underlying error text or table/backend names, message contains 16-char hex ref-id, correlation IDs are unique across calls, \`err_internal_no_cause\` also sanitizes.
- [x] \`cargo +nightly fmt --all\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)