### PR TITLE
chore(deps): bump wafer-run to 38d31640 (post-audit Pass 1-6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5956,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5976,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5986,11 +5986,11 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
- "hyper 1.9.0",
+ "form_urlencoded",
  "parking_lot",
  "serde_json",
  "tokio",
@@ -6002,10 +6002,11 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "parking_lot",
+ "percent-encoding",
  "serde_json",
  "tracing",
  "wafer-block",
@@ -6015,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6026,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "serde",
@@ -6038,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6048,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "futures",
@@ -6065,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6083,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6093,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6104,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6119,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6130,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6147,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6159,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6176,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "serde",
  "serde_json",
@@ -6186,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6215,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bb8bd2d1f09175388ef54e999adebfae5773ada3"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#38d3164063143b622ba903af2bd8d6149ed139af"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
## Summary

Lockfile bump to pick up wafer-run main after the 2026-05-14 audit's six refactor passes (wafer-run/wafer-run PRs #77 .. #86):

| # | Pass | Title |
|---|---|---|
| #77 | prereq | clippy fix under default-features = false |
| #78 | 1a | drop unused hyper dep (http-listener) |
| #79 | 1b | url decoders → percent-encoding / form_urlencoded |
| #80 | 1c | sql-utils: render_* collapsed into single macro |
| #81 | 1d | Go ErrorCode codegen → PascalCase |
| #82 | **2** | **BlockInfo::flow_config; drop env_or; sweep all blocks** |
| #83 | 3 | sqlite/postgres service.rs off raw SQL |
| #84 | 4 | delete legacy http.resp.* meta-key prefix family |
| #85 | 5 | StartupSnapshot scaffolding (foundation only) |
| #86 | 6 | FFI / macro panic surface hardening |

### Pass 2 downstream impact: none here

Pass 2 was flagged in the audit as breaking for downstream consumers due to env-var renames (`STORAGE_*` → `flow_config`/`WAFER_RUN__S3__*`, `DATABASE_URL` → `WAFER_RUN__POSTGRES__DATABASE_URL`, `SOLOBASE_FASTEMBED_*` → `WAFER_RUN__FASTEMBED__*`, `RATE_LIMIT_IP` → `WAFER_RUN__IP_RATE_LIMIT__DISABLE` with flipped semantics). Verified via grep that:

- None of those renamed env vars are set in solobase `.env*`, `.yml` deploy workflows, or Rust source.
- `BlockConfig::env_or` (also removed in #82) has no callers here.

So just a lockfile bump is sufficient.

### Build verification

`cargo build --workspace --exclude solobase-web` succeeds locally. `solobase-web` has 22 pre-existing browser-WASM build errors (tracked separately, identical set before and after this bump).

## Test plan

- [ ] CI: `cargo build --workspace`
- [ ] CI: `cargo test --workspace`
- [ ] Deploy preview (or smoke test): confirm wafer.run still serves after the bump