### PR TITLE
fix(security): wildcard Crypto WRAP grant for client resource scoping (SEC-015 consumer)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -126,6 +126,15 @@ impl Block for AdminBlock {
                 // Remove this grant via the admin UI to restrict network access.
                 wafer_run::ResourceGrant::read("*", "*")
                     .typed(wafer_run::types::ResourceType::Network),
+                // Default: allow all blocks to perform any crypto operation
+                // (hash/compare_hash/sign/verify/random_bytes). The runtime
+                // already isolates JWT signing keys per caller via HKDF
+                // (SEC-016), so this wildcard does not let a block forge
+                // another block's tokens. Tighten via the admin UI (e.g.
+                // restrict sign/verify to specific blocks) if a deployment
+                // wants per-op control.
+                wafer_run::ResourceGrant::read_write("*", "*")
+                    .typed(wafer_run::types::ResourceType::Crypto),
             ])
             .category(wafer_run::BlockCategory::Feature)
             .description("Administration panel for managing users, roles, variables, blocks, and logs. Provides SSR dashboard with stats, user management with role assignment, IAM (roles and API keys), environment variables editor, block management with feature toggles, and system/audit log viewer.")


### PR DESCRIPTION
## Summary

Consumer of wafer-run [#66](https://github.com/wafer-run/wafer-run/pull/66). That PR makes the crypto client pass \`wrap.resource = operation_name\` on every call, and elevates Crypto to a non-namespace resource type in WRAP (default-deny, grant-required).

Without this consumer-side grant, every block calling \`crypto::hash\` / \`sign\` / \`random_bytes\` etc. would be denied in production once #66 lands. The change adds a single wildcard \`*/* typed Crypto\` read-write grant to the admin block — preserves the historical "every block may call crypto" behavior.

Per-block JWT key isolation (SEC-016 fix) is unchanged: the runtime derives signing keys via HKDF from the caller_id, so a wildcard grant does not let block A forge block B's tokens. Operators who want per-op control (e.g. forbidding a particular block from \`sign\`) can tighten via the admin grants UI.

## Dependency

CI on this PR will fail until wafer-run #66 merges — \`.cargo/config.toml\` makes local dev work against the sibling \`wafer-run/\` checkout, but solobase CI resolves wafer-run via git. Merge order: wafer-run #66 → solobase main updates wafer-run rev → this PR rebases and goes green.

## Test plan

- [x] \`cargo test -p solobase-core\` (565 + 52 tests, all pass against local wafer-run @ \`fix/sec-client-resource-scoping\`)
- [x] WRAP audit unchanged: \`bash scripts/audit-wrap-grants.sh\` (50 callsites, 0 missing grants)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>