### PR TITLE
fix(web): eager init blocks after seal so demo auth bootstrap fires

### DIFF
--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -108,6 +108,28 @@ pub async fn initialize() -> Result<(), JsValue> {
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
+    // Eager init pass — mirror of the native CLI (`solobase server`) and
+    // Cloudflare runner. With lazy block init (wafer-run #106-#108), blocks
+    // only run `lifecycle(Init)` on first dispatch. The auth block's
+    // `Init` is what triggers `auth::bootstrap::run` (create the admin user
+    // from `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_{EMAIL,PASSWORD}`), but
+    // the demo login flow routes through `auth_ui` repos+crypto directly
+    // and never dispatches to `suppers-ai/auth` — so without an explicit
+    // eager init the bootstrap never runs and every login returns 401.
+    //
+    // Admin first (its migrations create the variables/block_settings
+    // tables other inits read), then everyone else. Slot caching makes the
+    // second `init_block(admin)` inside `init_all_blocks` a no-op.
+    if let Err(e) = wafer
+        .init_block(solobase_core::blocks::admin::ADMIN_BLOCK_ID)
+        .await
+    {
+        web_sys::console::warn_1(
+            &format!("solobase: admin block Init failed before init_all_blocks: {e}").into(),
+        );
+    }
+    wafer.init_all_blocks().await;
+
     builder::post_start(&wafer, &storage_block);
 
     web_sys::console::log_1(&"solobase: WAFER runtime started".into());


### PR DESCRIPTION
## Summary
Demo login at https://demo.solobase.dev currently returns **401 Unauthenticated** for the displayed `admin@example.com` / `admin123` credentials, even on a fresh browser with no prior OPFS state. Repro: Playwright clean profile → modal CTA → fill creds → Sign In → `POST /b/auth/api/login` 401.

**Root cause:** `crates/solobase-web/src/lib.rs` only called `wafer.seal()` after building the runtime. With lazy block init (wafer-run #106-#108, live on wafer.run since 2026-05-17), blocks now only run `lifecycle(Init)` on first dispatch. The login flow goes through `auth_ui::api::login` calling `users::find_by_email` / `local_credentials::find_by_user_id` / `crypto::compare_hash` / `sessions::create_for_user` directly via repos — it never dispatches a Message to the `suppers-ai/auth` block. The auth block's `Init` is precisely what triggers `auth::bootstrap::run` (the bit that creates the admin user from `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_{EMAIL,PASSWORD}`), so nothing ever bootstrapped the admin and *every* demo login was 401.

The native CLI (`crates/solobase/src/cli/server.rs:170` — `start_with_priority(&[admin])`) and the Cloudflare runner (`crates/solobase-cloudflare/src/lib.rs:248-264` — `init_block(admin)` then `init_all_blocks()`) already work around this for their targets. The browser build was missed — `start_with_priority` itself is `#[cfg(not(target_arch = "wasm32"))]`-gated, but `init_block` + `init_all_blocks` are not, so the CF-style pattern works in WASM.

## Change
After `wafer.seal()` in the browser `initialize()`:
- `init_block(admin)` first so admin's migrations land before any other block reads `variables` / `block_settings`.
- `init_all_blocks()` for everyone else (slot caching no-ops admin's second init).

Per-block init failures are logged-and-tolerated by `init_all_blocks`, matching the CF runner's resilience contract.

## Test plan
- [x] `cd crates/solobase-web && cargo check --target wasm32-unknown-unknown` — clean (4.53s).
- [ ] Build + deploy via `deploy-demo.yml` workflow (auto-fires on push to `main` that touches `crates/solobase-web/**`).
- [ ] On the new deploy, open https://demo.solobase.dev in a clean browser profile, fill `admin@example.com` / `admin123`, Sign In → land in the admin UI instead of 401.
- [ ] Service Worker console should show `auth: bootstrapped admin user: admin@example.com` on first cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)