### PR TITLE
fix(cloudflare): seed auto_generate secrets on boot

### DIFF
--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -199,7 +199,7 @@ where
         config_source::D1ConfigSource::with_overlay(db.clone(), overlay),
     );
     let builder = SolobaseBuilder::new()
-        .database(db)
+        .database(db.clone())
         .storage(bucket.clone())
         .config(cfg_svc)
         .crypto(crypto)
@@ -223,13 +223,30 @@ where
     //     Start dispatch — same semantics as the former start_without_bind).
     wafer.seal().await.map_err(|e| format!("wafer.seal: {e}"))?;
 
-    // 6d. Eager Init pass: fire `lifecycle(Init)` on every registered
-    //     block before the first request lands. Native callers get this
-    //     from `Wafer::start()`; the CF worker boot path doesn't call
-    //     `start()` (no `bind()` step), so without this admin block's
-    //     migrations would only run after a request happens to touch
-    //     admin transitively — leaving fresh deploys stuck pre-migration.
-    //     Init failures are logged-and-tolerated inside `init_all_blocks`.
+    // 6d. Init the admin block first so its migrations (incl. variables.block
+    //     in migration 002) have applied before we seed auto-generated
+    //     secrets. `init_all_blocks` iterates `HashMap::keys()` in unspecified
+    //     order, so without this explicit step a block that depends on a
+    //     seeded `auto_generate` key (e.g. `suppers-ai/products` and
+    //     `SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET`) could be the first one
+    //     initialised, permanent-fail on the missing key, and remain broken
+    //     for the slot's lifetime even after seeding completes.
+    if let Err(e) = wafer
+        .init_block(solobase_core::blocks::admin::ADMIN_BLOCK_ID)
+        .await
+    {
+        worker::console_log!("warn: admin block Init failed before seed_auto_generated: {e}",);
+    }
+
+    // 6e. Seed `auto_generate` ConfigVars (mirror of native CLI's
+    //     `seed_auto_generated`). Inserts random 32-byte hex values for keys
+    //     missing from the admin variables table — idempotent on repeat
+    //     cold-starts. Per-key failures are logged but tolerated.
+    runner::seed_auto_generated(&db).await;
+
+    // 6f. Eager Init pass for the remaining blocks. Slot caching makes admin
+    //     a no-op here. Init failures are logged-and-tolerated inside
+    //     `init_all_blocks`.
     wafer.init_all_blocks().await;
 
     solobase_core::builder::post_start(&wafer, &storage_block);

--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -14,8 +14,8 @@ pub(crate) const R2_BINDING: &str = "STORAGE";
 use std::{collections::HashMap, sync::Arc};
 
 pub(crate) use solobase_core::blocks::admin::BLOCK_SETTINGS_TABLE;
-use solobase_core::features::BlockSettings;
-use wafer_core::interfaces::database::service::{DatabaseService, ListOptions};
+use solobase_core::{blocks::admin::VARIABLES_TABLE, features::BlockSettings};
+use wafer_core::interfaces::database::service::{DatabaseService, Filter, FilterOp, ListOptions};
 
 /// Read the admin block-settings collection and convert to `BlockSettings`.
 ///
@@ -69,4 +69,104 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
             BlockSettings::default()
         }
     }
+}
+
+/// Auto-generate random secrets for every `ConfigVar` declared with
+/// `.auto_generate()` that doesn't yet have a row in the admin variables
+/// table. Native solobase does this in the CLI before runtime start
+/// (`solobase/src/cli/server.rs::seed_auto_generated`); the CF runner is
+/// the corresponding eager-seed pass for the Cloudflare target.
+///
+/// MUST be called after the admin block's `lifecycle(Init)` has finished
+/// (so admin migration 002 has added the `block` column the `D1ConfigSource`
+/// queries by) and BEFORE [`wafer_run::Wafer::init_all_blocks`] runs the
+/// rest of the inits — otherwise blocks that require an auto-gen key (e.g.
+/// `suppers-ai/products` and `SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET`) hit
+/// [`wafer_run::ConfigError::MissingRequired`], which is mapped to
+/// `InitError::Permanent` and cached for the slot's lifetime.
+///
+/// Idempotent: rows whose `key` already exists are left untouched.
+/// Per-key failures are logged but do not abort the loop — operators retain
+/// the manual `wrangler d1 execute` fallback for any key that fails to seed.
+pub(crate) async fn seed_auto_generated(db: &Arc<dyn DatabaseService>) {
+    let block_infos = solobase_core::blocks::all_block_infos();
+    for info in &block_infos {
+        for var in &info.config_keys {
+            if !var.auto_generate {
+                continue;
+            }
+            if let Err(e) = seed_one(db, &info.name, var).await {
+                worker::console_log!(
+                    "warn: seed_auto_generated failed for {} ({}): {e}",
+                    var.key,
+                    info.name,
+                );
+            }
+        }
+    }
+}
+
+/// Insert a single auto-generated secret row when no row with `var.key`
+/// already exists. Returns `Ok(())` on either insert or skip; bubbles up
+/// only D1 / RNG errors so the caller can log per-key.
+async fn seed_one(
+    db: &Arc<dyn DatabaseService>,
+    block_name: &str,
+    var: &wafer_block::ConfigVar,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let exists_opts = ListOptions {
+        filters: vec![Filter {
+            field: "key".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(var.key.clone()),
+        }],
+        limit: 1,
+        skip_count: true,
+        ..Default::default()
+    };
+    let listed = db.list(VARIABLES_TABLE, &exists_opts).await?;
+    if !listed.records.is_empty() {
+        return Ok(());
+    }
+
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes).map_err(|e| format!("getrandom: {e}"))?;
+    let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+
+    // `block` column matches what admin migration 002 backfills from `key`
+    // (key's first two `__`-delimited segments). We compute it from the
+    // block name via the canonical helper so both paths converge on the
+    // same SCREAMING_SNAKE prefix even if a key were ever introduced with
+    // a non-matching shape.
+    let block_col = crate::config_source::D1ConfigSource::screaming_block(block_name);
+    let now = chrono::Utc::now().to_rfc3339();
+    let id = format!("var_{}", uuid::Uuid::new_v4());
+
+    let mut data: HashMap<String, serde_json::Value> = HashMap::new();
+    data.insert("id".into(), serde_json::Value::String(id));
+    data.insert("key".into(), serde_json::Value::String(var.key.clone()));
+    data.insert("name".into(), serde_json::Value::String(var.name.clone()));
+    data.insert(
+        "description".into(),
+        serde_json::Value::String(var.description.clone()),
+    );
+    data.insert("value".into(), serde_json::Value::String(secret));
+    data.insert(
+        "warning".into(),
+        serde_json::Value::String(var.warning.clone()),
+    );
+    data.insert(
+        "sensitive".into(),
+        serde_json::Value::Number(serde_json::Number::from(1)),
+    );
+    data.insert("block".into(), serde_json::Value::String(block_col));
+    data.insert("created_at".into(), serde_json::Value::String(now.clone()));
+    data.insert("updated_at".into(), serde_json::Value::String(now));
+
+    db.create(VARIABLES_TABLE, data).await?;
+    worker::console_log!(
+        "auto-generated secret seeded for {} (no row existed)",
+        var.key
+    );
+    Ok(())
 }

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -12,6 +12,14 @@ pub(crate) use iam::{PERMISSIONS_TABLE, ROLES_TABLE, USER_ROLES_TABLE};
 pub(crate) use logs::{AUDIT_LOGS_TABLE, REQUEST_LOGS_TABLE, STORAGE_ACCESS_LOGS_TABLE};
 pub use settings::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE};
 
+/// Registered name of the admin block.
+///
+/// Mirror of [`crate::blocks::auth::AUTH_BLOCK_ID`] for callers that need to
+/// reference the admin block by name without hardcoding the string (e.g.
+/// `solobase-cloudflare` initialises the admin block first so its migrations
+/// have run before the runner seeds `auto_generate` secrets).
+pub const ADMIN_BLOCK_ID: &str = "suppers-ai/admin";
+
 /// Storage-permission rule rows (bucket/key pattern → ACL).
 pub(crate) const STORAGE_RULES_TABLE: &str = "suppers_ai__admin__storage_rules";
 /// Network-permission rule rows (egress allow/deny by URL pattern).


### PR DESCRIPTION
## Summary

- Port the native CLI's `seed_auto_generated` to the Cloudflare runner so `auto_generate` `ConfigVar`s (currently only `SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET`) self-seed on fresh D1, removing the rollback footgun documented in #184.
- Add `solobase_core::blocks::admin::ADMIN_BLOCK_ID` (mirrors `AUTH_BLOCK_ID`) so the CF runner can reference the admin block name without hardcoding the literal.
- Sequence boot as **seal → `init_block(admin)` → `seed_auto_generated` → `init_all_blocks`**. The explicit admin Init guarantees migration 002 (which adds `variables.block`) has applied before seeding. Seeding BEFORE `init_all_blocks` is critical: `ConfigError::MissingRequired` maps to `InitError::Permanent`, which is cached for the slot's lifetime, so seeding after a dependent block has failed Init wouldn't recover until the next cold-start.

## Why CI didn't catch this originally

Solobase CI runs against native sqlite, not D1. The CF runner + `D1ConfigSource` paths only execute in the deployed worker. The first end-to-end exercise of Phase 1's CF path against real D1 (2026-05-17) surfaced this gap; today's manual workaround was a `wrangler d1 execute INSERT INTO suppers_ai__admin__variables ...` per webhook secret.

## Test plan

- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- [x] `cargo check -p solobase` (native) — clean
- [x] `cargo test -p solobase-core --lib` — 627/627 pass
- [x] `cargo clippy -p solobase-cloudflare --target wasm32-unknown-unknown` — no new warnings on changed lines
- [ ] Deploy to wafer.run with a wiped D1 binding; verify `/_health` returns 200 with 31/31 blocks ok without manual `wrangler d1 execute` seeding
- [ ] Verify subsequent cold-start logs do NOT re-emit "auto-generated secret seeded for …" (idempotency)

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)