### PR TITLE
fix(web): align OPFS pre-create schemas with admin migration 001

### DIFF
--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -27,27 +27,31 @@ fn bridge_err(ctx: &str, e: JsValue) -> JsValue {
 /// secrets and previously-stored values.
 pub fn seed_and_load_variables() -> Result<HashMap<String, String>, JsValue> {
     // 1. Create the admin variables table if it does not exist.
-    //    Name matches `crate::blocks::admin::VARIABLES_COLLECTION` so the admin
-    //    block's CollectionSchema (run via wafer.start() migrations) finds the
-    //    same table and no-ops its CREATE TABLE IF NOT EXISTS.
+    //    Schema mirrors admin migration `001_admin_schema.sqlite.sql` *exactly*
+    //    (NOT NULL on every column the migration declares NOT NULL). Earlier
+    //    revisions used a looser pre-create here, which made the admin
+    //    migration's CREATE TABLE IF NOT EXISTS a no-op while still leaving
+    //    the table in place — exactly the schema-drift hazard that caused
+    //    the block_settings 401 bug. Keep this schema in lockstep with
+    //    `crates/solobase-core/src/blocks/admin/migrations/001_admin_schema.sqlite.sql`.
     bridge::db_exec_raw(
         "CREATE TABLE IF NOT EXISTS suppers_ai__admin__variables (
-            id TEXT PRIMARY KEY,
-            key TEXT NOT NULL UNIQUE,
-            name TEXT DEFAULT '',
-            description TEXT DEFAULT '',
-            value TEXT DEFAULT '',
-            warning TEXT DEFAULT '',
-            sensitive INTEGER DEFAULT 0,
-            updated_by TEXT DEFAULT '',
-            created_at TEXT DEFAULT (datetime('now')),
-            updated_at TEXT DEFAULT (datetime('now'))
+            id          TEXT PRIMARY KEY,
+            key         TEXT NOT NULL UNIQUE,
+            name        TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT '',
+            value       TEXT NOT NULL DEFAULT '',
+            warning     TEXT NOT NULL DEFAULT '',
+            sensitive   INTEGER NOT NULL DEFAULT 0,
+            updated_by  TEXT NOT NULL DEFAULT '',
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL
         )",
         "[]",
     )
     .map_err(|e| bridge_err("create variables table", e))?;
     bridge::db_exec_raw(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_suppers_ai__admin__variables_key ON suppers_ai__admin__variables (key)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__admin__variables_key_uniq ON suppers_ai__admin__variables (key)",
         "[]",
     )
     .map_err(|e| bridge_err("create variables key index", e))?;
@@ -161,19 +165,42 @@ fn seed_auto_generated() -> Result<(), JsValue> {
 /// Reads the `suppers_ai__admin__block_settings` table (creating it if needed)
 /// and returns a `BlockSettings` with the enabled/disabled state of each block.
 pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, JsValue> {
-    // Ensure table exists
+    // Ensure the table exists with the **canonical** strict schema from admin
+    // migration `001_admin_schema.sqlite.sql`. Previously this function pre-
+    // created a stale 4-column schema (block_name PK, enabled, timestamps) and
+    // seeded default rows; admin migration 001's CREATE TABLE IF NOT EXISTS
+    // then no-op'd against the existing table, so the migration columns
+    // (`id`, `current_hash`, `blessed_hash`) never landed. The first block to
+    // run `migration_helper::write_state` then found its pre-seeded row,
+    // entered the UPDATE branch, and failed with `no such column:
+    // blessed_hash` — surfacing as `auth migrations: block_settings update:
+    // Internal: internal database error`, which aborted auth's `lifecycle(Init)`
+    // permanently. With auth Init aborted, `auth::bootstrap::run` never ran
+    // and every demo login returned 401. Mirror of the native fix in
+    // solobase #182 (`server_config::load_block_settings`).
     bridge::db_exec_raw(
         "CREATE TABLE IF NOT EXISTS suppers_ai__admin__block_settings (
-            block_name TEXT PRIMARY KEY,
-            enabled INTEGER DEFAULT 1,
-            created_at TEXT DEFAULT (datetime('now')),
-            updated_at TEXT DEFAULT (datetime('now'))
+            id            TEXT PRIMARY KEY,
+            block_name    TEXT NOT NULL UNIQUE,
+            enabled       INTEGER NOT NULL DEFAULT 1,
+            current_hash  TEXT NOT NULL DEFAULT '',
+            blessed_hash  TEXT NOT NULL DEFAULT '',
+            created_at    TEXT NOT NULL,
+            updated_at    TEXT NOT NULL
         )",
         "[]",
     )
     .map_err(|e| bridge_err("create block_settings table", e))?;
+    bridge::db_exec_raw(
+        "CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__admin__block_settings_block_name_uniq \
+         ON suppers_ai__admin__block_settings (block_name)",
+        "[]",
+    )
+    .map_err(|e| bridge_err("create block_settings block_name index", e))?;
 
-    // Seed defaults for known blocks
+    // Seed defaults for known blocks. The strict schema demands `id`,
+    // `created_at`, `updated_at` — generate them inline via SQLite builtins
+    // so the seed remains a one-shot SQL statement per block.
     let defaults: &[(&str, bool)] = &[
         ("suppers-ai/auth", true),
         ("suppers-ai/admin", true),
@@ -187,7 +214,9 @@ pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, J
     for &(name, default) in defaults {
         let params = serde_json::json!([name, default as i32]);
         bridge::db_exec_raw(
-            "INSERT OR IGNORE INTO suppers_ai__admin__block_settings (block_name, enabled) VALUES (?, ?)",
+            "INSERT OR IGNORE INTO suppers_ai__admin__block_settings \
+             (id, block_name, enabled, created_at, updated_at) \
+             VALUES (lower(hex(randomblob(16))), ?, ?, datetime('now'), datetime('now'))",
             &params.to_string(),
         )
         .map_err(|e| bridge_err(&format!("seed block_setting {name}"), e))?;


### PR DESCRIPTION
## Summary

After [#209](https://github.com/suppers-ai/solobase/pull/209) wired eager `init_block(admin) + init_all_blocks` into the browser runtime, the demo at https://demo.solobase.dev still returned **401** on `POST /b/auth/api/login` for the seeded `admin@example.com` / `admin123`. Verified Playwright-fresh: signup of an arbitrary user succeeded (auth machinery is healthy), proving only the bootstrap admin was missing.

Built locally with diagnostic instrumentation. Re-calling `wafer.init_block(\"suppers-ai/auth\")` after `init_all_blocks` surfaced the cached `InitError`:

```
permanent init failure: lifecycle init failed:
Internal: auth migrations: block_settings update:
Internal: internal database error
```

**Root cause — same schema-drift class as solobase [#182](https://github.com/suppers-ai/solobase/pull/182), one repo over.** `solobase-web/src/config.rs::load_block_settings()` pre-created `suppers_ai__admin__block_settings` with a stale 4-column schema (`block_name PK, enabled, created_at, updated_at`) and seeded default rows for `suppers-ai/{auth,admin,files,products,legalpages,userportal,system}`. Then admin migration `001_admin_schema.sqlite.sql` ran `CREATE TABLE IF NOT EXISTS` — a no-op against the already-existing stale table — so the migration's `id`, `current_hash`, `blessed_hash` columns never landed.

The first block to run `migration_helper::write_state` (auth, in our case) then:
1. `upsert_block_settings_fields(auth, {current_hash, blessed_hash})` listed the table, found the pre-seeded `block_name = 'suppers-ai/auth'` row,
2. took the `db::update(table, &id, patch)` branch (`crates/solobase-core/src/migration_helper.rs:186-188`),
3. failed with `internal database error` because the table had no `id` column to key on,
4. propagated permanently up auth's `lifecycle(Init)` (strict propagation was the other half of [#182](https://github.com/suppers-ai/solobase/pull/182)),
5. `auth::bootstrap::run` never executed → no admin user → every demo login 401.

Native took the escape of deleting the pre-create entirely and relying on lazy admin Init ([#182](https://github.com/suppers-ai/solobase/pull/182)'s `server_config::load_block_settings` rewrite). WASM still needs the pre-create because `seed_and_load_variables()` + `load_block_settings()` run *before* the wafer builder consumes vars + features — there's no `init_block(admin)` to lean on yet — so we lock the pre-create schema into lockstep with admin migration 001 instead.

## Change

- `load_block_settings()`: rewrite the `CREATE TABLE IF NOT EXISTS` to match `crates/solobase-core/src/blocks/admin/migrations/001_admin_schema.sqlite.sql` *exactly* (id PK, NOT NULL on every column the migration declares NOT NULL, matching unique index). Update the seed `INSERT OR IGNORE` to provide `id` (`lower(hex(randomblob(16)))`), `created_at`, `updated_at`.
- `seed_and_load_variables()`: same drift, just hadn't bitten yet. Strict-schema the `suppers_ai__admin__variables` pre-create. Index name aligned to the migration's `suppers_ai__admin__variables_key_uniq`.

## Test plan

- [x] `cd crates/solobase-web && cargo check --target wasm32-unknown-unknown` — clean.
- [x] `solobase build --target web --release` + `solobase serve --target web --port 8765` → Playwright wipe OPFS + SW → `POST /b/auth/api/login` with `admin@example.com` / `admin123` → **200** with `roles: [\"admin\"]` JWT.
- [ ] Auto-deploy via `deploy-demo.yml` (touches `crates/solobase-web/**`).
- [ ] Clean-browser visit to https://demo.solobase.dev with `admin@example.com` / `admin123` → land in admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)