### PR TITLE
chore(rbp): wave 1a foundations (lock bump + sha256_hex helper + env filter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,6 +5907,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5920,6 +5921,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
  "wafer-block-macro",
  "wafer-flow",
  "wasm-bindgen-futures",
@@ -5928,6 +5930,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5940,8 +5943,10 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
+ "serde_json",
  "tracing",
  "wafer-block",
  "wafer-run",
@@ -5950,6 +5955,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5969,6 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5978,6 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5993,8 +6001,10 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
+ "parking_lot",
  "serde_json",
  "tracing",
  "wafer-block",
@@ -6004,6 +6014,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6014,6 +6025,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "serde",
@@ -6025,6 +6037,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6034,6 +6047,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "futures",
@@ -6050,6 +6064,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6067,6 +6082,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6076,6 +6092,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6086,6 +6103,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6100,6 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6110,6 +6129,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6126,6 +6146,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6137,6 +6158,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6153,6 +6175,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6162,6 +6185,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6190,6 +6214,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/auth/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth/bootstrap.rs
@@ -14,7 +14,6 @@
 //! If the `users` table is non-empty, [`run`] is a no-op regardless of env —
 //! bootstrap is a first-run mechanism only, never a "re-seed" trigger.
 
-use sha2::{Digest, Sha256};
 use wafer_core::clients::crypto;
 use wafer_run::{
     context::Context,
@@ -24,13 +23,8 @@ use wafer_run::{
 use super::{
     config::AuthConfig,
     repo::{bootstrap_tokens, local_credentials, users},
+    service::hash_token,
 };
-
-/// SHA-256 of `s`. Shared with bootstrap-token verification in
-/// `require_role`: the raw token is never stored.
-pub fn sha256(s: &str) -> Vec<u8> {
-    Sha256::digest(s.as_bytes()).to_vec()
-}
 
 /// Run the bootstrap step. Idempotent: returns `Ok(())` without side-effects
 /// when the `users` table is already populated.
@@ -130,7 +124,7 @@ pub(crate) async fn bootstrap_with_email_password(
 async fn bootstrap_with_token(ctx: &dyn Context, token: &str) -> Result<(), WaferError> {
     let expires = chrono::Utc::now() + chrono::Duration::hours(24);
     let expires_iso = expires.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-    bootstrap_tokens::insert(ctx, sha256(token), &expires_iso)
+    bootstrap_tokens::insert(ctx, hash_token(token), &expires_iso)
         .await
         .map_err(internal)?;
     Ok(())

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -82,6 +82,10 @@ pub(crate) mod helpers {
     /// for the legacy sessions write path (sessions repo hex-encodes inside
     /// `insert`). New token-table writes/lookups should go through
     /// `sha256_hex`.
+    #[expect(
+        dead_code,
+        reason = "wired up by Wave 1b token-storage migration (forgot_password / reset_password / verify / signup / pats)"
+    )]
     pub(crate) fn sha256_hex(s: &str) -> String {
         use sha2::{Digest, Sha256};
         use std::fmt::Write;

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -73,6 +73,26 @@ use crate::blocks::admin::USER_ROLES_TABLE;
 pub(crate) mod helpers {
     use super::*;
 
+    /// Canonical lowercase 64-char hex digest of `s`. Used everywhere we
+    /// store "hash of a secret token" in a TEXT column:
+    /// `users.reset_token`, `users.verification_token`, `pats.token_hash`,
+    /// `bootstrap_tokens.token_hash`, `refresh_tokens.token_hash`.
+    ///
+    /// Distinct from [`super::service::hash_token`] which returns `Vec<u8>`
+    /// for the legacy sessions write path (sessions repo hex-encodes inside
+    /// `insert`). New token-table writes/lookups should go through
+    /// `sha256_hex`.
+    pub(crate) fn sha256_hex(s: &str) -> String {
+        use sha2::{Digest, Sha256};
+        use std::fmt::Write;
+        let digest = Sha256::digest(s.as_bytes());
+        let mut out = String::with_capacity(64);
+        for b in digest {
+            let _ = write!(out, "{b:02x}");
+        }
+        out
+    }
+
     pub(crate) async fn get_user_roles(
         ctx: &dyn wafer_run::context::Context,
         user_id: &str,
@@ -344,6 +364,34 @@ pub(crate) mod helpers {
                 _ => format!("%{:02X}", b),
             })
             .collect()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn sha256_hex_known_value() {
+            assert_eq!(
+                sha256_hex("hello"),
+                "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            );
+        }
+
+        #[test]
+        fn sha256_hex_empty_string() {
+            assert_eq!(
+                sha256_hex(""),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            );
+        }
+
+        #[test]
+        fn sha256_hex_is_64_lowercase_hex() {
+            let h = sha256_hex("any input");
+            assert_eq!(h.len(), 64);
+            assert!(h.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        }
     }
 }
 

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -87,8 +87,9 @@ pub(crate) mod helpers {
         reason = "wired up by Wave 1b token-storage migration (forgot_password / reset_password / verify / signup / pats)"
     )]
     pub(crate) fn sha256_hex(s: &str) -> String {
-        use sha2::{Digest, Sha256};
         use std::fmt::Write;
+
+        use sha2::{Digest, Sha256};
         let digest = Sha256::digest(s.as_bytes());
         let mut out = String::with_capacity(64);
         for b in digest {
@@ -394,7 +395,9 @@ pub(crate) mod helpers {
         fn sha256_hex_is_64_lowercase_hex() {
             let h = sha256_hex("any input");
             assert_eq!(h.len(), 64);
-            assert!(h.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+            assert!(h
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
         }
     }
 }

--- a/crates/solobase-core/tests/auth/bootstrap_run.rs
+++ b/crates/solobase-core/tests/auth/bootstrap_run.rs
@@ -2,10 +2,11 @@
 //! already-seeded paths.
 
 use solobase_core::blocks::auth::{
-    bootstrap::{self, sha256},
+    bootstrap,
     config::AuthConfig,
     migrations,
     repo::{bootstrap_tokens, local_credentials, users},
+    service::hash_token,
 };
 
 use crate::common::MigrationTestCtx;
@@ -66,7 +67,7 @@ async fn token_path_inserts_bootstrap_token_row() {
 
     // The bootstrap_tokens row uses sha256(raw) as PK; is_valid checks
     // existence + unexpired.
-    let valid = bootstrap_tokens::is_valid(&ctx, &sha256("secret-token"))
+    let valid = bootstrap_tokens::is_valid(&ctx, &hash_token("secret-token"))
         .await
         .expect("is_valid");
     assert!(valid, "bootstrap token row must be installed and unexpired");

--- a/crates/solobase-native/src/env.rs
+++ b/crates/solobase-native/src/env.rs
@@ -44,9 +44,7 @@ pub(crate) fn filter_app_env_vars<I>(iter: I) -> HashMap<String, String>
 where
     I: IntoIterator<Item = (String, String)>,
 {
-    iter.into_iter()
-        .filter(|(k, _)| k.contains("__"))
-        .collect()
+    iter.into_iter().filter(|(k, _)| k.contains("__")).collect()
 }
 
 #[cfg(test)]
@@ -57,12 +55,21 @@ mod tests {
     fn filter_keeps_shared_and_block_scoped_drops_infra_and_plain() {
         let input = vec![
             // Shared app config — keep.
-            ("SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL".to_string(), "admin@example.com".to_string()),
+            (
+                "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL".to_string(),
+                "admin@example.com".to_string(),
+            ),
             // Block-scoped — keep.
-            ("SUPPERS_AI__AUTH__JWT_SECRET".to_string(), "abc".to_string()),
+            (
+                "SUPPERS_AI__AUTH__JWT_SECRET".to_string(),
+                "abc".to_string(),
+            ),
             // Infra — drop.
             ("SOLOBASE_LISTEN".to_string(), "0.0.0.0:8090".to_string()),
-            ("SOLOBASE_DB_PATH".to_string(), "data/solobase.db".to_string()),
+            (
+                "SOLOBASE_DB_PATH".to_string(),
+                "data/solobase.db".to_string(),
+            ),
             // Plain env vars without `__` — drop.
             ("PATH".to_string(), "/usr/bin".to_string()),
             ("HOME".to_string(), "/home/joris".to_string()),

--- a/crates/solobase-native/src/env.rs
+++ b/crates/solobase-native/src/env.rs
@@ -18,9 +18,15 @@ pub fn load_dotenv() {
     let _ = dotenvy::dotenv();
 }
 
-/// Collect env vars that are NOT prefixed `SOLOBASE_`. These are the
-/// app-level config vars the consumer may want to seed into a config
-/// service or a `variables` table.
+/// Collect env vars that look like app config — i.e. any key containing
+/// `__`. The workspace convention (per CLAUDE.md) is:
+///
+/// - `SOLOBASE_SHARED__*` — shared app config (any block reads it)
+/// - `{ORG}__{BLOCK}__*` — block-scoped (only the owner block + admin)
+/// - `SOLOBASE_*` (no `__`) — infrastructure, never seeded into the DB
+///
+/// The presence of `__` is the discriminator: every app/block config key
+/// contains it, infra keys never do.
 ///
 /// Consumers who want additional filtering (e.g., only env vars that
 /// match declared config var keys) should apply their own filter on top
@@ -29,7 +35,7 @@ pub fn collect_app_env_vars() -> HashMap<String, String> {
     filter_app_env_vars(std::env::vars())
 }
 
-/// Pure filter: drops any pair whose key starts with `SOLOBASE_`.
+/// Pure filter: keeps any pair whose key contains `__`.
 ///
 /// Split out so tests can exercise the filter without mutating the
 /// process environment (which is `unsafe` in Rust 2024 and races with
@@ -39,7 +45,7 @@ where
     I: IntoIterator<Item = (String, String)>,
 {
     iter.into_iter()
-        .filter(|(k, _)| !k.starts_with("SOLOBASE_"))
+        .filter(|(k, _)| k.contains("__"))
         .collect()
 }
 
@@ -48,18 +54,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn filter_app_env_vars_excludes_solobase_prefix() {
+    fn filter_keeps_shared_and_block_scoped_drops_infra_and_plain() {
         let input = vec![
-            ("SOLOBASE_INFRA_X".to_string(), "1".to_string()),
-            ("APP_Y".to_string(), "2".to_string()),
-            ("SOLOBASE_SHARED__FOO".to_string(), "3".to_string()),
+            // Shared app config — keep.
+            ("SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL".to_string(), "admin@example.com".to_string()),
+            // Block-scoped — keep.
+            ("SUPPERS_AI__AUTH__JWT_SECRET".to_string(), "abc".to_string()),
+            // Infra — drop.
+            ("SOLOBASE_LISTEN".to_string(), "0.0.0.0:8090".to_string()),
+            ("SOLOBASE_DB_PATH".to_string(), "data/solobase.db".to_string()),
+            // Plain env vars without `__` — drop.
             ("PATH".to_string(), "/usr/bin".to_string()),
+            ("HOME".to_string(), "/home/joris".to_string()),
         ];
         let out = filter_app_env_vars(input);
-        assert!(!out.contains_key("SOLOBASE_INFRA_X"));
-        assert!(!out.contains_key("SOLOBASE_SHARED__FOO"));
-        assert_eq!(out.get("APP_Y").map(String::as_str), Some("2"));
-        assert_eq!(out.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert!(out.contains_key("SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL"));
+        assert!(out.contains_key("SUPPERS_AI__AUTH__JWT_SECRET"));
+        assert!(!out.contains_key("SOLOBASE_LISTEN"));
+        assert!(!out.contains_key("SOLOBASE_DB_PATH"));
+        assert!(!out.contains_key("PATH"));
+        assert!(!out.contains_key("HOME"));
     }
 
     #[test]


### PR DESCRIPTION
First wave of the 2026-05-14 Rust best-practices remediation.

Wave 0 (wafer-run #71/#72/#73) landed earlier today; this PR is the smaller "1a" cut of the foundation work specced in `docs/superpowers/plans/2026-05-14-rust-best-practices-fix.md`. The bigger items (Task 1.4 token-storage migration + Task 1.6 run_migrations refactor) are split into a follow-up "Wave 1b" PR.

## Summary

- **Cargo.lock bumped** to wafer-run `bb8bd2d1` (post-Wave-0). Resolver now records `source = "git+..."` for wafer-block-* entries that had been missing it from the pre-Wave-0 resolution, plus transitive `url` / `serde_json` deps that upstream picked up.
- **Canonical `auth::helpers::sha256_hex(&str) -> String`** — added inside the existing `pub(crate) mod helpers` in `auth/mod.rs`. Wave 1b will wire it up at the `users.reset_token` / `users.verification_token` / `pats.token_hash` write+lookup sites. Marked `#[expect(dead_code)]` with a reason until then.
- **Collapsed `auth::bootstrap::sha256`** into `auth::service::hash_token` — bytewise identical, one internal caller (\`bootstrap_with_token\`). Closes one of the three duplicates the review's L247 flags.
- **`solobase-native::env::filter_app_env_vars`** now keeps any key containing `__` instead of stripping every `SOLOBASE_*`. Per CLAUDE.md the discriminator between app config and infra is `__`, not the `SOLOBASE_` prefix — fixes the silent dropping of `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_*` and removes the need for any downstream `std::env::var` workaround.

## Out of scope (Wave 1b)

- Task 1.4 — idempotent migration to hash existing plaintext reset/verification/PAT tokens at rest, plus rewriting the 5 write/lookup call sites.
- Task 1.6 — thread `run_migrations: bool` through CLI dispatch instead of `std::env::set_var`.
- The full L247 consolidation (sessions/bootstrap_tokens repos still keep their private `hex_encode` helpers) — left for Wave 2 group C.

## Test plan

- [x] `cargo test -p solobase-core --lib auth::helpers` — 3 new tests on `sha256_hex` pass.
- [x] `cargo test -p solobase-native --lib env::` — both filter tests pass.
- [x] `cargo check -p solobase-core -p solobase-native -p solobase` clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` no new lints from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)