### PR TITLE
refactor(legalpages): port block schema from ensure_table() to migration files

### DIFF
--- a/crates/solobase-core/src/blocks/legalpages/migrations/001_legalpages_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/legalpages/migrations/001_legalpages_schema.postgres.sql
@@ -1,0 +1,20 @@
+-- Legalpages block schema (Postgres parity — untested).
+-- Solobase deploys SQLite/D1 today; this file is included for parity with
+-- the auth/admin/files migration pattern. Validate before enabling
+-- Postgres for legalpages.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__legalpages__documents (
+    id            TEXT PRIMARY KEY,
+    doc_type      TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    content       TEXT NOT NULL DEFAULT '',
+    status        TEXT NOT NULL DEFAULT 'draft',
+    version       INTEGER NOT NULL DEFAULT 1,
+    created_by    TEXT NOT NULL DEFAULT '',
+    published_at  TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_legalpages_documents_doc_type_status
+    ON suppers_ai__legalpages__documents (doc_type, status);

--- a/crates/solobase-core/src/blocks/legalpages/migrations/001_legalpages_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/legalpages/migrations/001_legalpages_schema.sqlite.sql
@@ -1,0 +1,25 @@
+-- Legalpages block schema (SQLite / D1).
+--
+-- Replaces the implicit `ensure_table` materialization (TEXT-only columns,
+-- no indexes) for tables owned by `suppers-ai/legalpages`. CREATE TABLE
+-- IF NOT EXISTS is a no-op against existing prod tables, but the
+-- CREATE INDEX statement below adds the (doc_type, status) composite
+-- so the public `terms` / `privacy` lookups stop scanning the table.
+--
+-- Mirrored to 001_legalpages_schema.postgres.sql.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__legalpages__documents (
+    id            TEXT PRIMARY KEY,
+    doc_type      TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    content       TEXT NOT NULL DEFAULT '',
+    status        TEXT NOT NULL DEFAULT 'draft',
+    version       INTEGER NOT NULL DEFAULT 1,
+    created_by    TEXT NOT NULL DEFAULT '',
+    published_at  TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_legalpages_documents_doc_type_status
+    ON suppers_ai__legalpages__documents (doc_type, status);

--- a/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
@@ -1,0 +1,21 @@
+//! Legalpages block migrations. Delegated to `crate::migration_helper`.
+
+use wafer_core::clients::config;
+use wafer_run::context::Context;
+
+use crate::migration_helper;
+
+const SQL_001_SQLITE: &str = include_str!("001_legalpages_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_legalpages_schema.postgres.sql");
+
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
+        .await
+        .to_ascii_lowercase();
+    let sql = if backend == "postgres" {
+        SQL_001_POSTGRES
+    } else {
+        SQL_001_SQLITE
+    };
+    migration_helper::apply_if_blessed(ctx, "suppers-ai/legalpages", sql).await
+}

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -1,3 +1,4 @@
+mod migrations;
 mod pages;
 
 use std::collections::HashMap;
@@ -477,22 +478,11 @@ fn sanitize_html(input: &str) -> String {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for LegalPagesBlock {
     fn info(&self) -> BlockInfo {
-        use wafer_run::{types::CollectionSchema, AuthLevel};
+        use wafer_run::AuthLevel;
 
         BlockInfo::new("suppers-ai/legalpages", "0.0.1", "http-handler@v1", "Legal pages management with versioning and publishing")
             .instance_mode(InstanceMode::Singleton)
             .requires(vec!["wafer-run/database".into()])
-            .collections(vec![
-                CollectionSchema::new(COLLECTION)
-                    .field("doc_type", "string")
-                    .field("title", "string")
-                    .field_default("content", "text", "")
-                    .field_default("status", "string", "draft")
-                    .field_default("version", "int", "1")
-                    .field_default("created_by", "string", "")
-                    .field_optional("published_at", "datetime")
-                    .index(&["doc_type", "status"]),
-            ])
             .category(wafer_run::BlockCategory::Feature)
             .description("Legal document management with versioning and publishing. Create and manage terms of service, privacy policies, and other legal documents. Supports draft/published workflow with version tracking.")
             .endpoints(vec![
@@ -579,6 +569,12 @@ impl Block for LegalPagesBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if matches!(event.event_type, LifecycleType::Init) {
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("legalpages migrations: {e}"),
+                )
+            })?;
             self.seed_defaults(ctx).await;
         }
         Ok(())

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -276,6 +276,31 @@ mod tests {
     }
 
     #[test]
+    fn legalpages_sql_splits_into_expected_chunks() {
+        let sql_sqlite =
+            include_str!("blocks/legalpages/migrations/001_legalpages_schema.sqlite.sql");
+        let sqlite_count = split_statements(sql_sqlite)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            sqlite_count, 2,
+            "legalpages sqlite migration: expected 2 statements, got {sqlite_count}"
+        );
+
+        let sql_postgres =
+            include_str!("blocks/legalpages/migrations/001_legalpages_schema.postgres.sql");
+        let postgres_count = split_statements(sql_postgres)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            postgres_count, 2,
+            "legalpages postgres migration: expected 2 statements, got {postgres_count}"
+        );
+    }
+
+    #[test]
     fn files_sql_splits_into_expected_chunks() {
         // Counts the executable statements in the files block SQL files.
         // Fails if the SQL file is edited and the helper's splitter is broken


### PR DESCRIPTION
## Summary

Ports the `suppers-ai/legalpages` block from runtime `ensure_table()` auto-create to explicit SQL migration files, matching the canonical pattern already shipped for `auth`, `admin`, `files`, and `site/registry`.

- Adds `migrations/001_legalpages_schema.{sqlite,postgres}.sql` with the single owned table `suppers_ai__legalpages__documents` (typed columns + composite `(doc_type, status)` index)
- Wires `migrations::apply()` into the block's `Init` lifecycle via the shared hash-gated `migration_helper::apply_if_blessed`
- Drops `BlockInfo.collections(...)` from the block — schema is now owned by the migration files; no WRAP / capability code reads `BlockInfo.collections`
- Adds a parser-test (`legalpages_sql_splits_into_expected_chunks`) to `migration_helper::tests` covering both backend variants (2 statements each)

### Schema change vs. prior `ensure_table` materialization

| Column        | Before (`ensure_table`) | After (migration)               |
|---------------|-------------------------|---------------------------------|
| `version`     | TEXT                    | INTEGER NOT NULL DEFAULT 1      |
| `published_at`| TEXT (nullable)         | TEXT (nullable)                 |
| `(doc_type, status)` index | none       | `idx_legalpages_documents_doc_type_status` |

`CREATE TABLE IF NOT EXISTS` is a no-op against existing prod tables; the new `CREATE INDEX IF NOT EXISTS` adds the composite that the public `/b/legalpages/{terms,privacy}` lookup path filters on. Schema-change apply is gated by `SOLOBASE_RUN_MIGRATIONS=1` per the standard `migration-state-workflow`.

Tracker: `~/.claude/projects/.../ensure-table-removal-in-progress.md` (one of remaining `❌` rows; 7 still to go after this).

## Test plan

- [x] `cargo check -p solobase-core` — clean
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean (real CF wasm consumer)
- [x] `cargo check -p solobase-web --target wasm32-unknown-unknown` — clean (browser wasm consumer)
- [x] `cargo test -p solobase-core --lib` — 627 passed (same count, plus new parser test pulled in)
- [ ] Native solobase boot — verify migration applies once on fresh DB and no-ops on subsequent boots
- [ ] CF deploy with `SOLOBASE_RUN_MIGRATIONS=1` — verify `block_settings` row stamps for `suppers-ai/legalpages` and the new index appears in D1 schema dump

Note: direct `cargo check -p solobase-core --target wasm32-unknown-unknown` fails on `uuid` feature gating — this is **pre-existing on `main`**, not introduced by this PR (the crate is meant to be consumed via `solobase-web` / `solobase-cloudflare` features).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)