### PR TITLE
feat(admin): UI polish round — avatars, db cards, api-key copy, dialog modals, variables-table unify

### DIFF
--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -144,6 +144,17 @@ pub(in crate::blocks::admin) fn validate_readonly_query(
 ) -> Result<(), QueryValidationError> {
     let trimmed = query.trim();
 
+    // Strip one trailing `;` (and any whitespace after it) before the
+    // multi-statement check. Editors frequently auto-append a terminator,
+    // and the no-semicolon rule exists to block *piggy-backed* writes
+    // like `SELECT 1; DROP TABLE x` — a lone terminator carries none of
+    // that risk and produces a footgun otherwise. After stripping, a
+    // remaining `;` means there's more than one statement and we reject.
+    let trimmed = trimmed
+        .strip_suffix(';')
+        .map(|s| s.trim_end())
+        .unwrap_or(trimmed);
+
     // Reject multi-statement queries (prevent piggy-backed writes).
     if trimmed.contains(';') {
         return Err(QueryValidationError::Forbidden(
@@ -311,6 +322,28 @@ mod tests {
         assert!(validate_readonly_query("PRAGMA table_info(users)").is_ok());
         assert!(validate_readonly_query("PRAGMA index_list(users)").is_ok());
         assert!(validate_readonly_query("PRAGMA database_list").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_single_trailing_semicolon() {
+        // Editors frequently auto-append `;`. A lone trailing terminator
+        // is harmless; the no-semicolon rule exists to block piggy-backed
+        // writes, not statement terminators.
+        assert!(validate_readonly_query("SELECT * FROM users;").is_ok());
+        assert!(validate_readonly_query("SELECT * FROM users ;").is_ok());
+        assert!(validate_readonly_query("SELECT * FROM users;\n").is_ok());
+        assert!(validate_readonly_query("  SELECT 1 ;  ").is_ok());
+    }
+
+    #[test]
+    fn validate_still_rejects_multistatement_with_trailing_semicolon() {
+        // Two real statements, the second terminated — must still be
+        // rejected. Stripping one trailing `;` leaves the inner `;`
+        // visible to the multi-statement check.
+        let e = validate_readonly_query("SELECT 1; DROP TABLE users;").unwrap_err();
+        assert!(matches!(e, QueryValidationError::Forbidden(_)));
+        let e = validate_readonly_query("SELECT 1; SELECT 2;").unwrap_err();
+        assert!(matches!(e, QueryValidationError::Forbidden(_)));
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -301,9 +301,6 @@ impl Block for AdminBlock {
                     return pages::handle_user_delete(ctx, &msg, &user_id).await;
                 }
             }
-            if action == "create" && sub == "/users" {
-                return pages::handle_user_invite(ctx, &msg, input).await;
-            }
             if action == "create" && sub == "/iam/roles" {
                 return pages::handle_create_role(ctx, &msg, input).await;
             }

--- a/crates/solobase-core/src/blocks/admin/pages/database.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/database.rs
@@ -21,7 +21,7 @@ use crate::{
         helpers::{now_millis, parse_form_body, url_path_encode as pct_encode},
     },
     ui::{
-        html_response,
+        html_response, icons,
         shell::Topbar,
         templates::{list_page, PageHeader},
         SiteConfig, UserInfo,
@@ -95,9 +95,11 @@ fn backend_badge(table_count: usize) -> Markup {
 
 fn left_pane(tables: &[TableSummary], selected: Option<&str>, tab: Tab) -> Markup {
     // Group tables by their `org__block` prefix (first two `__`-separated
-    // segments). Tables without `__` (e.g. legacy `variables`) go at the top
-    // level. The auto-expand of the active group is handled inline via the
-    // `open` attribute on the `<details>`.
+    // segments). Tables without `__` (e.g. legacy `variables`) go in their
+    // own "Other" section. Each group renders as a small card with an
+    // org/block heading, a count badge, and an always-visible table list —
+    // no more collapsible `<details>` carets. The filter input below hides
+    // matching rows without needing to expand/collapse anything.
     use std::collections::BTreeMap;
     let mut groups: BTreeMap<String, Vec<&TableSummary>> = BTreeMap::new();
     let mut ungrouped: Vec<&TableSummary> = Vec::new();
@@ -117,61 +119,96 @@ fn left_pane(tables: &[TableSummary], selected: Option<&str>, tab: Tab) -> Marku
                 input #db-filter type="text"
                     placeholder="Filter tables…"
                     autocomplete="off"
-                    oninput="(function(e){var q=e.target.value.toLowerCase();document.querySelectorAll('[data-db-table]').forEach(function(li){var n=li.getAttribute('data-db-table');li.style.display=n.indexOf(q)>=0?'':'none';});document.querySelectorAll('.db-table-list__group').forEach(function(g){if(q){g.setAttribute('open','');}});})(event)";
+                    oninput="(function(e){var q=e.target.value.toLowerCase();var visible=0;document.querySelectorAll('[data-db-table]').forEach(function(li){var n=li.getAttribute('data-db-table');var show=n.indexOf(q)>=0;li.style.display=show?'':'none';if(show)visible++;});document.querySelectorAll('[data-db-group]').forEach(function(g){var anyVisible=g.querySelector('[data-db-table]:not([style*=\"none\"])');g.style.display=anyVisible?'':'none';});var empty=document.getElementById('db-filter-empty');if(empty)empty.style.display=visible===0?'':'none';})(event)";
             }
-            ul .db-table-list {
+            div .db-table-groups {
                 @if tables.is_empty() {
-                    li .db-table-list__empty .text-muted .text-sm { "No tables yet" }
+                    div .db-table-list__empty .text-muted .text-sm { "No tables yet" }
                 }
-                @for (group_name, group_tables) in &groups {
-                    @let group_has_selected = group_tables.iter().any(|t| selected == Some(t.name.as_str()));
-                    li {
-                        details .db-table-list__group open[group_has_selected] {
-                            summary .db-table-list__group-summary {
-                                span .db-table-list__group-name { (group_name) }
-                                span .db-table-list__group-count .text-muted .text-xs { (group_tables.len()) }
+                @for (group_key, group_tables) in &groups {
+                    @let (org, block) = group_label(group_key);
+                    section .db-table-group data-db-group=(group_key) {
+                        header .db-table-group__head {
+                            span .db-table-group__icon { (icons::package()) }
+                            div .db-table-group__title-wrap {
+                                span .db-table-group__title { (block) }
+                                span .db-table-group__org .text-muted { (org) }
                             }
-                            ul .db-table-list .db-table-list--nested {
-                                @for t in group_tables {
-                                    @let active = selected == Some(t.name.as_str());
-                                    @let encoded_name = pct_encode(&t.name);
-                                    @let leaf = t.name.rsplit("__").next().unwrap_or(&t.name);
-                                    li data-db-table=(t.name.to_lowercase()) {
-                                        a .db-table-list__item .(if active { "is-active" } else { "" })
-                                            aria-current=[active.then_some("page")]
-                                            href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                                            hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                                            hx-target="#content"
-                                            hx-push-url="true"
-                                        {
-                                            span .db-table-list__name { (leaf) }
-                                            span .db-table-list__count .text-muted .text-xs { (t.row_count) }
-                                        }
+                            span .db-table-group__count { (group_tables.len()) }
+                        }
+                        ul .db-table-group__list {
+                            @for t in group_tables {
+                                @let active = selected == Some(t.name.as_str());
+                                @let encoded_name = pct_encode(&t.name);
+                                @let leaf = t.name.rsplit("__").next().unwrap_or(&t.name);
+                                li data-db-table=(t.name.to_lowercase()) {
+                                    a .db-table-list__item .(if active { "is-active" } else { "" })
+                                        aria-current=[active.then_some("page")]
+                                        href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-target="#content"
+                                        hx-push-url="true"
+                                    {
+                                        span .db-table-list__name { (leaf) }
+                                        span .db-table-list__count .text-muted .text-xs { (t.row_count) }
                                     }
                                 }
                             }
                         }
                     }
                 }
-                @for t in &ungrouped {
-                    @let active = selected == Some(t.name.as_str());
-                    @let encoded_name = pct_encode(&t.name);
-                    li data-db-table=(t.name.to_lowercase()) {
-                        a .db-table-list__item .(if active { "is-active" } else { "" })
-                            aria-current=[active.then_some("page")]
-                            href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                            hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
-                            hx-target="#content"
-                            hx-push-url="true"
-                        {
-                            span .db-table-list__name { (t.name) }
-                            span .db-table-list__count .text-muted .text-xs { (t.row_count) }
+                @if !ungrouped.is_empty() {
+                    section .db-table-group data-db-group="_other" {
+                        header .db-table-group__head {
+                            span .db-table-group__icon { (icons::database()) }
+                            div .db-table-group__title-wrap {
+                                span .db-table-group__title { "Other" }
+                                span .db-table-group__org .text-muted { "no block prefix" }
+                            }
+                            span .db-table-group__count { (ungrouped.len()) }
+                        }
+                        ul .db-table-group__list {
+                            @for t in &ungrouped {
+                                @let active = selected == Some(t.name.as_str());
+                                @let encoded_name = pct_encode(&t.name);
+                                li data-db-table=(t.name.to_lowercase()) {
+                                    a .db-table-list__item .(if active { "is-active" } else { "" })
+                                        aria-current=[active.then_some("page")]
+                                        href={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-get={"/b/admin/database?table=" (encoded_name) "&tab=" (tab.as_query())}
+                                        hx-target="#content"
+                                        hx-push-url="true"
+                                    {
+                                        span .db-table-list__name { (t.name) }
+                                        span .db-table-list__count .text-muted .text-xs { (t.row_count) }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
+                div #db-filter-empty .db-table-list__empty .text-muted .text-sm
+                    style="display:none" { "No tables match." }
             }
         }
     }
+}
+
+/// Split an `org__block` group key into a display-friendly `(org, block)`
+/// pair. `suppers_ai__admin` → `("suppers-ai", "admin")`. Leaves the value
+/// alone if it doesn't have a `__` (shouldn't happen given the caller's
+/// split, but keeps this helper defensive for tests).
+fn group_label(group_key: &str) -> (String, String) {
+    let (org_raw, block) = match group_key.split_once("__") {
+        Some((a, b)) => (a.to_string(), b.to_string()),
+        None => (String::new(), group_key.to_string()),
+    };
+    // DB-safe identifiers use `_` where the block name's `org/block` form
+    // uses `-` (so `suppers-ai/admin` lands as `suppers_ai__admin`).
+    // Reverse that for the org-label display only — block names are valid
+    // ident segments and don't need translation here.
+    let org_display = org_raw.replace('_', "-");
+    (org_display, block)
 }
 
 fn right_pane_tabs(selected: Option<&str>, tab: Tab) -> Markup {
@@ -436,4 +473,30 @@ pub async fn handle_database_query(
         Err(e) => render_sql_error(&format!("Query error: {}", e)),
     };
     html_response(fragment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_label_translates_underscores_to_dashes_in_org() {
+        // `org__block` keys come from splitting table names like
+        // `suppers_ai__admin__users` on `__`. The org segment uses `_` as
+        // its separator; the display form uses `-`, matching how blocks
+        // are referenced everywhere else (e.g. "suppers-ai/admin").
+        let (org, block) = group_label("suppers_ai__admin");
+        assert_eq!(org, "suppers-ai");
+        assert_eq!(block, "admin");
+    }
+
+    #[test]
+    fn group_label_handles_single_segment_keys() {
+        // Defensive: caller currently never passes a single-segment key,
+        // but if it ever does we put the whole thing into `block` rather
+        // than panicking.
+        let (org, block) = group_label("variables");
+        assert_eq!(org, "");
+        assert_eq!(block, "variables");
+    }
 }

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -1,4 +1,4 @@
-use maud::{html, Markup, PreEscaped};
+use maud::{html, Markup};
 use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions, SortField};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
@@ -14,7 +14,7 @@ use crate::{
     },
     ui::{
         self,
-        components::{self, button, pagination, BtnVariant, CtrlSize},
+        components::{self, pagination},
         icons,
         shell::Topbar,
         templates::{list_page, PageHeader},
@@ -71,29 +71,6 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 (api_keys_tab(ctx).await)
             }
         }
-        // Invite-user modal — always present so the topbar action works
-        // regardless of which tab is active. Posts back to
-        // /b/admin/users (create) and swaps the users table.
-        (components::modal("invite-user", "Invite user", html! {
-            form hx-post="/b/admin/users" hx-target="#users-tab-content" {
-                div .form-group {
-                    label .form-label .required for="invite-email" { "Email" }
-                    input .form-input type="email" #invite-email name="email" placeholder="user@example.com" required;
-                }
-                div .form-group {
-                    label .form-label .required for="invite-password" { "Initial password" }
-                    input .form-input type="text" #invite-password name="password" placeholder="At least 8 chars" minlength="8" required;
-                }
-                div .form-group {
-                    label .form-label for="invite-name" { "Name" }
-                    input .form-input type="text" #invite-name name="name" placeholder="Optional";
-                }
-                div .form-actions {
-                    button .btn .btn-secondary type="button" onclick="closeModal('invite-user')" { "Cancel" }
-                    button .btn .btn-primary type="submit" { "Invite" }
-                }
-            }
-        }))
     };
 
     let body = list_page(
@@ -114,12 +91,7 @@ pub async fn users_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         user.as_ref(),
         Topbar {
             crumbs: crumb("Users"),
-            primary_action: Some(button(
-                BtnVariant::Primary,
-                CtrlSize::Sm,
-                "+ Invite user",
-                PreEscaped(r##"onclick="openModal('invite-user')""##.to_string()),
-            )),
+            primary_action: None,
             subtitle: Some("Manage accounts, roles, and API keys"),
             show_palette: true,
         },
@@ -419,101 +391,6 @@ pub async fn handle_user_delete(ctx: &dyn Context, msg: &Message, user_id: &str)
     )
     .await;
     ui::html_response_with_toast(html! {}, "User deleted", "success")
-}
-
-/// POST /b/admin/users (invite-user modal form)
-pub async fn handle_user_invite(
-    ctx: &dyn Context,
-    msg: &Message,
-    input: InputStream,
-) -> OutputStream {
-    use wafer_core::clients::crypto;
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
-    let bytes = input.collect_to_bytes().await;
-    let body = parse_form_body(&bytes);
-
-    let email = body
-        .get("email")
-        .map(String::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    let password = body.get("password").map(String::as_str).unwrap_or("");
-    let name = body
-        .get("name")
-        .map(String::as_str)
-        .unwrap_or("")
-        .to_string();
-    if email.is_empty() {
-        return err_bad_request("Email is required");
-    }
-    if password.len() < 8 {
-        return err_bad_request("Password must be at least 8 characters");
-    }
-
-    // Reject duplicate email — emails are unique in practice though the
-    // table doesn't carry a UNIQUE constraint.
-    match db::get_by_field(
-        ctx,
-        USERS,
-        "email",
-        serde_json::Value::String(email.clone()),
-    )
-    .await
-    {
-        Ok(_) => return err_bad_request("A user with that email already exists"),
-        Err(e) if e.code == ErrorCode::NotFound => {}
-        Err(_) => {}
-    }
-
-    let password_hash = match crypto::hash(ctx, password).await {
-        Ok(h) => h,
-        Err(e) => return err_internal("Failed to hash password", e),
-    };
-
-    let mut data = helpers::json_map(serde_json::json!({
-        "email": email,
-        "password_hash": password_hash,
-        "name": name,
-        "disabled": false,
-        "email_verified": false,
-        "avatar_url": "",
-        "oauth_provider": "",
-        "verification_token": "",
-        "reset_token": "",
-        "reset_token_expires": null,
-        "last_verification_sent": null,
-        "last_login_at": null,
-        "deleted_at": null,
-    }));
-    helpers::stamp_created(&mut data);
-
-    let new_user = match db::create(ctx, USERS, data).await {
-        Ok(u) => u,
-        Err(e) => return err_internal("Failed", e.message),
-    };
-
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "user.invite",
-        &format!("users/{}", new_user.id),
-        &ip,
-    )
-    .await;
-
-    // Return the refreshed users-tab content (table + pagination) so it
-    // slots into #users-tab-content via innerHTML swap. Trigger toast +
-    // close-modal client-side.
-    let content = users_tab(ctx, msg, &admin_id).await;
-    let trigger = r#"{"showToast":{"message":"User invited","type":"success"},"closeModal":{"id":"invite-user"}}"#;
-    ResponseBuilder::new()
-        .set_header("HX-Trigger", trigger)
-        .body(
-            content.into_string().into_bytes(),
-            "text/html; charset=utf-8",
-        )
 }
 
 /// POST /b/admin/iam/roles (create role from modal form)

--- a/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/api_keys.rs
@@ -112,6 +112,20 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
             if !msg.get_meta("http.header.hx-request").is_empty() {
                 let key_for_display = key_string.clone();
                 let name = record.str_field("name").to_string();
+                // Inline JS handler for the copy button. The key text lives
+                // in #new-api-key — read `innerText` (not the JS string) so
+                // we never have to escape the key into a JS literal, and so
+                // the button works even if the swap re-renders without the
+                // original closure scope.
+                let copy_js = "\
+                    var el=document.getElementById('new-api-key');\
+                    var t=el?el.innerText:'';\
+                    if(t&&navigator.clipboard){\
+                        navigator.clipboard.writeText(t).then(function(){\
+                            var b=event.currentTarget;b.textContent='Copied';\
+                            setTimeout(function(){b.textContent='Copy'},1500);\
+                        });\
+                    }";
                 let markup = maud::html! {
                     div .card style="margin-bottom: var(--spacing-md)" {
                         div .card__head { h3 .card__title { "Key created — save it now" } }
@@ -119,17 +133,20 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
                             p style="margin:0 0 var(--spacing-sm); font-size: 13px; color: var(--text-secondary)" {
                                 "This is the only time the full key will be shown. Copy it now."
                             }
-                            code style="display: block; padding: var(--spacing-sm); background: var(--bg-secondary); border-radius: var(--radius-md); font-family: ui-monospace, Menlo, monospace; font-size: 13px; word-break: break-all" {
-                                (key_for_display)
+                            div style="display:flex; gap: var(--spacing-sm); align-items: stretch" {
+                                code #new-api-key style="flex:1 1 auto; padding: var(--spacing-sm); background: var(--bg-secondary); border-radius: var(--radius-md); font-family: ui-monospace, Menlo, monospace; font-size: 13px; word-break: break-all; user-select: all" {
+                                    (key_for_display)
+                                }
+                                button type="button" .btn .btn-secondary .btn-sm
+                                    style="flex: 0 0 auto"
+                                    onclick=(copy_js)
+                                { "Copy" }
                             }
                             p style="margin: var(--spacing-sm) 0 0; font-size: var(--text-xs); color: var(--text-muted)" {
                                 "Name: " (name)
                             }
                         }
                     }
-                    // Reload the api-keys tab below the new-key card by
-                    // pointing the form's swap target. We reuse the
-                    // existing JS toggle by triggering an HX event.
                 };
                 let trigger = r#"{"showToast":{"message":"API key created","type":"success"},"closeModal":{"id":"create-api-key"}}"#;
                 crate::blocks::helpers::ResponseBuilder::new()

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -20,7 +20,11 @@ use crate::{
 /// Tabs navigation across the storage-admin sub-pages
 /// (Overview / Buckets / Shares / Quotas). `active` matches the
 /// crumb label so the active tab can be highlighted.
-fn admin_tabs(active: &str) -> Markup {
+///
+/// Designed to slot into `list_page`'s `filters` arg (the same slot the
+/// Users tabs use), so the tab strip lives inside `.page--list` and picks
+/// up the page padding consistently.
+pub(crate) fn admin_tabs(active: &str) -> Markup {
     let items: &[(&str, &str)] = &[
         ("Overview", "/b/storage/admin/"),
         ("Buckets", "/b/storage/admin/buckets"),
@@ -81,20 +85,12 @@ fn files_page_with_action<'a>(
         subtitle,
         show_palette: true,
     };
-    let body_with_tabs = html! {
-        (admin_tabs(crumb_label))
-        (content)
-    };
-    crate::ui::shelled_response(
-        msg,
-        title,
-        config,
-        &groups,
-        user,
-        path,
-        topbar,
-        body_with_tabs,
-    )
+    // Tabs are now embedded into `list_page` by each caller (in the
+    // `filters` slot, matching how the Users page wires its tab strip).
+    // That keeps the storage admin pages' padding consistent with
+    // `/b/admin/users`; previously the tabs sat outside `.page--list`
+    // and lost the page gutter.
+    crate::ui::shelled_response(msg, title, config, &groups, user, path, topbar, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -147,13 +143,15 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     let stats = load_admin_stats(ctx).await;
 
+    let stats_markup = render_admin_overview_stats(&stats);
+    let filters = html! { (admin_tabs("Overview")) (stats_markup) };
     let body = list_page(
         PageHeader {
             title: "",
             subtitle: None,
             primary_action: None,
         },
-        Some(render_admin_overview_stats(&stats)),
+        Some(filters),
         render_admin_overview_quotas_hint(stats.quotas_count),
         None,
     );
@@ -312,7 +310,7 @@ pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Buckets")),
         html! {
             (render_admin_buckets_table(&rows))
             (super::pages_user::render_new_bucket_modal())
@@ -458,7 +456,7 @@ pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Shares")),
         render_admin_shares_table(&rows),
         None,
     );
@@ -558,7 +556,7 @@ pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
             subtitle: None,
             primary_action: None,
         },
-        None,
+        Some(admin_tabs("Quotas")),
         render_admin_quotas_table(&rows),
         None,
     );

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -143,16 +143,21 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     let stats = load_admin_stats(ctx).await;
 
-    let stats_markup = render_admin_overview_stats(&stats);
-    let filters = html! { (admin_tabs("Overview")) (stats_markup) };
+    // Tabs go in the `filters` slot (their padding gutter matches
+    // /b/admin/users); stats live in the body. Keeping them in separate
+    // slots prevents `.page-filters` (display:flex) from putting tabs
+    // and the stats-grid side-by-side at wide viewports.
     let body = list_page(
         PageHeader {
             title: "",
             subtitle: None,
             primary_action: None,
         },
-        Some(filters),
-        render_admin_overview_quotas_hint(stats.quotas_count),
+        Some(admin_tabs("Overview")),
+        html! {
+            (render_admin_overview_stats(&stats))
+            (render_admin_overview_quotas_hint(stats.quotas_count))
+        },
         None,
     );
 

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -261,6 +261,95 @@
 	border-top: 1px solid var(--border-color);
 }
 
+/* Native <dialog> modals (used by the files browser's "New bucket" form,
+   etc). The .modal box rules above target the htmx-driven overlay/box
+   pattern; this block re-centers and pads the native-dialog variant,
+   draws a ::backdrop scrim, and gives the inner form sensible spacing.
+   The screenshot of the bucket modal landing in the top-left corner
+   without backdrop dimming is the symptom that motivated this block. */
+dialog.modal {
+	position: fixed;
+	inset: 0;
+	margin: auto;
+	height: fit-content;
+	padding: 1.5rem;
+	border: 1px solid var(--border-color);
+}
+dialog.modal::backdrop {
+	background: rgba(0, 0, 0, 0.5);
+	backdrop-filter: blur(2px);
+}
+dialog.modal h3 {
+	margin: 0 0 1rem;
+	font-size: 1.125rem;
+	font-weight: 600;
+}
+dialog.modal label {
+	display: block;
+	margin-bottom: 0.375rem;
+}
+dialog.modal label > span {
+	display: block;
+	margin-bottom: 0.375rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--text-primary);
+}
+dialog.modal input[type="text"],
+dialog.modal input[type="email"],
+dialog.modal input[type="number"],
+dialog.modal input[type="password"] {
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	font-size: 0.875rem;
+	color: var(--text-primary);
+	background: var(--bg-card, #fff);
+}
+dialog.modal input:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 1px;
+	border-color: var(--primary-color);
+}
+dialog.modal .form-hint {
+	margin: 0.375rem 0 1rem;
+}
+dialog.modal .checkbox-label {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	margin: 0.5rem 0 1.25rem;
+	font-size: 0.875rem;
+	font-weight: normal;
+	color: var(--text-primary);
+}
+dialog.modal .checkbox-label > span {
+	display: inline;
+	margin: 0;
+	font-weight: normal;
+}
+dialog.modal .checkbox-label input[type="checkbox"] {
+	margin-top: 0.2em;
+	accent-color: var(--primary-color);
+}
+dialog.modal .modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	margin-top: 1rem;
+}
+dialog.modal .modal-error {
+	display: block;
+	margin: 0 0 0.75rem;
+	padding: 0.5rem 0.75rem;
+	border-radius: 6px;
+	background: #fee2e2;
+	color: #991b1b;
+	font-size: 0.875rem;
+}
+dialog.modal .modal-error[hidden] { display: none; }
+
 /* Empty State */
 .empty-state {
 	text-align: center; padding: 3rem 1.5rem;

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -578,7 +578,7 @@
 .badge--danger { background: #fee2e2; color: #991b1b; }
 
 /* ===== Avatar ===== */
-.avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-full); color: #fff; font-weight: 600; }
+.avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-full); background: var(--primary-color); color: #fff; font-weight: 600; }
 .avatar--sm { width: 22px; height: 22px; font-size: var(--text-xs); }
 .avatar--md { width: 32px; height: 32px; font-size: var(--text-sm); }
 .avatar--lg { width: 48px; height: 48px; font-size: var(--text-lg); }
@@ -635,6 +635,75 @@
 .db-table-list__item.is-active { background: #fef9e7; border: 1px solid #f0d78c; }
 .db-table-list__name { font-weight: 500; word-break: break-all; }
 .db-table-list__empty { padding: 8px; }
+
+/* Grouped tables (left pane) — one card per `org__block` prefix */
+.db-table-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+.db-table-group {
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-card, #fff);
+  overflow: hidden;
+}
+.db-table-group__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-secondary, #f8f9fa);
+  border-bottom: 1px solid var(--border, #e2e8f0);
+}
+.db-table-group__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--primary-color);
+  flex: 0 0 auto;
+}
+.db-table-group__icon svg { width: 16px; height: 16px; }
+.db-table-group__title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.db-table-group__title {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary, #0f172a);
+  word-break: break-all;
+}
+.db-table-group__org {
+  font-size: 11px;
+  letter-spacing: 0.01em;
+}
+.db-table-group__count {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--primary-color);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+}
+.db-table-group__list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 6px;
+}
 .db-panel { padding: 4px 0; }
 .db-panel__head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .db-panel__head h3 { font-size: 14px; margin: 0; word-break: break-all; }

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -636,13 +636,14 @@
 .db-table-list__name { font-weight: 500; word-break: break-all; }
 .db-table-list__empty { padding: 8px; }
 
-/* Grouped tables (left pane) — one card per `org__block` prefix */
+/* Grouped tables (left pane) — one card per `org__block` prefix.
+   No inner max-height: groups expand to fit all their rows and the page
+   itself scrolls. The earlier 60vh + overflow-y clipped rows mid-line at
+   the scroll edges, which read like the list was broken. */
 .db-table-groups {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 60vh;
-  overflow-y: auto;
 }
 .db-table-group {
   border: 1px solid var(--border, #e2e8f0);

--- a/crates/solobase-core/src/ui/components.rs
+++ b/crates/solobase-core/src/ui/components.rs
@@ -577,27 +577,21 @@ pub fn badge(variant: BadgeVariant, label: &str) -> maud::Markup {
     html! { span class=(variant.class()) { (label) } }
 }
 
-/// Avatar — gradient circle keyed off email hash. Deterministic.
+/// Avatar — flat brand-orange circle with the seed's first character. The
+/// initial varies per user, but the background does not: a single brand
+/// color across every avatar is calmer to scan than a wall of per-hash
+/// hues, and the colored variants previously made the admin lists feel
+/// like distinct personas instead of rows of the same shape.
 pub fn avatar(seed: &str, size: CtrlSize) -> maud::Markup {
-    use maud::{html, PreEscaped};
-    // FNV-1a 32-bit — small, deterministic, no deps.
-    let mut h: u32 = 0x811c_9dc5;
-    for b in seed.as_bytes() {
-        h ^= *b as u32;
-        h = h.wrapping_mul(0x0100_0193);
-    }
-    let hue = (h % 360) as i32;
-    let hue2 = (hue + 35) % 360;
+    use maud::html;
     let initial = seed.chars().next().unwrap_or('?').to_ascii_uppercase();
     let size_class = match size {
         CtrlSize::Sm => "avatar--sm",
         CtrlSize::Md => "avatar--md",
         CtrlSize::Lg => "avatar--lg",
     };
-    let style =
-        format!("background: linear-gradient(135deg, hsl({hue} 80% 70%), hsl({hue2} 75% 55%));");
     html! {
-        span class={ "avatar " (size_class) } style=(PreEscaped(style)) { (initial) }
+        span class={ "avatar " (size_class) } { (initial) }
     }
 }
 
@@ -702,13 +696,27 @@ mod tests {
     }
 
     #[test]
+    fn avatar_uses_brand_color_for_every_seed() {
+        // Background lives in CSS (`.avatar { background: var(--primary-color) }`),
+        // so the rendered markup carries no inline gradient/hue style — every
+        // avatar is the same flat brand-orange circle, only the initial varies.
+        let a = avatar("alice@example.com", CtrlSize::Md).into_string();
+        let b = avatar("bob@example.com", CtrlSize::Md).into_string();
+        for s in [&a, &b] {
+            assert!(!s.contains("linear-gradient"), "no gradient in markup: {s}");
+            assert!(!s.contains("hsl("), "no inline hue in markup: {s}");
+            assert!(s.contains("avatar--md"), "size class present: {s}");
+        }
+        assert!(a.contains(">A</span>"), "alice initial A: {a}");
+        assert!(b.contains(">B</span>"), "bob initial B: {b}");
+    }
+
+    #[test]
     fn avatar_is_deterministic_per_seed() {
+        // Two calls with the same seed render identical markup.
         let a = avatar("alice@example.com", CtrlSize::Md).into_string();
         let b = avatar("alice@example.com", CtrlSize::Md).into_string();
         assert_eq!(a, b);
-        // Different seed → different style.
-        let c = avatar("bob@example.com", CtrlSize::Md).into_string();
-        assert_ne!(a, c);
     }
 
     #[test]

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -149,6 +149,14 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
 // SQLite variable seeding and loading
 // ---------------------------------------------------------------------------
 
+/// Canonical variables table name, sourced from the admin block so the
+/// boot loader and the `/b/admin/settings/variables` UI always read and
+/// write the same place. Earlier versions used a bare `variables` table
+/// here, which drifted from the admin block's prefixed `CollectionSchema`
+/// and silently divided the config into two stores. The constant lives
+/// in `solobase-core::blocks::admin` so there's no second source of truth.
+const VARIABLES_TABLE: &str = solobase_core::blocks::admin::VARIABLES_TABLE;
+
 /// Ensure the variables table exists, seed from env vars, and return all variables.
 fn seed_and_load_variables(
     db_path: &str,
@@ -163,9 +171,17 @@ fn seed_and_load_variables(
     let conn =
         rusqlite::Connection::open(db_path).with_context(|| format!("open SQLite at {db_path}"))?;
 
-    // Create variables table if it doesn't exist
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS variables (
+    // Create variables table if it doesn't exist.
+    //
+    // Boot runs before WAFER, so the admin block's lifecycle hasn't created
+    // the table yet — we have to pre-create it via raw SQL. Schema mirrors
+    // the admin block's `CollectionSchema`: the user-visible columns are
+    // declared there, and `ensure_table` adds the `id`/`created_at`/
+    // `updated_at` columns the WAFER DB client expects. Pre-creating here
+    // with the union of both is harmless (the columns line up; later
+    // `ensure_table` calls see they exist and skip).
+    let create_sql = format!(
+        "CREATE TABLE IF NOT EXISTS \"{VARIABLES_TABLE}\" (
             id TEXT PRIMARY KEY,
             key TEXT NOT NULL UNIQUE,
             name TEXT DEFAULT '',
@@ -177,18 +193,21 @@ fn seed_and_load_variables(
             created_at TEXT DEFAULT (datetime('now')),
             updated_at TEXT DEFAULT (datetime('now'))
         );
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_variables_key ON variables (key);",
-    )
-    .context("create variables table")?;
+        CREATE UNIQUE INDEX IF NOT EXISTS \"idx_{VARIABLES_TABLE}_key\" \
+         ON \"{VARIABLES_TABLE}\" (key);"
+    );
+    conn.execute_batch(&create_sql)
+        .context("create variables table")?;
 
     // Seed from env vars (INSERT OR IGNORE — existing DB values take priority)
     {
+        let insert_sql = format!(
+            "INSERT OR IGNORE INTO \"{VARIABLES_TABLE}\" \
+             (id, key, value, sensitive, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))"
+        );
         let mut stmt = conn
-            .prepare(
-                "INSERT OR IGNORE INTO variables \
-                 (id, key, value, sensitive, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))",
-            )
+            .prepare(&insert_sql)
             .context("prepare seed-variables statement")?;
 
         for (key, value) in env_vars {
@@ -205,8 +224,9 @@ fn seed_and_load_variables(
 
     // Load all variables
     let mut vars = HashMap::new();
+    let select_sql = format!("SELECT key, value FROM \"{VARIABLES_TABLE}\"");
     let mut stmt = conn
-        .prepare("SELECT key, value FROM variables")
+        .prepare(&select_sql)
         .context("prepare SELECT variables statement")?;
     let rows = stmt
         .query_map([], |row| {
@@ -236,12 +256,13 @@ fn seed_auto_generated(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     let block_infos = solobase_core::blocks::all_block_infos();
     let all_vars = solobase_core::config_vars::collect_all_config_vars(&block_infos);
 
+    let insert_sql = format!(
+        "INSERT OR IGNORE INTO \"{VARIABLES_TABLE}\" \
+         (id, key, name, description, value, warning, sensitive, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'), datetime('now'))"
+    );
     let mut stmt = conn
-        .prepare(
-            "INSERT OR IGNORE INTO variables \
-             (id, key, name, description, value, warning, sensitive, created_at, updated_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'), datetime('now'))",
-        )
+        .prepare(&insert_sql)
         .context("prepare auto-generate statement")?;
 
     let mut seed =


### PR DESCRIPTION
## Summary

Five small admin-area fixes that came out of a UI walk-through (2026-05-14), rebased onto current main on top of the rbp-A..G remediation passes.

- **Avatar colors** — drop per-email gradient; `.avatar` now uses `var(--primary-color)` so the same user renders consistently across admin lists. Initials still vary per seed.
- **API key copy button** — only-time-shown keys get a flex row with a "Copy" button (uses `navigator.clipboard.writeText` on `#new-api-key`, falls back to manual select-all).
- **Remove invite-user feature** — drops the topbar action, the modal, the POST `/b/admin/users` handler, and its dispatch arm. Invite was duplicative with the bootstrap flow + auth signup.
- **Storage admin page padding** — `/b/storage/admin/*` tabs now drop into the `list_page` filters slot (same as `/b/admin/users`), restoring the page gutter so storage matches users visually.
- **Database tables list** — flat `<details>` tree → discrete card-style groups, one per `org__block` prefix, with icon + name + count badge. Filter input collapses groups whose rows all hide, plus an empty state when nothing matches. "Other" group catches rows with no `__` prefix.
- **db list + storage stats layout** (follow-up) — drop the inner `max-height` that clipped cards; move the storage stats grid out of the filters slot so tabs and stats stack vertically instead of side-by-side on wide viewports.
- **Variables table unified** — boot loader (`cli/server.rs::seed_and_load_variables`) now writes to `suppers_ai__admin__variables` (the WAFER-correct prefixed name owned by the admin block) instead of the bare `variables` table. The two-tables divergence silently broke admin-UI edits + made auto-generated secrets invisible. Uses the `VARIABLES_TABLE` const re-exported from `solobase_core::blocks::admin` for a single source of truth.
- **SQL editor trailing `;`** — `validate_readonly_query` now strips one trailing semicolon before the multi-statement check. Two new unit tests (`validate_accepts_single_trailing_semicolon`, `validate_still_rejects_multistatement_with_trailing_semicolon`) cover the accept-one + reject-many cases. No change to the executed query.
- **Native `<dialog>` styling** — the bucket-create dialog was previously unstyled (the existing `.modal` CSS targeted the older htmx-overlay pattern). Adds `dialog.modal` + `::backdrop` + form-element styling so the modal centers + has padding + has a backdrop scrim.

## Notes on the rebase

This branch was originally cut on 2026-05-14 from an older main; the 3 base commits (`auto-bootstrap admin on loopback`, `verify session JWTs`, `promote Permissions sidebar`) had already shipped via squash-merged PRs #155 and #157. Rebased the 5 unique commits onto current main with two conflict resolutions:

1. **`crates/solobase-core/src/blocks/admin/pages/users.rs`** — rbp-B kept `handle_user_invite` while this branch removes invite-user end-to-end. The dispatch arm + topbar + modal were already auto-merged-away; deleted the stranded function body.
2. **`crates/solobase/src/cli/server.rs`** — combined this branch's `VARIABLES_TABLE` renaming with rbp-F's `.context(…)?` anyhow style across 3 hunks (CREATE+seed INSERT, SELECT prepare, auto-gen INSERT). The branch's original `unwrap_or_else(process::exit)` / `.expect()` patterns were superseded by rbp-F's newer error handling.

## Test plan

- [x] `cargo build --workspace --exclude solobase-web --exclude solobase-cloudflare` — clean
- [x] `cargo test -p solobase-core --lib validate_accepts_single_trailing_semicolon` — passes
- [x] `cargo test -p solobase-core --lib validate_still_rejects_multistatement_with_trailing_semicolon` — passes
- [ ] Local UI walk-through: bucket-create dialog renders centered, db tables list shows cards, API-key creation shows copy button, invite-user gone from users page topbar, SQL editor accepts `SELECT 1;`
- [ ] Verify variables seeded on a fresh DB end up in `suppers_ai__admin__variables`, are editable from `/b/admin/settings/variables`, and the runtime reads them post-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)