### PR TITLE
feat(admin): hash-gate seed_defaults (config-snapshot spec PR 3)

### DIFF
--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -50,6 +50,12 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string();
+                    let seed_defaults_hash = r
+                        .data
+                        .get("seed_defaults_hash")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
                     Some((
                         name,
                         BlockState {
@@ -58,6 +64,7 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
                                 current_hash,
                                 blessed_hash,
                             },
+                            seed_defaults_hash,
                         },
                     ))
                 })

--- a/crates/solobase-core/src/blocks/admin/migrations/003_block_settings_seed_hash.postgres.sql
+++ b/crates/solobase-core/src/blocks/admin/migrations/003_block_settings_seed_hash.postgres.sql
@@ -1,0 +1,11 @@
+-- Mirror of 003_block_settings_seed_hash.sqlite.sql for PostgreSQL.
+--
+-- Adds a `seed_defaults_hash` column to suppers_ai__admin__block_settings
+-- so `admin::settings::seed_defaults` can hash-gate itself the same way
+-- `migration_helper::apply_if_blessed` gates DDL.
+--
+-- Spec: docs/superpowers/specs/2026-05-14-config-snapshot-and-migration-gate-design.md
+--       § "Hash-gate seed_defaults like migrations" (PR 3)
+
+ALTER TABLE suppers_ai__admin__block_settings
+    ADD COLUMN IF NOT EXISTS seed_defaults_hash TEXT NOT NULL DEFAULT '';

--- a/crates/solobase-core/src/blocks/admin/migrations/003_block_settings_seed_hash.sqlite.sql
+++ b/crates/solobase-core/src/blocks/admin/migrations/003_block_settings_seed_hash.sqlite.sql
@@ -1,0 +1,15 @@
+-- Add a `seed_defaults_hash` column to suppers_ai__admin__block_settings.
+--
+-- Stores a SHA-256 hex digest of the deterministic seed payload that
+-- `admin::settings::seed_defaults` last applied to the `variables` table.
+-- On cold start, when the cached hash matches the current
+-- `shared_config_vars()` hash, `seed_defaults` short-circuits before
+-- issuing any D1 query — dropping the residual ~100 D1 reads/day attributed
+-- to that function in prod (the bulk `list_all` introduced by PR 2 of the
+-- 2026-05-14 config-snapshot spec).
+--
+-- Spec: docs/superpowers/specs/2026-05-14-config-snapshot-and-migration-gate-design.md
+--       § "Hash-gate seed_defaults like migrations" (PR 3)
+
+ALTER TABLE suppers_ai__admin__block_settings
+    ADD COLUMN seed_defaults_hash TEXT NOT NULL DEFAULT '';

--- a/crates/solobase-core/src/blocks/admin/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/migrations/mod.rs
@@ -22,6 +22,8 @@ const SQL_001_SQLITE: &str = include_str!("001_admin_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_admin_schema.postgres.sql");
 const SQL_002_SQLITE: &str = include_str!("002_variables_block_column.sqlite.sql");
 const SQL_002_POSTGRES: &str = include_str!("002_variables_block_column.postgres.sql");
+const SQL_003_SQLITE: &str = include_str!("003_block_settings_seed_hash.sqlite.sql");
+const SQL_003_POSTGRES: &str = include_str!("003_block_settings_seed_hash.postgres.sql");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Backend {
@@ -43,8 +45,8 @@ async fn backend(ctx: &dyn Context) -> Backend {
 /// the `;\n…` boundary between files.
 fn concatenated_sql(b: Backend) -> String {
     match b {
-        Backend::Sqlite => format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}"),
-        Backend::Postgres => format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}"),
+        Backend::Sqlite => format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}\n{SQL_003_SQLITE}"),
+        Backend::Postgres => format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}\n{SQL_003_POSTGRES}"),
     }
 }
 
@@ -64,10 +66,11 @@ mod tests {
     use super::{concatenated_sql, Backend};
 
     #[test]
-    fn concatenated_sqlite_contains_both_migrations() {
+    fn concatenated_sqlite_contains_all_migrations() {
         let sql = concatenated_sql(Backend::Sqlite);
-        // Spot-check the 001 schema (the variables UNIQUE INDEX) and the
-        // 002 follow-up (ALTER TABLE ADD COLUMN block) are both present.
+        // Spot-check the 001 schema (the variables UNIQUE INDEX), the
+        // 002 follow-up (ALTER TABLE ADD COLUMN block), and the 003
+        // follow-up (ADD COLUMN seed_defaults_hash) are all present.
         assert!(
             sql.contains("suppers_ai__admin__variables_key_uniq"),
             "missing 001 marker; got len={}",
@@ -83,10 +86,15 @@ mod tests {
             "missing 002 index; got len={}",
             sql.len()
         );
+        assert!(
+            sql.contains("ADD COLUMN seed_defaults_hash"),
+            "missing 003 ADD COLUMN seed_defaults_hash; got len={}",
+            sql.len()
+        );
     }
 
     #[test]
-    fn concatenated_postgres_contains_both_migrations() {
+    fn concatenated_postgres_contains_all_migrations() {
         let sql = concatenated_sql(Backend::Postgres);
         assert!(
             sql.contains("suppers_ai__admin__variables_key_uniq"),
@@ -95,7 +103,12 @@ mod tests {
         );
         assert!(
             sql.contains("ADD COLUMN"),
-            "missing 002 ALTER COLUMN; got len={}",
+            "missing 002/003 ALTER COLUMN; got len={}",
+            sql.len()
+        );
+        assert!(
+            sql.contains("seed_defaults_hash"),
+            "missing 003 seed_defaults_hash column; got len={}",
             sql.len()
         );
     }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -336,8 +336,62 @@ async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 }
 
+/// Full block name of the admin block — the `block_settings` row whose
+/// `seed_defaults_hash` column gates this function.
+const ADMIN_BLOCK_NAME: &str = "suppers-ai/admin";
+
+/// Compute a deterministic SHA-256 hex digest over the declared shared
+/// config vars. Anything that affects the seed outcome (key, name,
+/// description, default, warning, sensitive flag) feeds the hash; sort by
+/// key so map ordering can't make two equivalent inputs hash differently.
+///
+/// `var.auto_generate` / `var.optional` don't affect what `seed_defaults`
+/// writes — they're consumed by `seed_auto_generated` (CF runner) and the
+/// startup validator respectively — so they're intentionally omitted.
+fn seed_payload_hash(vars: &[types::ConfigVar]) -> String {
+    use std::fmt::Write as _;
+    let mut keys: Vec<&types::ConfigVar> = vars.iter().collect();
+    keys.sort_by(|a, b| a.key.cmp(&b.key));
+    let mut buf = String::with_capacity(vars.len() * 128);
+    for v in keys {
+        let sensitive = if v.input_type == types::InputType::Password {
+            1
+        } else {
+            0
+        };
+        // Fixed shape per var: `key\x1fname\x1fdescription\x1fdefault\x1fwarning\x1fsensitive\x1e`.
+        // ASCII unit-separator (0x1f) + record-separator (0x1e) bracket
+        // each field so embedded newlines / colons in description text
+        // can't collide field boundaries across different var shapes.
+        let _ = write!(
+            &mut buf,
+            "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1e}",
+            v.key, v.name, v.description, v.default, v.warning, sensitive,
+        );
+    }
+    crate::migration_helper::sha256_hex_bytes(buf.as_bytes())
+}
+
 pub async fn seed_defaults(ctx: &dyn Context) {
     let vars = crate::config_vars::shared_config_vars();
+
+    // Hash-gate: if the cached `block_settings.seed_defaults_hash` row for
+    // the admin block already matches the current declared-vars hash, every
+    // shared var was seeded against the same metadata last time — there is
+    // no outcome change possible and we can skip the entire seed (zero D1
+    // queries). Mirrors `migration_helper::apply_if_blessed`'s gate; reads
+    // the same in-memory snapshot the migration helper does, so warm cold
+    // starts cost zero round-trips. See 2026-05-14 config-snapshot spec
+    // § "Hash-gate seed_defaults like migrations" (PR 3).
+    let code_hash = seed_payload_hash(&vars);
+    let json = ctx
+        .config_get(crate::features::BLOCK_SETTINGS_CONFIG_KEY)
+        .unwrap_or("{}");
+    let cached_hash =
+        crate::features::BlockSettings::state_for(json, ADMIN_BLOCK_NAME).seed_defaults_hash;
+    if cached_hash == code_hash && !code_hash.is_empty() {
+        return;
+    }
 
     // Single bulk fetch of every existing variable, then in-memory diff
     // per declared shared var. Replaces the per-var `get_by_field` loop
@@ -416,5 +470,184 @@ pub async fn seed_defaults(ctx: &dyn Context) {
                 }
             }
         }
+    }
+
+    // Stamp the new hash on the admin block_settings row so the next cold
+    // start short-circuits before issuing `list_all`. Failures here are
+    // logged but non-fatal — the seed itself succeeded, and the worst case
+    // is that the next isolate re-runs the bulk `list_all` (the same cost
+    // we paid this run). Matches the "silent on error" stance of the
+    // per-var upsert/create calls above; the `block_settings` row may not
+    // exist yet (admin migrations create it on the same `Init` pass),
+    // which is why we use `upsert_block_settings_fields` rather than
+    // assuming a row.
+    let mut patch = std::collections::HashMap::new();
+    patch.insert(
+        "seed_defaults_hash".to_string(),
+        serde_json::Value::String(code_hash),
+    );
+    if let Err(e) =
+        crate::migration_helper::upsert_block_settings_fields(ctx, ADMIN_BLOCK_NAME, patch).await
+    {
+        tracing::warn!(
+            err = %e,
+            "seed_defaults: failed to stamp seed_defaults_hash; next cold start will re-run the bulk list_all"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wafer_core::clients::database::{Filter, FilterOp};
+
+    use super::*;
+    use crate::test_support::TestContext;
+
+    /// `seed_payload_hash` is independent of input order (sorts by `key`).
+    #[test]
+    fn payload_hash_independent_of_input_order() {
+        let a = types::ConfigVar::new("AAA", "first", "1");
+        let b = types::ConfigVar::new("BBB", "second", "2");
+        let h1 = seed_payload_hash(&[a.clone(), b.clone()]);
+        let h2 = seed_payload_hash(&[b, a]);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+
+    /// Hash changes whenever any seed-relevant field changes.
+    #[test]
+    fn payload_hash_sensitive_to_each_field() {
+        let base = vec![types::ConfigVar::new("KEY", "desc", "def")];
+        let h_base = seed_payload_hash(&base);
+
+        let mut name_changed = base.clone();
+        name_changed[0].name = "label".into();
+        assert_ne!(h_base, seed_payload_hash(&name_changed));
+
+        let mut desc_changed = base.clone();
+        desc_changed[0].description = "different".into();
+        assert_ne!(h_base, seed_payload_hash(&desc_changed));
+
+        let mut default_changed = base.clone();
+        default_changed[0].default = "other".into();
+        assert_ne!(h_base, seed_payload_hash(&default_changed));
+
+        let mut warning_changed = base.clone();
+        warning_changed[0].warning = "careful".into();
+        assert_ne!(h_base, seed_payload_hash(&warning_changed));
+
+        let mut sensitive_changed = base.clone();
+        sensitive_changed[0].input_type = types::InputType::Password;
+        assert_ne!(h_base, seed_payload_hash(&sensitive_changed));
+    }
+
+    /// End-to-end: after `seed_defaults` runs once, the admin
+    /// `block_settings` row carries the current hash. Wiring that hash into
+    /// the next cold-start's config snapshot short-circuits `seed_defaults`
+    /// before it can touch the `variables` table — even if every row was
+    /// deleted between starts.
+    #[tokio::test]
+    async fn second_call_with_matching_snapshot_hash_short_circuits() {
+        let ctx = TestContext::new().await;
+
+        // 1. Run admin migrations so the block_settings + variables tables
+        //    exist (with the new seed_defaults_hash column).
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        // 2. First seed run — populates variables + stamps the hash row.
+        seed_defaults(&ctx).await;
+        let var_count_after_first = db::list_all(&ctx, VARIABLES_TABLE, vec![])
+            .await
+            .expect("list variables")
+            .len();
+        assert!(
+            var_count_after_first > 0,
+            "first seed_defaults should populate at least one variable"
+        );
+
+        // 3. Read the stamped hash from the block_settings row directly.
+        let admin_rows = db::list_all(
+            &ctx,
+            crate::blocks::admin::settings::BLOCK_SETTINGS_TABLE,
+            vec![Filter {
+                field: "block_name".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(ADMIN_BLOCK_NAME.to_string()),
+            }],
+        )
+        .await
+        .expect("list block_settings");
+        assert_eq!(
+            admin_rows.len(),
+            1,
+            "admin block_settings row should be present after first seed_defaults"
+        );
+        let stamped_hash = admin_rows[0].str_field("seed_defaults_hash").to_string();
+        let code_hash = seed_payload_hash(&crate::config_vars::shared_config_vars());
+        assert_eq!(
+            stamped_hash, code_hash,
+            "stamped seed_defaults_hash should match current declared vars",
+        );
+
+        // 4. Simulate a fresh cold start: build a new TestContext (fresh
+        //    in-memory DB — no variables, no block_settings row), but
+        //    pre-populate the config snapshot with the stamped hash. This
+        //    mirrors what the production loader does on the next boot.
+        let mut next_ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&next_ctx)
+            .await
+            .expect("apply admin migrations on next ctx");
+        let snapshot = serde_json::json!({
+            ADMIN_BLOCK_NAME: { "enabled": true, "seed_defaults_hash": stamped_hash }
+        })
+        .to_string();
+        next_ctx.set_config(crate::features::BLOCK_SETTINGS_CONFIG_KEY, &snapshot);
+
+        // 5. seed_defaults should short-circuit before any list_all on
+        //    variables — leaving the (empty) variables table untouched.
+        seed_defaults(&next_ctx).await;
+        let var_count_after_second = db::list_all(&next_ctx, VARIABLES_TABLE, vec![])
+            .await
+            .expect("list variables on next ctx")
+            .len();
+        assert_eq!(
+            var_count_after_second, 0,
+            "seed_defaults should short-circuit when snapshot hash matches; \
+             expected 0 rows in fresh variables table, got {}",
+            var_count_after_second
+        );
+    }
+
+    /// When the snapshot's cached hash differs from the current code hash
+    /// (e.g. a new shared var was declared), `seed_defaults` runs again
+    /// and re-stamps the row.
+    #[tokio::test]
+    async fn mismatched_snapshot_hash_re_runs_seed() {
+        let mut ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        // Pre-populate the snapshot with a deliberately-wrong hash.
+        let snapshot = serde_json::json!({
+            ADMIN_BLOCK_NAME: {
+                "enabled": true,
+                "seed_defaults_hash": "deadbeef".to_string(),
+            }
+        })
+        .to_string();
+        ctx.set_config(crate::features::BLOCK_SETTINGS_CONFIG_KEY, &snapshot);
+
+        seed_defaults(&ctx).await;
+        let count = db::list_all(&ctx, VARIABLES_TABLE, vec![])
+            .await
+            .expect("list variables")
+            .len();
+        assert!(
+            count > 0,
+            "mismatched snapshot hash should still run the seed; got 0 rows"
+        );
     }
 }

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -22,14 +22,22 @@ pub trait FeatureConfig: wafer_run::MaybeSend + wafer_run::MaybeSync {
 }
 
 /// Per-block runtime state stored in `suppers_ai__admin__block_settings`.
-/// Both `enabled` and `migration` live on the same row, loaded together by
-/// the per-isolate cache.
+/// Both `enabled`, `migration`, and `seed_defaults_hash` live on the same
+/// row, loaded together by the per-isolate cache.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct BlockState {
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default)]
     pub migration: MigrationState,
+    /// SHA-256 hex of the deterministic seed payload last applied by
+    /// `admin::settings::seed_defaults`. Empty = never seeded (or pre-PR3
+    /// row). When this matches the current hash of `shared_config_vars()`,
+    /// `seed_defaults` short-circuits before issuing any D1 query. Only the
+    /// `suppers-ai/admin` row uses this field today — other blocks leave
+    /// it empty.
+    #[serde(default)]
+    pub seed_defaults_hash: String,
 }
 
 /// Hashes that gate `migration_helper::apply_if_blessed`.
@@ -70,6 +78,7 @@ impl BlockSettings {
                     BlockState {
                         enabled,
                         migration: MigrationState::default(),
+                        seed_defaults_hash: String::new(),
                     },
                 )
             })
@@ -87,6 +96,7 @@ impl BlockSettings {
             .unwrap_or_else(|| BlockState {
                 enabled: true,
                 migration: MigrationState::default(),
+                seed_defaults_hash: String::new(),
             })
     }
 
@@ -126,6 +136,7 @@ impl BlockSettings {
         let missing = || BlockState {
             enabled: true,
             migration: MigrationState::default(),
+            seed_defaults_hash: String::new(),
         };
         let value: serde_json::Value = match serde_json::from_str(json) {
             Ok(v) => v,

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -118,6 +118,30 @@ async fn write_state(
     block_name: &str,
     state: &MigrationState,
 ) -> Result<(), String> {
+    let mut patch = std::collections::HashMap::new();
+    patch.insert(
+        "current_hash".to_string(),
+        serde_json::json!(state.current_hash),
+    );
+    patch.insert(
+        "blessed_hash".to_string(),
+        serde_json::json!(state.blessed_hash),
+    );
+    upsert_block_settings_fields(ctx, block_name, patch).await
+}
+
+/// Upsert a subset of columns on the `suppers_ai__admin__block_settings` row
+/// keyed by `block_name`. Creates the row with `enabled=true` if absent,
+/// preserves every column not present in `patch` otherwise.
+///
+/// Shared by `migration_helper::write_state` (migration hash columns) and
+/// `admin::settings::seed_defaults` (seed_defaults_hash column) so both
+/// hash-gates write through the same single-row-per-block primitive.
+pub(crate) async fn upsert_block_settings_fields(
+    ctx: &dyn Context,
+    block_name: &str,
+    patch: std::collections::HashMap<String, serde_json::Value>,
+) -> Result<(), String> {
     use wafer_core::clients::database::{Filter, FilterOp, ListOptions, SortField};
 
     let opts = ListOptions {
@@ -137,45 +161,37 @@ async fn write_state(
 
     let existing = db::list(ctx, BLOCK_SETTINGS_TABLE, &opts)
         .await
-        .map_err(|e| format!("migration state lookup: {e}"))?;
+        .map_err(|e| format!("block_settings lookup: {e}"))?;
 
     if !existing.records.is_empty() {
         let id = existing.records[0].id.clone();
-        let mut patch = std::collections::HashMap::new();
-        patch.insert(
-            "current_hash".to_string(),
-            serde_json::json!(state.current_hash),
-        );
-        patch.insert(
-            "blessed_hash".to_string(),
-            serde_json::json!(state.blessed_hash),
-        );
         db::update(ctx, BLOCK_SETTINGS_TABLE, &id, patch)
             .await
-            .map_err(|e| format!("migration state update: {e}"))?;
+            .map_err(|e| format!("block_settings update: {e}"))?;
     } else {
-        let mut data = std::collections::HashMap::new();
+        let mut data = patch;
         data.insert("block_name".to_string(), serde_json::json!(block_name));
-        data.insert("enabled".to_string(), serde_json::json!(true));
-        data.insert(
-            "current_hash".to_string(),
-            serde_json::json!(state.current_hash),
-        );
-        data.insert(
-            "blessed_hash".to_string(),
-            serde_json::json!(state.blessed_hash),
-        );
+        data.entry("enabled".to_string())
+            .or_insert(serde_json::json!(true));
         db::create(ctx, BLOCK_SETTINGS_TABLE, data)
             .await
-            .map_err(|e| format!("migration state create: {e}"))?;
+            .map_err(|e| format!("block_settings create: {e}"))?;
     }
     Ok(())
 }
 
-fn sha256_hex(sql: &str) -> String {
+/// Compute a SHA-256 hex digest. Re-exported for callers (e.g.
+/// `admin::settings::seed_defaults`) that hash-gate against a payload other
+/// than SQL bytes but want to share the same digest algorithm with
+/// `apply_if_blessed`.
+pub(crate) fn sha256_hex_bytes(payload: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(sql.as_bytes());
+    hasher.update(payload);
     hex::encode(hasher.finalize())
+}
+
+fn sha256_hex(sql: &str) -> String {
+    sha256_hex_bytes(sql.as_bytes())
 }
 
 /// Split `sql` on `;` outside `--` line comments. Returns byte-range slices


### PR DESCRIPTION
## Summary

PR 3 of the [2026-05-14 config-snapshot + migration-gate design spec](../blob/main/docs/superpowers/specs/2026-05-14-config-snapshot-and-migration-gate-design.md) (§ \"Hash-gate seed_defaults like migrations\"). PR 1 (wafer-run snapshot wiring) and PR 2 (#189: admin migration gate + seed_defaults bulk fetch) already landed; this pushes the residual ~100 D1 reads/day attributed to seed_defaults to ~0.

- New \`003_block_settings_seed_hash\` migration adds a \`seed_defaults_hash\` TEXT column to \`suppers_ai__admin__block_settings\`. \`BlockState\` carries it through the snapshot JSON; the CF loader (\`solobase-cloudflare/src/runner.rs\`) reads it.
- \`migration_helper\` factors \`write_state\` into a reusable \`upsert_block_settings_fields(block_name, patch)\` primitive and exposes \`sha256_hex_bytes\` so \`admin::settings::seed_defaults\` shares the same SHA-256 digest algorithm \`apply_if_blessed\` uses for SQL bytes.
- \`admin::settings::seed_defaults\` hashes \`shared_config_vars()\` deterministically (sort by key, fixed-shape per-var encoding with ASCII unit/record separators on the six seed-relevant fields: key, name, description, default, warning, sensitive). When the cached snapshot hash matches the current hash, it returns before issuing any D1 call. After seeding succeeds, the hash is stamped on the admin block_settings row via the shared upsert primitive — tolerating the missing-row case since admin migrations and seed_defaults run on the same \`Init\` pass.

## Test plan

- [x] \`cargo check -p solobase-core\` (native) clean
- [x] \`cargo check -p solobase-cloudflare --target wasm32-unknown-unknown\` clean
- [x] \`cargo check -p solobase-web --target wasm32-unknown-unknown\` clean
- [x] \`cargo test -p solobase-core --lib\` — 630 passed, 0 failed (4 new tests: hash determinism, per-field hash sensitivity, end-to-end snapshot short-circuit confirms zero variables-table rows on second call with matching snapshot hash, mismatched-hash re-run path)
- [ ] After merge + deploy with \`--run-migrations\` (003 schema change), verify \`wrangler d1 insights\` shows \`variables\` reads drop to ~0/day on cold isolates

🤖 Generated with [Claude Code](https://claude.com/claude-code)