### PR TITLE
fix(share): use typed db::increment_field_where, drop exec_raw + hardcoded Backend (SEC-056)

### DIFF
--- a/crates/solobase-cloudflare/src/database.rs
+++ b/crates/solobase-cloudflare/src/database.rs
@@ -537,6 +537,42 @@ impl DatabaseService for D1DatabaseService {
         Ok(())
     }
 
+    async fn increment_field_where(
+        &self,
+        collection: &str,
+        col: &str,
+        delta: i64,
+        filters: &[Filter],
+    ) -> Result<i64, DatabaseError> {
+        let table = sanitize_ident(collection);
+        let safe_col = sanitize_ident(col);
+
+        let (where_sql, mut params) = build_where_clause(filters);
+        // SET clause binds delta first, then the filter params.
+        params.insert(0, JsValue::from_f64(delta as f64));
+
+        let sql = format!("UPDATE {table} SET {safe_col} = {safe_col} + ? WHERE {where_sql}");
+
+        let result = self
+            .db
+            .prepare(&sql)
+            .bind(&params)
+            .map_err(db_err)?
+            .run()
+            .await
+            .map_err(db_err)?;
+
+        // worker-rs 0.7 exposes D1Result::meta().changes (Option<usize>) for
+        // mutations — use it so callers get a real rows_affected, unlike the
+        // older exec_raw path which always returned 0.
+        let changes = result
+            .meta()
+            .map_err(db_err)?
+            .and_then(|m| m.changes)
+            .unwrap_or(0);
+        Ok(changes as i64)
+    }
+
     async fn ensure_schema_table(&self, table: &Table) -> Result<(), DatabaseError> {
         // D1 schema is managed externally via Wrangler migrations
         let _ = table;

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -196,7 +196,6 @@ async fn increment_access_count_atomic(
     max: i64,
 ) -> Result<bool, wafer_run::WaferError> {
     use wafer_core::interfaces::database::service::{Filter, FilterOp};
-    use wafer_sql_utils::{value::sea_values_to_json, Backend};
 
     let mut filters: Vec<Filter> = vec![Filter {
         field: "id".into(),
@@ -210,14 +209,6 @@ async fn increment_access_count_atomic(
             value: serde_json::json!(max),
         });
     }
-    let (sql, vals) = wafer_sql_utils::query::build_increment_field_where(
-        SHARES_TABLE,
-        "access_count",
-        1,
-        &filters,
-        Backend::Sqlite,
-    );
-    let args = sea_values_to_json(vals);
-    let rows = db::exec_raw(ctx, &sql, &args).await?;
+    let rows = db::increment_field_where(ctx, SHARES_TABLE, "access_count", 1, &filters).await?;
     Ok(rows > 0)
 }


### PR DESCRIPTION
## Summary

Producer-side of SEC-056 shipped in wafer-run #142; this is the consumer migration.

- `solobase-cloudflare`: native D1 `increment_field_where` impl. Surfaces real `rows_affected` via `D1Result::meta().changes` (worker-rs 0.7.5 exposes it) instead of always returning 0 like the previous `exec_raw` path.
- `solobase-core/src/blocks/files/share.rs`: replaces the `db::exec_raw` + hardcoded `Backend::Sqlite` call site with `db::increment_field_where`. Drops the unused `wafer_sql_utils::{value, Backend}` imports; behaviour, filters and CAS-cap semantics are unchanged.

## Latent-bug fix on wafer.run (D1)

The pre-existing `exec_raw` path always returned `Ok(0)` on D1 because the old impl never inspected `D1Result::meta().changes`. That made `share.rs`'s `increment_access_count_atomic` always resolve to `Ok(false)` after the atomic UPDATE — the row got bumped, but the caller mis-reported the CAS as 'cap reached' and emitted \"Share link access limit reached\". The new D1 impl wires `meta().changes` through, so `Ok(true)`/`Ok(false)` finally reflects reality on wafer.run. (No new regression on SQLite/Postgres — both already returned real row counts.)

## Test plan

- [x] `cargo check --workspace --exclude solobase --exclude solobase-cloudflare --exclude solobase-web` (native; wasm-only crates excluded as usual)
- [x] `cargo check --target wasm32-unknown-unknown -p solobase-cloudflare -p solobase-web`
- [x] `cargo test -p solobase-core --lib files` — 58 passed
- [x] `bash scripts/audit-wrap-grants.sh` — \"OK — no missing WRAP grants\"
- [x] `cargo +nightly fmt --all -- --check`

## Notes

- Depends on wafer-run #142 (merged).
- Audit-allow pragma count unchanged — share.rs's `exec_raw` was never covered by one, so there's no pragma to drop.
- Removes the last `Backend::Sqlite` hardcode from `share.rs`; the call is now dialect-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)