### PR TITLE
refactor(db): drop D1 lazy CREATE TABLE on insert + fix test fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5931,7 +5930,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5944,7 +5942,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5956,7 +5953,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5976,7 +5972,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5986,7 +5981,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -6002,7 +5996,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6016,7 +6009,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6027,7 +6019,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde",
@@ -6039,7 +6030,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6049,7 +6039,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "futures",
@@ -6066,7 +6055,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6084,7 +6072,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6094,7 +6081,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6105,7 +6091,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6120,7 +6105,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6131,7 +6115,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6148,7 +6131,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6160,7 +6142,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6177,7 +6158,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6187,7 +6167,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6216,7 +6195,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#909fabddac907ae0f73d0bb8b5c9ebc9136aeda3"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -3,19 +3,21 @@
 //! Implements the shared `DatabaseService` trait from wafer-core so D1Block
 //! can reuse the shared message handler.
 //!
-//! ## Lazy schema (cached)
+//! ## Lazy column-add (cached)
 //!
-//! Mirrors `wafer-block-sqlite`'s lazy-schema semantics: reads against a
-//! missing table return empty/NotFound (instead of erroring), and the
-//! first `create()` against a collection runs `CREATE TABLE IF NOT EXISTS`
-//! + `PRAGMA table_info` to materialize the table from the data keys.
+//! Tables themselves must exist before any `create()` — every block ships
+//! explicit `migrations/*.sql` applied from the `Init` lifecycle. Reads
+//! against a missing table still return empty/NotFound (mirrors
+//! `wafer-block-sqlite`), but writes against a missing table now surface
+//! D1's `no such table` instead of silently materializing it.
 //!
-//! Schema checks are cached per-isolate via `SCHEMA_CACHE`. After a table
-//! is verified once, subsequent inserts to the same columns skip the
-//! schema work entirely. Blocks that own their schema (e.g. `auth`,
-//! `admin`) materialize tables via per-block `migrations/*.sql` applied
-//! from `Init` lifecycle — `ensure_schema` is the fallback for blocks
-//! that don't declare a schema.
+//! What survives: on `create()` we run `PRAGMA table_info` + the necessary
+//! `ALTER TABLE ADD COLUMN` for any data key not yet on the table, matching
+//! the `update` / `update_where` paths in sqlite + postgres.
+//!
+//! Schema checks are cached per-isolate via `SCHEMA_CACHE`. After a column
+//! set is verified once, subsequent inserts to the same columns skip both
+//! the PRAGMA and any ALTERs entirely.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -99,11 +101,12 @@ impl D1DatabaseService {
             .collect())
     }
 
-    /// Ensure `table` exists and has columns for every key in `data`.
-    /// First call per (isolate, table) runs CREATE TABLE + PRAGMA + ALTER
-    /// as needed; subsequent calls hit the in-memory cache and skip the
-    /// schema work entirely.
-    async fn ensure_schema(
+    /// Ensure every key in `data` is a column on `table`.
+    /// First call per (isolate, table) runs PRAGMA + the needed ALTERs;
+    /// subsequent calls hit the in-memory cache and skip the schema work
+    /// entirely. The table itself must already exist — block migrations
+    /// run at `Init` are responsible for that.
+    async fn ensure_columns(
         &self,
         table: &str,
         data: &HashMap<String, serde_json::Value>,
@@ -123,13 +126,7 @@ impl D1DatabaseService {
             }
         }
 
-        // Slow path: ensure the table exists with the needed columns.
-        let ddl = ensure_table_sql(table, data.keys().map(|k| k.as_str()));
-        self.db
-            .prepare(&ddl)
-            .run()
-            .await
-            .map_err(|e| db_err(format!("ensure_table {}: {e}", table)))?;
+        // Slow path: ALTER in any missing columns.
         self.add_missing_columns(table, data).await?;
 
         // Re-read the column set and update the cache so subsequent
@@ -297,12 +294,12 @@ impl DatabaseService for D1DatabaseService {
         data.entry("updated_at".to_string())
             .or_insert_with(|| serde_json::Value::String(now));
 
-        // Lazy schema: materialize the table on first insert. Cached per
-        // isolate — first call per (isolate, table) runs CREATE TABLE IF
-        // NOT EXISTS + PRAGMA table_info + any ALTER TABLE ADD COLUMN
-        // needed; subsequent calls hit the in-memory cache and skip all
-        // schema work.
-        self.ensure_schema(&table, &data).await?;
+        // Lazy column-add: matches the sqlite/postgres `create` paths.
+        // The table itself must already exist via the block's migration
+        // files. Cached per isolate — first call per (isolate, table) runs
+        // PRAGMA table_info + any ALTER TABLE ADD COLUMN needed; subsequent
+        // calls hit the in-memory cache and skip all schema work.
+        self.ensure_columns(&table, &data).await?;
 
         let mut columns = vec!["id".to_string()];
         let mut placeholders = vec!["?".to_string()];
@@ -632,37 +629,6 @@ fn db_err(e: impl std::fmt::Display) -> DatabaseError {
     DatabaseError::Internal(e.to_string())
 }
 
-/// Build the `CREATE TABLE IF NOT EXISTS` DDL for lazy schema
-/// materialization. Mirrors `wafer-block-sqlite::ensure_table`: TEXT for
-/// every column; `id` is PRIMARY KEY (added if not in the data keys).
-///
-/// Pure function so it can be unit-tested without a D1 instance.
-pub(crate) fn ensure_table_sql<'a>(
-    table: &str,
-    data_keys: impl IntoIterator<Item = &'a str>,
-) -> String {
-    let safe_table = sanitize_ident(table);
-    let mut col_defs: Vec<String> = Vec::new();
-    let mut has_id = false;
-    for key in data_keys {
-        let safe_key = sanitize_ident(key);
-        if key == "id" {
-            col_defs.insert(0, "id TEXT PRIMARY KEY".to_string());
-            has_id = true;
-        } else {
-            col_defs.push(format!("{safe_key} TEXT"));
-        }
-    }
-    if !has_id {
-        col_defs.insert(0, "id TEXT PRIMARY KEY".to_string());
-    }
-    format!(
-        "CREATE TABLE IF NOT EXISTS {} ({})",
-        safe_table,
-        col_defs.join(", ")
-    )
-}
-
 /// Whether a D1 error message indicates the target table doesn't exist.
 /// D1 surfaces SQLite's `no such table: X` verbatim through the JsValue
 /// error; we string-match because the `worker::Error` type doesn't expose
@@ -701,10 +667,8 @@ fn json_to_record(val: serde_json::Value) -> Record {
     }
 }
 
-// Note: unit tests for `ensure_table_sql` and `is_no_such_table` are
+// Note: unit tests for `is_no_such_table` and `is_duplicate_column` are
 // omitted because `solobase-cloudflare` only compiles on
 // `wasm32-unknown-unknown` (the R2/D1 services hold `!Send` JsFutures).
 // `cargo test -p solobase-cloudflare` errors before reaching the test
-// module. End-to-end validation comes from a real CF deploy against an
-// empty D1: registry-block init must seed the reserved orgs without
-// erroring on "no such table".
+// module. End-to-end validation comes from a real CF deploy.

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -429,10 +429,11 @@ mod tests {
 
     #[tokio::test]
     async fn init_applies_migrations_and_runs_bootstrap_on_fresh_ctx() {
-        // Fresh TestContext — no auth tables, no config block. Calling
-        // `service.init` must run migrations (creating the users table) and
-        // then run bootstrap (which is a no-op without admin env vars set).
-        let ctx = Arc::new(TestContext::new().await);
+        // Admin migrations are pre-applied so the `block_settings` tracking
+        // table exists — `apply_if_blessed` requires it to upsert the
+        // `current_hash` row. In production `register_all_static_blocks`
+        // registers admin first, so its Init runs before auth's.
+        let ctx = Arc::new(TestContext::with_admin().await);
         let service = AuthServiceImpl::new(BlockState::for_test(ctx.clone()));
 
         service
@@ -452,7 +453,8 @@ mod tests {
     async fn init_is_idempotent() {
         // Running init twice must be safe — migrations track applied
         // versions and bootstrap short-circuits when users already exist.
-        let ctx = Arc::new(TestContext::new().await);
+        // Admin pre-applied for the same reason as above.
+        let ctx = Arc::new(TestContext::with_admin().await);
         let service = AuthServiceImpl::new(BlockState::for_test(ctx.clone()));
 
         service.init(&*ctx).await.expect("first init");

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -1,5 +1,5 @@
 mod cloud;
-mod migrations;
+pub(crate) mod migrations;
 pub(crate) mod models;
 mod pages_admin;
 pub(crate) mod pages_user;

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -1288,7 +1288,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn bucket_list_page_renders_user_buckets() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let owner = "admin_1"; // admin_msg's default user_id
         seed_two_buckets(&ctx, owner).await;
 
@@ -1311,7 +1311,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn bucket_list_page_empty_state_for_fresh_user() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
 
         let msg = admin_msg("retrieve", "/b/storage/");
         let resp = bucket_list_page(&ctx, &msg).await;
@@ -1323,7 +1323,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn bucket_list_page_hides_other_users_buckets() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         // Seed admin_1's buckets.
         seed_two_buckets(&ctx, "admin_1").await;
         // Seed one bucket for a different user.
@@ -1344,7 +1344,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn bucket_list_page_renders_new_bucket_button() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let msg = admin_msg("retrieve", "/b/storage/");
         let body = output_html(bucket_list_page(&ctx, &msg).await).await;
 
@@ -1366,7 +1366,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn bucket_list_page_renders_new_bucket_modal() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let msg = admin_msg("retrieve", "/b/storage/");
         let body = output_html(bucket_list_page(&ctx, &msg).await).await;
 
@@ -1412,7 +1412,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn object_list_page_root_renders_files_and_folders() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         seed_two_buckets(&ctx, "admin_1").await;
 
         let msg = admin_msg("retrieve", "/b/storage/photos/");
@@ -1433,7 +1433,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn object_list_page_with_prefix_strips_filename() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         seed_two_buckets(&ctx, "admin_1").await;
 
         let msg = admin_msg("retrieve", "/b/storage/photos/nested/");
@@ -1447,7 +1447,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn object_list_page_404_for_unknown_bucket() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let mut msg = admin_msg("retrieve", "/b/storage/missing/");
         msg.set_meta("http.header.accept", "text/html");
         let resp = object_list_page(&ctx, &msg, "missing", "").await;
@@ -1462,7 +1462,7 @@ mod integration_tests {
     async fn object_list_page_404_for_other_users_bucket() {
         // Cross-user isolation: a bucket owned by another user must 404,
         // not render its contents.
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("name".into(), json!("secrets"));
         row.insert("created_by".into(), json!("other_user"));
@@ -1480,7 +1480,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn object_list_page_renders_empty_state_for_empty_bucket() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         // seed_two_buckets seeds `docs` with no objects.
         seed_two_buckets(&ctx, "admin_1").await;
 
@@ -1496,7 +1496,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn cloudstorage_page_renders_shares_and_quota() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
 
         // Seed a share + a quota row owned by admin_1.
         let mut share: HashMap<String, serde_json::Value> = HashMap::new();
@@ -1529,7 +1529,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn cloudstorage_page_hides_other_users_shares() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         // Seed admin_1's share.
         let mut mine: HashMap<String, serde_json::Value> = HashMap::new();
         mine.insert("token".into(), json!("mine"));
@@ -1557,7 +1557,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn object_list_page_includes_files_browser_js() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         seed_two_buckets(&ctx, "admin_1").await;
 
         let msg = admin_msg("retrieve", "/b/storage/photos/");
@@ -1584,7 +1584,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn cloudstorage_page_includes_files_browser_js() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
 
         let msg = admin_msg("retrieve", "/b/cloudstorage/");
         let resp = cloudstorage_page(&ctx, &msg).await;
@@ -1604,7 +1604,7 @@ mod integration_tests {
     async fn object_list_page_shows_actual_size_from_text_columns() {
         // SQLite TEXT columns store integers as strings (see MEMORY.md
         // wafer-wrap-table-naming). The renderer must coerce both shapes.
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let mut bucket: HashMap<String, serde_json::Value> = HashMap::new();
         bucket.insert("name".into(), json!("photos"));
         bucket.insert("created_by".into(), json!("admin_1"));
@@ -1638,7 +1638,7 @@ mod integration_tests {
         // A bucket name containing `</script>` would prematurely close the
         // <script type="application/json"> bootstrap carrier. The render
         // path must escape `<` so that no `</script>` appears in the JSON.
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_files().await;
         let mut bucket: HashMap<String, serde_json::Value> = HashMap::new();
         bucket.insert("name".into(), json!("foo</script>bar"));
         bucket.insert("created_by".into(), json!("admin_1"));

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-mod migrations;
+pub(crate) mod migrations;
 mod pages;
 
 const TABLE: &str = "suppers_ai__userportal__buttons";
@@ -793,9 +793,9 @@ mod cross_block_tests {
 
     #[tokio::test]
     async fn list_buttons_action_returns_json_array_in_sort_order() {
-        let ctx = TestContext::new().await;
+        let ctx = TestContext::with_userportal().await;
 
-        // Seed two buttons via db::create (lazy table creation).
+        // Seed two buttons through the userportal-owned `buttons` table.
         db::create(
             &ctx,
             TABLE,

--- a/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
@@ -104,7 +104,7 @@ mod tests {
     };
 
     async fn ctx_with_userportal() -> TestContext {
-        let mut ctx = TestContext::with_auth().await;
+        let mut ctx = TestContext::with_userportal().await;
         ctx.register_block("suppers-ai/userportal", Arc::new(UserPortalBlock));
         ctx
     }

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -1,5 +1,5 @@
 pub mod ingestion;
-mod migrations;
+pub(crate) mod migrations;
 pub mod pages;
 pub mod pages_ui;
 pub mod service;

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -419,8 +419,7 @@ mod integration_tests {
     /// Seed one row in the vector registry plus the matching `_meta` table
     /// so the listing has both a registry entry and a vector count to show.
     async fn seed_docs_index(ctx: &TestContext) {
-        // Registry row. The SQLite service auto-creates the table on first
-        // insert (`ensure_table`) so we don't need DDL here.
+        // Registry row.
         let mut registry_row: HashMap<String, serde_json::Value> = HashMap::new();
         registry_row.insert("prefixed_name".into(), json!("suppers_ai__vector__docs"));
         registry_row.insert("model".into(), json!("fastembed"));
@@ -430,9 +429,18 @@ mod integration_tests {
             .await
             .expect("seed registry row");
 
-        // Vectors live in `{prefixed}_meta` (see `pages.rs::ingest`), so the
-        // count loader queries that table — not the bare `prefixed_name`.
-        // Seed there to exercise the production code path.
+        // Per-index `_meta` table — created on demand in production by the
+        // upstream `wafer-run/vector` runtime block via `vclient::create_index`
+        // (see vector/migrations/mod.rs header). The runtime no longer
+        // auto-creates tables on first insert, so the test materialises it
+        // explicitly with the columns the count loader expects.
+        db::exec_raw(
+            ctx,
+            "CREATE TABLE IF NOT EXISTS suppers_ai__vector__docs_meta (id TEXT PRIMARY KEY, vector_id TEXT, created_at TEXT, updated_at TEXT)",
+            &[],
+        )
+        .await
+        .expect("create _meta table");
         let mut meta_row: HashMap<String, serde_json::Value> = HashMap::new();
         meta_row.insert("vector_id".into(), json!("v1"));
         db::create(ctx, "suppers_ai__vector__docs_meta", meta_row)
@@ -442,7 +450,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn index_list_page_renders_admin_view() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_vector().await;
         seed_docs_index(&ctx).await;
 
         let msg = admin_msg("retrieve", "/b/vector/");
@@ -469,7 +477,7 @@ mod integration_tests {
     async fn index_list_page_renders_empty_state_on_fresh_db() {
         // No registry table at all: handler must fall through cleanly to
         // the "No vector indexes yet" empty state, not error out.
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_vector().await;
 
         let msg = admin_msg("retrieve", "/b/vector/");
         let resp = index_list_page(&ctx, &msg).await;
@@ -487,7 +495,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn index_detail_page_404_for_missing() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_vector().await;
         let mut msg = admin_msg("retrieve", "/b/vector/missing/");
         // Browser-style request → not_found_response returns the styled
         // 404 page; without text/html it returns the JSON err path which
@@ -505,7 +513,7 @@ mod integration_tests {
     async fn index_detail_page_404_for_invalid_name() {
         // Names with disallowed characters never reach the database —
         // they're rejected at the route boundary by validate_index_name.
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_vector().await;
         let mut msg = admin_msg("retrieve", "/b/vector/bad-name/");
         msg.set_meta("http.header.accept", "text/html");
         let out = index_detail_page(&ctx, &msg, "bad-name").await;
@@ -518,7 +526,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn index_detail_page_happy_path() {
-        let ctx = TestContext::with_auth().await;
+        let ctx = TestContext::with_vector().await;
         seed_docs_index(&ctx).await;
 
         let msg = admin_msg("retrieve", "/b/vector/docs/");

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -106,16 +106,66 @@ impl TestContext {
         self
     }
 
-    /// Build a `TestContext` with the auth-block migrations applied.
+    /// Build a `TestContext` with admin + auth block migrations applied.
     ///
     /// Convenience constructor for tests that need the
     /// `suppers_ai__auth__{users,orgs,sessions,provider_links,...}` schema
     /// in place — most repo and handler tests do.
+    ///
+    /// Admin migrations run first so that the
+    /// `suppers_ai__admin__block_settings` tracking table exists before
+    /// auth's `apply_if_blessed` upserts its `current_hash` row. In
+    /// production this ordering is guaranteed by `register_all_static_blocks`
+    /// (admin is registered first); here we enforce it explicitly.
     pub async fn with_auth() -> Self {
         let ctx = Self::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations in test fixture");
         crate::blocks::auth::migrations::apply(&ctx)
             .await
             .expect("apply auth migrations in test fixture");
+        ctx
+    }
+
+    /// Build a `TestContext` with admin migrations applied (only).
+    ///
+    /// Use this for tests that exercise a block's own `init()` / migration
+    /// application directly — the prerequisite is that
+    /// `suppers_ai__admin__block_settings` exists so `apply_if_blessed` can
+    /// upsert its tracking row.
+    pub async fn with_admin() -> Self {
+        let ctx = Self::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations in test fixture");
+        ctx
+    }
+
+    /// Build a `TestContext` with admin + auth + files migrations applied.
+    pub async fn with_files() -> Self {
+        let ctx = Self::with_auth().await;
+        crate::blocks::files::migrations::apply(&ctx)
+            .await
+            .expect("apply files migrations in test fixture");
+        ctx
+    }
+
+    /// Build a `TestContext` with admin + auth + userportal migrations applied.
+    pub async fn with_userportal() -> Self {
+        let ctx = Self::with_auth().await;
+        crate::blocks::userportal::migrations::apply(&ctx)
+            .await
+            .expect("apply userportal migrations in test fixture");
+        ctx
+    }
+
+    /// Build a `TestContext` with admin + auth + vector migrations applied.
+    pub async fn with_vector() -> Self {
+        let ctx = Self::with_auth().await;
+        crate::blocks::vector::migrations::apply(&ctx)
+            .await
+            .expect("apply vector migrations in test fixture");
         ctx
     }
 

--- a/crates/solobase-core/tests/auth/bootstrap_run.rs
+++ b/crates/solobase-core/tests/auth/bootstrap_run.rs
@@ -28,7 +28,7 @@ fn cfg_empty() -> AuthConfig {
 
 #[tokio::test]
 async fn email_password_path_creates_admin_with_local_credentials() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     bootstrap::run(&ctx, &cfg_email_pw("root@x.io", "pw"))
@@ -58,7 +58,7 @@ async fn email_password_path_creates_admin_with_local_credentials() {
 
 #[tokio::test]
 async fn token_path_inserts_bootstrap_token_row() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     bootstrap::run(&ctx, &cfg_token("secret-token"))
@@ -82,7 +82,7 @@ async fn token_path_inserts_bootstrap_token_row() {
 
 #[tokio::test]
 async fn no_config_is_noop() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     bootstrap::run(&ctx, &cfg_empty())
@@ -94,7 +94,7 @@ async fn no_config_is_noop() {
 
 #[tokio::test]
 async fn skipped_when_users_already_exist() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     users::insert(

--- a/crates/solobase-core/tests/auth/common.rs
+++ b/crates/solobase-core/tests/auth/common.rs
@@ -26,7 +26,23 @@ pub struct MigrationTestCtx {
 }
 
 impl MigrationTestCtx {
-    pub fn new() -> Self {
+    /// Construct a test context with admin migrations pre-applied.
+    ///
+    /// Admin's migrations create `suppers_ai__admin__block_settings`, the
+    /// tracking table every other block's `apply_if_blessed` upserts into.
+    /// In production this is guaranteed by registration order
+    /// (`register_all_static_blocks` puts admin first); here we enforce it
+    /// in the fixture so auth tests can call `migrations::apply` without
+    /// the call failing on a missing tracking table.
+    pub async fn new() -> Self {
+        let ctx = Self::raw();
+        solobase_core::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations (bootstraps block_settings)");
+        ctx
+    }
+
+    fn raw() -> Self {
         let svc = Arc::new(
             wafer_block_sqlite::service::SQLiteDatabaseService::open_in_memory()
                 .expect("open in-memory sqlite"),

--- a/crates/solobase-core/tests/auth/login_session_row.rs
+++ b/crates/solobase-core/tests/auth/login_session_row.rs
@@ -124,7 +124,7 @@ async fn invoke_login_drain(ctx: &MigrationTestCtx, email: &str, password: &str)
 
 #[tokio::test]
 async fn login_creates_one_session_row_keyed_by_access_token_hash() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     let user_id = seed_password_user(&ctx, "alice@example.com", "hunter2hunter2").await;
 
     let resp_body = invoke_login(&ctx, "alice@example.com", "hunter2hunter2").await;
@@ -162,7 +162,7 @@ async fn login_creates_one_session_row_keyed_by_access_token_hash() {
 
 #[tokio::test]
 async fn invalid_credentials_do_not_create_a_session_row() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     let user_id = seed_password_user(&ctx, "bob@example.com", "correct-horse").await;
 
     invoke_login_drain(&ctx, "bob@example.com", "WRONG-password").await;
@@ -178,7 +178,7 @@ async fn invalid_credentials_do_not_create_a_session_row() {
 
 #[tokio::test]
 async fn two_logins_produce_two_distinct_session_rows() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     let user_id = seed_password_user(&ctx, "carol@example.com", "passw0rd-passw0rd").await;
 
     let _ = invoke_login(&ctx, "carol@example.com", "passw0rd-passw0rd").await;
@@ -208,7 +208,7 @@ async fn two_logins_produce_two_distinct_session_rows() {
 /// This is what the user sees in their browser at `/b/userportal/sessions`.
 #[tokio::test]
 async fn userportal_sessions_page_renders_row_after_login() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     let user_id = seed_password_user(&ctx, "diana@example.com", "diana-password").await;
 
     let _ = invoke_login(&ctx, "diana@example.com", "diana-password").await;

--- a/crates/solobase-core/tests/auth/migrations_001.rs
+++ b/crates/solobase-core/tests/auth/migrations_001.rs
@@ -27,7 +27,7 @@ const EXPECTED_TABLES: &[&str] = &[
 
 #[tokio::test]
 async fn migration_001_creates_all_tables() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration 001 apply");
 
     let rows = db::query_raw(
@@ -58,7 +58,7 @@ async fn migration_001_creates_all_tables() {
 
 #[tokio::test]
 async fn migration_001_is_idempotent() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("first apply");
     migrations::apply(&ctx)
         .await

--- a/crates/solobase-core/tests/auth/migrations_002.rs
+++ b/crates/solobase-core/tests/auth/migrations_002.rs
@@ -10,7 +10,7 @@ const EXPECTED_RESERVED: &[&str] = &["solobase", "suppers-ai", "wafer", "wafer-r
 
 #[tokio::test]
 async fn migration_002_seeds_four_reserved_orgs_idempotently() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("first apply");
     migrations::apply(&ctx)
         .await

--- a/crates/solobase-core/tests/auth/oauth_callback_repo.rs
+++ b/crates/solobase-core/tests/auth/oauth_callback_repo.rs
@@ -21,7 +21,7 @@ use crate::common::MigrationTestCtx;
 /// no prior link, no prior email → insert user, upsert link.
 #[tokio::test]
 async fn first_oauth_login_creates_user_and_link() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     // No prior link.
@@ -85,7 +85,7 @@ async fn first_oauth_login_creates_user_and_link() {
 /// the existing link is found → user_id reused → no new user row.
 #[tokio::test]
 async fn re_login_same_provider_ref_no_duplicate_user() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     // Seed the user + initial link (first login).
@@ -155,7 +155,7 @@ async fn re_login_same_provider_ref_no_duplicate_user() {
 /// bound to the SAME user_id.
 #[tokio::test]
 async fn same_email_different_provider_merges_to_same_user() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     // Carol first logged in via GitHub.

--- a/crates/solobase-core/tests/auth/pat_issue.rs
+++ b/crates/solobase-core/tests/auth/pat_issue.rs
@@ -12,7 +12,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn issue_inserts_row_and_token_is_prefixed() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     let user = users::insert(
@@ -50,7 +50,7 @@ async fn issue_inserts_row_and_token_is_prefixed() {
 
 #[tokio::test]
 async fn issue_with_expiry_stores_expires_at() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     let user = users::insert(
@@ -80,7 +80,7 @@ async fn issue_with_expiry_stores_expires_at() {
 
 #[tokio::test]
 async fn two_issues_produce_distinct_tokens() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     let user = users::insert(

--- a/crates/solobase-core/tests/auth/repo_cli_codes.rs
+++ b/crates/solobase-core/tests/auth/repo_cli_codes.rs
@@ -37,7 +37,7 @@ fn iso_plus_secs(secs: i64) -> String {
 
 #[tokio::test]
 async fn insert_then_take_returns_row_and_deletes() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid = mk_user(&ctx, "a@x.com").await;
 
@@ -66,7 +66,7 @@ async fn insert_then_take_returns_row_and_deletes() {
 
 #[tokio::test]
 async fn take_unknown_returns_none() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let row = cli_codes::take(&ctx, &hash(99)).await.expect("take");
     assert!(row.is_none());
@@ -74,7 +74,7 @@ async fn take_unknown_returns_none() {
 
 #[tokio::test]
 async fn take_expired_returns_none_and_deletes() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid = mk_user(&ctx, "a@x.com").await;
 
@@ -101,7 +101,7 @@ async fn take_expired_returns_none_and_deletes() {
 
 #[tokio::test]
 async fn delete_expired_drops_only_expired_rows() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid = mk_user(&ctx, "a@x.com").await;
     cli_codes::insert(

--- a/crates/solobase-core/tests/auth/repo_orgs.rs
+++ b/crates/solobase-core/tests/auth/repo_orgs.rs
@@ -28,7 +28,7 @@ async fn mk_user(ctx: &MigrationTestCtx, email: &str) -> String {
 
 #[tokio::test]
 async fn find_by_name_returns_none_for_unknown() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let row = orgs::find_by_name(&ctx, "does-not-exist").await.unwrap();
     assert!(row.is_none());
@@ -36,7 +36,7 @@ async fn find_by_name_returns_none_for_unknown() {
 
 #[tokio::test]
 async fn upsert_claimed_inserts_then_finds() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid = mk_user(&ctx, "u@x.com").await;
     let row = orgs::upsert_claimed(
@@ -65,7 +65,7 @@ async fn upsert_claimed_inserts_then_finds() {
 
 #[tokio::test]
 async fn upsert_claimed_conflict_on_name() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let a = mk_user(&ctx, "a@x.com").await;
     let b = mk_user(&ctx, "b@x.com").await;
@@ -96,7 +96,7 @@ async fn upsert_claimed_conflict_on_name() {
 
 #[tokio::test]
 async fn upsert_claimed_conflict_on_verified_ref() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let a = mk_user(&ctx, "a@x.com").await;
     let b = mk_user(&ctx, "b@x.com").await;
@@ -130,7 +130,7 @@ async fn reserved_orgs_do_not_block_claiming_same_provider_ref() {
     // Reserved orgs don't participate in the verified_via/verified_ref
     // conflict — the partial unique index has `WHERE is_reserved = 0`. A
     // reserved row with no provider ref shouldn't block a real claim.
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     // Migration 002 seeded 'wafer-run' as reserved with NULL verified_ref.
     let uid = mk_user(&ctx, "u@x.com").await;

--- a/crates/solobase-core/tests/auth/repo_pats.rs
+++ b/crates/solobase-core/tests/auth/repo_pats.rs
@@ -10,7 +10,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn pat_insert_find_with_scopes() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let u = users::insert(
@@ -60,7 +60,7 @@ async fn pat_insert_find_with_scopes() {
 
 #[tokio::test]
 async fn pat_insert_with_multi_scope_and_expiry() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let u = users::insert(
@@ -102,7 +102,7 @@ async fn pat_insert_with_multi_scope_and_expiry() {
 
 #[tokio::test]
 async fn pat_find_missing_returns_none() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let none_hash = [0u8; 32];
@@ -121,7 +121,7 @@ async fn pat_token_hash_is_stored_as_hex_string_not_json_byte_array() {
     // `decode_bytes` now expects from string-shaped rows.
     use wafer_core::clients::database as db;
 
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let u = users::insert(

--- a/crates/solobase-core/tests/auth/repo_provider_links.rs
+++ b/crates/solobase-core/tests/auth/repo_provider_links.rs
@@ -25,7 +25,7 @@ async fn mk_user(ctx: &MigrationTestCtx, email: &str) -> String {
 
 #[tokio::test]
 async fn upsert_insert_then_update_same_provider_ref() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid1 = mk_user(&ctx, "a@example.com").await;
     let uid2 = mk_user(&ctx, "b@example.com").await;
@@ -108,7 +108,7 @@ async fn upsert_insert_then_update_same_provider_ref() {
 
 #[tokio::test]
 async fn find_missing_is_none() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     assert!(provider_links::find_by_provider_ref(&ctx, "github", "nope")
         .await
@@ -118,7 +118,7 @@ async fn find_missing_is_none() {
 
 #[tokio::test]
 async fn provider_axis_is_independent() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
     let uid_gh = mk_user(&ctx, "gh@example.com").await;
     let uid_goog = mk_user(&ctx, "goog@example.com").await;

--- a/crates/solobase-core/tests/auth/repo_sessions.rs
+++ b/crates/solobase-core/tests/auth/repo_sessions.rs
@@ -10,7 +10,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn insert_find_touch_delete_expired() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let u = users::insert(
@@ -87,7 +87,7 @@ async fn insert_find_touch_delete_expired() {
 
 #[tokio::test]
 async fn find_by_token_hash_missing_returns_none() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let none_hash = [0u8; 32];

--- a/crates/solobase-core/tests/auth/repo_users.rs
+++ b/crates/solobase-core/tests/auth/repo_users.rs
@@ -7,7 +7,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn insert_then_find_by_email_and_id() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let inserted = users::insert(
@@ -52,7 +52,7 @@ async fn insert_then_find_by_email_and_id() {
 
 #[tokio::test]
 async fn insert_with_avatar_roundtrips() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migration apply");
 
     let inserted = users::insert(

--- a/crates/solobase-core/tests/auth/service_require_role.rs
+++ b/crates/solobase-core/tests/auth/service_require_role.rs
@@ -27,7 +27,7 @@ fn bearer(tok: &str) -> Message {
 
 #[tokio::test]
 async fn require_role_user_admin_and_bootstrap_token() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let admin = users::insert(

--- a/crates/solobase-core/tests/auth/service_require_token.rs
+++ b/crates/solobase-core/tests/auth/service_require_token.rs
@@ -27,7 +27,7 @@ fn cookie(tok: &str) -> Message {
 
 #[tokio::test]
 async fn require_token_enforces_scope_and_rejects_session_cookies() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let u = users::insert(

--- a/crates/solobase-core/tests/auth/service_require_user.rs
+++ b/crates/solobase-core/tests/auth/service_require_user.rs
@@ -28,7 +28,7 @@ fn msg_with_bearer(token: &str) -> Message {
 
 #[tokio::test]
 async fn require_user_accepts_session_cookie_and_pat_and_rejects_missing() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let u = users::insert(
@@ -113,7 +113,7 @@ async fn require_user_accepts_session_cookie_and_pat_and_rejects_missing() {
 
 #[tokio::test]
 async fn require_user_rejects_expired_session_and_pat() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let u = users::insert(

--- a/crates/solobase-core/tests/auth/service_user_profile.rs
+++ b/crates/solobase-core/tests/auth/service_user_profile.rs
@@ -15,7 +15,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn user_profile_returns_row_with_empty_orgs() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let u = users::insert(
@@ -45,7 +45,7 @@ async fn user_profile_returns_row_with_empty_orgs() {
 
 #[tokio::test]
 async fn user_profile_missing_user_is_not_found() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let svc = AuthServiceImpl::new(BlockState::for_test(ctx.clone()));
@@ -61,7 +61,7 @@ async fn user_profile_missing_user_is_not_found() {
 
 #[tokio::test]
 async fn user_profile_maps_non_admin_role_to_user() {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
 
     let u = users::insert(

--- a/crates/solobase-core/tests/auth/session_issue.rs
+++ b/crates/solobase-core/tests/auth/session_issue.rs
@@ -12,7 +12,7 @@ use crate::common::MigrationTestCtx;
 
 #[tokio::test]
 async fn issue_for_inserts_row_and_returns_prefixed_token() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     let user = users::insert(
@@ -56,7 +56,7 @@ async fn issue_for_inserts_row_and_returns_prefixed_token() {
 
 #[tokio::test]
 async fn two_issues_produce_distinct_tokens() {
-    let ctx = MigrationTestCtx::new();
+    let ctx = MigrationTestCtx::new().await;
     migrations::apply(&ctx).await.expect("migrations");
 
     let user = users::insert(

--- a/crates/solobase-core/tests/auth/verify_org_admin.rs
+++ b/crates/solobase-core/tests/auth/verify_org_admin.rs
@@ -36,7 +36,7 @@ struct Harness {
 }
 
 async fn boot() -> Harness {
-    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new());
+    let ctx: Arc<dyn Context> = Arc::new(MigrationTestCtx::new().await);
     migrations::apply(ctx.as_ref()).await.expect("migrations");
     let state = BlockState::for_test(ctx.clone()).with_org_admin_cache(OrgAdminCache::default());
     Harness {


### PR DESCRIPTION
## Summary

- **solobase-cloudflare**: rename `ensure_schema` → `ensure_columns`, drop the lazy `CREATE TABLE IF NOT EXISTS` half, keep the lazy `ALTER TABLE ADD COLUMN` half (cached per isolate, matching sqlite + postgres). Delete the now-unused `ensure_table_sql` pure helper. Tables themselves must come from block migrations applied at \`Init\` via \`apply_if_blessed\` + \`db::ddl\`.
- **test fixtures**: \`TestContext::with_auth\` now applies admin migrations first so \`suppers_ai__admin__block_settings\` exists when auth's \`apply_if_blessed\` upserts its tracking row. New helpers \`with_admin\`, \`with_files\`, \`with_userportal\`, \`with_vector\` follow the same pattern. \`tests/auth/common.rs::MigrationTestCtx::new\` is now async + pre-applies admin migrations; 47 call sites updated to \`.await\`.
- **vector page test**: the per-index \`_meta\` table is materialised in production by \`vclient::create_index\` (vector migrations explicitly document this) — the seeding test now emits an explicit \`CREATE TABLE\` for it instead of leaning on the lazy create.

Pairs with [wafer-run #140](https://github.com/wafer-run/wafer-run/pull/140), which drops the matching sqlite + postgres lazy CREATE TABLE.

## Why the fixture changes are in this PR

When wafer-run #140 lands and solobase rebuilds against it, the test fixtures fail without these changes — the shim was masking two real latent bugs (admin-migrations-prerequisite + vector \`_meta\` lazy-create). Landing both PRs without the test fixes would red-CI solobase. They're packaged together so the deletion can roll forward cleanly.

## Test plan

- [x] \`cargo check -p solobase-cloudflare --target wasm32-unknown-unknown\` clean
- [x] \`cargo check -p solobase-browser --target wasm32-unknown-unknown\` clean
- [x] \`cargo test --workspace --exclude solobase-browser --exclude solobase-cloudflare --exclude solobase-web\` — all 638 native tests green, 0 failures
- [ ] Reviewer to confirm \`vclient::create_index\` actually materialises \`{prefixed}_meta\` in production (vector tests fall over without it)
- [ ] Manual D1 smoke against wafer.run after wafer-run #140 lands and a redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)