### PR TITLE
chore(solobase-core): stop activating wafer-run/wasmi unconditionally

### DIFF
--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -39,8 +39,12 @@ native-embedding = [
 ]
 
 [dependencies]
-# WAFER types + WASM interpreter (wasmi required for lockfile Path B loader)
-wafer-run = { workspace = true, features = ["wasmi"] }
+# WAFER types. The wasmi interpreter is no longer pulled in unconditionally:
+# the WasmiBlock use sites in builder.rs (discovery + Path B loader) are
+# already gated under solobase-core's `wasm` feature, which itself activates
+# `wafer-run/wasm`. Consumers that don't need runtime WASM-block loading
+# (e.g. wafer-site) drop wasmi entirely.
+wafer-run = { workspace = true }
 # wafer-core for clients and interface traits
 wafer-core = { workspace = true }
 # wafer-block — wire types + codec used directly by feature blocks that


### PR DESCRIPTION
## Summary

Drop the vestigial `features = ["wasmi"]` activation on solobase-core's `wafer-run` dep. The two `WasmiBlock` use sites in `builder.rs` (discovery + Path B loader) are already `#[cfg(feature = "wasm")]`-gated, and the `wasm` feature itself activates `wafer-run/wasm` → `wafer-run/wasmi`. So the explicit `features = ["wasmi"]` on the dep line was over-cautious — it pulled wasmi in for every solobase-core consumer regardless of whether that consumer needed runtime WASM-block loading.

After this change:
- Consumers that enable `solobase-core/wasm` (default-on) still get wasmi via the proper chain.
- Consumers that disable solobase-core defaults (e.g. wafer-site on Cloudflare Workers) drop wasmi entirely from their compiled WASM.

No code changes — the use sites were already correctly gated.

## Motivation

Companion to [wafer-run/site#TBD](https://github.com/wafer-run/site) (drops `features = ["wasmi"]` from wafer-site's own wafer-run dep). Together they restore wafer.run cold-start health by removing ~1.13 MB / ~19% of the wafer-site WASM bundle — the wasmi interpreter + wast + wat parser that wafer-site doesn't use.

## Measurements (taken in the wafer-site context with both changes applied)

| Metric | Before | After | Δ |
|---|---|---|---|
| `build/index_bg.wasm` size | 5.83 MB | 4.70 MB | **−1.13 MB (−19.4%)** |
| `twiggy garbage` unreachable | 1.06 MB | 62 bytes | −99.99% |
| `cargo tree -i wasmi` | present | "no such crate" | gone |

## Test plan

- [x] `cargo check -p solobase-core` (default features) — passes
- [x] `cargo check --workspace` — passes (pre-existing test compile breakage on solobase-cloudflare lib test is unrelated; `Rc<RefCell>` Send issue)
- [x] Companion wafer-site change confirms wasmi drops out of the dep tree
- [ ] Reviewer: confirm no other consumer relies on the implicit `wafer-run/wasmi` activation (only `solobase-core/wasm` consumers should activate it, and `cargo tree -i wasmi` post-PR confirms none of the current workspace consumers do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)