### PR TITLE
refactor(cargo): drop llm → block-messages implication (post-#191)

### DIFF
--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -50,16 +50,16 @@ wasm = ["wafer-run/wasm"]
 # `suppers-ai/llm` block dispatch; turning off `block-llm` while leaving
 # `llm` on would still drag the block module in.
 #
-# Also implies `block-messages` because `blocks::llm::pages` reads from
-# the messages contexts/entries tables via their constants. Future work
-# could move those constants to a shared crate to decouple, but for now
-# the llm UI cannot compile without the messages module.
+# `block-messages` is intentionally NOT implied: PR #191 hoisted the
+# messages table/column constants used by `blocks::llm::pages` into
+# `solobase-core::messages_schema`, so the llm UI no longer depends on
+# the messages block module being compiled in. Enabling `llm` without
+# `block-messages` now compiles cleanly.
 llm = [
     "dep:tokio",
     "dep:tokio-stream",
     "reqwest/stream",
     "block-llm",
-    "block-messages",
 ]
 # Native ONNX-backed embedding block (suppers-ai/fastembed) + SQLite
 # vector service. Pulls in wafer-block-fastembed (ONNX Runtime) and


### PR DESCRIPTION
## Summary

Follow-up flagged by PR #191 (llm/messages decouple). Now that the
messages table/column constants live in `solobase-core::messages_schema`
(hoisted in #191), the defensive `block-messages` entry added to the
`llm` feature in #188 is dead weight.

- Remove `block-messages` from the `llm` feature list in
  `crates/solobase-core/Cargo.toml`.
- Rewrite the comment block above `llm = [...]` to document the new
  contract: enabling `llm` no longer requires `block-messages`.

## Verification

- `cargo check -p solobase-core --no-default-features --features sqlite,storage-local,llm` — clean (this was the failure mode pre-#191).
- `cargo check -p solobase-core` (defaults) — clean.
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean.
- `cargo test -p solobase-core --lib` — 638 passed.

Refs #188 #191.

## Test plan

- [x] Minimum feature set compiles (`sqlite,storage-local,llm`).
- [x] Default features compile.
- [x] wasm32-unknown-unknown (`solobase-cloudflare`) compiles.
- [x] `solobase-core --lib` tests pass (638).

🤖 Generated with [Claude Code](https://claude.com/claude-code)