### PR TITLE
refactor(llm): decouple table constants from messages block (allow llm w/o block-messages)

### DIFF
--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -14,10 +14,12 @@ use wafer_run::{context::Context, types::*, OutputStream};
 
 use super::SETTINGS_TABLE;
 use crate::{
-    blocks::{
-        helpers::RecordExt,
-        messages::service::{CONTEXTS_TABLE, ENTRIES_TABLE},
-    },
+    blocks::helpers::RecordExt,
+    // Read messages-owned rows by table name. Constants live in a sibling
+    // module (not under `blocks::messages`) so the LLM block compiles
+    // without pulling in the messages block module — runtime WRAP grants
+    // declared by `MessagesBlock` still authorize the cross-block read.
+    messages_schema::{CONTEXTS_TABLE, ENTRIES_TABLE},
     ui::{
         components, icons, nav_groups,
         shell::{Crumb, Topbar},

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -11,8 +11,11 @@ use wafer_run::{context::Context, WaferError};
 
 use crate::blocks::helpers::{self, json_map};
 
-pub const CONTEXTS_TABLE: &str = "suppers_ai__messages__contexts";
-pub const ENTRIES_TABLE: &str = "suppers_ai__messages__entries";
+// Table-name constants live in `crate::messages_schema` so consumers
+// (e.g. the LLM chat UI) can reference them without compiling this module.
+// Re-exported here so existing `messages::service::{CONTEXTS_TABLE,
+// ENTRIES_TABLE}` references inside the messages block continue to resolve.
+pub use crate::messages_schema::{CONTEXTS_TABLE, ENTRIES_TABLE};
 
 /// Build an `Equal` filter for `field` when `value` is present. Mirrors the
 /// per-field `if let Some(...) { filters.push(...) }` pattern used across

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -10,7 +10,6 @@ use wafer_core::clients::{
 use wafer_run::{context::Context, WaferError};
 
 use crate::blocks::helpers::{self, json_map};
-
 // Table-name constants live in `crate::messages_schema` so consumers
 // (e.g. the LLM chat UI) can reference them without compiling this module.
 // Re-exported here so existing `messages::service::{CONTEXTS_TABLE,

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config_vars;
 pub mod crypto;
 pub mod features;
 pub mod flows;
+pub mod messages_schema;
 pub mod migration_helper;
 pub mod migrations;
 pub mod pipeline;

--- a/crates/solobase-core/src/messages_schema.rs
+++ b/crates/solobase-core/src/messages_schema.rs
@@ -1,0 +1,28 @@
+//! Shared table-name constants for the `suppers-ai/messages` block.
+//!
+//! These live outside `blocks/messages/` so that consumers which read
+//! messages-owned rows by table name (today: the LLM chat UI in
+//! `blocks/llm/pages.rs`) can reference them without forcing the messages
+//! block module — and its dependencies — to compile.
+//!
+//! The `MessagesBlock` impl re-exports from here, so existing
+//! `blocks::messages::service::{CONTEXTS_TABLE, ENTRIES_TABLE}` references
+//! continue to resolve. New consumers should import directly from this
+//! module.
+//!
+//! Why a sibling of `blocks/`?
+//! - The constants describe the on-disk schema contract, not block logic;
+//!   keeping them in a leaf module with zero deps is the only way to make
+//!   them feature-independent (a `blocks/messages/tables.rs` would still
+//!   live inside the gated `messages` module tree).
+//! - WRAP grants are still declared by `MessagesBlock::info()` (the
+//!   schema-owning block); other blocks read rows via runtime grants, not by
+//!   re-declaring ownership.
+
+/// Table backing `suppers-ai/messages` contexts (conversations, tasks,
+/// notifications, …). Owned by the messages block.
+pub const CONTEXTS_TABLE: &str = "suppers_ai__messages__contexts";
+
+/// Table backing `suppers-ai/messages` entries (messages, artifacts,
+/// notifications, status changes). Owned by the messages block.
+pub const ENTRIES_TABLE: &str = "suppers_ai__messages__entries";


### PR DESCRIPTION
## Summary

- Hoist `CONTEXTS_TABLE` / `ENTRIES_TABLE` out of `blocks/messages/service.rs` into a new sibling module `solobase_core::messages_schema`, so `blocks/llm/pages.rs` can read messages-owned tables by name without importing from the messages block module.
- Unblocks PR #188 (per-block Cargo features) from having to encode `llm -> block-messages` in its feature graph. The remaining `MessagesBlock`-owned WRAP grants in `blocks/messages/mod.rs` stay where they are (the schema-owning block declares them); the cross-module *type* dependency from `llm` to `messages` is what this PR removes.

## Motivation

From PR #188's body:

> The one remaining cross-block direct reference is `blocks::llm::pages` reading `messages::service::{CONTEXTS_TABLE, ENTRIES_TABLE}`. That keeps `feature = "llm"` strictly stronger than `block-messages` for now (encoded in Cargo). Decoupling is a follow-up: hoist the table constants into a shared types module so the LLM UI can read them without compiling the messages block.

This PR is that follow-up. Once both land, the `llm` feature in #188 can drop its `block-messages` implication.

## Chosen home for the constants: option (a) — sibling of `blocks/`

Per the task brief, the options were:
- (a) New `crates/solobase-core/src/messages_schema.rs` sibling of `blocks/`.
- (b) Move to `wafer-core` / another shared crate.
- (c) Re-export from a single `blocks::messages::tables` module.

I picked (a). A `blocks/messages/tables.rs` (option c) would still live inside the gated `messages` module tree, so it would not be reachable when `block-messages` is feature-gated off — defeating the point. (b) is overkill: these are solobase-internal table names that no wafer-* crate has any business knowing. (a) is the minimal hoist that actually makes the constants feature-independent. The new module is leaf-level (zero deps) and has a doc comment explaining the rationale.

`blocks/messages/service.rs` now re-exports from `crate::messages_schema`, so existing `messages::service::{CONTEXTS_TABLE, ENTRIES_TABLE}` references inside the messages block (notably the WRAP grants and `CollectionSchema` declarations in `MessagesBlock::info()`) keep resolving without churn.

## What about the Cargo.toml change?

The task brief said to "drop the `llm` → `block-messages` implication" in `solobase-core/Cargo.toml`. There is nothing to drop on `main` today — the per-block features (`block-messages`, `block-llm`, etc.) only exist on PR #188's branch. Once #188 merges (or rebases onto this), the implication can be dropped there. No Cargo.toml changes in this PR.

## Verification

- `cargo check -p solobase-core` (defaults): clean.
- `cargo check -p solobase-core --no-default-features --features sqlite,storage-local,llm`: clean.
- `cargo test -p solobase-core --lib`: **626 passed; 0 failed.**
- `cargo check -p solobase-core --target wasm32-unknown-unknown`: same pre-existing `uuid` / `getrandom` `js`-feature compile error as `main` HEAD (`cargo check -p solobase-core --target wasm32-unknown-unknown` on a stashed clean tree reproduces the identical failure). Wasm32 builds normally go through `solobase-cloudflare`, which provides the `getrandom/js` feature. Not introduced by this PR.

## Test plan

- [x] Defaults still compile.
- [x] `llm` feature compiles without changes.
- [x] Lib test suite passes (626/626).
- [x] No `blocks::messages::` import left in `blocks/llm/pages.rs` (`grep messages` shows only `messages_schema::{...}` plus local UI variable names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)