### PR TITLE
feat(config): wire embedder snapshot + admin migration gate + seed_defaults bulk fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5956,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5976,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5986,7 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -6002,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6027,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6049,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "futures",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6084,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6094,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6105,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6131,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6160,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6177,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6216,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#7cd32a311f39ed2e9d5072cbbf4f20921c95ee05"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -190,6 +190,10 @@ where
     let crypto = make_jwt_crypto_service(jwt_secret);
     let network = make_fetch_network_service();
     let logger = make_console_logger();
+    // Clone the map for the snapshot below before `make_config_service`
+    // consumes it — the snapshot and the async ConfigService must carry
+    // identical data (see comment at the `set_config_snapshot` call site).
+    let snapshot = cfg_svc_map.clone();
     let cfg_svc = make_config_service(cfg_svc_map);
 
     // 5. ConfigSource: D1-backed lazy per-block fetch. The overlay layers
@@ -213,6 +217,16 @@ where
 
     // 6. Build runtime.
     let (mut wafer, storage_block) = builder.build().map_err(|e| format!("builder.build: {e}"))?;
+
+    // 6a. Wire the env-var snapshot into `RuntimeContext.config` so blocks
+    //     can read embedder-provided keys via `ctx.config_get` synchronously
+    //     (no D1 round-trip per lookup). This is the missing wiring that
+    //     left `migration_helper::apply_if_blessed` reading "{}" for
+    //     `BLOCK_SETTINGS_CONFIG_KEY` on every cold isolate — see the
+    //     2026-05-14 config-snapshot spec. Same data as `make_config_service`;
+    //     the snapshot is the synchronous read path, the config block is
+    //     the async write surface.
+    wafer.set_config_snapshot(snapshot);
 
     // 6b. Consumer post-build hook (override flows / configs before start).
     //     Receives the R2-backed StorageService so consumers can register

--- a/crates/solobase-core/src/blocks/admin/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/migrations/mod.rs
@@ -5,14 +5,18 @@
 //! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
 //! Falls back to `sqlite` when the config block is not registered.
 //!
-//! Statements are executed one-by-one through `wafer-run/database`'s typed
-//! `db::ddl` message contract — the WRAP-aware path that lets any
-//! attributable caller run `CREATE TABLE` / `CREATE INDEX` against its own
-//! (`{org}__{block}__*`) tables without an admin grant. The parser splits
-//! on bare `;` outside of `--` line comments.
+//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
+//! the helper handles statement splitting + the `current_hash` /
+//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
+//! `suppers_ai__admin__block_settings` once applied. Earlier versions of
+//! this module called `db::ddl` directly in a loop, bypassing the gate
+//! and re-running every DDL on every cold isolate (~2,800 D1 queries/day
+//! on wafer.run — see the 2026-05-14 config-snapshot spec).
 
-use wafer_core::clients::{config, database as db};
+use wafer_core::clients::config;
 use wafer_run::context::Context;
+
+const ADMIN_BLOCK_NAME: &str = "suppers-ai/admin";
 
 const SQL_001_SQLITE: &str = include_str!("001_admin_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_admin_schema.postgres.sql");
@@ -33,128 +37,66 @@ async fn backend(ctx: &dyn Context) -> Backend {
     }
 }
 
-/// Apply all admin migrations in order. Idempotent: every `CREATE TABLE` /
-/// `CREATE INDEX` uses `IF NOT EXISTS`. Migration 002 is *not* fully
-/// idempotent — `ALTER TABLE … ADD COLUMN` errors if the column already
-/// exists (SQLite) — but the column-existence check happens before the
-/// migration runner picks the script up. The runner guards against
-/// re-application via the migration-state hash (see
-/// `solobase-cloud-target` runbook + `SOLOBASE_RUN_MIGRATIONS` flag).
+/// Concatenate the per-backend migration scripts into a single blob so
+/// `apply_if_blessed` records one `current_hash` covering both. Mirrors the
+/// auth block's concatenation pattern; `apply_if_blessed`'s splitter handles
+/// the `;\n…` boundary between files.
+fn concatenated_sql(b: Backend) -> String {
+    match b {
+        Backend::Sqlite => format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}"),
+        Backend::Postgres => format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}"),
+    }
+}
+
+/// Apply all admin migrations through the shared migration-state gate.
+/// Idempotent across cold starts: once the gate stamps a `current_hash` row
+/// in `block_settings`, subsequent boots short-circuit before issuing any
+/// DDL. Schema changes require a `--run-migrations` redeploy (see
+/// `migration-state-workflow` in user memory).
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
     let b = backend(ctx).await;
-    let (sql_001, sql_002) = match b {
-        Backend::Sqlite => (SQL_001_SQLITE, SQL_002_SQLITE),
-        Backend::Postgres => (SQL_001_POSTGRES, SQL_002_POSTGRES),
-    };
-    apply_script(ctx, sql_001)
-        .await
-        .map_err(|e| format!("migration 001: {e}"))?;
-    apply_script(ctx, sql_002)
-        .await
-        .map_err(|e| format!("migration 002: {e}"))?;
-    Ok(())
-}
-
-async fn apply_script(ctx: &dyn Context, sql: &str) -> Result<(), String> {
-    for stmt in split_statements(sql) {
-        if !has_executable_content(&stmt) {
-            continue;
-        }
-        let trimmed = stmt.trim();
-        db::ddl(ctx, trimmed)
-            .await
-            .map_err(|e| format!("ddl failed on `{trimmed}`: {e}"))?;
-    }
-    Ok(())
-}
-
-fn split_statements(sql: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut current = String::new();
-    let mut in_line_comment = false;
-    for ch in sql.chars() {
-        if in_line_comment {
-            current.push(ch);
-            if ch == '\n' {
-                in_line_comment = false;
-            }
-            continue;
-        }
-        if ch == '-' && current.ends_with('-') {
-            in_line_comment = true;
-            current.push(ch);
-            continue;
-        }
-        if ch == ';' {
-            out.push(std::mem::take(&mut current));
-            continue;
-        }
-        current.push(ch);
-    }
-    if !current.is_empty() {
-        out.push(current);
-    }
-    out
-}
-
-fn has_executable_content(stmt: &str) -> bool {
-    stmt.lines().any(|line| {
-        let l = line.trim();
-        !l.is_empty() && !l.starts_with("--")
-    })
+    let sql = concatenated_sql(b);
+    crate::migration_helper::apply_if_blessed(ctx, ADMIN_BLOCK_NAME, &sql).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{has_executable_content, split_statements, SQL_001_SQLITE, SQL_002_SQLITE};
+    use super::{concatenated_sql, Backend};
 
     #[test]
-    fn embedded_sqlite_script_parses_into_statements() {
-        let parts: Vec<_> = split_statements(SQL_001_SQLITE)
-            .into_iter()
-            .filter(|s| has_executable_content(s))
-            .collect();
-        // 9 tables + their CREATE INDEX statements (some tables have 1 index,
-        // user_roles/audit_logs/request_logs/storage_access_logs/wrap_grants).
+    fn concatenated_sqlite_contains_both_migrations() {
+        let sql = concatenated_sql(Backend::Sqlite);
+        // Spot-check the 001 schema (the variables UNIQUE INDEX) and the
+        // 002 follow-up (ALTER TABLE ADD COLUMN block) are both present.
         assert!(
-            parts.len() >= 10,
-            "expected at least 10 statements, got {}: {:?}",
-            parts.len(),
-            parts
+            sql.contains("suppers_ai__admin__variables_key_uniq"),
+            "missing 001 marker; got len={}",
+            sql.len()
         );
-        // Spot-check that the variables UNIQUE INDEX is present.
-        assert!(parts
-            .iter()
-            .any(|s| s.contains("suppers_ai__admin__variables_key_uniq")));
+        assert!(
+            sql.contains("ADD COLUMN block"),
+            "missing 002 ALTER COLUMN; got len={}",
+            sql.len()
+        );
+        assert!(
+            sql.contains("suppers_ai__admin__variables_block_idx"),
+            "missing 002 index; got len={}",
+            sql.len()
+        );
     }
 
     #[test]
-    fn embedded_sqlite_002_parses_into_three_statements() {
-        // ALTER TABLE + UPDATE … SET block = CASE … END + CREATE INDEX.
-        let parts: Vec<_> = split_statements(SQL_002_SQLITE)
-            .into_iter()
-            .filter(|s| has_executable_content(s))
-            .collect();
-        assert_eq!(
-            parts.len(),
-            3,
-            "expected 3 statements (ALTER + UPDATE + CREATE INDEX), got {}: {:?}",
-            parts.len(),
-            parts
+    fn concatenated_postgres_contains_both_migrations() {
+        let sql = concatenated_sql(Backend::Postgres);
+        assert!(
+            sql.contains("suppers_ai__admin__variables_key_uniq"),
+            "missing 001 marker; got len={}",
+            sql.len()
         );
-        assert!(parts.iter().any(|s| s.contains("ADD COLUMN block")));
-        assert!(parts
-            .iter()
-            .any(|s| s.contains("suppers_ai__admin__variables_block_idx")));
-    }
-
-    #[test]
-    fn split_handles_line_comments_and_semicolons() {
-        let sql = "-- header\nCREATE TABLE foo (id TEXT);\n-- ; in comment\nCREATE INDEX bar ON foo (id);";
-        let parts: Vec<_> = split_statements(sql)
-            .into_iter()
-            .filter(|s| has_executable_content(s))
-            .collect();
-        assert_eq!(parts.len(), 2);
+        assert!(
+            sql.contains("ADD COLUMN"),
+            "missing 002 ALTER COLUMN; got len={}",
+            sql.len()
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -339,6 +339,20 @@ async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
 pub async fn seed_defaults(ctx: &dyn Context) {
     let vars = crate::config_vars::shared_config_vars();
 
+    // Single bulk fetch of every existing variable, then in-memory diff
+    // per declared shared var. Replaces the per-var `get_by_field` loop
+    // that issued 2× D1 queries per shared var × cold isolate (~5k D1
+    // reads/day in prod — see 2026-05-14 config-snapshot spec). On a
+    // bulk failure we treat every key as missing, which falls into the
+    // create-with-INSERT-OR-IGNORE-equivalent path; consistent with the
+    // prior code's silent-on-error stance.
+    let existing: HashMap<String, _> = db::list_all(ctx, VARIABLES_TABLE, vec![])
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|record| (record.str_field("key").to_string(), record))
+        .collect();
+
     for var in &vars {
         let sensitive: i32 = if var.input_type == types::InputType::Password {
             1
@@ -351,19 +365,12 @@ pub async fn seed_defaults(ctx: &dyn Context) {
             &var.name
         };
 
-        // Check if key exists already and only refresh metadata when at
-        // least one declared field actually differs. Without this guard
-        // every isolate cold-start re-writes every shared config var
-        // (~80 vars × cold-starts/day ≈ ~900 useless UPDATEs/day in prod).
-        match db::get_by_field(
-            ctx,
-            VARIABLES_TABLE,
-            "key",
-            serde_json::Value::String(var.key.clone()),
-        )
-        .await
-        {
-            Ok(record) => {
+        match existing.get(&var.key) {
+            Some(record) => {
+                // Only refresh metadata when at least one declared field
+                // actually differs. Without this guard every isolate cold-start
+                // re-writes every shared config var (~80 vars × cold-starts/day
+                // ≈ ~900 useless UPDATEs/day in prod).
                 let same_name = record.str_field("name") == name.as_str();
                 let same_desc = record.str_field("description") == var.description;
                 let same_warn = record.str_field("warning") == var.warning;
@@ -386,7 +393,7 @@ pub async fn seed_defaults(ctx: &dyn Context) {
                 )
                 .await;
             }
-            Err(_) => {
+            None => {
                 // Seed from process env when set (lets `.env` bootstrap a
                 // fresh deployment), otherwise fall back to the declared
                 // default. Empty env values are treated as unset so that

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -92,6 +92,25 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
         config_service.set(solobase_core::migration_helper::RUN_MIGRATIONS_KEY, "1");
     }
 
+    // Build the parallel snapshot map fed to `Wafer::set_config_snapshot`.
+    // `EnvConfigService` is the async (`wafer-run/config`) read surface;
+    // the snapshot is the synchronous `ctx.config_get` surface. Both must
+    // carry the same data so `migration_helper::apply_if_blessed` (which
+    // reads `BLOCK_SETTINGS_CONFIG_KEY` + `SOLOBASE_RUN_MIGRATIONS` via
+    // `config_get`) sees the boot values without a per-call D1 hop. See
+    // `docs/superpowers/specs/2026-05-14-config-snapshot-and-migration-gate-design.md`.
+    let mut snapshot: HashMap<String, String> = vars.clone();
+    snapshot.insert(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY.to_string(),
+        features.to_config_json(),
+    );
+    if run_migrations {
+        snapshot.insert(
+            solobase_core::migration_helper::RUN_MIGRATIONS_KEY.to_string(),
+            "1".to_string(),
+        );
+    }
+
     let (mut wafer, storage_block) = SolobaseBuilder::new()
         .database(solobase_native::make_sqlite_database_service(
             &infra.db_path,
@@ -110,6 +129,12 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
         .sqlite_db_path(&infra.db_path)
         .build()
         .context("build solobase runtime")?;
+
+    // 7b. Wire the env-var snapshot into `RuntimeContext.config` so blocks
+    //     can read embedder-provided keys via `ctx.config_get` synchronously.
+    //     Mirrors the cloudflare embedder; both surfaces carry identical
+    //     data (see snapshot construction above).
+    wafer.set_config_snapshot(snapshot);
 
     // 8. Native-only: register http-listener.
     //    solobase dispatches all HTTP traffic through the `site-main` flow


### PR DESCRIPTION
## Summary

PR 2 of the [2026-05-14 config-snapshot + migration-gate design](../blob/main/docs/superpowers/specs/2026-05-14-config-snapshot-and-migration-gate-design.md) (workspace-owned spec). Producer side landed in [wafer-run #138](https://github.com/wafer-run/wafer-run/pull/138). Three coordinated changes — each targets a distinct cold-start D1 read amplifier called out in the spec:

- **Wire `wafer.set_config_snapshot(env_vars)` in both embedders** (`solobase-cloudflare/src/lib.rs` + `solobase/src/cli/server.rs`). Until now `RuntimeContext.config` was always empty unless the caller passed a per-call HashMap, so `ctx.config_get(BLOCK_SETTINGS_CONFIG_KEY)` in `migration_helper::apply_if_blessed` always saw `\"{}\"` and treated every block as fresh-install. The new snapshot carries the same data as the async ConfigService — it is the synchronous read path that the helper expected all along.
- **Port `admin/migrations::apply` to `apply_if_blessed`.** The admin block was the only one bypassing the migration gate, so admin DDL re-ran every cold isolate (~2,800 D1 queries/day on wafer.run) even after the snapshot wiring lands. Migrations 001 + 002 are concatenated into a single SQL blob so `apply_if_blessed` records one `current_hash` covering both — mirrors the auth block's multi-file concatenation pattern. The duplicate local `split_statements` / `has_executable_content` helpers are removed (migration_helper owns them); the old parser tests are rewritten as hash-coverage spot-checks.
- **Rewrite `admin/settings::seed_defaults` to a single `db::list_all` + in-memory diff.** Replaces the per-var `db::get_by_field` loop that issued 2 D1 queries per shared var per cold isolate (~5,000 reads/day in prod). Field-by-field metadata diff and the env-or-default seed-value logic are preserved verbatim — only the lookup strategy changed.

Expected aggregate impact (spec section \"Expected impact\"): ~8,000 fewer D1 reads/day on wafer.run, ~48% of current read budget.

## Notable mid-execution surprise

Bumping wafer-run to PR #138's commit (`4a6ce71`) surfaced an unrelated regression from the `missing_docs` doc-coverage sweep: `CorsBlock`, `RouterBlock`, and `WebBlock` (along with their `new()` constructors) had been narrowed from `pub` to `pub(crate)`, breaking the wasm-only block registration in `solobase-core/src/builder.rs` (the `register_static_block!` macro is a no-op on wasm32, so wasm consumers construct these blocks directly). Fixed at root cause in wafer-run [#139](https://github.com/wafer-run/wafer-run/pull/139) (already merged as `909fabd`); this PR pins to that revision so the wasm target builds.

## Test plan

- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean
- [x] `cargo check -p solobase` (native) clean
- [x] `cargo test -p solobase-core --lib` — 626/626 pass
- [x] `cargo test -p solobase --lib` — 22/22 pass
- [ ] Post-deploy: D1 read budget drops as predicted (24h validation per spec section \"Verification plan\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)