### PR TITLE
fix(cloudflare): eager init + D1ConfigSource bootstrap resilience (closes #183)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5956,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5976,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5986,7 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -6002,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6027,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "serde",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6049,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "futures",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6084,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6094,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6105,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6131,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6160,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6177,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "serde",
  "serde_json",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6216,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#bd12a4af6478198f696c7b34c25c1dad613f84b2"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/src/config_source.rs
+++ b/crates/solobase-cloudflare/src/config_source.rs
@@ -81,6 +81,12 @@ impl D1ConfigSource {
     /// `screaming_block`. Uses [`DatabaseService::list`] with a single
     /// [`FilterOp::Equal`] filter; the new index on `(block)` (migration
     /// 002) makes this an indexed lookup, not a scan.
+    ///
+    /// Tolerates `no such column: block` on pre-migration-002 D1s (fresh
+    /// CF deploys before the admin block's Init has run its migrations):
+    /// returns an empty map so blocks fall back to their `ConfigVar`
+    /// defaults. The next request — after admin's Init has added the
+    /// column — uses the proper indexed path.
     pub(crate) async fn fetch_block_variables(
         &self,
         screaming_block: &str,
@@ -96,7 +102,13 @@ impl D1ConfigSource {
             skip_count: true,
             ..Default::default()
         };
-        let rows = self.db.list(VARIABLES_TABLE, &opts).await?;
+        let rows = match self.db.list(VARIABLES_TABLE, &opts).await {
+            Ok(rows) => rows,
+            Err(e) if e.to_string().contains("no such column: block") => {
+                return Ok(HashMap::new());
+            }
+            Err(e) => return Err(Box::new(e)),
+        };
         Ok(rows
             .records
             .into_iter()

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -222,6 +222,16 @@ where
     // 6c. Seal the runtime (composite/uses/capability/snapshot, no bind, no
     //     Start dispatch — same semantics as the former start_without_bind).
     wafer.seal().await.map_err(|e| format!("wafer.seal: {e}"))?;
+
+    // 6d. Eager Init pass: fire `lifecycle(Init)` on every registered
+    //     block before the first request lands. Native callers get this
+    //     from `Wafer::start()`; the CF worker boot path doesn't call
+    //     `start()` (no `bind()` step), so without this admin block's
+    //     migrations would only run after a request happens to touch
+    //     admin transitively — leaving fresh deploys stuck pre-migration.
+    //     Init failures are logged-and-tolerated inside `init_all_blocks`.
+    wafer.init_all_blocks().await;
+
     solobase_core::builder::post_start(&wafer, &storage_block);
 
     // 7. Convert request → message; preserve auth header in meta.


### PR DESCRIPTION
## Summary

Closes #183 — CF deploys can now bootstrap from a fresh D1 without operator intervention.

## Background

Today's Phase 1 prod rollout to wafer.run (2026-05-17) reproduced the gap. Auto-rollback fired twice with:

\`\`\`
ERROR D1_ERROR: no such column: block at offset 49: SQLITE_ERROR
block \`wafer-run/security-headers\` init transient failure: config fetch failed
\`\`\`

Investigation showed two coupled issues:

1. **CF runner had no eager-init pass.** \`Wafer::start()\`'s eager Init loop is gated behind \`#[cfg(not(target_arch = "wasm32"))]\` and the CF runner calls \`seal()\` but not \`start()\` (no \`bind()\` step). Lazy init in place, no block's Init lifecycle ever fired until a request happened to touch it transitively. Admin's migrations (which add the schema D1ConfigSource depends on) never ran.

2. **D1ConfigSource depended on schema admin block creates.** \`D1ConfigSource.fetch_block_variables\` queries \`WHERE block = ?\` against \`suppers_ai__admin__variables\`. The \`block\` column is added by admin migration 002. On a fresh D1, admin's Init can't run because its first config load fails — circular dependency.

## Fix

**(1)** \`solobase-cloudflare/src/lib.rs\` calls \`wafer.init_all_blocks().await\` after \`wafer.seal()\` (wafer-run #107 added the public method).

**(2)** \`D1ConfigSource.fetch_block_variables\` catches \`no such column: block\` and returns \`Ok(empty)\` instead of propagating. Admin's Init resolves to defaults, runs migration 002, subsequent queries use the indexed path.

## Bootstrap flow (fresh D1)

1. \`wafer.seal()\` → snapshots ready
2. \`wafer.init_all_blocks()\` → walks every registered block
3. Admin's init: D1ConfigSource fails-soft (column missing) → admin gets empty config → admin's lifecycle Init fires → \`apply_if_blessed\` runs migrations 001 + 002 → \`block\` column now exists
4. Subsequent block inits: D1ConfigSource queries the indexed \`WHERE block = ?\` path normally

## Test plan

- [x] cargo check -p solobase-cloudflare --target wasm32-unknown-unknown clean
- [x] cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare clean
- [x] cargo test -p solobase-core --lib (627 pass)
- [ ] CI green (rust, e2e, wasm build, etc.)
- [ ] Manual: next prod redeploy of wafer.run should succeed without manual \`wrangler d1 execute\` (current prod is already migrated, so this PR is a no-op for it; the fix matters for future fresh deploys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)