### PR TITLE
feat(cloudflare): enable Workers observability in generated wrangler.toml

### DIFF
--- a/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
@@ -113,6 +113,16 @@ fn base_toml(cfg: &CloudflareConfig) -> toml::Value {
         Value::Array(vec![Value::Table(r2_entry)]),
     );
 
+    // Workers Logs (a.k.a. Workers Observability). Off by default at the
+    // platform; we turn it on so dashboard logs + the `wrangler tail`
+    // request envelope are populated. `head_sampling_rate = 1.0` captures
+    // every invocation — fine at wafer-site's traffic, dial down via
+    // `wrangler_overrides_path` if a deployment grows.
+    let mut obs = toml::map::Map::new();
+    obs.insert("enabled".into(), Value::Boolean(true));
+    obs.insert("head_sampling_rate".into(), Value::Float(1.0));
+    root.insert("observability".into(), Value::Table(obs));
+
     Value::Table(root)
 }
 


### PR DESCRIPTION
## Summary

- Adds `[observability] enabled = true, head_sampling_rate = 1.0` to the base wrangler.toml emitted by `solobase build --target cloudflare`.
- Without this, the deployed worker has no Workers Logs.
- Takes effect on next deploy. **Does NOT fix the current 1102 outage** — observability is forward-looking.

## Why now

wafer.run hit `error code: 1102` on every route at 2026-05-15 ~00:01 UTC and is still down. Investigation was blind because:
- Dashboard Logs view was empty (observability never turned on).
- `wrangler tail` saw nothing — tail attaches inside user code, and a module-init startup-CPU failure crashes before any handler runs.
- `wrangler d1 insights` only showed historic D1 query patterns, not request-level errors.

This PR closes the visibility gap for the next time something breaks at this layer.

## Sampling

`head_sampling_rate = 1.0` (capture every invocation). At wafer-site's current ~5–10k req/day this is well within the included Workers Logs allotment. If a future consumer of `solobase build --target cloudflare` runs at higher volume, it can override via the existing `wrangler_overrides_path` deep-merge without touching this generator.

## Test plan

- [ ] `cargo check -p solobase` — passes locally.
- [ ] After merge, run `solobase build --target cloudflare` and verify the generated `target/solobase-cloudflare/wrangler.toml` contains the `[observability]` block.
- [ ] After next prod deploy, hit wafer.run, then check CF dashboard → Workers & Pages → wafer-site → Logs — entries should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)