### PR TITLE
fix(security): PKCE verifier server-side store (SEC-040)

### DIFF
--- a/crates/solobase-core/src/blocks/auth/migrations/003_oauth_pkce_states.postgres.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/003_oauth_pkce_states.postgres.sql
@@ -1,0 +1,12 @@
+-- OAuth PKCE state store (SEC-040). See the sqlite variant for full rationale.
+CREATE TABLE IF NOT EXISTS suppers_ai__auth__oauth_pkce_states (
+    state_id      TEXT PRIMARY KEY,
+    provider      TEXT NOT NULL,
+    code_verifier TEXT NOT NULL,
+    redirect_uri  TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    expires_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suppers_ai__auth__oauth_pkce_states_expires_at_idx
+    ON suppers_ai__auth__oauth_pkce_states (expires_at);

--- a/crates/solobase-core/src/blocks/auth/migrations/003_oauth_pkce_states.sqlite.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/003_oauth_pkce_states.sqlite.sql
@@ -1,0 +1,20 @@
+-- OAuth PKCE state store (SEC-040).
+--
+-- Replaces the previous client-visible state JWT (which embedded the PKCE
+-- code_verifier in plaintext). The client receives only an opaque random
+-- `state_id`; the verifier + redirect_uri + provider sit server-side and
+-- are looked up by state_id during the callback.
+--
+-- Single-use: the callback reads and deletes the row in one step. Rows
+-- past `expires_at` are also treated as missing.
+CREATE TABLE IF NOT EXISTS suppers_ai__auth__oauth_pkce_states (
+    state_id      TEXT PRIMARY KEY,
+    provider      TEXT NOT NULL,
+    code_verifier TEXT NOT NULL,
+    redirect_uri  TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    expires_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suppers_ai__auth__oauth_pkce_states_expires_at_idx
+    ON suppers_ai__auth__oauth_pkce_states (expires_at);

--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -13,15 +13,17 @@ const SQL_001_SQLITE: &str = include_str!("001_auth_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_auth_schema.postgres.sql");
 const SQL_002_SQLITE: &str = include_str!("002_reserved_orgs.sqlite.sql");
 const SQL_002_POSTGRES: &str = include_str!("002_reserved_orgs.postgres.sql");
+const SQL_003_SQLITE: &str = include_str!("003_oauth_pkce_states.sqlite.sql");
+const SQL_003_POSTGRES: &str = include_str!("003_oauth_pkce_states.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
     let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
         .await
         .to_ascii_lowercase();
     let sql = if backend == "postgres" {
-        format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}")
+        format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}\n{SQL_003_POSTGRES}")
     } else {
-        format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}")
+        format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}\n{SQL_003_SQLITE}")
     };
     migration_helper::apply_if_blessed(ctx, "suppers-ai/auth", &sql).await
 }

--- a/crates/solobase-core/src/blocks/auth/repo/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/mod.rs
@@ -9,6 +9,7 @@ pub mod api_keys;
 pub mod bootstrap_tokens;
 pub mod cli_codes;
 pub mod local_credentials;
+pub mod oauth_pkce;
 pub mod orgs;
 pub mod pats;
 pub mod provider_links;

--- a/crates/solobase-core/src/blocks/auth/repo/oauth_pkce.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/oauth_pkce.rs
@@ -1,0 +1,238 @@
+//! Row-level access over `suppers_ai__auth__oauth_pkce_states` (SEC-040).
+//!
+//! Holds OAuth PKCE state during the round-trip from the authorization
+//! endpoint to the callback. The client only sees an opaque `state_id`;
+//! the secret `code_verifier`, provider name, and redirect_uri live here,
+//! keyed by `state_id` and bounded by `expires_at`.
+//!
+//! [`take`] performs select-then-delete so a given `state_id` can only
+//! be redeemed once. Rows past `expires_at` are treated as missing and
+//! also dropped on lookup as a side effect — a periodic sweeper is
+//! additive, not load-bearing for correctness.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+use wafer_core::clients::database as db;
+use wafer_run::context::Context;
+
+use super::RepoError;
+
+pub const TABLE: &str = "suppers_ai__auth__oauth_pkce_states";
+
+/// Payload for [`insert`].
+#[derive(Debug, Clone)]
+pub struct NewPkceState<'a> {
+    pub state_id: &'a str,
+    pub provider: &'a str,
+    pub code_verifier: &'a str,
+    pub redirect_uri: &'a str,
+    /// Absolute expiry time as ISO-8601 (`%Y-%m-%dT%H:%M:%SZ`).
+    pub expires_at: &'a str,
+}
+
+/// Row returned by [`take`]: everything the callback needs to complete the
+/// token exchange. `state_id` is excluded because the caller already has it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PkceStateRow {
+    pub provider: String,
+    pub code_verifier: String,
+    pub redirect_uri: String,
+    pub expires_at: String,
+}
+
+fn now_iso() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn row_from_map(m: &HashMap<String, Value>) -> Result<PkceStateRow, RepoError> {
+    let s = |k: &str| m.get(k).and_then(Value::as_str).map(str::to_owned);
+    Ok(PkceStateRow {
+        provider: s("provider").ok_or_else(|| RepoError::Db("missing provider".into()))?,
+        code_verifier: s("code_verifier")
+            .ok_or_else(|| RepoError::Db("missing code_verifier".into()))?,
+        redirect_uri: s("redirect_uri")
+            .ok_or_else(|| RepoError::Db("missing redirect_uri".into()))?,
+        expires_at: s("expires_at").unwrap_or_default(),
+    })
+}
+
+/// Insert a new PKCE state row.
+///
+/// PRIMARY-KEY collisions on `state_id` indicate a generator failure (the
+/// caller is expected to pull fresh random bytes), surfaced as `RepoError::Db`.
+pub async fn insert(ctx: &dyn Context, new: NewPkceState<'_>) -> Result<(), RepoError> {
+    let now = now_iso();
+    let mut data: HashMap<String, Value> = HashMap::new();
+    data.insert("state_id".into(), json!(new.state_id));
+    data.insert("provider".into(), json!(new.provider));
+    data.insert("code_verifier".into(), json!(new.code_verifier));
+    data.insert("redirect_uri".into(), json!(new.redirect_uri));
+    data.insert("created_at".into(), json!(now));
+    data.insert("expires_at".into(), json!(new.expires_at));
+    db::create(ctx, TABLE, data)
+        .await
+        .map_err(|e| RepoError::Db(format!("oauth_pkce insert: {e}")))?;
+    Ok(())
+}
+
+/// Look up a PKCE state by `state_id` and simultaneously delete it.
+///
+/// Returns `Ok(None)` if the state is missing OR present-but-expired (the
+/// expired row is still deleted as a side effect — single-use even on
+/// timeout). Uses `db::take_by_filters` which dispatches to
+/// `DELETE … WHERE … RETURNING *` (sqlite 3.35+, postgres) so the read
+/// and delete are atomic in a single statement.
+pub async fn take(ctx: &dyn Context, state_id: &str) -> Result<Option<PkceStateRow>, RepoError> {
+    let rows = db::take_by_filters(
+        ctx,
+        TABLE,
+        vec![db::Filter {
+            field: "state_id".into(),
+            operator: db::FilterOp::Equal,
+            value: json!(state_id),
+        }],
+    )
+    .await
+    .map_err(|e| RepoError::Db(format!("oauth_pkce take: {e}")))?;
+    let Some(r) = rows.into_iter().next() else {
+        return Ok(None);
+    };
+    let row = row_from_map(&r.data)?;
+    if row.expires_at.as_str() < now_iso().as_str() {
+        // Row was present but expired — already deleted as a side effect.
+        return Ok(None);
+    }
+    Ok(Some(row))
+}
+
+/// Deletes all rows whose `expires_at < cutoff`. Returns the number deleted.
+/// Intended for a background sweeper (TODO: not yet wired) — not required
+/// for correctness since [`take`] also drops expired rows on read.
+#[allow(dead_code)]
+pub async fn delete_expired(ctx: &dyn Context, cutoff: &str) -> Result<u64, RepoError> {
+    let n = db::delete_by_filters_count(
+        ctx,
+        TABLE,
+        vec![db::Filter {
+            field: "expires_at".into(),
+            operator: db::FilterOp::LessThan,
+            value: json!(cutoff),
+        }],
+    )
+    .await
+    .map_err(|e| RepoError::Db(format!("oauth_pkce delete_expired: {e}")))?;
+    Ok(n.max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    fn iso_plus_seconds(secs: i64) -> String {
+        let dt = chrono::Utc::now() + chrono::Duration::seconds(secs);
+        dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    }
+
+    #[tokio::test]
+    async fn insert_then_take_returns_row_and_deletes() {
+        let ctx = TestContext::with_auth().await;
+        let expires = iso_plus_seconds(600);
+        insert(
+            &ctx,
+            NewPkceState {
+                state_id: "state-1",
+                provider: "github",
+                code_verifier: "verifier-abc",
+                redirect_uri: "https://example.test/b/auth/oauth/callback",
+                expires_at: &expires,
+            },
+        )
+        .await
+        .expect("insert");
+
+        let row = take(&ctx, "state-1")
+            .await
+            .expect("take")
+            .expect("row present");
+        assert_eq!(row.provider, "github");
+        assert_eq!(row.code_verifier, "verifier-abc");
+        assert_eq!(
+            row.redirect_uri,
+            "https://example.test/b/auth/oauth/callback"
+        );
+
+        // Second take returns None — single-use.
+        assert!(take(&ctx, "state-1").await.expect("take").is_none());
+    }
+
+    #[tokio::test]
+    async fn take_returns_none_for_unknown_state_id() {
+        let ctx = TestContext::with_auth().await;
+        assert!(take(&ctx, "missing").await.expect("take").is_none());
+    }
+
+    #[tokio::test]
+    async fn take_treats_expired_rows_as_missing() {
+        let ctx = TestContext::with_auth().await;
+        // Insert with expires_at in the past.
+        let past = iso_plus_seconds(-10);
+        insert(
+            &ctx,
+            NewPkceState {
+                state_id: "state-expired",
+                provider: "google",
+                code_verifier: "v",
+                redirect_uri: "https://example.test/cb",
+                expires_at: &past,
+            },
+        )
+        .await
+        .expect("insert");
+
+        assert!(take(&ctx, "state-expired").await.expect("take").is_none());
+        // And the row is gone (single-use even on timeout).
+        assert!(take(&ctx, "state-expired").await.expect("take").is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_expired_drops_only_expired_rows() {
+        let ctx = TestContext::with_auth().await;
+        let past = iso_plus_seconds(-60);
+        let future = iso_plus_seconds(600);
+        insert(
+            &ctx,
+            NewPkceState {
+                state_id: "old",
+                provider: "github",
+                code_verifier: "v1",
+                redirect_uri: "https://example.test/cb",
+                expires_at: &past,
+            },
+        )
+        .await
+        .unwrap();
+        insert(
+            &ctx,
+            NewPkceState {
+                state_id: "new",
+                provider: "github",
+                code_verifier: "v2",
+                redirect_uri: "https://example.test/cb",
+                expires_at: &future,
+            },
+        )
+        .await
+        .unwrap();
+
+        let cutoff = iso_plus_seconds(0);
+        let deleted = delete_expired(&ctx, &cutoff).await.expect("sweep");
+        assert_eq!(deleted, 1);
+
+        // Old gone, new still takeable.
+        assert!(take(&ctx, "old").await.unwrap().is_none());
+        let row = take(&ctx, "new").await.unwrap().expect("present");
+        assert_eq!(row.code_verifier, "v2");
+    }
+}

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use wafer_core::clients::{config, crypto, database as db, network};
+use wafer_core::clients::{config, database as db, network};
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use crate::blocks::{
@@ -11,7 +11,7 @@ use crate::blocks::{
         helpers::{
             build_auth_cookie, ensure_admin_role, generate_tokens, store_refresh_token, urlencode,
         },
-        repo::{provider_links, users},
+        repo::{oauth_pkce, provider_links, users},
         USERS_TABLE,
     },
     helpers::{err_bad_request, err_forbidden, err_internal, json_map, ResponseBuilder},
@@ -30,31 +30,20 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         return err_bad_request("Missing code or state parameter");
     }
 
-    // Verify CSRF state token and extract provider name
-    let state_claims = match crypto::verify(ctx, state).await {
-        Ok(c) => c,
-        Err(_) => return err_bad_request("Invalid or expired OAuth state"),
+    // SEC-040: look up the server-side PKCE state by the opaque `state_id`
+    // the provider echoed back. `take` is single-use (DELETE … RETURNING),
+    // so a replayed callback or a stolen state_id can only redeem once,
+    // and a state past `expires_at` is treated as missing.
+    let pkce_row = match oauth_pkce::take(ctx, state).await {
+        Ok(Some(row)) => row,
+        Ok(None) => return err_bad_request("Invalid or expired OAuth state"),
+        Err(e) => return err_internal(&format!("OAuth state lookup failed: {e}")),
     };
-    let state_type = state_claims
-        .get("type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    if state_type != "oauth_state" {
-        return err_bad_request("Invalid OAuth state token");
-    }
-    let provider = state_claims
-        .get("provider")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    if provider.is_empty() {
-        return err_bad_request("Missing provider in OAuth state");
-    }
-    let code_verifier = state_claims
-        .get("code_verifier")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+    let provider = pkce_row.provider.clone();
+    let code_verifier = pkce_row.code_verifier.clone();
+    // Use the redirect_uri stored at start-time so the provider's exact-
+    // match check passes even if the live config changed mid-flow.
+    let redirect_uri = pkce_row.redirect_uri.clone();
 
     let client_id = config::get_default(
         ctx,
@@ -72,12 +61,6 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
             provider.to_uppercase()
         ),
         "",
-    )
-    .await;
-    let redirect_uri = config::get_default(
-        ctx,
-        "SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI",
-        "http://localhost:8090/b/auth/oauth/callback",
     )
     .await;
 

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
@@ -1,15 +1,21 @@
 //! GET /b/auth/oauth/login — relocated from auth/oauth.rs::handle_oauth_login in Task 5.
 
-use std::{collections::HashMap, time::Duration};
-
 use sha2::{Digest, Sha256};
-use wafer_core::clients::{config, crypto};
+use wafer_core::clients::config;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use crate::blocks::{
-    auth::helpers::urlencode,
+    auth::{
+        helpers::urlencode,
+        repo::oauth_pkce::{self, NewPkceState},
+    },
     helpers::{err_bad_request, err_forbidden, err_internal, ok_json},
 };
+
+/// PKCE state TTL: 10 minutes. OAuth round-trips complete in seconds; this
+/// is forgiving enough for a slow user on a captive-portal Wi-Fi without
+/// keeping abandoned-flow rows around indefinitely.
+const PKCE_STATE_TTL_SECS: i64 = 600;
 
 /// Generate a PKCE code verifier (43-128 chars, URL-safe).
 fn generate_pkce_verifier() -> Result<String, String> {
@@ -21,6 +27,13 @@ fn generate_pkce_verifier() -> Result<String, String> {
 fn pkce_challenge(verifier: &str) -> String {
     let hash = Sha256::digest(verifier.as_bytes());
     crate::crypto::base64_url_encode(&hash)
+}
+
+/// Random opaque OAuth `state` parameter sent to the provider. 32 random
+/// bytes hex-encoded (64 chars) — fits any provider's state-length limit.
+fn generate_state_id() -> Result<String, String> {
+    let bytes = crate::crypto::random_bytes(32)?;
+    Ok(crate::blocks::helpers::hex_encode(&bytes))
 }
 
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -51,44 +64,51 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     )
     .await;
 
-    // Generate PKCE code verifier and challenge
+    // Generate PKCE code verifier and challenge.
     let code_verifier = match generate_pkce_verifier() {
         Ok(v) => v,
         Err(e) => return err_internal(&format!("Failed to generate PKCE verifier: {e}")),
     };
     let code_challenge = pkce_challenge(&code_verifier);
 
-    // Generate CSRF state token (signed JWT containing the provider name + PKCE verifier)
-    let mut state_claims = HashMap::new();
-    state_claims.insert(
-        "provider".to_string(),
-        serde_json::Value::String(provider.to_string()),
-    );
-    state_claims.insert(
-        "type".to_string(),
-        serde_json::Value::String("oauth_state".to_string()),
-    );
-    state_claims.insert(
-        "code_verifier".to_string(),
-        serde_json::Value::String(code_verifier),
-    );
-    let state = match crypto::sign(ctx, &state_claims, Duration::from_secs(600)).await {
+    // SEC-040: the PKCE `code_verifier` is the client-side secret half of
+    // PKCE. Previously it rode in a client-visible JWT (defeats the point of
+    // PKCE entirely). Persist it server-side keyed by a random `state_id`
+    // and send only the opaque id to the provider.
+    let state_id = match generate_state_id() {
         Ok(s) => s,
-        Err(e) => return err_internal(&format!("Failed to generate state: {e}")),
+        Err(e) => return err_internal(&format!("Failed to generate state id: {e}")),
     };
+    let expires_at = (chrono::Utc::now() + chrono::Duration::seconds(PKCE_STATE_TTL_SECS))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    if let Err(e) = oauth_pkce::insert(
+        ctx,
+        NewPkceState {
+            state_id: &state_id,
+            provider,
+            code_verifier: &code_verifier,
+            redirect_uri: &redirect_uri,
+            expires_at: &expires_at,
+        },
+    )
+    .await
+    {
+        return err_internal(&format!("Failed to persist OAuth state: {e}"));
+    }
 
     let auth_url = match provider {
         "google" => format!(
             "https://accounts.google.com/o/oauth2/v2/auth?client_id={}&redirect_uri={}&response_type=code&scope=openid%20email%20profile&state={}&code_challenge={}&code_challenge_method=S256",
-            client_id, redirect_uri, urlencode(&state), urlencode(&code_challenge)
+            client_id, redirect_uri, urlencode(&state_id), urlencode(&code_challenge)
         ),
         "github" => format!(
             "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=user:email&state={}",
-            client_id, redirect_uri, urlencode(&state)
+            client_id, redirect_uri, urlencode(&state_id)
         ),
         "microsoft" => format!(
             "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id={}&redirect_uri={}&response_type=code&scope=openid%20email%20profile&state={}&code_challenge={}&code_challenge_method=S256",
-            client_id, redirect_uri, urlencode(&state), urlencode(&code_challenge)
+            client_id, redirect_uri, urlencode(&state_id), urlencode(&code_challenge)
         ),
         _ => return err_bad_request(&format!("Unsupported provider: {}", provider)),
     };


### PR DESCRIPTION
## Summary

Closes **SEC-040 (LOW)** — `crates/solobase-core/src/blocks/auth_ui/oauth/start.rs:71-78` previously embedded the PKCE `code_verifier` in a client-visible state JWT and consumed it from `oauth/callback.rs:53-54,92-93,102-103`. The verifier is supposed to be the secret half of PKCE (only the client and the OAuth provider should know it until exchange time); placing it in a client-visible JWT defeats the protection entirely.

## Changes

- New migration `003_oauth_pkce_states.{sqlite,postgres}.sql` creates `suppers_ai__auth__oauth_pkce_states` (`state_id` PK, `provider`, `code_verifier`, `redirect_uri`, `created_at`, `expires_at`, plus an `expires_at` index). Wired into `auth/migrations/mod.rs` and concatenated into the block's hash-gated SQL bundle.
- New repo module `auth/repo/oauth_pkce.rs` with `insert`, `take` (atomic select-then-delete via `db::take_by_filters`, treats expired rows as missing), and `delete_expired` (additive sweeper, not yet wired — see Deferred below).
- `oauth/start.rs`: generates a 32-byte hex `state_id`, inserts a row with the verifier + provider + redirect_uri + 10-minute `expires_at`, and sends only the opaque `state_id` as the OAuth `state` parameter. No more `crypto::sign` of the state bag.
- `oauth/callback.rs`: replaces JWT verify with `oauth_pkce::take(state_id)`. Single-use and expiring by construction. Uses the stored `redirect_uri` for the token exchange (matches provider's redirect-uri equality check even if config changes mid-flow).
- Existing `suppers_ai__auth__*` WRAP wildcard grants already cover the new table; no grant changes needed.

## Audit of state bag fields
The previous JWT contained `provider`, `type` (always `"oauth_state"`), and `code_verifier`. The `type` discriminator becomes vestigial once state is opaque + server-side, so it's dropped. `redirect_uri` is added so the callback exchange uses the exact URI captured at start time.

## Deferred
- Periodic prune of expired rows: not wired. Abandoned flows leave rows behind but at low volume (10-min TTL). `delete_expired(cutoff)` exists for a future sweeper.

## Test plan
- [x] `cargo build -p solobase-core`
- [x] `cargo test -p solobase-core` — 624 tests pass (4 new `oauth_pkce` tests: round-trip, missing-state, expired-treated-as-missing, sweeper)
- [x] `cargo +nightly fmt --all`
- [ ] Manual OAuth round-trip against a real provider sandbox (out of scope for unit suite; pre-prod can wipe & redeploy per `active-development-can-wipe-prod-db`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)