### PR TITLE
feat(t2i-engine): fail upfront when WebGPU adapter is missing

### DIFF
--- a/crates/solobase-browser/assets/t2i-engine.js
+++ b/crates/solobase-browser/assets/t2i-engine.js
@@ -34,15 +34,38 @@ async function loadTransformers() {
     return _transformers;
 }
 
-let _fp16Supported = null;
-async function detectFp16() {
-    if (_fp16Supported !== null) return _fp16Supported;
-    try {
-        const adapter = await navigator.gpu?.requestAdapter();
-        _fp16Supported = !!adapter?.features?.has('shader-f16');
-    } catch (_e) {
-        _fp16Supported = false;
+// Recognizable marker callers (e.g. gizza-ai/imagine) can match on to
+// surface a friendly "WebGPU is missing" message. Keep stable; if you
+// rename it, update the consumer in gizza-ai/blocks/imagine/src/lib.rs.
+const WEBGPU_UNAVAILABLE_MARKER = 'webgpu-unavailable';
+
+// Throws an Error whose message starts with WEBGPU_UNAVAILABLE_MARKER when
+// the browser exposes no WebGPU adapter at all. The model layers all run
+// on device `webgpu`, so without an adapter loading would fail later
+// inside transformers.js with an opaque message. Failing upfront with a
+// stable marker lets consumers render a clear bubble.
+async function requireWebGpuAdapter() {
+    if (!navigator.gpu) {
+        throw new Error(`${WEBGPU_UNAVAILABLE_MARKER}: navigator.gpu is undefined`);
     }
+    let adapter;
+    try {
+        adapter = await navigator.gpu.requestAdapter();
+    } catch (e) {
+        throw new Error(`${WEBGPU_UNAVAILABLE_MARKER}: requestAdapter threw: ${e?.message ?? e}`);
+    }
+    if (!adapter) {
+        throw new Error(`${WEBGPU_UNAVAILABLE_MARKER}: no WebGPU adapter available`);
+    }
+    return adapter;
+}
+
+// shader-f16 is preferred (smaller / faster) but not required — the dtype
+// table below has an fp32 fallback for adapters without it.
+let _fp16Supported = null;
+async function detectFp16(adapter) {
+    if (_fp16Supported !== null) return _fp16Supported;
+    _fp16Supported = !!adapter?.features?.has('shader-f16');
     return _fp16Supported;
 }
 
@@ -68,8 +91,9 @@ async function ensureLoaded(modelId, onProgress) {
         _processor = null;
         _modelId = null;
     }
+    const adapter = await requireWebGpuAdapter();
     const { AutoProcessor, MultiModalityCausalLM } = await loadTransformers();
-    const fp16 = await detectFp16();
+    const fp16 = await detectFp16(adapter);
     const dtype = fp16
         ? {
               prepare_inputs_embeds: 'q4',


### PR DESCRIPTION
## Summary
- Adds `requireWebGpuAdapter()` at the top of `ensureLoaded` in `t2i-engine.js`. When the page exposes no WebGPU at all, the engine now fails immediately with an `Error` whose message starts with the stable marker `webgpu-unavailable:` — instead of letting `MultiModalityCausalLM.from_pretrained` fail later inside transformers.js with an opaque message.
- Threads the same adapter into `detectFp16` so we only probe `navigator.gpu` once.
- `shader-f16` is intentionally **not** required — the existing dtype table already has an fp32 fallback. The real hard requirement is a WebGPU adapter, which is what the spec's `chrome://flags/#enable-unsafe-webgpu` actually enables.

The marker is the contract consumers depend on. The companion gizza-ai PR (https://github.com/gizza-ai/gizza-ai — `feat/imagine-webgpu-unavailable-message`) pattern-matches it in the `gizza-ai/imagine` skill block to render a friendly assistant bubble explaining the limitation.

Closes the last UX gap from `docs/superpowers/specs/2026-05-13-gizza-ai-slash-commands-design.md`; all other items in that spec shipped earlier.

## Test plan
- [ ] Deploy to a Chrome instance without WebGPU (no flag) → `/imagine cat` in gizza chat surfaces the friendly bubble instead of a raw error chip.
- [ ] Deploy to a Chrome instance with WebGPU enabled → `/imagine cat` still produces an image as before.
- [ ] Verify the marker `webgpu-unavailable:` is still the literal substring at the front of the thrown error message (a quick grep, no source-of-truth lives elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)