### PR TITLE
fix(scripts/audit-wrap-grants): follow `use ... as ...` alias rebinds

### DIFF
--- a/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
@@ -193,7 +193,6 @@ async fn migrate_one(ctx: &dyn Context, record: &Record) -> MigrateOutcome {
     };
 
     let row = config_to_row(&cfg);
-    // audit-allow: aliased-table-constant — PROVIDERS_TABLE aliases schema::TABLE ("suppers_ai__llm__providers"); llm writing to its own table, no grant needed
     match db::create(ctx, PROVIDERS_TABLE, row).await {
         Ok(_) => MigrateOutcome::Inserted,
         Err(e) if e.code == ErrorCode::AlreadyExists => {

--- a/scripts/audit-wrap-grants.sh
+++ b/scripts/audit-wrap-grants.sh
@@ -252,8 +252,23 @@ resolve_module_path() {
     # crate:: outside blocks/ is uncommon for the names we care about; bail.
     echo ""; return
   fi
+  # `super` walks one module level up. For a regular `foo.rs`, the file's
+  # module is `foo` inside `dir`, so `super` = `dir` = the file's own
+  # directory — no `dirname` needed. For `mod.rs`, the file's module IS
+  # `dir`, so `super` = parent of `dir` — one `dirname` needed. The script's
+  # `start_dir` is `dirname(start_file)` (= `dir` in both cases), so:
+  #   * regular file: skip dirname on the FIRST `super::` only
+  #   * mod.rs: dirname on every `super::`
+  local skip_first_dirname=0
+  if [[ "$(basename "$start_file")" != "mod.rs" ]]; then
+    skip_first_dirname=1
+  fi
   while [[ "$path" == super::* ]]; do
-    start_dir="$(dirname "$start_dir")"
+    if [ "$skip_first_dirname" -eq 1 ]; then
+      skip_first_dirname=0
+    else
+      start_dir="$(dirname "$start_dir")"
+    fi
     path="${path#super::}"
   done
   if [[ "$path" == self::* ]]; then


### PR DESCRIPTION
## Summary

`scripts/audit-wrap-grants.sh` resolved aliased imports like
`use super::super::schema::{TABLE as PROVIDERS_TABLE}` incorrectly,
producing nondeterministic false-positive grant violations.

Root cause was an off-by-one in `resolve_module_path`: every `super::`
segment walked one directory up, but Rust's `super` from a regular
`foo.rs` already refers to the file's containing directory (only
ADDITIONAL `super::` segments should `dirname` up). For `mod.rs` files
the existing behavior is correct — their module IS the directory.

When path resolution failed, `resolve_token` fell through to the
ambiguous `BLOCK_CONST` bare-name fallback and picked some other
`TABLE` const in scope. PR #195 surfaced this with:

```rust
use super::super::{
    schema::{config_to_row, TABLE as PROVIDERS_TABLE},
};
// ...
db::create(ctx, PROVIDERS_TABLE, row).await
```

CI flagged `suppers-ai/llm → suppers_ai__products__pricing_templates`;
local runs flagged `→ suppers_ai__files__cloud_quotas`. Actual target:
`suppers_ai__llm__providers` (llm writing its own table — no grant
needed). PR #195 worked around this with a `// audit-allow:
aliased-table-constant` pragma; this PR removes the pragma now that
resolution is correct.

## Changes

- `scripts/audit-wrap-grants.sh`: branch `resolve_module_path` on
  `basename != "mod.rs"` to skip the first `super::` dirname for
  regular files. Phase 1.6's existing `FILE_USE_VALUE` cache then
  resolves the alias to the right file's `TABLE` const, bypassing
  the ambiguous bare-name fallback.
- `crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs`:
  drop the now-unneeded `// audit-allow: aliased-table-constant`
  pragma.

## Test plan

- [x] `bash scripts/audit-wrap-grants.sh` exits 0 with no missing grants
- [x] "skipped via audit-allow pragmas" count is 3 (was 4)
- [x] Synthetic smoke: `use super::super::schema::TABLE as SMOKE;` +
      `db::create(ctx, SMOKE, ...)` resolves correctly (llm own-table → OK)
- [x] Synthetic smoke: `use crate::blocks::auth::repo::users::TABLE as FOREIGN;`
      from llm correctly flags MISSING grant (proves cross-block crate-rooted
      alias resolution works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)