### PR TITLE
refactor(vector): port static schema from ensure_table() to migration files

### DIFF
--- a/crates/solobase-core/src/blocks/vector/migrations/001_vector_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/vector/migrations/001_vector_schema.postgres.sql
@@ -1,0 +1,15 @@
+-- Initial vector schema (Postgres parity — untested).
+-- Solobase deploys SQLite/D1 today; this file is included for parity with
+-- the auth/files/messages-migrations pattern. The vector block itself is
+-- SQLite-only (sqlite-vec extension), so this Postgres path will only
+-- become reachable if/when a Postgres-native vector backend lands. Validate
+-- before enabling Postgres for the vector block.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__vector__registry (
+    prefixed_name   TEXT PRIMARY KEY,
+    model           TEXT NOT NULL DEFAULT '',
+    dimensions      INTEGER NOT NULL DEFAULT 0,
+    keyword_search  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_vector_registry_model
+    ON suppers_ai__vector__registry (model);

--- a/crates/solobase-core/src/blocks/vector/migrations/001_vector_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/vector/migrations/001_vector_schema.sqlite.sql
@@ -1,0 +1,30 @@
+-- Initial vector schema (SQLite / D1).
+--
+-- Replaces the inline `ensure_registry()` CREATE TABLE DDL that previously
+-- ran on every `create_index` call in `pages.rs`. CREATE TABLE IF NOT EXISTS
+-- is a no-op against existing prod tables; the new index on `model` backs
+-- the registry-by-model scans that the embed/query paths use.
+--
+-- Scope note: this migration ONLY covers the static block-owned `registry`
+-- catalog. The per-index storage tables (`{prefixed}_meta`, `{prefixed}_fts`,
+-- and the `vec0` virtual table) are intentionally NOT created here — their
+-- names are user-supplied at runtime (`suppers_ai__vector__{user_name}`) and
+-- their DDL lives in the upstream `wafer-run/vector` runtime block, which
+-- the `vclient::create_index(ctx, cfg)` call dispatches to. Migrating those
+-- to a static .sql file is impossible by construction; migrating them to a
+-- typed `db::ddl` call at create-index time would just be a thinner wrapper
+-- around what `wafer-run/vector` already does. See the corresponding
+-- comment in `pages.rs::create_index`.
+--
+-- Mirrored to 001_vector_schema.postgres.sql.
+
+CREATE TABLE IF NOT EXISTS suppers_ai__vector__registry (
+    prefixed_name   TEXT PRIMARY KEY,
+    model           TEXT NOT NULL DEFAULT '',
+    dimensions      INTEGER NOT NULL DEFAULT 0,
+    keyword_search  INTEGER NOT NULL DEFAULT 0
+);
+-- Backs `load_index_metadata` lookups by `prefixed_name` (PK already covers
+-- this) and future model-rollup queries (e.g. "all indexes on bge-m3").
+CREATE INDEX IF NOT EXISTS idx_vector_registry_model
+    ON suppers_ai__vector__registry (model);

--- a/crates/solobase-core/src/blocks/vector/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/migrations/mod.rs
@@ -1,0 +1,67 @@
+//! Vector block migrations. Delegated to `crate::migration_helper`.
+//!
+//! Backend selection mirrors `files/migrations/mod.rs`: read
+//! `SOLOBASE_SHARED__DATABASE__BACKEND` from the config snapshot, fall back
+//! to `sqlite` when the config block is not registered. The actual apply +
+//! gating + statement splitting lives in
+//! [`crate::migration_helper::apply_if_blessed`].
+//!
+//! Scope: only the static `suppers_ai__vector__registry` catalog. Per-index
+//! storage tables (`{prefixed}_meta`, `{prefixed}_fts`, vec0 virtual) are
+//! materialized on demand by the upstream `wafer-run/vector` runtime block
+//! via `vclient::create_index` — their names are user-supplied at runtime
+//! and so cannot be expressed as a static SQL migration. See the SQL file
+//! header for the long-form rationale.
+
+use wafer_core::clients::config;
+use wafer_run::context::Context;
+
+use crate::migration_helper;
+
+const SQL_001_SQLITE: &str = include_str!("001_vector_schema.sqlite.sql");
+const SQL_001_POSTGRES: &str = include_str!("001_vector_schema.postgres.sql");
+
+pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
+        .await
+        .to_ascii_lowercase();
+    let sql = if backend == "postgres" {
+        SQL_001_POSTGRES
+    } else {
+        SQL_001_SQLITE
+    };
+    migration_helper::apply_if_blessed(ctx, "suppers-ai/vector", sql).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SQL_001_POSTGRES, SQL_001_SQLITE};
+
+    /// The migration_helper statement splitter splits on bare `;` outside
+    /// `--` line comments. Make sure every embedded statement parses into
+    /// at least the table count we expect — protects against a stray
+    /// `;` inside a comment / string literal silently dropping DDL.
+    fn count_create_table(sql: &str) -> usize {
+        sql.match_indices("CREATE TABLE IF NOT EXISTS ").count()
+    }
+    fn count_create_index(sql: &str) -> usize {
+        sql.match_indices("CREATE INDEX IF NOT EXISTS ").count()
+    }
+
+    #[test]
+    fn sqlite_script_has_expected_tables_and_indexes() {
+        // 1 table: registry
+        assert_eq!(count_create_table(SQL_001_SQLITE), 1);
+        // 1 index: model lookup (PK already covers prefixed_name)
+        assert_eq!(count_create_index(SQL_001_SQLITE), 1);
+        assert!(SQL_001_SQLITE.contains("suppers_ai__vector__registry"));
+        assert!(SQL_001_SQLITE.contains("idx_vector_registry_model"));
+    }
+
+    #[test]
+    fn postgres_script_has_expected_tables_and_indexes() {
+        assert_eq!(count_create_table(SQL_001_POSTGRES), 1);
+        assert_eq!(count_create_index(SQL_001_POSTGRES), 1);
+        assert!(SQL_001_POSTGRES.contains("suppers_ai__vector__registry"));
+    }
+}

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -1,4 +1,5 @@
 pub mod ingestion;
+mod migrations;
 pub mod pages;
 pub mod pages_ui;
 pub mod service;
@@ -129,9 +130,17 @@ impl Block for VectorBlock {
 
     async fn lifecycle(
         &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
+        ctx: &dyn Context,
+        event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
+        if matches!(event.event_type, LifecycleType::Init) {
+            migrations::apply(ctx).await.map_err(|e| {
+                WaferError::new(
+                    wafer_run::ErrorCode::Internal,
+                    format!("vector migrations: {e}"),
+                )
+            })?;
+        }
         Ok(())
     }
 }

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -46,7 +46,7 @@ use wafer_core::{
     interfaces::vector::{get_model, DEFAULT_MODEL},
 };
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
-use wafer_sql_utils::{ddl, introspect, query, upsert, value::sea_values_to_json, Backend};
+use wafer_sql_utils::{introspect, query, upsert, value::sea_values_to_json, Backend};
 
 use super::{
     ingestion::{self, DEFAULT_CHUNK_TOKENS, DEFAULT_OVERLAP_RATIO},
@@ -63,22 +63,11 @@ use crate::blocks::helpers::{
 /// model to re-embed text with, and whether keyword search was enabled —
 /// without spelunking through DDL on every query.
 ///
-/// Schema: `suppers_ai__vector__registry(prefixed_name TEXT PK, model TEXT,
-/// dimensions INTEGER, keyword_search INTEGER)`.
+/// Schema lives in `migrations/001_vector_schema.{sqlite,postgres}.sql` and
+/// is applied at block Init via `apply_if_blessed`. The column layout is:
+/// `(prefixed_name TEXT PK, model TEXT, dimensions INTEGER,
+/// keyword_search INTEGER)`.
 const REGISTRY_TABLE: &str = "suppers_ai__vector__registry";
-
-/// `Table` builder for the registry — fed through `ddl::build_create_table`
-/// so the DDL is dialect-portable even though the rest of the vector block
-/// is SQLite-only (sqlite-vec extension).
-fn registry_schema() -> wafer_core::interfaces::database::service::Table {
-    use wafer_core::interfaces::database::service::{col_int, col_text, pk, Table};
-    let mut table = Table::new(REGISTRY_TABLE);
-    table.columns.push(pk("prefixed_name"));
-    table.columns.push(col_text("model"));
-    table.columns.push(col_int("dimensions"));
-    table.columns.push(col_int("keyword_search"));
-    table
-}
 
 /// Route dispatcher for the `suppers-ai/vector` block.
 ///
@@ -209,9 +198,10 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
     // an internal error rather than silently swallowing it; the operator
     // can retry create (idempotent at the registry level via OR REPLACE
     // and harmless at vclient level because the index already exists).
-    if let Err(e) = ensure_registry(ctx).await {
-        return err_internal("registry init failed", e);
-    }
+    //
+    // The registry table itself is owned by the block's
+    // `migrations/001_vector_schema.*.sql` script (run at block Init via
+    // `apply_if_blessed`), so no inline CREATE TABLE is required here.
     let (sql, vals) = upsert::build_upsert(
         REGISTRY_TABLE,
         &[
@@ -254,17 +244,6 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
         "metric": cfg.metric,
         "keyword_search": cfg.keyword_search,
     }))
-}
-
-/// Idempotently create the registry table.
-async fn ensure_registry(ctx: &dyn Context) -> Result<(), WaferError> {
-    let sql = ddl::build_create_table(&registry_schema(), Backend::Sqlite).map_err(|e| {
-        WaferError::new(
-            wafer_block::ErrorCode::INTERNAL,
-            format!("Failed to build registry CREATE TABLE: {e}"),
-        )
-    })?;
-    db::exec_raw(ctx, &sql, &[]).await.map(|_| ())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `crates/solobase-core/src/blocks/vector/migrations/{001_vector_schema.sqlite.sql, 001_vector_schema.postgres.sql, mod.rs}` for the one static block-owned table (`suppers_ai__vector__registry`) and wires `migrations::apply` into the `Init` lifecycle. Same pattern as solobase #137 / #190 / #192 / #193 / #194 / #195.
- Removes the inline `ensure_registry()` + `registry_schema()` helpers that previously ran `CREATE TABLE` on every `create_index` call. The migration now runs once at boot through `apply_if_blessed` (hash-gated; `SOLOBASE_RUN_MIGRATIONS=1` for schema changes).
- Adds `idx_vector_registry_model` so future model-rollup queries are index-backed instead of full-scanning the catalog. Existing `prefixed_name` lookups stay PK-served.

## Dynamic per-index tables — decision

The vector block creates **N** runtime per-index tables per user-created index: `{prefixed}_meta`, `{prefixed}_fts`, and a `vec0` virtual table — names are `suppers_ai__vector__{user_name}…`, where `user_name` is user-supplied at `create_index` time. These are **not** materialized by solobase: the upstream `wafer-run/vector` runtime block owns their DDL via `vclient::create_index(ctx, cfg)`, dispatched from `pages.rs::create_index`. They stay on that path because:

1. Their names aren't known at compile time, so a static `.sql` file can't express them.
2. A wrapper `db::ddl` call at create-index time would just duplicate what `wafer-run/vector` already does (FTS5 setup + vec0 dimensions wiring).

Both the SQL file header and `migrations/mod.rs` document this scope split.

## Tracker

Last block on the ensure_table-removal list (`/workspace/.../ensure-table-removal-in-progress.md`). With this merged, `wafer-block-sqlite`'s `ensure_table()` shim can be retired as a follow-up once a deploy has run `--run-migrations` on every existing DB.

## Test plan

- [x] `cargo check -p solobase-core` clean
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean
- [x] `cargo test -p solobase-core --lib` → 640 passed (was ~638; 2 new parser tests for sqlite/postgres script shape)
- [x] Migration parser tests assert 1 table + 1 index per dialect

🤖 Generated with [Claude Code](https://claude.com/claude-code)