### PR TITLE
refactor(userportal): port block schema from ensure_table() to migration files

### DIFF
--- a/crates/solobase-core/src/blocks/userportal/migrations/001_userportal_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/userportal/migrations/001_userportal_schema.postgres.sql
@@ -1,0 +1,20 @@
+-- User portal block schema (PostgreSQL).
+--
+-- Mirror of 001_userportal_schema.sqlite.sql. INTEGER (not BOOLEAN) used
+-- for any flag-style columns to match `record.i64_field(...)` reads in
+-- block code (none here, but kept for consistency with the auth/admin
+-- migrations). CREATE TABLE/INDEX IF NOT EXISTS is idempotent across
+-- repeated `Init` lifecycle events.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons (
+    id          TEXT PRIMARY KEY,
+    label       TEXT NOT NULL DEFAULT '',
+    icon        TEXT NOT NULL DEFAULT 'package',
+    path        TEXT NOT NULL DEFAULT '',
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suppers_ai__userportal__buttons_sort_order_idx
+    ON suppers_ai__userportal__buttons (sort_order);

--- a/crates/solobase-core/src/blocks/userportal/migrations/001_userportal_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/userportal/migrations/001_userportal_schema.sqlite.sql
@@ -1,0 +1,26 @@
+-- User portal block schema (SQLite / D1).
+--
+-- Replaces the implicit `ensure_table` materialization for
+-- `suppers_ai__userportal__buttons` (TEXT-only columns, no indexes) with
+-- explicit DDL. Mirrors the `CollectionSchema::new(TABLE)` declaration in
+-- `blocks/userportal/mod.rs`: `label`, `icon` (default "package"), `path`,
+-- `sort_order` (int default 0), plus the standard `id`/`created_at`/
+-- `updated_at` columns the helpers stamp.
+--
+-- A `sort_order` index makes the `load_buttons` ORDER BY usable without
+-- a full scan as the table grows.
+--
+-- Mirrored to 001_userportal_schema.postgres.sql.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons (
+    id          TEXT PRIMARY KEY,
+    label       TEXT NOT NULL DEFAULT '',
+    icon        TEXT NOT NULL DEFAULT 'package',
+    path        TEXT NOT NULL DEFAULT '',
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suppers_ai__userportal__buttons_sort_order_idx
+    ON suppers_ai__userportal__buttons (sort_order);

--- a/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
@@ -1,0 +1,83 @@
+//! User portal block migrations. Applied from the block's `Init` lifecycle.
+//!
+//! Mirrors the admin/auth/files migration pattern. SQL files are embedded
+//! with `include_str!`. Backend selection reads the
+//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
+//! Falls back to `sqlite` when unset.
+//!
+//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
+//! the helper handles statement splitting + the `current_hash` /
+//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
+//! `suppers_ai__admin__block_settings` once applied.
+
+use wafer_core::clients::config;
+use wafer_run::context::Context;
+
+use crate::migration_helper;
+
+const USERPORTAL_BLOCK_NAME: &str = "suppers-ai/userportal";
+
+const SQL_001_SQLITE: &str = include_str!("001_userportal_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_userportal_schema.postgres.sql");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Sqlite,
+    Postgres,
+}
+
+async fn backend(ctx: &dyn Context) -> Backend {
+    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
+    match raw.to_ascii_lowercase().as_str() {
+        "postgres" => Backend::Postgres,
+        _ => Backend::Sqlite,
+    }
+}
+
+fn concatenated_sql(b: Backend) -> String {
+    match b {
+        Backend::Sqlite => SQL_001_SQLITE.to_string(),
+        Backend::Postgres => SQL_001_POSTGRES.to_string(),
+    }
+}
+
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let b = backend(ctx).await;
+    let sql = concatenated_sql(b);
+    migration_helper::apply_if_blessed(ctx, USERPORTAL_BLOCK_NAME, &sql).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{concatenated_sql, Backend};
+
+    #[test]
+    fn sqlite_script_creates_buttons_table_and_sort_order_index() {
+        let sql = concatenated_sql(Backend::Sqlite);
+        assert!(
+            sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"),
+            "missing buttons CREATE TABLE; got len={}",
+            sql.len()
+        );
+        assert!(
+            sql.contains("suppers_ai__userportal__buttons_sort_order_idx"),
+            "missing sort_order index; got len={}",
+            sql.len()
+        );
+    }
+
+    #[test]
+    fn postgres_script_creates_buttons_table_and_sort_order_index() {
+        let sql = concatenated_sql(Backend::Postgres);
+        assert!(
+            sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"),
+            "missing buttons CREATE TABLE; got len={}",
+            sql.len()
+        );
+        assert!(
+            sql.contains("suppers_ai__userportal__buttons_sort_order_idx"),
+            "missing sort_order index; got len={}",
+            sql.len()
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     },
 };
 
+mod migrations;
 mod pages;
 
 const TABLE: &str = "suppers_ai__userportal__buttons";
@@ -142,9 +143,17 @@ impl Block for UserPortalBlock {
 
     async fn lifecycle(
         &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
+        ctx: &dyn Context,
+        event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
+        if matches!(event.event_type, LifecycleType::Init) {
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("userportal migrations: {e}"),
+                )
+            })?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the implicit `ensure_table()` materialization for `suppers_ai__userportal__buttons` (TEXT-only columns, no indexes) with explicit DDL in `migrations/001_userportal_schema.{sqlite,postgres}.sql`, applied via `crate::migration_helper::apply_if_blessed` from the userportal block's `Init` lifecycle.
- Same pattern as auth/admin/files. New `sort_order` index backs the `load_buttons` ORDER BY without a full scan — `CollectionSchema` is advisory under the auto-create path and never materialized it.
- `CollectionSchema` declaration on `BlockInfo` is kept: admin `pages/blocks.rs`, `pages/permissions.rs`, and `embed_cloudflare.rs` still read it as advisory metadata.

Tracker: `ensure-table-removal-in-progress` — `solobase-core/blocks/userportal/` flips to migrated.

## Test plan

- [x] `cargo check -p solobase-core` clean.
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean (CI's wasm gate; bare `solobase-core` wasm check fails on a pre-existing `uuid` feature issue on both `main` and this branch).
- [x] `cargo test -p solobase-core --lib` passes (628 tests; previously 626 + 2 new SQL parser tests for sqlite + postgres scripts).
- [ ] Post-merge: deploy with `SOLOBASE_RUN_MIGRATIONS=1` so `apply_if_blessed` stamps the userportal migration hash. The `CREATE TABLE IF NOT EXISTS` keeps existing prod rows; the new index is the only schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)