### PR TITLE
fix(web,browser): break stale-OPFS recovery loop on demo

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -11,9 +11,17 @@ async function boot() {
     }
 
     // Recovery path: a previous boot's SW self-destructed and signalled the
-    // page to set the breaker. Wipe all SW + cache state, force a fresh
-    // document fetch via a cache-busting query string, and let the next
-    // load proceed normally.
+    // page to set the breaker. Wipe all SW + cache state AND clear OPFS,
+    // force a fresh document fetch via a cache-busting query string, and let
+    // the next load proceed normally.
+    //
+    // OPFS wipe is the critical step for any schema-drift class of bug: if
+    // the OPFS DB was written by a prior build with an incompatible schema,
+    // re-registering the SW against the same OPFS will keep failing
+    // `initialize()` and re-entering recovery forever (caches + SW are
+    // already innocent in that scenario). For a browser-local demo this
+    // costs the user's local rows but breaks the loop; that trade-off is
+    // why self-destruct fires in the first place.
     if (sessionStorage.getItem(SW_RECOVER_KEY)) {
         sessionStorage.removeItem(SW_RECOVER_KEY);
         status.textContent = 'Recovering from stale cache...';
@@ -24,6 +32,16 @@ async function boot() {
             for (const k of keys) await caches.delete(k);
         } catch (e) {
             console.error('[__APP_NAME__] cache wipe failed:', e);
+        }
+        try {
+            if (navigator.storage && navigator.storage.getDirectory) {
+                const root = await navigator.storage.getDirectory();
+                for await (const [name] of root.entries()) {
+                    await root.removeEntry(name, { recursive: true });
+                }
+            }
+        } catch (e) {
+            console.error('[__APP_NAME__] OPFS wipe failed:', e);
         }
         const url = new URL(window.location.href);
         url.searchParams.set('_freshen', String(Date.now()));

--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -165,6 +165,35 @@ fn seed_auto_generated() -> Result<(), JsValue> {
 /// Reads the `suppers_ai__admin__block_settings` table (creating it if needed)
 /// and returns a `BlockSettings` with the enabled/disabled state of each block.
 pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, JsValue> {
+    // First-time migration: users who visited a build before solobase #210
+    // have a stale 4-column `suppers_ai__admin__block_settings` table
+    // (block_name PK, enabled, created_at, updated_at). `CREATE TABLE IF
+    // NOT EXISTS` below would no-op against it and the seed `INSERT` would
+    // then fail with `no such column: id` — propagating up as an
+    // `initialize()` error, which makes sw.js self-destruct, but loader.js's
+    // recovery only wipes SW + Cache Storage, never OPFS, so the next page
+    // load lands on the same stale schema and the loop repeats forever.
+    //
+    // Detect the stale schema via `pragma_table_info` and drop the table so
+    // the strict CREATE below installs the canonical schema. Block_settings
+    // is runtime state (enabled flags + per-block migration hashes), not
+    // user data — losing the pre-seeded rows on this one-shot migration is
+    // acceptable; they get re-seeded below from `defaults`.
+    let table_info = bridge::db_query_raw(
+        "SELECT name FROM pragma_table_info('suppers_ai__admin__block_settings')",
+        "[]",
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+    let table_exists = table_info != "[]" && !table_info.is_empty();
+    let has_id_column = table_info.contains("\"id\"");
+    if table_exists && !has_id_column {
+        bridge::db_exec_raw(
+            "DROP TABLE IF EXISTS suppers_ai__admin__block_settings",
+            "[]",
+        )
+        .map_err(|e| bridge_err("drop stale block_settings table", e))?;
+    }
+
     // Ensure the table exists with the **canonical** strict schema from admin
     // migration `001_admin_schema.sqlite.sql`. Previously this function pre-
     // created a stale 4-column schema (block_name PK, enabled, timestamps) and


### PR DESCRIPTION
## Summary

User report: after [#210](https://github.com/suppers-ai/solobase/pull/210) landed and re-deployed `demo.solobase.dev`, anyone who had visited an earlier broken build hit an **infinite reload loop** instead of the working login.

Trace:

1. The user's OPFS held the pre-[#210](https://github.com/suppers-ai/solobase/pull/210) stale-schema `suppers_ai__admin__block_settings` table (`block_name PK` only — no `id`/`current_hash`/`blessed_hash`).
2. The new build's `load_block_settings()` ran `CREATE TABLE IF NOT EXISTS` against the existing table → no-op.
3. The seed `INSERT OR IGNORE INTO ... (id, ...)` then failed with `no such column: id` and propagated up `initialize()` as `Err`.
4. `sw.js` caught the error and called `selfDestruct()` — unregister + `postMessage('sw-self-destruct')` + `clients.navigate(c.url)`.
5. `loader.js`'s recovery path wiped SW registrations + Cache Storage and reloaded with a `_freshen` busted URL — **but never touched OPFS**.
6. The reload re-registered the SW against the same stale OPFS, `initialize()` failed identically, self-destruct fired again, loop forever.

Fresh-OPFS users (e.g. clean Playwright contexts in the [#210](https://github.com/suppers-ai/solobase/pull/210) verification) had nothing to migrate from, so the bug didn't surface during PR verification.

## Change

Two complementary fixes:

* **`crates/solobase-web/src/config.rs`** — `load_block_settings()` now detects the stale schema via `pragma_table_info('suppers_ai__admin__block_settings')` (no `id` column means a pre-#210 pre-create wrote it) and `DROP`s the table before the canonical `CREATE TABLE` installs the strict schema. The `defaults` block then re-seeds the rows. `block_settings` is runtime state (enabled flags + per-block migration hashes), not user data, so the one-shot drop is acceptable.
* **`crates/solobase-browser/assets/loader.js.tmpl`** — the recovery path now also clears OPFS (iterate `navigator.storage.getDirectory()` entries, `removeEntry` recursive). Defense-in-depth: any future schema-drift class of bug that survives the SW + Cache wipe but re-fails against the same OPFS now self-resolves on the recovery reload instead of looping. This is exactly the bug class the self-destruct mechanism exists to handle in the first place — wiping OPFS belongs in the same recovery pass.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` — clean.
- [x] `solobase build --target web --release` + `solobase serve` → Playwright fresh OPFS → `POST /b/auth/api/login admin@example.com / admin123` → **200**.
- [ ] On the new deploy, an old-build visitor's tab should: (a) hit recovery once (cleared OPFS), then (b) cold-init the new build and land on the login page rather than looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)