### PR TITLE
refactor(products): port block schema from ensure_table() to migration files

### DIFF
--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
@@ -1,0 +1,172 @@
+-- Products block schema (PostgreSQL).
+--
+-- Mirror of 001_products_schema.sqlite.sql. INTEGER (not BOOLEAN) is used
+-- for boolean-like columns to match the JSON-value round-trips used by
+-- block code. DOUBLE PRECISION is used for the float price columns.
+-- CREATE TABLE IF NOT EXISTS makes this idempotent across repeated `Init`
+-- lifecycle events.
+--
+-- Solobase deploys SQLite/D1 today; this file is included for parity with
+-- the auth/files migrations pattern. Validate before enabling Postgres
+-- for the products block.
+
+-- Products ----------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__products (
+    id                    TEXT PRIMARY KEY,
+    name                  TEXT NOT NULL,
+    description           TEXT NOT NULL DEFAULT '',
+    slug                  TEXT NOT NULL DEFAULT '',
+    price                 DOUBLE PRECISION NOT NULL DEFAULT 0,
+    base_price            DOUBLE PRECISION NOT NULL DEFAULT 0,
+    currency              TEXT NOT NULL DEFAULT 'USD',
+    status                TEXT NOT NULL DEFAULT 'draft',
+    category              TEXT NOT NULL DEFAULT '',
+    tags                  TEXT NOT NULL DEFAULT '[]',
+    metadata              TEXT NOT NULL DEFAULT '{}',
+    image_url             TEXT NOT NULL DEFAULT '',
+    stock                 INTEGER NOT NULL DEFAULT 0,
+    group_id              TEXT NOT NULL DEFAULT '',
+    type_id               TEXT NOT NULL DEFAULT '',
+    group_template_id     TEXT NOT NULL DEFAULT '',
+    product_template_id   TEXT NOT NULL DEFAULT '',
+    pricing_template_id   TEXT NOT NULL DEFAULT '',
+    requires              TEXT NOT NULL DEFAULT '',
+    created_by            TEXT NOT NULL DEFAULT '',
+    deleted_at            TEXT,
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_status_idx
+    ON suppers_ai__products__products (status);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_group_id_idx
+    ON suppers_ai__products__products (group_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_created_by_idx
+    ON suppers_ai__products__products (created_by);
+
+-- Groups ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__groups (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    description         TEXT NOT NULL DEFAULT '',
+    template_id         TEXT NOT NULL DEFAULT '',
+    group_template_id   TEXT NOT NULL DEFAULT '',
+    user_id             TEXT NOT NULL DEFAULT '',
+    status              TEXT NOT NULL DEFAULT 'active',
+    created_by          TEXT NOT NULL DEFAULT '',
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
+
+-- Types -------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__types (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    is_system   INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+-- Pricing templates -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__pricing_templates (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    price_formula   TEXT NOT NULL DEFAULT '',
+    template_data   TEXT NOT NULL DEFAULT '{}',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+-- Purchases ---------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__purchases (
+    id                          TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL,
+    status                      TEXT NOT NULL DEFAULT 'pending',
+    total_cents                 BIGINT NOT NULL DEFAULT 0,
+    amount_cents                BIGINT NOT NULL DEFAULT 0,
+    currency                    TEXT NOT NULL DEFAULT 'USD',
+    provider                    TEXT NOT NULL DEFAULT 'manual',
+    metadata                    TEXT NOT NULL DEFAULT '{}',
+    stripe_payment_intent_id    TEXT NOT NULL DEFAULT '',
+    provider_payment_intent_id  TEXT NOT NULL DEFAULT '',
+    approved_at                 TEXT,
+    refunded_at                 TEXT,
+    refunded_by                 TEXT NOT NULL DEFAULT '',
+    refund_reason               TEXT NOT NULL DEFAULT '',
+    payment_at                  TEXT,
+    created_at                  TEXT NOT NULL,
+    updated_at                  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_user_id_idx
+    ON suppers_ai__products__purchases (user_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_status_idx
+    ON suppers_ai__products__purchases (status);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_provider_payment_intent_idx
+    ON suppers_ai__products__purchases (provider_payment_intent_id);
+
+-- Line items --------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__line_items (
+    id            TEXT PRIMARY KEY,
+    purchase_id   TEXT NOT NULL,
+    product_id    TEXT NOT NULL,
+    product_name  TEXT NOT NULL DEFAULT '',
+    quantity      INTEGER NOT NULL DEFAULT 1,
+    unit_price    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    total_price   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    variables     TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__line_items_purchase_id_idx
+    ON suppers_ai__products__line_items (purchase_id);
+
+-- Group templates ---------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__group_templates (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    display_name  TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+-- Product templates -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__product_templates (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    display_name  TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+-- Variables (pricing-formula inputs) --------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__variables (
+    id             TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    var_type       TEXT NOT NULL DEFAULT 'number',
+    default_value  TEXT,
+    scope          TEXT NOT NULL DEFAULT 'system',
+    product_id     TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+);
+
+-- Subscriptions -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__subscriptions (
+    id                       TEXT PRIMARY KEY,
+    user_id                  TEXT NOT NULL,
+    stripe_customer_id       TEXT NOT NULL DEFAULT '',
+    stripe_subscription_id   TEXT NOT NULL DEFAULT '',
+    plan                     TEXT NOT NULL DEFAULT '',
+    status                   TEXT NOT NULL DEFAULT '',
+    grace_period_end         TEXT,
+    addon_projects           BIGINT NOT NULL DEFAULT 0,
+    addon_requests           BIGINT NOT NULL DEFAULT 0,
+    addon_r2_bytes           BIGINT NOT NULL DEFAULT 0,
+    addon_d1_bytes           BIGINT NOT NULL DEFAULT 0,
+    created_at               TEXT NOT NULL,
+    updated_at               TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__products__subscriptions_user_id_uniq
+    ON suppers_ai__products__subscriptions (user_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__subscriptions_stripe_sub_id_idx
+    ON suppers_ai__products__subscriptions (stripe_subscription_id);

--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
@@ -1,0 +1,181 @@
+-- Products block schema (SQLite / D1).
+--
+-- Replaces the implicit `ensure_table` materialization (TEXT-only columns,
+-- no indexes) for tables owned by `suppers-ai/products`. CREATE TABLE
+-- IF NOT EXISTS is a no-op against existing prod tables, but the CREATE
+-- INDEX statements below add indexes the auto-create path was silently
+-- skipping (CollectionSchema indexes are advisory under ensure_table).
+--
+-- Also creates the `subscriptions` table which was previously missing
+-- from CollectionSchema entirely — stripe.rs writes to it on
+-- `checkout.session.completed` and the addon_* columns were materialized
+-- as TEXT then queried via COALESCE(.., 0).
+--
+-- Mirrored to 001_products_schema.postgres.sql.
+
+-- Products ----------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__products (
+    id                    TEXT PRIMARY KEY,
+    name                  TEXT NOT NULL,
+    description           TEXT NOT NULL DEFAULT '',
+    slug                  TEXT NOT NULL DEFAULT '',
+    price                 REAL NOT NULL DEFAULT 0,
+    base_price            REAL NOT NULL DEFAULT 0,
+    currency              TEXT NOT NULL DEFAULT 'USD',
+    status                TEXT NOT NULL DEFAULT 'draft',
+    category              TEXT NOT NULL DEFAULT '',
+    tags                  TEXT NOT NULL DEFAULT '[]',
+    metadata              TEXT NOT NULL DEFAULT '{}',
+    image_url             TEXT NOT NULL DEFAULT '',
+    stock                 INTEGER NOT NULL DEFAULT 0,
+    group_id              TEXT NOT NULL DEFAULT '',
+    type_id               TEXT NOT NULL DEFAULT '',
+    group_template_id     TEXT NOT NULL DEFAULT '',
+    product_template_id   TEXT NOT NULL DEFAULT '',
+    pricing_template_id   TEXT NOT NULL DEFAULT '',
+    requires              TEXT NOT NULL DEFAULT '',
+    created_by            TEXT NOT NULL DEFAULT '',
+    deleted_at            TEXT,
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_status_idx
+    ON suppers_ai__products__products (status);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_group_id_idx
+    ON suppers_ai__products__products (group_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__products_created_by_idx
+    ON suppers_ai__products__products (created_by);
+
+-- Groups ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__groups (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    description         TEXT NOT NULL DEFAULT '',
+    template_id         TEXT NOT NULL DEFAULT '',
+    group_template_id   TEXT NOT NULL DEFAULT '',
+    user_id             TEXT NOT NULL DEFAULT '',
+    status              TEXT NOT NULL DEFAULT 'active',
+    created_by          TEXT NOT NULL DEFAULT '',
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
+
+-- Types -------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__types (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    is_system   INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+-- Pricing templates -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__pricing_templates (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    price_formula   TEXT NOT NULL DEFAULT '',
+    template_data   TEXT NOT NULL DEFAULT '{}',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+-- Purchases ---------------------------------------------------------------
+-- Includes columns referenced by stripe.rs that were missing from the
+-- CollectionSchema declaration: `provider_payment_intent_id`, `approved_at`.
+CREATE TABLE IF NOT EXISTS suppers_ai__products__purchases (
+    id                          TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL,
+    status                      TEXT NOT NULL DEFAULT 'pending',
+    total_cents                 INTEGER NOT NULL DEFAULT 0,
+    amount_cents                INTEGER NOT NULL DEFAULT 0,
+    currency                    TEXT NOT NULL DEFAULT 'USD',
+    provider                    TEXT NOT NULL DEFAULT 'manual',
+    metadata                    TEXT NOT NULL DEFAULT '{}',
+    stripe_payment_intent_id    TEXT NOT NULL DEFAULT '',
+    provider_payment_intent_id  TEXT NOT NULL DEFAULT '',
+    approved_at                 TEXT,
+    refunded_at                 TEXT,
+    refunded_by                 TEXT NOT NULL DEFAULT '',
+    refund_reason               TEXT NOT NULL DEFAULT '',
+    payment_at                  TEXT,
+    created_at                  TEXT NOT NULL,
+    updated_at                  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_user_id_idx
+    ON suppers_ai__products__purchases (user_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_status_idx
+    ON suppers_ai__products__purchases (status);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__purchases_provider_payment_intent_idx
+    ON suppers_ai__products__purchases (provider_payment_intent_id);
+
+-- Line items --------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__line_items (
+    id            TEXT PRIMARY KEY,
+    purchase_id   TEXT NOT NULL,
+    product_id    TEXT NOT NULL,
+    product_name  TEXT NOT NULL DEFAULT '',
+    quantity      INTEGER NOT NULL DEFAULT 1,
+    unit_price    REAL NOT NULL DEFAULT 0,
+    total_price   REAL NOT NULL DEFAULT 0,
+    variables     TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__line_items_purchase_id_idx
+    ON suppers_ai__products__line_items (purchase_id);
+
+-- Group templates ---------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__group_templates (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    display_name  TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+-- Product templates -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__product_templates (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    display_name  TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+-- Variables (pricing-formula inputs) --------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__products__variables (
+    id             TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    var_type       TEXT NOT NULL DEFAULT 'number',
+    default_value  TEXT,
+    scope          TEXT NOT NULL DEFAULT 'system',
+    product_id     TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+);
+
+-- Subscriptions -----------------------------------------------------------
+-- Written by stripe.rs webhook handlers, queried by handlers.rs for
+-- subscription/addon lookup. Was previously absent from CollectionSchema
+-- and materialized via ensure_table on first insert (TEXT-only columns,
+-- including the addon_* counts that are written + read as INTEGER).
+CREATE TABLE IF NOT EXISTS suppers_ai__products__subscriptions (
+    id                       TEXT PRIMARY KEY,
+    user_id                  TEXT NOT NULL,
+    stripe_customer_id       TEXT NOT NULL DEFAULT '',
+    stripe_subscription_id   TEXT NOT NULL DEFAULT '',
+    plan                     TEXT NOT NULL DEFAULT '',
+    status                   TEXT NOT NULL DEFAULT '',
+    grace_period_end         TEXT,
+    addon_projects           INTEGER NOT NULL DEFAULT 0,
+    addon_requests           INTEGER NOT NULL DEFAULT 0,
+    addon_r2_bytes           INTEGER NOT NULL DEFAULT 0,
+    addon_d1_bytes           INTEGER NOT NULL DEFAULT 0,
+    created_at               TEXT NOT NULL,
+    updated_at               TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__products__subscriptions_user_id_uniq
+    ON suppers_ai__products__subscriptions (user_id);
+CREATE INDEX IF NOT EXISTS suppers_ai__products__subscriptions_stripe_sub_id_idx
+    ON suppers_ai__products__subscriptions (stripe_subscription_id);

--- a/crates/solobase-core/src/blocks/products/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/products/migrations/mod.rs
@@ -1,0 +1,34 @@
+//! Products block migrations. Delegated to `crate::migration_helper`.
+//!
+//! Mirrors the auth/files migration pattern. SQL is embedded via
+//! `include_str!`. Backend selection reads the
+//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key
+//! (`sqlite` | `postgres`). Falls back to `sqlite` when the config block
+//! is not registered.
+//!
+//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
+//! the helper handles statement splitting + the `current_hash` /
+//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
+//! `suppers_ai__admin__block_settings` once applied.
+
+use wafer_core::clients::config;
+use wafer_run::context::Context;
+
+use crate::migration_helper;
+
+const PRODUCTS_BLOCK_NAME: &str = "suppers-ai/products";
+
+const SQL_001_SQLITE: &str = include_str!("001_products_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_products_schema.postgres.sql");
+
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
+        .await
+        .to_ascii_lowercase();
+    let sql = if backend == "postgres" {
+        SQL_001_POSTGRES
+    } else {
+        SQL_001_SQLITE
+    };
+    migration_helper::apply_if_blessed(ctx, PRODUCTS_BLOCK_NAME, sql).await
+}

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -1,4 +1,5 @@
 mod handlers;
+mod migrations;
 pub(crate) mod models;
 mod pages;
 mod pricing;
@@ -271,6 +272,15 @@ impl Block for ProductsBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if event.event_type == LifecycleType::Init {
+            // Apply block-owned schema migrations before any seeding so the
+            // default-template inserts below land on a known column set.
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("products migrations: {e}"),
+                )
+            })?;
+
             // Seed default templates if they don't exist — these are required by FK constraints
             // on the groups and products tables.
             use wafer_core::clients::database as db;

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -305,8 +305,7 @@ mod tests {
     fn products_sql_splits_into_expected_chunks() {
         // Counts the executable statements in the products block SQL files.
         // 10 CREATE TABLE + 9 CREATE INDEX = 19 statements per backend.
-        let sql_sqlite =
-            include_str!("blocks/products/migrations/001_products_schema.sqlite.sql");
+        let sql_sqlite = include_str!("blocks/products/migrations/001_products_schema.sqlite.sql");
         let sqlite_count = split_statements(sql_sqlite)
             .into_iter()
             .filter(|s| has_executable_content(s))

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -300,4 +300,31 @@ mod tests {
             "files postgres migration: expected 14 statements, got {postgres_count}"
         );
     }
+
+    #[test]
+    fn products_sql_splits_into_expected_chunks() {
+        // Counts the executable statements in the products block SQL files.
+        // 10 CREATE TABLE + 9 CREATE INDEX = 19 statements per backend.
+        let sql_sqlite =
+            include_str!("blocks/products/migrations/001_products_schema.sqlite.sql");
+        let sqlite_count = split_statements(sql_sqlite)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            sqlite_count, 19,
+            "products sqlite migration: expected 19 statements, got {sqlite_count}"
+        );
+
+        let sql_postgres =
+            include_str!("blocks/products/migrations/001_products_schema.postgres.sql");
+        let postgres_count = split_statements(sql_postgres)
+            .into_iter()
+            .filter(|s| has_executable_content(s))
+            .count();
+        assert_eq!(
+            postgres_count, 19,
+            "products postgres migration: expected 19 statements, got {postgres_count}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces runtime `ensure_table()` auto-create with explicit migration SQL for all `suppers-ai/products` tables. Mirrors the canonical pattern from `auth/migrations/` and `files/migrations/` (per-backend `.sql` files via `include_str!`, dispatched on `SOLOBASE_SHARED__DATABASE__BACKEND`, applied via `migration_helper::apply_if_blessed` from `Init` lifecycle).
- 5th of 9 blocks moved off auto-create (after `auth`, `admin`, `site/registry`, `files`). Remaining: `llm`, `messages`, `legalpages`, `userportal`; `vector` needs separate treatment for dynamic per-index tables.
- Tracker memory: `ensure-table-removal-in-progress`.

## What the migration captures that `ensure_table()` was dropping

**10 tables, 9 indexes** (auto-create previously produced TEXT-only columns with zero indexes):

| Table | Indexes added |
|---|---|
| `products` | `status`, `group_id`, `created_by` |
| `purchases` | `user_id`, `status`, `provider_payment_intent_id` |
| `line_items` | `purchase_id` |
| `subscriptions` | UNIQUE `user_id`, `stripe_subscription_id` |

**Numeric column types** corrected where the code path was writing/reading `INTEGER` / `REAL` through TEXT columns:
- `products`: `price`, `base_price` (REAL); `stock` (INTEGER)
- `purchases`: `total_cents`, `amount_cents` (BIGINT/INTEGER)
- `line_items`: `quantity` (INTEGER); `unit_price`, `total_price` (REAL)
- `subscriptions`: `addon_projects`, `addon_requests`, `addon_r2_bytes`, `addon_d1_bytes` (INTEGER/BIGINT) — previously TEXT round-tripped through `COALESCE(.., 0)`.

**Missing tables/columns now declared**:
- `suppers_ai__products__subscriptions` was absent from `CollectionSchema` entirely; `stripe.rs` upserts into it from `checkout.session.completed`, `customer.subscription.updated`, etc.
- `purchases.provider_payment_intent_id`, `purchases.approved_at` were referenced by `stripe.rs` but not declared.

## Notable cross-table refs

- `purchases.user_id` → `auth.users.id` (was declared via `field_ref` in the old `CollectionSchema` — kept as a plain TEXT column + index, since SQLite/D1 FK enforcement is off by default and the existing path never created the FK).
- `line_items.purchase_id` → `purchases.id` (queried with `FilterOp::In` from `stripe.rs::handle_user_has_access_to_product`).
- `subscriptions.user_id` UNIQUE so the deterministic `sub_{user_id}` upsert keeps a single row per user.

`CollectionSchema` declarations are kept on `BlockInfo` (advisory only — `admin/pages/blocks.rs` and `admin/pages/permissions.rs` render them in the admin UI; same shape as the files-block PR #137).

## Test plan

- [x] `cargo check -p solobase-core`
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` (validates WASM build path; standalone `cargo check -p solobase-core --target wasm32-unknown-unknown` fails on pre-existing `uuid` feature gating, not introduced by this PR)
- [x] `cargo test -p solobase-core --lib` — 627 passed (+1 new test `migration_helper::tests::products_sql_splits_into_expected_chunks`, but it falls within the existing tally since 626 + 1 = 627 — the count matches the pre-PR baseline)
- [ ] Manual: deploy to staging with `SOLOBASE_RUN_MIGRATIONS=1` and verify `idx_purchases_user_id` shows up in `EXPLAIN QUERY PLAN` for a user-purchase lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)