### PR TITLE
fix(rbp): wave 1b token-storage hashing + run_migrations refactor (SEC review L210-215)

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -82,10 +82,6 @@ pub(crate) mod helpers {
     /// for the legacy sessions write path (sessions repo hex-encodes inside
     /// `insert`). New token-table writes/lookups should go through
     /// `sha256_hex`.
-    #[expect(
-        dead_code,
-        reason = "wired up by Wave 1b token-storage migration (forgot_password / reset_password / verify / signup / pats)"
-    )]
     pub(crate) fn sha256_hex(s: &str) -> String {
         use std::fmt::Write;
 

--- a/crates/solobase-core/src/blocks/auth/repo/pats.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/pats.rs
@@ -34,16 +34,42 @@ fn now_iso() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
+/// Decode the stored `token_hash` value back into raw bytes.
+///
+/// Storage format is a lowercase 64-char hex string (matches what
+/// `sessions`/`tokens` already do — see review L215). Legacy rows
+/// serialised as JSON byte arrays still decode through the array arm,
+/// so a partially-migrated DB keeps working until the operator wipes /
+/// re-seeds the PAT table.
 fn decode_bytes(v: &Value) -> Option<Vec<u8>> {
+    fn decode_hex(s: &str) -> Option<Vec<u8>> {
+        if s.len() % 2 != 0 {
+            return None;
+        }
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+            .collect()
+    }
+
     match v {
         Value::Array(arr) => Some(
             arr.iter()
                 .filter_map(|x| x.as_u64().map(|n| n as u8))
                 .collect(),
         ),
-        Value::String(s) => Some(s.as_bytes().to_vec()),
+        Value::String(s) => decode_hex(s),
         _ => None,
     }
+}
+
+fn hex_encode_bytes(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 /// Decode scopes from whatever shape the backend returned.
@@ -92,7 +118,10 @@ pub async fn insert(ctx: &dyn Context, new: NewPat) -> Result<(), RepoError> {
     let scopes_json = serde_json::to_string(&new.scopes)
         .map_err(|e| RepoError::Db(format!("scopes ser: {e}")))?;
     let mut data: HashMap<String, Value> = HashMap::new();
-    data.insert("token_hash".into(), json!(new.token_hash));
+    data.insert(
+        "token_hash".into(),
+        json!(hex_encode_bytes(&new.token_hash)),
+    );
     data.insert("user_id".into(), json!(new.user_id));
     data.insert("name".into(), json!(new.name));
     data.insert("scopes".into(), json!(scopes_json));
@@ -140,7 +169,7 @@ pub async fn find_by_token_hash(
         vec![db::Filter {
             field: "token_hash".into(),
             operator: db::FilterOp::Equal,
-            value: json!(hash),
+            value: json!(hex_encode_bytes(hash)),
         }],
     )
     .await
@@ -170,7 +199,7 @@ pub async fn delete_by_id(
             db::Filter {
                 field: "token_hash".into(),
                 operator: db::FilterOp::Equal,
-                value: json!(token_hash),
+                value: json!(hex_encode_bytes(token_hash)),
             },
             db::Filter {
                 field: "user_id".into(),
@@ -196,7 +225,7 @@ pub async fn touch_last_used(ctx: &dyn Context, hash: &[u8]) -> Result<(), RepoE
         vec![db::Filter {
             field: "token_hash".into(),
             operator: db::FilterOp::Equal,
-            value: json!(hash),
+            value: json!(hex_encode_bytes(hash)),
         }],
         data,
     )

--- a/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
@@ -4,7 +4,7 @@ use wafer_core::clients::{crypto, database as db};
 use wafer_run::{context::Context, types::Message, InputStream, OutputStream};
 
 use crate::blocks::{
-    auth::USERS_TABLE,
+    auth::{helpers::sha256_hex, USERS_TABLE},
     helpers::{err_bad_request, err_internal, hex_encode, json_map, ok_json},
 };
 
@@ -34,15 +34,19 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         Err(_) => return ok_json(&serde_json::json!({"message": safe_msg})),
     };
 
-    // Generate reset token (expires in 1 hour)
+    // Generate reset token (expires in 1 hour). The raw token goes in the
+    // email link; only its SHA-256 hex digest is persisted, so a leak of
+    // the row (admin SQL explorer, backup, log dump, any block with read
+    // grant on the users table) does not become a password-reset oracle.
     let reset_token = match crypto::random_bytes(ctx, 32).await {
         Ok(bytes) => hex_encode(&bytes),
         Err(e) => return err_internal("Token generation failed", e),
     };
+    let reset_token_hash = sha256_hex(&reset_token);
 
     let expires = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
     let mut data = json_map(serde_json::json!({
-        "reset_token": reset_token,
+        "reset_token": reset_token_hash,
         "reset_token_expires": expires
     }));
     crate::blocks::helpers::stamp_updated(&mut data);
@@ -51,7 +55,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         return err_internal("Failed to store reset token", e);
     }
 
-    // Send reset email
+    // Send the raw token in the email; the hash lives only in the DB.
     send_reset_email(ctx, &email_lower, &reset_token).await;
 
     ok_json(&serde_json::json!({"message": safe_msg}))

--- a/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
@@ -5,6 +5,7 @@ use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::{
+        helpers::sha256_hex,
         repo::{local_credentials, tokens},
         USERS_TABLE,
     },
@@ -37,12 +38,13 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         );
     }
 
-    // Find user by reset token
+    // Find user by reset token. The DB column stores `sha256_hex(raw)`;
+    // hash the supplied token the same way before comparing.
     let user = match db::get_by_field(
         ctx,
         USERS_TABLE,
         "reset_token",
-        serde_json::Value::String(body.token.clone()),
+        serde_json::Value::String(sha256_hex(&body.token)),
     )
     .await
     {

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -5,7 +5,7 @@ use wafer_run::{context::Context, types::Message, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{build_auth_cookie, generate_tokens, store_refresh_token},
+        helpers::{build_auth_cookie, generate_tokens, sha256_hex, store_refresh_token},
         repo::{local_credentials, sessions, users},
         service::hash_token,
         USERS_TABLE,
@@ -182,10 +182,17 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
 
     // Set email_verified and verification_token on the legacy USERS_TABLE row
     // (Plan A2 users table stores email_verified too — keep them in sync).
+    // Persist only `sha256_hex(raw)`; the raw token goes out only in the
+    // verification email below.
     {
+        let stored_verification = if verification_token.is_empty() {
+            String::new()
+        } else {
+            sha256_hex(&verification_token)
+        };
         let mut upd = json_map(serde_json::json!({
             "email_verified": !require_verification,
-            "verification_token": verification_token.clone(),
+            "verification_token": stored_verification,
         }));
         crate::blocks::helpers::stamp_updated(&mut upd);
         if let Err(e) = db::update(ctx, USERS_TABLE, &user.id, upd).await {

--- a/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
@@ -7,7 +7,7 @@ use wafer_run::{context::Context, types::Message, InputStream, OutputStream};
 
 use crate::{
     blocks::{
-        auth::{brand_panel, USERS_TABLE},
+        auth::{brand_panel, helpers::sha256_hex, USERS_TABLE},
         helpers::{err_bad_request, err_internal, hex_encode, json_map, ok_json, RecordExt},
     },
     ui,
@@ -42,12 +42,14 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
         return err_bad_request("Missing verification token");
     }
 
-    // Find user by verification token
+    // Find user by verification token. The DB column stores
+    // `sha256_hex(raw)`; hash the supplied token the same way before
+    // comparing.
     let user = match db::get_by_field(
         ctx,
         USERS_TABLE,
         "verification_token",
-        serde_json::Value::String(token.clone()),
+        serde_json::Value::String(sha256_hex(&token)),
     )
     .await
     {
@@ -135,15 +137,18 @@ pub async fn handle_resend(ctx: &dyn Context, input: InputStream) -> OutputStrea
         }
     }
 
-    // Generate new token
+    // Generate new token. The raw token goes in the email link; only its
+    // SHA-256 hex digest is persisted so a row-read leak doesn't grant
+    // verification.
     let new_token = match crypto::random_bytes(ctx, 32).await {
         Ok(bytes) => hex_encode(&bytes),
         Err(e) => return err_internal("Token generation failed", e),
     };
+    let new_token_hash = sha256_hex(&new_token);
 
     let now = crate::blocks::helpers::now_rfc3339();
     let mut data = json_map(serde_json::json!({
-        "verification_token": new_token,
+        "verification_token": new_token_hash,
         "last_verification_sent": now
     }));
     crate::blocks::helpers::stamp_updated(&mut data);

--- a/crates/solobase-core/tests/auth/repo_pats.rs
+++ b/crates/solobase-core/tests/auth/repo_pats.rs
@@ -111,3 +111,57 @@ async fn pat_find_missing_returns_none() {
         .expect("lookup");
     assert!(hit.is_none());
 }
+
+#[tokio::test]
+async fn pat_token_hash_is_stored_as_hex_string_not_json_byte_array() {
+    // Regression guard for the 2026-05-14 rust best-practices review (L215).
+    // Prior shape was `json!(new.token_hash)` which serialised to
+    // `[12, 34, ...]`. Hex strings are the format the rest of the auth
+    // surface uses (sessions, tokens, bootstrap_tokens) and the format
+    // `decode_bytes` now expects from string-shaped rows.
+    use wafer_core::clients::database as db;
+
+    let ctx = MigrationTestCtx::new();
+    migrations::apply(&ctx).await.expect("migration apply");
+
+    let u = users::insert(
+        &ctx,
+        users::NewUser {
+            email: "hex@example.com".into(),
+            display_name: "Hex".into(),
+            avatar_url: None,
+            role: "user".into(),
+        },
+    )
+    .await
+    .expect("seed user");
+
+    let raw_hash = [0xab_u8; 32];
+    pats::insert(
+        &ctx,
+        pats::NewPat {
+            token_hash: raw_hash.to_vec(),
+            user_id: u.id.clone(),
+            name: "wire-format".into(),
+            scopes: vec![],
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("insert pat");
+
+    let rows = db::list_all(&ctx, pats::TABLE, vec![])
+        .await
+        .expect("list pats");
+    let stored = rows[0].data.get("token_hash").expect("token_hash present");
+    let s = stored
+        .as_str()
+        .expect("token_hash is a string, not a JSON array");
+    assert_eq!(s.len(), 64, "hex digest is 64 chars");
+    assert!(
+        s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "hex digest is lowercase ascii-hex: got {s:?}"
+    );
+    assert_eq!(s, "ab".repeat(32));
+}

--- a/crates/solobase/src/cli/cli_args.rs
+++ b/crates/solobase/src/cli/cli_args.rs
@@ -37,7 +37,7 @@ pub enum Command {
         #[arg(long)]
         port: Option<u16>,
 
-        /// Apply pending block migrations on startup. Sets SOLOBASE_RUN_MIGRATIONS=1.
+        /// Apply pending block migrations on startup.
         /// Blocks whose SQL hash has changed will be applied and their blessed_hash updated.
         /// Safe to run on every deploy but slower; omit once schema is stable.
         #[arg(long)]
@@ -52,9 +52,11 @@ pub enum Command {
         #[arg(long)]
         release: bool,
 
-        /// Apply pending block migrations on deploy. Sets SOLOBASE_RUN_MIGRATIONS=1.
+        /// Apply pending block migrations on deploy.
         /// Required after adding or modifying migration SQL in any block.
         /// The first deploy after upgrading solobase must pass this flag.
+        /// For --target cloudflare, threads `SOLOBASE_RUN_MIGRATIONS=1` to
+        /// the deployed Worker via `wrangler deploy --var`.
         #[arg(long)]
         run_migrations: bool,
     },

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -66,7 +66,12 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result<()> {
+pub async fn serve(
+    repo_root: &Path,
+    release: bool,
+    port: Option<u16>,
+    run_migrations: bool,
+) -> Result<()> {
     build(repo_root, release).await?;
 
     let out_dir = repo_root.join("target/solobase-cloudflare");
@@ -96,6 +101,11 @@ pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result
     if let Some(p) = port {
         dev.args(["--port", &p.to_string()]);
     }
+    // Pass the flag to the Worker via wrangler's `--var` so the deployed
+    // bundle's `apply_if_blessed` sees it through `ctx.config_get`.
+    if run_migrations {
+        dev.args(["--var", "SOLOBASE_RUN_MIGRATIONS:1"]);
+    }
     let status = dev.status()?;
     if !status.success() {
         bail!("wrangler dev failed (exit {:?})", status.code());
@@ -103,7 +113,7 @@ pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result
     Ok(())
 }
 
-pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
+pub async fn deploy(repo_root: &Path, release: bool, run_migrations: bool) -> Result<()> {
     let cfg = env::load(repo_root)?;
     let _ = env::require_api_token()?; // account_id already validated by load()
 
@@ -121,7 +131,18 @@ pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
         println!("-> D1 migrations applied to {}", cfg.d1.database_name);
     }
 
-    cf_deploy::wrangler_deploy(&wrangler_toml)?;
+    // Block-SQL migrations (the in-Worker hash-gated `apply_if_blessed`
+    // sweep) gate on `SOLOBASE_RUN_MIGRATIONS=1` in the Worker env. The
+    // D1-side schema migrations above run during `wrangler d1 migrations
+    // apply` and are independent of this flag.
+    cf_deploy::wrangler_deploy_with_vars(
+        &wrangler_toml,
+        if run_migrations {
+            &[("SOLOBASE_RUN_MIGRATIONS", "1")]
+        } else {
+            &[]
+        },
+    )?;
 
     let assets_root = out_dir.join("assets");
     let n = cf_deploy::r2_upload_dir(&cfg.r2.bucket_name, &assets_root)?;

--- a/crates/solobase/src/cli/flows/embed_native.rs
+++ b/crates/solobase/src/cli/flows/embed_native.rs
@@ -40,7 +40,12 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn serve(repo_root: &Path, release: bool, _port: Option<u16>) -> Result<()> {
+pub async fn serve(
+    repo_root: &Path,
+    release: bool,
+    _port: Option<u16>,
+    run_migrations: bool,
+) -> Result<()> {
     build(repo_root, release).await?;
 
     // Locate target/<profile>/<bin-name>. Read Cargo.toml to find the bin.
@@ -68,7 +73,16 @@ pub async fn serve(repo_root: &Path, release: bool, _port: Option<u16>) -> Resul
     if !bin.is_file() {
         return Err(anyhow!("expected binary at {bin:?} after cargo build"));
     }
-    let mut child = Command::new(&bin).current_dir(repo_root).spawn()?;
+    // Embed flow exec's the user's bin as a subprocess. Pass the
+    // run-migrations flag via the child's env (scoped to that child),
+    // rather than mutating the CLI's own process env via `set_var` (unsafe
+    // in Rust 2024, and would leak into any other child the CLI spawns).
+    let mut cmd = Command::new(&bin);
+    cmd.current_dir(repo_root);
+    if run_migrations {
+        cmd.env(solobase_core::migration_helper::RUN_MIGRATIONS_KEY, "1");
+    }
+    let mut child = cmd.spawn()?;
     let status = child.wait()?;
     std::process::exit(status.code().unwrap_or(1));
 }

--- a/crates/solobase/src/cli/flows/embed_web.rs
+++ b/crates/solobase/src/cli/flows/embed_web.rs
@@ -51,7 +51,15 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result<()> {
+pub async fn serve(
+    repo_root: &Path,
+    release: bool,
+    port: Option<u16>,
+    _run_migrations: bool,
+) -> Result<()> {
+    // Web serve runs a static-file server over the wasm bundle; the
+    // wasm itself owns its own runtime-side migration state. The flag is
+    // accepted for CLI-symmetry but has nothing to do at this layer.
     build(repo_root, release).await?;
     let port = port.unwrap_or(8080);
     let cfg = config::find_and_load(repo_root)?.0;

--- a/crates/solobase/src/cli/flows/sealed_native.rs
+++ b/crates/solobase/src/cli/flows/sealed_native.rs
@@ -34,7 +34,12 @@ pub async fn build(repo_root: &Path, _release: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn serve(repo_root: &Path, release: bool, _port: Option<u16>) -> Result<()> {
+pub async fn serve(
+    repo_root: &Path,
+    release: bool,
+    _port: Option<u16>,
+    run_migrations: bool,
+) -> Result<()> {
     build(repo_root, release).await?;
-    crate::cli::server::run().await
+    crate::cli::server::run(run_migrations).await
 }

--- a/crates/solobase/src/cli/flows/sealed_web.rs
+++ b/crates/solobase/src/cli/flows/sealed_web.rs
@@ -58,7 +58,15 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result<()> {
+pub async fn serve(
+    repo_root: &Path,
+    release: bool,
+    port: Option<u16>,
+    _run_migrations: bool,
+) -> Result<()> {
+    // Web serve runs a static-file server over the wasm bundle; the
+    // wasm itself owns its own runtime-side migration state. The flag is
+    // accepted for CLI-symmetry but has nothing to do at this layer.
     build(repo_root, release).await?;
     let port = port.unwrap_or(8080);
     let dist = repo_root.join("dist");

--- a/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
@@ -9,11 +9,20 @@ use anyhow::{bail, Context, Result};
 use super::assets::mime_for_path;
 
 pub fn wrangler_deploy(wrangler_toml: &Path) -> Result<()> {
-    let status = Command::new("wrangler")
-        .args(["deploy", "--config"])
-        .arg(wrangler_toml)
-        .status()
-        .context("run wrangler deploy")?;
+    wrangler_deploy_with_vars(wrangler_toml, &[])
+}
+
+/// `wrangler deploy` plus zero or more `--var KEY:VALUE` flags injected
+/// into the Worker's runtime env. Used by the Solobase CLI to plumb
+/// `solobase deploy --run-migrations` through to the Worker's
+/// `apply_if_blessed` hash-gated migration sweep.
+pub fn wrangler_deploy_with_vars(wrangler_toml: &Path, vars: &[(&str, &str)]) -> Result<()> {
+    let mut cmd = Command::new("wrangler");
+    cmd.args(["deploy", "--config"]).arg(wrangler_toml);
+    for (k, v) in vars {
+        cmd.args(["--var", &format!("{k}:{v}")]);
+    }
+    let status = cmd.status().context("run wrangler deploy")?;
     if !status.success() {
         bail!("wrangler deploy failed (exit {:?})", status.code());
     }

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -18,7 +18,14 @@ use crate::cli::server_config::{filter_to_declared_keys, load_block_settings, lo
 /// Boot the native server end-to-end. The body mirrors the previous
 /// `main()` exactly; the signature is `pub async fn run()` so the new
 /// dispatcher can `await` it as the sealed × native flow.
-pub async fn run() -> anyhow::Result<()> {
+///
+/// `run_migrations` mirrors `solobase serve --run-migrations`. When `true`
+/// the boot path stamps `SOLOBASE_RUN_MIGRATIONS=1` into the config
+/// snapshot directly (so [`migration_helper::apply_if_blessed`] sees it),
+/// instead of the prior `std::env::set_var` smuggle. Rust 2024 makes
+/// process-env mutation `unsafe`, and the smuggle leaked into any child
+/// process the boot path might spawn — neither was the right channel.
+pub async fn run(run_migrations: bool) -> anyhow::Result<()> {
     // 1. Load .env file (before reading any env vars)
     load_dotenv();
 
@@ -63,6 +70,9 @@ pub async fn run() -> anyhow::Result<()> {
         solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
         &features.to_config_json(),
     );
+    if run_migrations {
+        config_service.set(solobase_core::migration_helper::RUN_MIGRATIONS_KEY, "1");
+    }
 
     let (mut wafer, storage_block) = SolobaseBuilder::new()
         .database(solobase_native::make_sqlite_database_service(

--- a/crates/solobase/src/main.rs
+++ b/crates/solobase/src/main.rs
@@ -55,22 +55,16 @@ async fn run() -> anyhow::Result<()> {
             port,
             run_migrations,
         } => {
-            if run_migrations {
-                std::env::set_var("SOLOBASE_RUN_MIGRATIONS", "1");
-            }
             let target = default_target(&ctx, target)?;
-            dispatch_serve(&ctx, target, release, port).await
+            dispatch_serve(&ctx, target, release, port, run_migrations).await
         }
         Command::Deploy {
             target,
             release,
             run_migrations,
         } => {
-            if run_migrations {
-                std::env::set_var("SOLOBASE_RUN_MIGRATIONS", "1");
-            }
             let target = default_target(&ctx, target)?;
-            dispatch_deploy(&ctx, target, release).await
+            dispatch_deploy(&ctx, target, release, run_migrations).await
         }
     }
 }
@@ -94,26 +88,42 @@ async fn dispatch_serve(
     target: Target,
     release: bool,
     port: Option<u16>,
+    run_migrations: bool,
 ) -> anyhow::Result<()> {
     let repo_root = &ctx.cwd;
     match (detect_mode(ctx), target) {
-        (Mode::Sealed, Target::Native) => sealed_native::serve(repo_root, release, port).await,
-        (Mode::Sealed, Target::Web) => sealed_web::serve(repo_root, release, port).await,
+        (Mode::Sealed, Target::Native) => {
+            sealed_native::serve(repo_root, release, port, run_migrations).await
+        }
+        (Mode::Sealed, Target::Web) => {
+            sealed_web::serve(repo_root, release, port, run_migrations).await
+        }
         (Mode::Sealed, Target::Cloudflare) => anyhow::bail!(
             "--target cloudflare requires a Cargo package; sealed mode not yet implemented"
         ),
-        (Mode::Embed, Target::Native) => embed_native::serve(repo_root, release, port).await,
-        (Mode::Embed, Target::Web) => embed_web::serve(repo_root, release, port).await,
+        (Mode::Embed, Target::Native) => {
+            embed_native::serve(repo_root, release, port, run_migrations).await
+        }
+        (Mode::Embed, Target::Web) => {
+            embed_web::serve(repo_root, release, port, run_migrations).await
+        }
         (Mode::Embed, Target::Cloudflare) => {
-            embed_cloudflare::serve(repo_root, release, port).await
+            embed_cloudflare::serve(repo_root, release, port, run_migrations).await
         }
     }
 }
 
-async fn dispatch_deploy(ctx: &ModeContext, target: Target, release: bool) -> anyhow::Result<()> {
+async fn dispatch_deploy(
+    ctx: &ModeContext,
+    target: Target,
+    release: bool,
+    run_migrations: bool,
+) -> anyhow::Result<()> {
     let repo_root = &ctx.cwd;
     match (detect_mode(ctx), target) {
-        (Mode::Embed, Target::Cloudflare) => embed_cloudflare::deploy(repo_root, release).await,
+        (Mode::Embed, Target::Cloudflare) => {
+            embed_cloudflare::deploy(repo_root, release, run_migrations).await
+        }
         (Mode::Sealed, Target::Cloudflare) => anyhow::bail!(
             "--target cloudflare requires a Cargo package; sealed mode not yet implemented"
         ),


### PR DESCRIPTION
Second wave of the 2026-05-14 Rust best-practices remediation. Builds on Wave 1a (PR #165) which added the canonical `auth::helpers::sha256_hex`, env filter fix, and dep bump. Spec: `docs/superpowers/specs/2026-05-14-rust-best-practices-fix-design.md`.

## Summary

**Task 1.4 — hash reset/verification/PAT tokens at rest** (commit \`411a37e\`)

Fixes the three Critical findings the review's "auth + auth_ui" section opens with:

- L210 — `users.reset_token` stored plaintext: any DB-read primitive (admin SQL explorer, backup leak, log dump, any block with a \`read\` grant on \`suppers_ai__auth__users\`) was a password-reset oracle.
- L211 — `users.verification_token` same story for email verification.
- L215 — `pats.token_hash` serialised as a JSON byte array (\`[12,34,…]\`) instead of hex.

Wires Wave 1a's \`auth::helpers::sha256_hex\` into every write + lookup:
- \`forgot_password\` / \`reset_password\` / \`verify::handle\` / \`verify::handle_resend\` / \`signup\` — persist \`sha256_hex(raw)\`; the raw token only goes out in the email link.
- \`pats\` repo — \`token_hash\` now stored as lowercase 64-char hex at the wire boundary. Public \`PatRow.token_hash\` / \`NewPat\` keep their \`Vec<u8>\` shape; the repo hex-encodes inside \`insert\` / \`find_by_token_hash\` / \`delete_by_id\` / \`touch_last_used\`. \`decode_bytes\` keeps the legacy JSON-array arm so a partially-migrated DB still decodes.

Regression test asserts the on-disk shape is a hex string, not a JSON array — guards against \`json!(Vec<u8>)\` re-appearing.

**Task 1.6 — drop \`std::env::set_var("SOLOBASE_RUN_MIGRATIONS")\` smuggle** (commit \`4e6a35c\`)

\`solobase serve --run-migrations\` and \`solobase deploy --run-migrations\` previously set the process-wide env var so \`migration_helper::apply_if_blessed\` would see it later via the config service's \`std::env::var\` fallback. Rust 2024 makes \`set_var\` \`unsafe\` (races with concurrent \`getenv\`/\`setenv\`), and the value leaked into every child the CLI spawned.

Threaded explicitly through dispatch:
- \`cli::server::run(run_migrations: bool)\` stamps the key into the config snapshot directly.
- \`embed_native::serve\` passes the flag via \`Command::env(...)\` on the spawned user-bin — scoped to that child only.
- \`embed_cloudflare::serve\` / \`deploy\` add \`--var SOLOBASE_RUN_MIGRATIONS:1\` to \`wrangler dev\` / \`wrangler deploy\` so the deployed Worker actually sees it. **Genuine behaviour fix** — the prior set_var only affected the local CLI process and never reached the Worker, so \`solobase deploy --run-migrations --target cloudflare\` was effectively a no-op for the Worker-side hash-gated migration sweep.

## Migration / rollout notes

- **No data migration.** Per the active-development-can-wipe-prod-db convention, wafer.run D1+R2 is wipeable. Existing local dev rows with plaintext reset/verification tokens fail lookup after this lands; operators should clear \`users.reset_token\` / \`users.verification_token\` / re-seed PATs.
- The CF deploy --var change means the **next** \`solobase deploy --run-migrations\` on wafer.run will actually run the block-SQL hash-gated migration sweep on the Worker. Recommend verifying the result against the post-deploy runbook before relying on it.

## Test plan

- [x] \`cargo test -p solobase-core --test auth\` — 53/53 pass (incl. new \`pat_token_hash_is_stored_as_hex_string_not_json_byte_array\`).
- [x] \`cargo test -p solobase-core\` — 621/621 lib tests pass.
- [x] \`cargo test -p solobase --lib\` — 8/8 pass.
- [x] \`cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare\` clean.
- [x] \`cargo +nightly fmt --all -- --check\` clean.
- [ ] Manual: signup → request password reset → reset link arrives → consume link → succeeds (round-trip the new hashed-token paths).
- [ ] Manual: \`solobase serve --run-migrations\` against a dev DB — block-settings row picks up the new SQL hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)