### PR TITLE
fix(solobase-core): enable uuid 'js' feature on wasm32 for direct cargo check

### DIFF
--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -213,3 +213,10 @@ wiremock = "0.6"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3"
+# `uuid` on wasm32 needs a JS-backed RNG source (uuid 1.21+ compile-errors
+# without one of `js`, `rng-getrandom`, or `rng-rand`). Consumers like
+# solobase-cloudflare and solobase-web already enable `uuid/js` explicitly
+# in their own manifests; this stanza makes a bare
+# `cargo check -p solobase-core --target wasm32-unknown-unknown` build
+# clean too, without affecting native builds.
+uuid = { workspace = true, features = ["js"] }


### PR DESCRIPTION
## Summary
- `cargo check -p solobase-core --target wasm32-unknown-unknown --no-default-features` fails on uuid 1.21's `compile_error!` requiring one of `js`, `rng-getrandom`, or `rng-rand` for wasm32. Production consumers (`solobase-cloudflare`, `solobase-web`) already enable `uuid/js` in their own `Cargo.toml`, so live wasm32 builds are unaffected — but a bare crate-level check reproduces the failure on baseline main. Noted by reporters of today's PRs (#190, #191, #192, #193, #194, #195, #196).
- Fix: add `uuid = { workspace = true, features = ["js"] }` to the existing `[target.'cfg(target_arch = "wasm32")'.dependencies]` stanza in `crates/solobase-core/Cargo.toml`. Additive — native builds unaffected; consumers' explicit `features = ["js"]` keeps working.

## Exact error symptom (before fix)
```
error: to use `uuid` on `wasm32-unknown-unknown`, specify a source of randomness using one of the `js`, `rng-getrandom`, or `rng-rand` features
   --> uuid-1.21.0/src/rng.rs:104:5
error[E0433]: failed to resolve: could not find `RngImp` in `imp`
```

## Note on remaining wasm32 default-features failure
A bare `cargo check -p solobase-core --target wasm32-unknown-unknown` (with defaults on) still fails on tokio's `"Only features sync,macros,io-util,rt,time are supported on wasm"`. That is by design — the `llm` default feature is documented as native-only in `Cargo.toml`, and consumers correctly use `default-features = false`. Out of scope for this PR.

## Test plan
- [x] `cargo check -p solobase-core --target wasm32-unknown-unknown --no-default-features` — clean
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- [x] `cargo check -p solobase-web --target wasm32-unknown-unknown` — clean
- [x] `cargo check -p solobase-core` (native) — clean
- [x] `cargo test -p solobase-core --lib` — 638 passed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>