### PR TITLE
refactor(solobase-core): untangle cross-block direct calls (Phase 0b prep)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -235,12 +235,16 @@ impl Block for AdminBlock {
             if api_rest.starts_with("/custom-tables") {
                 return custom_tables::handle(ctx, &msg, input).await;
             }
-            // Delegate admin storage to Files block
+            // Delegate admin storage to Files block via call_block so WRAP
+            // sees the call as cross-block (admin → files) instead of an
+            // in-process direct function call. The Files block recognizes
+            // the `/admin/storage/...` path and routes it to its admin
+            // sub-handler.
             if api_rest.starts_with("/storage") {
                 msg.set_meta("req.resource", format!("/admin{}", api_rest));
-                return crate::blocks::files::handle_admin_storage(ctx, msg, input).await;
+                return ctx.call_block("suppers-ai/files", msg, input).await;
             }
-            // Delegate admin cloud storage to Files block
+            // Delegate admin cloud storage to Files block via call_block.
             if api_rest.starts_with("/cloudstorage") {
                 msg.set_meta(
                     "req.resource",
@@ -249,7 +253,7 @@ impl Block for AdminBlock {
                         api_rest.strip_prefix("/cloudstorage").unwrap_or("")
                     ),
                 );
-                return crate::blocks::files::handle_admin_cloud(ctx, msg, input).await;
+                return ctx.call_block("suppers-ai/files", msg, input).await;
             }
             return err_not_found("not found");
         }

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -127,6 +127,20 @@ impl Block for FilesBlock {
         let mut msg = msg;
         let path = msg.path().to_string();
 
+        // Admin-block delegation: when the Admin block routes a request for
+        // `/admin/storage/...` or `/admin/b/cloudstorage/...` through
+        // `ctx.call_block("suppers-ai/files", ...)`, the messages already
+        // carry the normalized admin path. Authorization (admin role check)
+        // is enforced by the Admin block before delegation; we accept the
+        // calls here without re-checking so the admin path stays a thin
+        // pass-through to the sub-module handlers that own the SQL.
+        if path.starts_with("/admin/storage") {
+            return storage::handle_admin(ctx, msg, input).await;
+        }
+        if path.starts_with("/admin/b/cloudstorage") {
+            return cloud::handle(ctx, msg, input).await;
+        }
+
         // Admin SSR pages at /b/storage/admin/...
         if path.starts_with("/b/storage/admin") && msg.action() == "retrieve" {
             let is_admin = helpers::is_admin(&msg);
@@ -265,26 +279,6 @@ impl Block for FilesBlock {
         }
         Ok(())
     }
-}
-
-/// Admin storage delegation — called from the Admin block's API section.
-/// Expects msg path already normalized to `/admin/storage/...`.
-pub async fn handle_admin_storage(
-    ctx: &dyn Context,
-    msg: Message,
-    input: InputStream,
-) -> OutputStream {
-    storage::handle_admin(ctx, msg, input).await
-}
-
-/// Admin cloud storage delegation — called from the Admin block's API section.
-/// Expects msg path already normalized to `/admin/b/cloudstorage/...`.
-pub async fn handle_admin_cloud(
-    ctx: &dyn Context,
-    msg: Message,
-    input: InputStream,
-) -> OutputStream {
-    cloud::handle(ctx, msg, input).await
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -45,24 +45,14 @@ const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
 const DEFAULT_MODEL_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_MODEL";
 pub(super) const DEFAULT_PROVIDER: &str = "suppers-ai/provider-llm";
 
-/// Read the cross-block default LLM target — the `(provider_block, model)`
-/// pair other blocks (e.g. vector contextual retrieval) should use when they
-/// have no caller-supplied preference.
-///
-/// Returns `None` when no model is configured. The provider falls back to
-/// [`DEFAULT_PROVIDER`] if its env var is unset, but the model has no built-in
-/// default — operators must set `SUPPERS_AI__LLM__DEFAULT_MODEL` for a target
-/// to be available. Callers should treat `None` as "no LLM configured" and
-/// take a degraded path (skip the LLM step, return an error, etc.).
-pub(crate) async fn default_target(ctx: &dyn Context) -> Option<(String, String)> {
-    let provider = config::get_default(ctx, DEFAULT_PROVIDER_VAR, DEFAULT_PROVIDER).await;
-    let model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
-    if model.is_empty() || provider.is_empty() {
-        None
-    } else {
-        Some((provider, model))
-    }
-}
+// The previous in-process `default_target()` helper has moved to a
+// `GET /b/llm/api/internal/default-target` route — see
+// `handle_default_target` below. Other blocks (e.g. vector contextual
+// retrieval) now fetch the target via `ctx.call_block("suppers-ai/llm", ...)`
+// rather than importing this module directly. That keeps the cross-block
+// dependency at the wire level (call_block) instead of the link level
+// (Rust use-path), which is what unblocks per-block Cargo features in
+// Phase 0b PR-2.
 
 // ---------------------------------------------------------------------------
 // Inter-block call helpers
@@ -229,6 +219,29 @@ impl LlmBlock {
     }
 
     // --- Config ---
+
+    /// Inter-block discovery: returns the default `(provider, model)` target
+    /// other blocks should use when they have no caller-supplied preference.
+    ///
+    /// Wire format:
+    /// * `200 {"provider": "...", "model": "..."}` when configured
+    /// * `200 {"provider": null, "model": null}` when no model is configured
+    ///   (callers should take a degraded path — same contract as the previous
+    ///   in-process `default_target()` returning `None`).
+    async fn handle_default_target(&self, ctx: &dyn Context) -> OutputStream {
+        let provider = config::get_default(ctx, DEFAULT_PROVIDER_VAR, DEFAULT_PROVIDER).await;
+        let model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
+        if model.is_empty() || provider.is_empty() {
+            return ok_json(&serde_json::json!({
+                "provider": serde_json::Value::Null,
+                "model": serde_json::Value::Null,
+            }));
+        }
+        ok_json(&serde_json::json!({
+            "provider": provider,
+            "model": model,
+        }))
+    }
 
     async fn handle_get_config(&self, ctx: &dyn Context) -> OutputStream {
         let default_provider =
@@ -442,6 +455,17 @@ impl Block for LlmBlock {
         let path = msg.path();
         let is_api = path.contains("/api/");
         let user_id = msg.user_id().to_string();
+
+        // Inter-block discovery endpoint: returns the configured default
+        // `(provider, model)` target. Only accessible from another block (the
+        // caller_id is set by `ctx.call_block`); never reachable from external
+        // HTTP because the shared pipeline strips the caller id.
+        if action == "retrieve" && path == "/b/llm/api/internal/default-target" {
+            if ctx.caller_id().is_none() {
+                return crate::blocks::helpers::err_not_found("not found");
+            }
+            return self.handle_default_target(ctx).await;
+        }
 
         // All endpoints require authentication
         if user_id.is_empty() {

--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -1,4 +1,4 @@
-pub mod a2a;
+pub(crate) mod a2a;
 pub mod pages;
 pub mod rest;
 pub mod service;
@@ -197,6 +197,12 @@ impl Block for MessagesBlock {
                 .summary("Delete entry")
                 .auth(AuthLevel::Authenticated)
                 .tags(&["entries"]),
+            // A2A JSON-RPC endpoint — routed from the shared pipeline. Auth
+            // is enforced by the JSON-RPC method handlers themselves.
+            BlockEndpoint::post("/a2a")
+                .summary("A2A JSON-RPC endpoint")
+                .description("JSON-RPC dispatch for SendMessage, GetTask, ListTasks, CancelTask")
+                .tags(&["a2a"]),
         ])
         .can_disable(true)
         .default_enabled(true)
@@ -212,7 +218,14 @@ impl Block for MessagesBlock {
         let is_api = path.contains("/api/");
         let user_id = msg.user_id().to_string();
 
-        // All endpoints require authentication
+        // A2A JSON-RPC endpoint — protocol-public (auth handled by the
+        // JSON-RPC method handlers themselves). Routed from the shared
+        // pipeline via `ctx.call_block("suppers-ai/messages", ...)`.
+        if path == "/a2a" {
+            return a2a::handle_a2a(ctx, msg, input).await;
+        }
+
+        // All other endpoints require authentication
         if user_id.is_empty() {
             return ui::forbidden_response(&msg);
         }

--- a/crates/solobase-core/src/blocks/vector/ingestion.rs
+++ b/crates/solobase-core/src/blocks/vector/ingestion.rs
@@ -24,9 +24,9 @@
 use wafer_block::wire::llm::{ChatContent, ChatMessage, ChatRequest, ChatRole, ChunkDelta};
 #[cfg(feature = "llm")]
 use wafer_core::clients::llm;
+use wafer_run::{context::Context, types::WaferError};
 #[cfg(feature = "llm")]
 use wafer_run::{types::Message, InputStream};
-use wafer_run::{context::Context, types::WaferError};
 
 /// Approximate max tokens per chunk. We use whitespace-split as a proxy
 /// for tokenization — close enough for bge-m3 / MiniLM at this

--- a/crates/solobase-core/src/blocks/vector/ingestion.rs
+++ b/crates/solobase-core/src/blocks/vector/ingestion.rs
@@ -24,10 +24,9 @@
 use wafer_block::wire::llm::{ChatContent, ChatMessage, ChatRequest, ChatRole, ChunkDelta};
 #[cfg(feature = "llm")]
 use wafer_core::clients::llm;
-use wafer_run::{context::Context, types::WaferError};
-
 #[cfg(feature = "llm")]
-use crate::blocks::llm as llm_block;
+use wafer_run::{types::Message, InputStream};
+use wafer_run::{context::Context, types::WaferError};
 
 /// Approximate max tokens per chunk. We use whitespace-split as a proxy
 /// for tokenization — close enough for bge-m3 / MiniLM at this
@@ -113,7 +112,7 @@ pub async fn add_context(
     if chunks.is_empty() {
         return Ok(chunks);
     }
-    let Some((provider, model)) = llm_block::default_target(ctx).await else {
+    let Some((provider, model)) = default_llm_target(ctx).await else {
         tracing::debug!("contextual retrieval skipped: no default LLM model configured");
         return Ok(chunks);
     };
@@ -163,6 +162,37 @@ pub async fn add_context(
         .into_iter()
         .map(|c| format!("{context}\n\n{c}"))
         .collect())
+}
+
+/// Fetch the default `(provider, model)` LLM target via the llm block's
+/// internal discovery route. Returns `None` when no model is configured or
+/// when the llm block isn't registered — both cases trigger the same
+/// "degrade silently" fallback in `add_context`.
+///
+/// Going through `ctx.call_block(...)` rather than a direct in-process
+/// function call is what keeps the vector block independent of the llm
+/// block at the type/dep level — that's the dependency edge Phase 0b PR-2
+/// will turn into a Cargo feature gate.
+#[cfg(feature = "llm")]
+async fn default_llm_target(ctx: &dyn Context) -> Option<(String, String)> {
+    let resource = "/b/llm/api/internal/default-target";
+    let mut msg = Message::new(format!("retrieve:{resource}"));
+    msg.set_meta("req.action", "retrieve");
+    msg.set_meta("req.resource", resource);
+    msg.set_meta("http.method", "GET");
+    msg.set_meta("http.path", resource);
+
+    let out = ctx
+        .call_block("suppers-ai/llm", msg, InputStream::empty())
+        .await;
+    let buf = out.collect_buffered().await.ok()?;
+    let body: serde_json::Value = serde_json::from_slice(&buf.body).ok()?;
+    let provider = body.get("provider")?.as_str()?.to_string();
+    let model = body.get("model")?.as_str()?.to_string();
+    if provider.is_empty() || model.is_empty() {
+        return None;
+    }
+    Some((provider, model))
 }
 
 #[cfg(feature = "llm")]

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -99,9 +99,12 @@ pub async fn handle_request(
         }
     }
 
-    // A2A JSON-RPC endpoint
+    // A2A JSON-RPC endpoint — dispatch into the messages block via
+    // `call_block` so WRAP sees the call as cross-block (pipeline → messages)
+    // and so the route can be feature-gated alongside the rest of the
+    // messages block in Phase 0b PR-2.
     if msg.path() == "/a2a" {
-        return crate::blocks::messages::a2a::handle_a2a(ctx, msg, input).await;
+        return ctx.call_block("suppers-ai/messages", msg, input).await;
     }
 
     // Capture request info before routing (for logging)


### PR DESCRIPTION
## Summary

Untangles the three remaining in-process cross-block function calls in solobase-core by routing them through `ctx.call_block(...)`. This is Phase 0b PR-1 ("untangle") — the prerequisite that lets [Phase 0b PR-2](../docs/superpowers/handoffs/2026-05-18-phase-0-feature-gating-handoff.md) add per-block Cargo features without other blocks breaking at link time.

### Edges refactored

| # | Before | After |
|---|--------|-------|
| 1 | `admin/mod.rs` calls `crate::blocks::files::handle_admin_storage` + `handle_admin_cloud` directly | `ctx.call_block("suppers-ai/files", ...)` — Files block grew `/admin/storage/*` and `/admin/b/cloudstorage/*` arms at the top of `handle` |
| 2 | `pipeline.rs` calls `crate::blocks::messages::a2a::handle_a2a` directly | `ctx.call_block("suppers-ai/messages", ...)` — Messages block recognizes `path == "/a2a"` and dispatches internally |
| 3 | `vector/ingestion.rs` calls `crate::blocks::llm::default_target` directly | `ctx.call_block("suppers-ai/llm", ...)` against a new `GET /b/llm/api/internal/default-target` route — `default_target()` helper removed |

### Routes added to target blocks

- **`suppers-ai/files`**: `/admin/storage/*` and `/admin/b/cloudstorage/*` (delegated from admin block; admin gate stays in the caller).
- **`suppers-ai/messages`**: `POST /a2a` JSON-RPC endpoint (was previously handled inline in the pipeline). Added to `BlockInfo.endpoints` so OpenAPI/agent-card discovery picks it up.
- **`suppers-ai/llm`**: `GET /b/llm/api/internal/default-target`. **Caller-restricted** — rejected unless `ctx.caller_id().is_some()`, so external HTTP can't reach it. Returns `{"provider": ..., "model": ...}` with both fields null when no model is configured (same degraded-path contract as the previous `Option<(String, String)>`).

### Architectural notes

- **No SQL or storage behavior changes** — the refactor is call-graph-only. The same handlers run, just one async hop further away.
- The Admin block's `/admin/storage/*` path is normalized **before** dispatch (caller sets `req.resource`), so the Files block sees the already-normalized admin path — same shape the direct function calls used.
- WRAP now sees these dispatches with the correct cross-block caller identity (previously the calls inherited the original request's caller, since they were in-process). That's strictly more correct; no existing grants need to change because the called handlers don't touch resources outside their own block.
- One small surface: making `messages::a2a` `pub(crate)` (was `pub`) — only the pipeline imported it.

### Out of scope (per handoff)

The handoff identified 6 cross-block edges total. The other 3 are intentionally not addressed here:
- Edges 2 & 3 (shared constants) — these are compile-time constants, not function calls; will be relocated to a shared `solobase-core::types` module in a separate cleanup.
- Edge 6 (ammonia) — that's a third-party crate dep, not a cross-block call.

## Test plan

- [x] `cargo check -p solobase-core` clean
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean
- [x] `cargo test -p solobase-core --lib` — 627 passed, 0 failed
- [x] `cargo clippy -p solobase-core --lib` — no new warnings on any of the 6 changed files
- [ ] Manual smoke (deferred to a release-prep PR): admin storage page lists buckets, A2A `SendMessage` JSON-RPC round-trips, vector ingest with contextual retrieval still prepends summaries.

Unblocks: Phase 0b PR-2 (per-block Cargo feature gating). See [2026-05-18-phase-0-feature-gating-handoff.md](../docs/superpowers/handoffs/2026-05-18-phase-0-feature-gating-handoff.md).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)