### PR TITLE
fix(ci): unblock CI Main pipeline

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -53,7 +53,7 @@ jobs:
         run: cd crates/solobase-web && wasm-pack build --target web --release --out-dir pkg
 
       - name: Run clippy
-        run: cargo clippy --workspace --exclude solobase-web
+        run: cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare
 
   test:
     name: Tests
@@ -85,7 +85,7 @@ jobs:
         run: cd crates/solobase-web && wasm-pack build --target web --release --out-dir pkg
 
       - name: Run tests
-        run: cargo test --workspace --exclude solobase-web
+        run: cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare
 
   wasm:
     name: WASM Build
@@ -252,7 +252,7 @@ jobs:
         run: cd crates/solobase-web && wasm-pack build --target web --release --out-dir pkg
 
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --exclude solobase-web --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --exclude solobase-web --exclude solobase-cloudflare --lcov --output-path lcov.info
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/crates/solobase-core/src/blocks/auth_ui/api/logout.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/logout.rs
@@ -6,7 +6,10 @@ use crate::{
     blocks::{
         auth::{
             helpers::build_auth_cookie,
-            repo::{jwt_blocklist::{self, NewBlocklistEntry}, tokens},
+            repo::{
+                jwt_blocklist::{self, NewBlocklistEntry},
+                tokens,
+            },
         },
         helpers::ResponseBuilder,
     },

--- a/crates/solobase-core/src/crypto.rs
+++ b/crates/solobase-core/src/crypto.rs
@@ -444,7 +444,7 @@ mod tests {
         let secret = "test-secret";
         let token = sign_access_jwt(secret, "user-a", Some("jti-1"), 3600);
         let mut msg = Message::new("http.request");
-        extract_auth_meta(&ctx, &format!("Bearer {token}"), secret, &mut msg).await;
+        extract_auth_meta(&ctx, &format!("Bearer {token}"), secret, "", &mut msg).await;
         assert_eq!(msg.get_meta(wafer_run::meta::META_AUTH_USER_ID), "user-a");
         assert_eq!(msg.get_meta(META_AUTH_JTI), "jti-1");
         assert!(!msg.get_meta(META_AUTH_EXP).is_empty());
@@ -470,7 +470,7 @@ mod tests {
         .expect("insert blocklist row");
 
         let mut msg = Message::new("http.request");
-        extract_auth_meta(&ctx, &format!("Bearer {token}"), secret, &mut msg).await;
+        extract_auth_meta(&ctx, &format!("Bearer {token}"), secret, "", &mut msg).await;
         // Blocklisted: no auth meta should be set — request continues as
         // anonymous, same as if the JWT had expired or been tampered with.
         assert_eq!(msg.get_meta(wafer_run::meta::META_AUTH_USER_ID), "");
@@ -498,11 +498,11 @@ mod tests {
         let live = sign_access_jwt(secret, "user-a", Some("session-2"), 3600);
 
         let mut m1 = Message::new("http.request");
-        extract_auth_meta(&ctx, &format!("Bearer {blocked}"), secret, &mut m1).await;
+        extract_auth_meta(&ctx, &format!("Bearer {blocked}"), secret, "", &mut m1).await;
         assert_eq!(m1.get_meta(wafer_run::meta::META_AUTH_USER_ID), "");
 
         let mut m2 = Message::new("http.request");
-        extract_auth_meta(&ctx, &format!("Bearer {live}"), secret, &mut m2).await;
+        extract_auth_meta(&ctx, &format!("Bearer {live}"), secret, "", &mut m2).await;
         assert_eq!(m2.get_meta(wafer_run::meta::META_AUTH_USER_ID), "user-a");
     }
 }


### PR DESCRIPTION
## Summary

CI Main has been red on every push since 2026-05-05. Three independent regressions, fixed together because they all block the same pipeline.

- **logout.rs fmt** — nested `use` from PR #162 was never run through nightly rustfmt.
- **`extract_auth_meta` tests** — PR #162 added `expected_iss` as the 4th arg; four unit tests in `crypto.rs` (lines 447/473/501/505) still called the old 4-arg signature. Tests don't exercise the iss check, so they pass `""` (matches the doc-comment escape hatch on the function).
- **`ci-main.yml` missing `--exclude solobase-cloudflare`** — `solobase-cloudflare` is intentionally wasm32-only (workspace `Cargo.toml` comment: `JsFuture` is `!Send`, so its trait impls can't satisfy `+ Send` on the host build). `default-members` excludes it for bare `cargo` invocations, but `--workspace` in the CI commands overrides default-members. `ci.yml` (PR CI) already has the exclude; this just mirrors it on `clippy`, `test`, and `llvm-cov`.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare --no-run` — compiles
- [x] `cargo test -p solobase-core --lib extract_auth_meta` — 3/3 pass
- [ ] CI Main green on this branch's merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)