### PR TITLE
refactor(llm): port block schema from ensure_table() to migration files

### DIFF
--- a/crates/solobase-core/src/blocks/llm/migrations/001_llm_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/llm/migrations/001_llm_schema.postgres.sql
@@ -1,0 +1,39 @@
+-- LLM block schema (PostgreSQL).
+--
+-- Mirror of 001_llm_schema.sqlite.sql. INTEGER (not BOOLEAN) is used for
+-- boolean-like columns to match `record.i64_field(...)` reads in block
+-- code. CREATE TABLE IF NOT EXISTS makes this idempotent across repeated
+-- `Init` lifecycle events.
+
+-- Per-thread provider/model overrides ------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__llm__settings (
+    id             TEXT PRIMARY KEY,
+    thread_id      TEXT NOT NULL,
+    provider_block TEXT NOT NULL DEFAULT '',
+    model          TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__llm__settings_thread_id_idx
+    ON suppers_ai__llm__settings (thread_id);
+
+-- Provider configurations ------------------------------------------------
+-- Secrets are NOT stored here: providers reference an entry in
+-- `suppers_ai__admin__variables` via `key_var`. See `schema.rs` for the
+-- ProviderConfig <-> row encoding (api_key is runtime-only and never
+-- persisted).
+CREATE TABLE IF NOT EXISTS suppers_ai__llm__providers (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    protocol   TEXT NOT NULL,
+    endpoint   TEXT NOT NULL,
+    key_var    TEXT,
+    models     TEXT NOT NULL DEFAULT '[]',
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__llm__providers_name_uniq
+    ON suppers_ai__llm__providers (name);
+CREATE INDEX IF NOT EXISTS suppers_ai__llm__providers_enabled_idx
+    ON suppers_ai__llm__providers (enabled);

--- a/crates/solobase-core/src/blocks/llm/migrations/001_llm_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/llm/migrations/001_llm_schema.sqlite.sql
@@ -1,0 +1,42 @@
+-- LLM block schema (SQLite / D1).
+--
+-- Replaces the implicit `ensure_table` materialization (TEXT-only columns,
+-- no indexes) for tables owned by `suppers-ai/llm`. CREATE TABLE IF NOT
+-- EXISTS is a no-op against existing prod tables, but the CREATE INDEX
+-- statements below add the missing UNIQUE/indexes so the in-band lookups
+-- (`thread_id`, `enabled`, `name`) stop scanning the whole table.
+--
+-- Mirrored to 001_llm_schema.postgres.sql.
+
+-- Per-thread provider/model overrides ------------------------------------
+CREATE TABLE IF NOT EXISTS suppers_ai__llm__settings (
+    id             TEXT PRIMARY KEY,
+    thread_id      TEXT NOT NULL,
+    provider_block TEXT NOT NULL DEFAULT '',
+    model          TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS suppers_ai__llm__settings_thread_id_idx
+    ON suppers_ai__llm__settings (thread_id);
+
+-- Provider configurations ------------------------------------------------
+-- Secrets are NOT stored here: providers reference an entry in
+-- `suppers_ai__admin__variables` via `key_var`. See `schema.rs` for the
+-- ProviderConfig <-> row encoding (api_key is runtime-only and never
+-- persisted).
+CREATE TABLE IF NOT EXISTS suppers_ai__llm__providers (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    protocol   TEXT NOT NULL,
+    endpoint   TEXT NOT NULL,
+    key_var    TEXT,
+    models     TEXT NOT NULL DEFAULT '[]',
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__llm__providers_name_uniq
+    ON suppers_ai__llm__providers (name);
+CREATE INDEX IF NOT EXISTS suppers_ai__llm__providers_enabled_idx
+    ON suppers_ai__llm__providers (enabled);

--- a/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
@@ -193,6 +193,7 @@ async fn migrate_one(ctx: &dyn Context, record: &Record) -> MigrateOutcome {
     };
 
     let row = config_to_row(&cfg);
+    // audit-allow: aliased-table-constant — PROVIDERS_TABLE aliases schema::TABLE ("suppers_ai__llm__providers"); llm writing to its own table, no grant needed
     match db::create(ctx, PROVIDERS_TABLE, row).await {
         Ok(_) => MigrateOutcome::Inserted,
         Err(e) if e.code == ErrorCode::AlreadyExists => {

--- a/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use wafer_core::clients::database::{self as db, Record};
 use wafer_run::{context::Context, types::ErrorCode};
 
-use super::{
+use super::super::{
     providers::{
         config::{ProviderConfig, ProviderProtocol},
         ProviderLlmService,
@@ -35,7 +35,7 @@ use super::{
 
 /// The legacy providers collection. Owned by the provider-llm block (still
 /// present on-disk on upgrade paths) — we read once, migrate, and drop.
-pub(super) const LEGACY_TABLE: &str = "suppers_ai__provider_llm__providers";
+pub(in crate::blocks::llm) const LEGACY_TABLE: &str = "suppers_ai__provider_llm__providers";
 
 const LEGACY_OPENAI_KEY_VAR: &str = "SUPPERS_AI__PROVIDER_LLM__OPENAI_KEY";
 const LEGACY_ANTHROPIC_KEY_VAR: &str = "SUPPERS_AI__PROVIDER_LLM__ANTHROPIC_KEY";
@@ -43,7 +43,9 @@ const LEGACY_ANTHROPIC_KEY_VAR: &str = "SUPPERS_AI__PROVIDER_LLM__ANTHROPIC_KEY"
 /// Map a legacy provider row's `data` HashMap into a new-schema
 /// [`ProviderConfig`]. Pure function — no DB access — so it's testable
 /// without any runtime scaffolding.
-pub(super) fn map_legacy_row(data: &HashMap<String, serde_json::Value>) -> Option<ProviderConfig> {
+pub(in crate::blocks::llm) fn map_legacy_row(
+    data: &HashMap<String, serde_json::Value>,
+) -> Option<ProviderConfig> {
     let name = data.get("name").and_then(|v| v.as_str())?.to_string();
     if name.is_empty() {
         return None;
@@ -117,7 +119,7 @@ pub(super) fn map_legacy_row(data: &HashMap<String, serde_json::Value>) -> Optio
 /// fatal). The legacy table is only dropped after every row was attempted.
 /// After a successful migration, the `ProviderLlmService` is refreshed from
 /// the new table so chat works immediately without a restart.
-pub(super) async fn migrate_legacy_providers(
+pub(in crate::blocks::llm) async fn migrate_legacy_providers(
     ctx: &dyn Context,
     provider_svc: &ProviderLlmService,
 ) -> Result<(), String> {
@@ -237,7 +239,7 @@ async fn reload_service(ctx: &dyn Context, provider_svc: &ProviderLlmService) {
     };
     let mut configs = Vec::with_capacity(records.len());
     for rec in &records {
-        match super::schema::row_to_config(rec) {
+        match super::super::schema::row_to_config(rec) {
             Ok(cfg) if cfg.enabled => configs.push(cfg),
             Ok(_) => {}
             Err(e) => {

--- a/crates/solobase-core/src/blocks/llm/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/mod.rs
@@ -1,0 +1,126 @@
+//! LLM block migrations. Applied from the block's `Init` lifecycle.
+//!
+//! Mirrors the files block's migration pattern (see `files/migrations/mod.rs`).
+//! SQL files are embedded with `include_str!`. Backend selection reads the
+//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
+//! Falls back to `sqlite` when the config block is not registered.
+//!
+//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
+//! the helper handles statement splitting + the `current_hash` /
+//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
+//! `suppers_ai__admin__block_settings` once applied. Replaces the implicit
+//! `ensure_table` materialisation that previously created these tables on
+//! first insert (TEXT-only columns, no indexes — see solobase
+//! `ensure-table-removal-in-progress`).
+//!
+//! The sibling [`legacy_providers`] module hosts the one-shot row-copy
+//! migration from the retired `suppers_ai__provider_llm__providers` table
+//! into the new `suppers_ai__llm__providers` table. It is invoked
+//! separately from `LlmBlock::lifecycle(Init)` because it needs a handle
+//! to the in-memory `ProviderLlmService` (to refresh it post-copy).
+
+pub(in crate::blocks::llm) mod legacy_providers;
+
+use wafer_core::clients::config;
+use wafer_run::context::Context;
+
+use crate::migration_helper;
+
+const LLM_BLOCK_NAME: &str = "suppers-ai/llm";
+
+const SQL_001_SQLITE: &str = include_str!("001_llm_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_llm_schema.postgres.sql");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Sqlite,
+    Postgres,
+}
+
+async fn backend(ctx: &dyn Context) -> Backend {
+    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
+    match raw.to_ascii_lowercase().as_str() {
+        "postgres" => Backend::Postgres,
+        _ => Backend::Sqlite,
+    }
+}
+
+fn sql_for(b: Backend) -> &'static str {
+    match b {
+        Backend::Sqlite => SQL_001_SQLITE,
+        Backend::Postgres => SQL_001_POSTGRES,
+    }
+}
+
+/// Apply LLM schema migrations through the shared migration-state gate.
+/// Idempotent across cold starts: once the gate stamps a `current_hash`
+/// row in `block_settings`, subsequent boots short-circuit before issuing
+/// any DDL. Schema changes require a `--run-migrations` redeploy (see
+/// `migration-state-workflow` in user memory).
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let b = backend(ctx).await;
+    migration_helper::apply_if_blessed(ctx, LLM_BLOCK_NAME, sql_for(b)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sql_for, Backend};
+
+    fn split_statements(sql: &str) -> usize {
+        // Inline mirror of `migration_helper::split_statements`'s
+        // semicolon-on-newline split, filtering empty/comment-only chunks.
+        // Kept here so the parser test guards regressions against the
+        // committed SQL without depending on the helper's pub surface.
+        sql.split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .filter(|s| {
+                s.lines().any(|line| {
+                    let l = line.trim();
+                    !l.is_empty() && !l.starts_with("--")
+                })
+            })
+            .count()
+    }
+
+    #[test]
+    fn sqlite_sql_splits_into_expected_chunks() {
+        // 2 tables + 3 indexes = 5 executable statements.
+        let count = split_statements(sql_for(Backend::Sqlite));
+        assert_eq!(count, 5, "sqlite llm migration: expected 5 statements");
+    }
+
+    #[test]
+    fn postgres_sql_splits_into_expected_chunks() {
+        let count = split_statements(sql_for(Backend::Postgres));
+        assert_eq!(count, 5, "postgres llm migration: expected 5 statements");
+    }
+
+    #[test]
+    fn sqlite_creates_both_tables() {
+        let sql = sql_for(Backend::Sqlite);
+        assert!(
+            sql.contains("suppers_ai__llm__settings"),
+            "missing settings table"
+        );
+        assert!(
+            sql.contains("suppers_ai__llm__providers"),
+            "missing providers table"
+        );
+    }
+
+    #[test]
+    fn sqlite_declares_required_indexes() {
+        let sql = sql_for(Backend::Sqlite);
+        assert!(sql.contains("suppers_ai__llm__settings_thread_id_idx"));
+        assert!(sql.contains("suppers_ai__llm__providers_name_uniq"));
+        assert!(sql.contains("suppers_ai__llm__providers_enabled_idx"));
+    }
+
+    #[test]
+    fn postgres_creates_both_tables() {
+        let sql = sql_for(Backend::Postgres);
+        assert!(sql.contains("suppers_ai__llm__settings"));
+        assert!(sql.contains("suppers_ai__llm__providers"));
+    }
+}

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -15,7 +15,7 @@ use wafer_run::{
     InputStream, OutputStream,
 };
 
-use self::{providers::ProviderLlmService, schema::providers_schema};
+use self::providers::ProviderLlmService;
 use crate::blocks::helpers::{
     self, err_bad_request, err_internal, err_internal_no_cause, err_not_found, json_map, ok_json,
 };
@@ -341,7 +341,7 @@ impl LlmBlock {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for LlmBlock {
     fn info(&self) -> BlockInfo {
-        use wafer_run::{types::CollectionSchema, AuthLevel};
+        use wafer_run::AuthLevel;
 
         BlockInfo::new(
             "suppers-ai/llm",
@@ -356,14 +356,11 @@ impl Block for LlmBlock {
             "wafer-run/database".into(),
             "wafer-run/config".into(),
         ])
-        .collections(vec![
-            CollectionSchema::new(SETTINGS_TABLE)
-                .field("thread_id", "string")
-                .field_default("provider_block", "string", "")
-                .field_default("model", "string", "")
-                .index(&["thread_id"]),
-            providers_schema(),
-        ])
+        // Tables (`suppers_ai__llm__settings`, `suppers_ai__llm__providers`)
+        // are owned by `migrations/001_llm_schema.{sqlite,postgres}.sql` and
+        // applied via `migrations::apply` in `lifecycle(Init)` below. No
+        // `.collections(...)` declaration — schema is no longer materialised
+        // implicitly via `ensure_table` on first insert.
         .category(wafer_run::BlockCategory::Feature)
         .description(
             "LLM orchestrator. Routes chat requests to provider-llm or local-llm backends, \
@@ -547,11 +544,23 @@ impl Block for LlmBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if matches!(event.event_type, LifecycleType::Init) {
-            // One-shot migration from `suppers_ai__provider_llm__providers`.
+            // Schema migrations first — must run before any row-level work
+            // below, otherwise the legacy-row copy + reload would hit
+            // ensure_table fallback paths instead of the indexed table.
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("llm migrations: {e}"),
+                )
+            })?;
+            // One-shot row copy from `suppers_ai__provider_llm__providers`.
             // Idempotent: if the legacy table is gone, returns immediately.
             // Any per-row failure is logged, not fatal — admins can inspect
             // the log and fix individual rows.
-            if let Err(e) = migrations::migrate_legacy_providers(ctx, &self.provider_svc).await {
+            if let Err(e) =
+                migrations::legacy_providers::migrate_legacy_providers(ctx, &self.provider_svc)
+                    .await
+            {
                 tracing::warn!("legacy provider migration reported error: {e}");
             }
             // Always load enabled providers into the in-memory service on

--- a/crates/solobase-core/src/blocks/llm/schema.rs
+++ b/crates/solobase-core/src/blocks/llm/schema.rs
@@ -14,23 +14,10 @@
 use std::collections::HashMap;
 
 use wafer_core::clients::database::Record;
-use wafer_run::types::CollectionSchema;
 
 use super::providers::config::{ProviderConfig, ProviderProtocol};
 
 pub const TABLE: &str = "suppers_ai__llm__providers";
-
-/// Table declaration for `suppers_ai__llm__providers`.
-pub fn providers_schema() -> CollectionSchema {
-    CollectionSchema::new(TABLE)
-        .field_unique("name", "string")
-        .field("protocol", "string")
-        .field("endpoint", "string")
-        .field_optional("key_var", "string")
-        .field_default("models", "json", "[]")
-        .field_default("enabled", "int", "1")
-        .index(&["enabled"])
-}
 
 /// Encode a [`ProviderConfig`] as a row payload for insert/update.
 ///
@@ -148,60 +135,6 @@ mod tests {
     use wafer_core::clients::database::Record;
 
     use super::*;
-
-    #[test]
-    fn schema_declares_collection_name() {
-        let s = providers_schema();
-        assert_eq!(s.name, TABLE);
-    }
-
-    #[test]
-    fn schema_declares_all_expected_fields() {
-        let s = providers_schema();
-        let by_name: HashMap<&str, &wafer_run::types::FieldSchema> =
-            s.fields.iter().map(|f| (f.name.as_str(), f)).collect();
-
-        let name = by_name.get("name").expect("name field");
-        assert_eq!(name.field_type, "string");
-        assert!(name.unique, "`name` must be unique");
-
-        let protocol = by_name.get("protocol").expect("protocol field");
-        assert_eq!(protocol.field_type, "string");
-
-        let endpoint = by_name.get("endpoint").expect("endpoint field");
-        assert_eq!(endpoint.field_type, "string");
-
-        assert!(
-            !by_name.contains_key("api_key_encrypted"),
-            "api_key_encrypted must not exist — secrets live in suppers_ai__admin__variables"
-        );
-        assert!(
-            !by_name.contains_key("api_key"),
-            "api_key must not exist — providers reference secrets via key_var only"
-        );
-
-        let key_var = by_name.get("key_var").expect("key_var field");
-        assert_eq!(key_var.field_type, "string");
-        assert!(key_var.optional, "`key_var` must be optional");
-
-        let models = by_name.get("models").expect("models field");
-        assert_eq!(models.field_type, "json");
-        assert_eq!(models.default_value, "[]");
-
-        let enabled = by_name.get("enabled").expect("enabled field");
-        assert_eq!(enabled.field_type, "int");
-        assert_eq!(enabled.default_value, "1");
-    }
-
-    #[test]
-    fn schema_has_enabled_index() {
-        let s = providers_schema();
-        assert!(
-            s.indexes.iter().any(|ix| ix.fields == vec!["enabled"]),
-            "expected an index on [enabled]; got {:?}",
-            s.indexes
-        );
-    }
 
     #[test]
     fn config_to_row_encodes_minimal_config() {


### PR DESCRIPTION
## Summary

- Replaces implicit `ensure_table()` materialisation of `suppers_ai__llm__settings` + `suppers_ai__llm__providers` with explicit per-backend SQL migration files at `crates/solobase-core/src/blocks/llm/migrations/001_llm_schema.{sqlite,postgres}.sql`.
- Schema is applied through `migration_helper::apply_if_blessed` from `LlmBlock::lifecycle(Init)`, matching the files/admin pattern. Subsequent boots short-circuit via the `current_hash`/`blessed_hash` gate in `suppers_ai__admin__block_settings`.
- Adds the indexes the existing code already assumed but `ensure_table` never created: `UNIQUE(providers.name)`, `(settings.thread_id)`, `(providers.enabled)`.
- Removes `providers_schema()` + `.collections(...)` from `BlockInfo` (no downstream WRAP/capability consumer reads them — grep-verified across solobase + wafer crates).
- The legacy one-shot row-copy from `suppers_ai__provider_llm__providers` moves to `migrations/legacy_providers.rs` and now runs **after** schema migrations so the target table is guaranteed to exist with the indexed shape before any inserts.

Tracker: 1 of 5 done (products / messages / legalpages / userportal still pending — running in parallel).

## Test plan

- [x] `cargo check -p solobase-core` — clean
- [x] `cargo test -p solobase-core --lib` — 628 passed (baseline 626; +5 new migration tests, -3 removed schema tests)
- [x] `cargo fmt --check` — clean
- [x] Parser tests verify 5 statements per backend SQL (2 CREATE TABLE + 3 CREATE INDEX) and exact table/index name presence
- [ ] `cargo check --target wasm32-unknown-unknown` — pre-existing baseline failure (uuid wasm32 / js feature not in solobase-core's transitive tree; see `solobase-web-wasm-build-broken` memory note). Not introduced by this PR — confirmed by `git stash` + re-running on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)