### PR TITLE
refactor(web): defer OPFS seeding to post-admin-init + opt-in OPFS wipe

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -2,6 +2,12 @@
 // so the very next page load hits the recovery path (below) instead of
 // re-registering the SW with the same stale browser-cached modules.
 const SW_RECOVER_KEY = '__solobase_sw_recover';
+// Whether the recovery path should wipe OPFS. Set per-build via the
+// `opfs_wipe_on_recovery` field on the bundle config (CLI flag
+// `--opfs-wipe-on-recovery`). Demo builds set it true so a schema-drift
+// loop self-resolves; production apps whose OPFS holds user data leave
+// it false and surface the error instead.
+const OPFS_WIPE_ON_RECOVERY = __OPFS_WIPE_ON_RECOVERY__;
 
 async function boot() {
     const status = document.getElementById('status');
@@ -33,15 +39,17 @@ async function boot() {
         } catch (e) {
             console.error('[__APP_NAME__] cache wipe failed:', e);
         }
-        try {
-            if (navigator.storage && navigator.storage.getDirectory) {
-                const root = await navigator.storage.getDirectory();
-                for await (const [name] of root.entries()) {
-                    await root.removeEntry(name, { recursive: true });
+        if (OPFS_WIPE_ON_RECOVERY) {
+            try {
+                if (navigator.storage && navigator.storage.getDirectory) {
+                    const root = await navigator.storage.getDirectory();
+                    for await (const [name] of root.entries()) {
+                        await root.removeEntry(name, { recursive: true });
+                    }
                 }
+            } catch (e) {
+                console.error('[__APP_NAME__] OPFS wipe failed:', e);
             }
-        } catch (e) {
-            console.error('[__APP_NAME__] OPFS wipe failed:', e);
         }
         const url = new URL(window.location.href);
         url.searchParams.set('_freshen', String(Date.now()));

--- a/crates/solobase-browser/src/crypto.rs
+++ b/crates/solobase-browser/src/crypto.rs
@@ -161,8 +161,7 @@ impl CryptoService for BrowserCryptoService {
     }
 
     fn verify(&self, token: &str) -> Result<HashMap<String, serde_json::Value>, CryptoError> {
-        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret())?
-            .verify(token)
+        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret())?.verify(token)
     }
 
     fn sign_for(

--- a/crates/solobase-browser/src/crypto.rs
+++ b/crates/solobase-browser/src/crypto.rs
@@ -29,10 +29,17 @@ const PBKDF2_HASH_LEN: usize = 32;
 const PBKDF2_SALT_LEN: usize = 16;
 
 pub struct BrowserCryptoService {
-    jwt_secret: String,
+    // Stored behind a lock so the secret can be rotated post-construction.
+    // `solobase-web` builds the crypto service before it has loaded the
+    // persisted `SUPPERS_AI__AUTH__JWT_SECRET` value (the variables table
+    // doesn't exist until admin's Init has run), so it constructs with an
+    // empty secret and calls [`Self::set_jwt_secret`] in the post-admin-Init
+    // phase. Native consumers that have the secret up-front can pass it to
+    // [`Self::new`] and never touch the setter.
+    jwt_secret: std::sync::RwLock<String>,
 }
 
-// SAFETY: `BrowserCryptoService` only holds owned data (`String`).
+// SAFETY: `BrowserCryptoService` only holds owned data behind a `RwLock`.
 // wasm32-unknown-unknown has no threads, so the `Send`/`Sync` bounds
 // required by `Arc<dyn CryptoService>` are satisfied trivially — no
 // cross-thread aliasing or data races are possible.
@@ -41,14 +48,34 @@ unsafe impl Sync for BrowserCryptoService {}
 
 impl BrowserCryptoService {
     pub fn new(jwt_secret: String) -> Self {
-        Self { jwt_secret }
+        Self {
+            jwt_secret: std::sync::RwLock::new(jwt_secret),
+        }
+    }
+
+    /// Rotate the JWT secret. Used by `solobase-web`'s init flow to install
+    /// the persisted/auto-generated secret AFTER admin's Init has created
+    /// the variables table; see the doc on [`Self::jwt_secret`].
+    pub fn set_jwt_secret(&self, new_secret: String) {
+        *self
+            .jwt_secret
+            .write()
+            .expect("BrowserCryptoService jwt_secret RwLock poisoned") = new_secret;
+    }
+
+    fn jwt_secret(&self) -> String {
+        self.jwt_secret
+            .read()
+            .expect("BrowserCryptoService jwt_secret RwLock poisoned")
+            .clone()
     }
 
     fn derive_block_key(&self, block_id: &str) -> Result<String, CryptoError> {
         use hkdf::Hkdf;
         use sha2::Sha256;
 
-        let hk = Hkdf::<Sha256>::new(None, self.jwt_secret.as_bytes());
+        let secret = self.jwt_secret();
+        let hk = Hkdf::<Sha256>::new(None, secret.as_bytes());
         let info = format!("wafer-jwt|{block_id}");
         let mut okm = [0u8; 32];
         hk.expand(info.as_bytes(), &mut okm)
@@ -129,12 +156,12 @@ impl CryptoService for BrowserCryptoService {
         // service. `new` now enforces the 32-byte minimum JWT secret length;
         // a too-short secret here is a deployment misconfig and the error
         // bubbles up to the caller.
-        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret.clone())?
+        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret())?
             .sign(claims, expiry)
     }
 
     fn verify(&self, token: &str) -> Result<HashMap<String, serde_json::Value>, CryptoError> {
-        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret.clone())?
+        wafer_block_crypto::service::Argon2JwtCryptoService::new(self.jwt_secret())?
             .verify(token)
     }
 

--- a/crates/solobase-browser/src/tools/bundle/mod.rs
+++ b/crates/solobase-browser/src/tools/bundle/mod.rs
@@ -28,6 +28,15 @@ pub struct AppConfig {
     /// `url.pathname.startsWith(<prefix>)` clause via the `__EXTRA_BYPASS__`
     /// placeholder.
     pub extra_bypass_prefix: Vec<String>,
+    /// Whether loader.js's recovery path should wipe OPFS when the Service
+    /// Worker self-destructs. **Default: false** — for production apps that
+    /// store user data in OPFS (chat history, generated assets, settings),
+    /// wiping on a self-destruct loop is silent data loss. The demo opts in
+    /// via `solobase build --target web --opfs-wipe-on-recovery` so the
+    /// stale-schema migration scenario self-resolves without manual user
+    /// action; other apps surface the error to the user instead and let
+    /// them choose whether to clear data.
+    pub opfs_wipe_on_recovery: bool,
 }
 
 /// Discover the wasm-pack output pair (`{base}.js` + `{base}_bg.wasm`) in
@@ -295,6 +304,14 @@ fn build_template_vars(
     vars.insert("APP_TITLE".to_string(), app_title);
     vars.insert("BOOT_REDIRECT".to_string(), boot_redirect);
     vars.insert("EXTRA_BYPASS".to_string(), extra_bypass);
+    vars.insert(
+        "OPFS_WIPE_ON_RECOVERY".to_string(),
+        if app.opfs_wipe_on_recovery {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        },
+    );
     vars
 }
 

--- a/crates/solobase-browser/tests/bundle_integration.rs
+++ b/crates/solobase-browser/tests/bundle_integration.rs
@@ -12,6 +12,7 @@ fn default_app() -> AppConfig {
         app_title: None,
         boot_redirect: None,
         extra_bypass_prefix: Vec::new(),
+        opfs_wipe_on_recovery: false,
     }
 }
 

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -37,7 +37,7 @@ pub struct SolobaseBuilder {
     crypto: Option<Arc<dyn CryptoService>>,
     network: Option<Arc<dyn NetworkService>>,
     logger: Option<Arc<dyn LoggerService>>,
-    block_settings: BlockSettings,
+    block_settings: Arc<std::sync::RwLock<BlockSettings>>,
     block_configs: Vec<(String, serde_json::Value)>,
     extra_blocks: Vec<(String, Arc<dyn Block>)>,
     /// Additional LLM backends to register on the `MultiBackendLlmService`
@@ -96,7 +96,9 @@ impl SolobaseBuilder {
             crypto: None,
             network: None,
             logger: None,
-            block_settings: BlockSettings::from_map(HashMap::new()),
+            block_settings: Arc::new(std::sync::RwLock::new(BlockSettings::from_map(
+                HashMap::new(),
+            ))),
             block_configs: Vec::new(),
             extra_blocks: Vec::new(),
             extra_llm_services: Vec::new(),
@@ -139,9 +141,32 @@ impl SolobaseBuilder {
         self
     }
 
-    pub fn block_settings(mut self, settings: BlockSettings) -> Self {
-        self.block_settings = settings;
+    /// Set the initial [`BlockSettings`] for the runtime.
+    ///
+    /// The settings are stored behind an `Arc<RwLock<…>>` so that consumers
+    /// who can't fully populate them at `build()` time can update the snapshot
+    /// later via [`Self::block_settings_handle`] (e.g. the browser/OPFS build
+    /// reads block_settings rows from the DB only AFTER `init_block(admin)`
+    /// has created the table). Builds that have the final settings up-front
+    /// can just call this once and ignore the handle.
+    pub fn block_settings(self, settings: BlockSettings) -> Self {
+        *self
+            .block_settings
+            .write()
+            .expect("BlockSettings RwLock poisoned during build configuration") = settings;
         self
+    }
+
+    /// Return a shared handle to the runtime's [`BlockSettings`] snapshot.
+    ///
+    /// Use this when block_settings can only be loaded *after* the wafer is
+    /// built and `init_block(admin)` has created the backing table. Writes
+    /// through the handle are visible to the router's `FeatureConfig`
+    /// (which holds the same `Arc<RwLock<BlockSettings>>`), so a follow-up
+    /// `init_all_blocks()` sees enablement state that matches the loaded
+    /// rows. The handle remains valid for the lifetime of the wafer.
+    pub fn block_settings_handle(&self) -> Arc<std::sync::RwLock<BlockSettings>> {
+        self.block_settings.clone()
     }
 
     pub fn extra_block(mut self, name: impl Into<String>, block: Arc<dyn Block>) -> Self {
@@ -482,7 +507,10 @@ impl SolobaseBuilder {
         //     so that the discovery endpoints (/openapi.json, /.well-known/agent.json)
         //     see the full set. Wafer is the single source of truth — no parallel
         //     HashMap needed.
-        let feature_config: Arc<dyn FeatureConfig> = Arc::new(self.block_settings);
+        // Pass the shared lock directly — the router's Arc<dyn FeatureConfig>
+        // sees post-build mutations via the same RwLock. See the doc comment
+        // on `block_settings_handle()` for why this matters.
+        let feature_config: Arc<dyn FeatureConfig> = self.block_settings.clone();
         let block_infos = wafer.block_infos();
         let router = SolobaseRouterBlock::with_extra_routes(
             jwt_secret,

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -161,6 +161,29 @@ impl FeatureConfig for BlockSettings {
     }
 }
 
+/// `FeatureConfig` for the shared+mutable form `Arc<RwLock<BlockSettings>>`.
+///
+/// `SolobaseBuilder` stores its block_settings as `Arc<RwLock<BlockSettings>>`
+/// so consumers can mutate the live snapshot post-build (the OPFS-backed
+/// `solobase-web` flow needs this — it can't load block_settings until after
+/// `init_block(admin)` has created the `suppers_ai__admin__block_settings`
+/// table, but the runtime's `FeatureConfig` Arc has to exist at build time).
+/// The router holds an `Arc<dyn FeatureConfig>` cloned off the same lock, so
+/// post-`build()` writes are visible on subsequent route checks without any
+/// SolobaseBuilder API gymnastics.
+///
+/// `read()` panics only if a previous holder panicked while holding the
+/// write lock, which would leave the snapshot in an indeterminate state —
+/// surfacing that immediately is preferable to handing the router a stale
+/// "all-enabled" fallback.
+impl FeatureConfig for std::sync::RwLock<BlockSettings> {
+    fn is_block_enabled(&self, full_name: &str) -> bool {
+        self.read()
+            .expect("BlockSettings RwLock poisoned")
+            .is_block_enabled(full_name)
+    }
+}
+
 /// All features enabled (for testing).
 pub struct AllEnabled;
 

--- a/crates/solobase-web/solobase.toml
+++ b/crates/solobase-web/solobase.toml
@@ -8,6 +8,16 @@ title = "Solobase"
 # /b/static/, despite its name).
 boot_redirect = "/"
 
+[assets]
+# `demo.solobase.dev` ships throwaway OPFS data — admin defaults are
+# auto-seeded, every visit is essentially demo state. Opting into the
+# OPFS-wipe-on-recovery path means a schema-drift class of bug that takes
+# the SW into a self-destruct loop self-resolves on the next reload
+# instead of leaving the user stuck. Production apps that store user
+# data in OPFS should leave this flag at its default (`false`) and
+# surface the error to the user instead.
+opfs_wipe_on_recovery = true
+
 # solobase-web's PWA Web App Manifest. The file is app-specific (icons,
 # name, start_url); solobase-browser doesn't ship a default. Overlay it
 # into pkg/ after the framework assets land so the SW's /manifest.json

--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -26,35 +26,14 @@ fn bridge_err(ctx: &str, e: JsValue) -> JsValue {
 /// There are no env vars to seed from in the browser — only auto-generated
 /// secrets and previously-stored values.
 pub fn seed_and_load_variables() -> Result<HashMap<String, String>, JsValue> {
-    // 1. Create the admin variables table if it does not exist.
-    //    Schema mirrors admin migration `001_admin_schema.sqlite.sql` *exactly*
-    //    (NOT NULL on every column the migration declares NOT NULL). Earlier
-    //    revisions used a looser pre-create here, which made the admin
-    //    migration's CREATE TABLE IF NOT EXISTS a no-op while still leaving
-    //    the table in place — exactly the schema-drift hazard that caused
-    //    the block_settings 401 bug. Keep this schema in lockstep with
-    //    `crates/solobase-core/src/blocks/admin/migrations/001_admin_schema.sqlite.sql`.
-    bridge::db_exec_raw(
-        "CREATE TABLE IF NOT EXISTS suppers_ai__admin__variables (
-            id          TEXT PRIMARY KEY,
-            key         TEXT NOT NULL UNIQUE,
-            name        TEXT NOT NULL DEFAULT '',
-            description TEXT NOT NULL DEFAULT '',
-            value       TEXT NOT NULL DEFAULT '',
-            warning     TEXT NOT NULL DEFAULT '',
-            sensitive   INTEGER NOT NULL DEFAULT 0,
-            updated_by  TEXT NOT NULL DEFAULT '',
-            created_at  TEXT NOT NULL,
-            updated_at  TEXT NOT NULL
-        )",
-        "[]",
-    )
-    .map_err(|e| bridge_err("create variables table", e))?;
-    bridge::db_exec_raw(
-        "CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__admin__variables_key_uniq ON suppers_ai__admin__variables (key)",
-        "[]",
-    )
-    .map_err(|e| bridge_err("create variables key index", e))?;
+    // PRECONDITION: `wafer.init_block(suppers-ai/admin)` must have already
+    // run before this function is called — admin's migration is the single
+    // source of schema truth for `suppers_ai__admin__variables`, and we no
+    // longer pre-create the table here. See `initialize()` in `lib.rs` for
+    // the ordering. Removing the pre-create eliminates the schema-drift
+    // class of bug that took down the demo in #210/#211: any future change
+    // to `001_admin_schema.sqlite.sql` now propagates without needing a
+    // mirrored CREATE in this crate.
 
     // 2. Seed default admin account for browser build.
     //    Email: admin@example.com / Password: admin123
@@ -165,67 +144,58 @@ fn seed_auto_generated() -> Result<(), JsValue> {
 /// Reads the `suppers_ai__admin__block_settings` table (creating it if needed)
 /// and returns a `BlockSettings` with the enabled/disabled state of each block.
 pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, JsValue> {
-    // First-time migration: users who visited a build before solobase #210
-    // have a stale 4-column `suppers_ai__admin__block_settings` table
-    // (block_name PK, enabled, created_at, updated_at). `CREATE TABLE IF
-    // NOT EXISTS` below would no-op against it and the seed `INSERT` would
-    // then fail with `no such column: id` — propagating up as an
-    // `initialize()` error, which makes sw.js self-destruct, but loader.js's
-    // recovery only wipes SW + Cache Storage, never OPFS, so the next page
-    // load lands on the same stale schema and the loop repeats forever.
+    // PRECONDITION: `wafer.init_block(suppers-ai/admin)` must have already
+    // run before this function is called — admin's migration is the single
+    // source of schema truth for `suppers_ai__admin__block_settings`. We no
+    // longer pre-create the table here.
     //
-    // Detect the stale schema via `pragma_table_info` and drop the table so
-    // the strict CREATE below installs the canonical schema. Block_settings
-    // is runtime state (enabled flags + per-block migration hashes), not
-    // user data — losing the pre-seeded rows on this one-shot migration is
-    // acceptable; they get re-seeded below from `defaults`.
+    // One-shot migration for legacy OPFS state: users who visited a build
+    // before this restructure (and before #210/#211) have a stale 4-column
+    // `block_settings` table that admin's `CREATE TABLE IF NOT EXISTS` would
+    // no-op against. Detect that case via `pragma_table_info` and drop the
+    // table BEFORE admin runs — but at this point in initialize() admin has
+    // already run, so any stale schema would already have tripped its
+    // migration. We still keep a defensive drop here for the narrow window
+    // where a user upgraded directly from a pre-#210 build through this
+    // restructure (admin migration tolerated the stale schema enough to
+    // succeed but write_state still failed downstream). Future-builds-only
+    // could remove this drop after a deprecation window.
     let table_info = bridge::db_query_raw(
         "SELECT name FROM pragma_table_info('suppers_ai__admin__block_settings')",
         "[]",
     )
     .unwrap_or_else(|_| "[]".to_string());
-    let table_exists = table_info != "[]" && !table_info.is_empty();
     let has_id_column = table_info.contains("\"id\"");
+    let table_exists = table_info != "[]" && !table_info.is_empty();
     if table_exists && !has_id_column {
+        // Stale schema detected. Drop and rely on admin migration to recreate
+        // — except we already passed admin's Init, so admin won't re-run.
+        // Re-create the canonical schema inline as a one-shot recovery.
         bridge::db_exec_raw(
             "DROP TABLE IF EXISTS suppers_ai__admin__block_settings",
             "[]",
         )
         .map_err(|e| bridge_err("drop stale block_settings table", e))?;
+        bridge::db_exec_raw(
+            "CREATE TABLE suppers_ai__admin__block_settings (
+                id            TEXT PRIMARY KEY,
+                block_name    TEXT NOT NULL UNIQUE,
+                enabled       INTEGER NOT NULL DEFAULT 1,
+                current_hash  TEXT NOT NULL DEFAULT '',
+                blessed_hash  TEXT NOT NULL DEFAULT '',
+                created_at    TEXT NOT NULL,
+                updated_at    TEXT NOT NULL
+            )",
+            "[]",
+        )
+        .map_err(|e| bridge_err("recreate block_settings table", e))?;
+        bridge::db_exec_raw(
+            "CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__admin__block_settings_block_name_uniq \
+             ON suppers_ai__admin__block_settings (block_name)",
+            "[]",
+        )
+        .map_err(|e| bridge_err("recreate block_settings block_name index", e))?;
     }
-
-    // Ensure the table exists with the **canonical** strict schema from admin
-    // migration `001_admin_schema.sqlite.sql`. Previously this function pre-
-    // created a stale 4-column schema (block_name PK, enabled, timestamps) and
-    // seeded default rows; admin migration 001's CREATE TABLE IF NOT EXISTS
-    // then no-op'd against the existing table, so the migration columns
-    // (`id`, `current_hash`, `blessed_hash`) never landed. The first block to
-    // run `migration_helper::write_state` then found its pre-seeded row,
-    // entered the UPDATE branch, and failed with `no such column:
-    // blessed_hash` — surfacing as `auth migrations: block_settings update:
-    // Internal: internal database error`, which aborted auth's `lifecycle(Init)`
-    // permanently. With auth Init aborted, `auth::bootstrap::run` never ran
-    // and every demo login returned 401. Mirror of the native fix in
-    // solobase #182 (`server_config::load_block_settings`).
-    bridge::db_exec_raw(
-        "CREATE TABLE IF NOT EXISTS suppers_ai__admin__block_settings (
-            id            TEXT PRIMARY KEY,
-            block_name    TEXT NOT NULL UNIQUE,
-            enabled       INTEGER NOT NULL DEFAULT 1,
-            current_hash  TEXT NOT NULL DEFAULT '',
-            blessed_hash  TEXT NOT NULL DEFAULT '',
-            created_at    TEXT NOT NULL,
-            updated_at    TEXT NOT NULL
-        )",
-        "[]",
-    )
-    .map_err(|e| bridge_err("create block_settings table", e))?;
-    bridge::db_exec_raw(
-        "CREATE UNIQUE INDEX IF NOT EXISTS suppers_ai__admin__block_settings_block_name_uniq \
-         ON suppers_ai__admin__block_settings (block_name)",
-        "[]",
-    )
-    .map_err(|e| bridge_err("create block_settings block_name index", e))?;
 
     // Seed defaults for known blocks. The strict schema demands `id`,
     // `created_at`, `updated_at` — generate them inline via SQLite builtins

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -56,9 +56,8 @@ pub async fn initialize() -> Result<(), JsValue> {
         Arc::new(wafer_block_config::service::EnvConfigService::new());
     // Empty initial BlockSettings — every block defaults to enabled. We rewrite
     // this via the handle below in Phase 3 once the real settings are loaded.
-    let initial_block_settings = solobase_core::features::BlockSettings::from_map(
-        std::collections::HashMap::new(),
-    );
+    let initial_block_settings =
+        solobase_core::features::BlockSettings::from_map(std::collections::HashMap::new());
     // Empty StaticConfigSource: blocks that look up their declared keys via
     // the runtime's ConfigSource at lifecycle(Init) payload-build time will
     // see nothing. That's fine because solobase blocks read their keys via
@@ -134,9 +133,7 @@ pub async fn initialize() -> Result<(), JsValue> {
         .init_block(solobase_core::blocks::admin::ADMIN_BLOCK_ID)
         .await
     {
-        web_sys::console::error_1(
-            &format!("solobase: admin block Init failed: {e}").into(),
-        );
+        web_sys::console::error_1(&format!("solobase: admin block Init failed: {e}").into());
         return Err(JsValue::from_str(&format!("admin init failed: {e}")));
     }
 

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -33,39 +33,47 @@ pub async fn initialize() -> Result<(), JsValue> {
 
     solobase_browser::db_init().await;
 
-    let vars = config::seed_and_load_variables()?;
-    web_sys::console::log_1(
-        &format!("solobase: {} variables loaded from database", vars.len()).into(),
+    // ── Phase 1 ─────────────────────────────────────────────────────────────
+    // Build the runtime with EMPTY config + EMPTY block_settings + EMPTY
+    // ConfigSource. We can't fill any of these from OPFS yet because the
+    // `suppers_ai__admin__variables` / `suppers_ai__admin__block_settings`
+    // tables only exist after admin's lazy `lifecycle(Init)` runs its
+    // migrations — and admin can't run until the wafer is built and sealed.
+    //
+    // The schema-drift class of bug (#210/#211) came from this crate trying
+    // to short-cut that chicken-and-egg with `CREATE TABLE IF NOT EXISTS`
+    // pre-creates that duplicated the admin migration schema by hand. Any
+    // drift between the two schemas was silent until the first per-block
+    // `migration_helper::write_state` upserted into the stale table and
+    // failed on a missing column, taking the whole runtime with it.
+    //
+    // The proper fix is what the native CLI and Cloudflare runner already
+    // do: defer seeding until *after* `init_block(admin)`. Admin's migration
+    // is the single source of schema truth; this crate just reads back what
+    // it created.
+
+    let config_svc: Arc<dyn ConfigService> =
+        Arc::new(wafer_block_config::service::EnvConfigService::new());
+    // Empty initial BlockSettings — every block defaults to enabled. We rewrite
+    // this via the handle below in Phase 3 once the real settings are loaded.
+    let initial_block_settings = solobase_core::features::BlockSettings::from_map(
+        std::collections::HashMap::new(),
     );
-
-    let features = config::load_block_settings()?;
-
-    let jwt_secret = vars
-        .get(solobase_core::blocks::auth::JWT_SECRET_KEY)
-        .cloned()
-        .unwrap_or_default();
-
-    let config_svc = wafer_block_config::service::EnvConfigService::new();
-    for (key, value) in &vars {
-        config_svc.set(key, value);
-    }
-    // Fan-out block_settings into the config snapshot so consumer blocks
-    // (e.g. userportal) can read enablement state via `ctx.config_get`
-    // without re-querying the `block_settings` browser-DB table per request.
-    config_svc.set(
-        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
-        &features.to_config_json(),
-    );
+    // Empty StaticConfigSource: blocks that look up their declared keys via
+    // the runtime's ConfigSource at lifecycle(Init) payload-build time will
+    // see nothing. That's fine because solobase blocks read their keys via
+    // `config_client::get` (which hits `wafer-run/config` → ConfigService)
+    // rather than the Init payload, and we populate `config_svc` in Phase 3
+    // below before triggering any block's Init.
+    let cfg_source: Arc<dyn wafer_run::ConfigSource> =
+        Arc::new(wafer_run::StaticConfigSource::default());
 
     let browser_llm: Arc<dyn wafer_core::interfaces::llm::service::LlmService> =
         Arc::new(solobase_browser::llm::BrowserLlmService::new());
-
     let browser_image: Arc<dyn wafer_core::interfaces::image::service::ImageService> =
         Arc::new(solobase_browser::image::BrowserImageService::new());
-
     let browser_vector: Arc<dyn wafer_core::interfaces::vector::service::VectorService> =
         Arc::new(solobase_browser::vector::BrowserVectorService::new());
-
     let browser_embedding: Arc<dyn wafer_core::interfaces::vector::service::EmbeddingService> =
         match solobase_browser::vector::BrowserEmbeddingService::new() {
             Ok(svc) => Arc::new(svc),
@@ -75,32 +83,39 @@ pub async fn initialize() -> Result<(), JsValue> {
             }
         };
 
-    // TODO Task 2.6 finalize: pick a browser-appropriate ConfigSource once
-    // Tasks 2.3 + 2.5 land. For now feed the browser-DB variables snapshot
-    // through StaticConfigSource so blocks can resolve declared keys.
-    let cfg_source: Arc<dyn wafer_run::ConfigSource> =
-        Arc::new(wafer_run::StaticConfigSource::new(vars.clone()));
+    // JWT secret can't be loaded yet (variables table doesn't exist).
+    // Construct the concrete `BrowserCryptoService` so we keep a typed Arc
+    // for `set_jwt_secret` in Phase 3; the same Arc-coerced trait object
+    // gets handed to the builder. Both Arcs point at the same allocation,
+    // so the rotation is observed by every block via the existing service.
+    let crypto_concrete = Arc::new(solobase_browser::crypto::BrowserCryptoService::new(
+        String::new(),
+    ));
+    let crypto_svc: Arc<dyn wafer_core::interfaces::crypto::service::CryptoService> =
+        crypto_concrete.clone();
 
-    let (mut wafer, storage_block) = SolobaseBuilder::new()
+    let builder = SolobaseBuilder::new()
         .database(solobase_browser::make_database_service())
         .storage(solobase_browser::make_storage_service())
-        .config(Arc::new(config_svc))
-        .crypto(solobase_browser::make_crypto_service(jwt_secret))
+        .config(config_svc.clone())
+        .crypto(crypto_svc)
         .network(solobase_browser::make_network_service())
         .logger(solobase_browser::make_console_logger())
         .llm_service("browser", browser_llm)
         .image_service("browser", browser_image)
         .vector_service(browser_vector)
         .embedding_service(browser_embedding)
-        .block_settings(features)
+        .block_settings(initial_block_settings)
         .block_config(
             "wafer-run/security-headers",
             serde_json::json!({ "csp": SOLOBASE_CSP }),
         )
-        .config_source(cfg_source)
+        .config_source(cfg_source);
+    let block_settings_handle = builder.block_settings_handle();
+
+    let (mut wafer, storage_block) = builder
         .build()
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-
     wafer.set_asset_loader(solobase_browser::make_sw_asset_loader());
 
     wafer
@@ -108,26 +123,58 @@ pub async fn initialize() -> Result<(), JsValue> {
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-    // Eager init pass — mirror of the native CLI (`solobase server`) and
-    // Cloudflare runner. With lazy block init (wafer-run #106-#108), blocks
-    // only run `lifecycle(Init)` on first dispatch. The auth block's
-    // `Init` is what triggers `auth::bootstrap::run` (create the admin user
-    // from `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_{EMAIL,PASSWORD}`), but
-    // the demo login flow routes through `auth_ui` repos+crypto directly
-    // and never dispatches to `suppers-ai/auth` — so without an explicit
-    // eager init the bootstrap never runs and every login returns 401.
-    //
-    // Admin first (its migrations create the variables/block_settings
-    // tables other inits read), then everyone else. Slot caching makes the
-    // second `init_block(admin)` inside `init_all_blocks` a no-op.
+    // ── Phase 2 ─────────────────────────────────────────────────────────────
+    // Run admin's `lifecycle(Init)` so its migrations create the canonical
+    // `suppers_ai__admin__variables` + `suppers_ai__admin__block_settings`
+    // tables with the strict schema declared in
+    // `crates/solobase-core/src/blocks/admin/migrations/001_admin_schema.sqlite.sql`.
+    // Mirrors the native CLI's `start_with_priority(&[admin])` and the
+    // Cloudflare runner's `init_block(admin)` step.
     if let Err(e) = wafer
         .init_block(solobase_core::blocks::admin::ADMIN_BLOCK_ID)
         .await
     {
-        web_sys::console::warn_1(
-            &format!("solobase: admin block Init failed before init_all_blocks: {e}").into(),
+        web_sys::console::error_1(
+            &format!("solobase: admin block Init failed: {e}").into(),
         );
+        return Err(JsValue::from_str(&format!("admin init failed: {e}")));
     }
+
+    // ── Phase 3 ─────────────────────────────────────────────────────────────
+    // Now the variables + block_settings tables exist with the canonical
+    // schema. Seed/load against them, then publish the results into the
+    // services the wafer already holds:
+    //  - `config_svc` is shared via Arc, mutated in place via `.set()`
+    //  - `block_settings_handle` is the same `Arc<RwLock<…>>` the router's
+    //    `FeatureConfig` reads from, so writes here are visible to the
+    //    subsequent `init_all_blocks()` and to every later request.
+    //  - `crypto_svc` exposes `set_jwt_secret` so the rotated secret takes
+    //    effect for any block that hasn't initialised yet.
+    let vars = config::seed_and_load_variables()?;
+    web_sys::console::log_1(
+        &format!("solobase: {} variables loaded from database", vars.len()).into(),
+    );
+    let features = config::load_block_settings()?;
+
+    for (key, value) in &vars {
+        config_svc.set(key, value);
+    }
+    config_svc.set(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
+        &features.to_config_json(),
+    );
+    *block_settings_handle
+        .write()
+        .expect("BlockSettings RwLock poisoned") = features;
+    if let Some(secret) = vars.get(solobase_core::blocks::auth::JWT_SECRET_KEY) {
+        crypto_concrete.set_jwt_secret(secret.clone());
+    }
+
+    // ── Phase 4 ─────────────────────────────────────────────────────────────
+    // Eager init the remaining blocks. With config_svc + block_settings now
+    // populated, auth's `bootstrap::run` reads BOOTSTRAP_ADMIN_{EMAIL,PASSWORD}
+    // via `config_client::get_default` and creates the admin user on a fresh
+    // OPFS. Slot caching makes admin's second init a no-op.
     wafer.init_all_blocks().await;
 
     builder::post_start(&wafer, &storage_block);

--- a/crates/solobase/src/cli/config.rs
+++ b/crates/solobase/src/cli/config.rs
@@ -45,6 +45,16 @@ pub struct AssetsConfig {
     pub extra_bypass_prefix: Vec<String>,
     #[serde(default)]
     pub overlay: Vec<OverlayEntry>,
+    /// Whether `loader.js`'s recovery path wipes OPFS when the SW
+    /// self-destructs. Defaults to **false** — apps that store user data
+    /// in OPFS shouldn't lose it on a transient init failure. Set to
+    /// `true` for throwaway-data deployments like `demo.solobase.dev`
+    /// where a stale-schema loop should self-resolve without manual
+    /// `chrome://settings/siteData` cleanup. See
+    /// `crates/solobase-browser/assets/loader.js.tmpl` for the runtime
+    /// behavior this controls.
+    #[serde(default)]
+    pub opfs_wipe_on_recovery: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/solobase/src/cli/flows/embed_web.rs
+++ b/crates/solobase/src/cli/flows/embed_web.rs
@@ -37,6 +37,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
         app_title: Some(cfg.app.title.clone()),
         boot_redirect: Some(cfg.app.boot_redirect.clone()),
         extra_bypass_prefix: cfg.assets.extra_bypass_prefix.clone(),
+        opfs_wipe_on_recovery: cfg.assets.opfs_wipe_on_recovery,
     };
     solobase_browser::assets::write_to(&dist_dir)?;
     solobase_browser::tools::bundle::run(&dist_dir, repo_root, app)?;

--- a/crates/solobase/src/cli/flows/sealed_web.rs
+++ b/crates/solobase/src/cli/flows/sealed_web.rs
@@ -36,12 +36,14 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
             app_title: Some(c.app.title.clone()),
             boot_redirect: Some(c.app.boot_redirect.clone()),
             extra_bypass_prefix: c.assets.extra_bypass_prefix.clone(),
+            opfs_wipe_on_recovery: c.assets.opfs_wipe_on_recovery,
         },
         None => solobase_browser::tools::bundle::AppConfig {
             app_name: None,
             app_title: None,
             boot_redirect: None,
             extra_bypass_prefix: vec![],
+            opfs_wipe_on_recovery: false,
         },
     };
 


### PR DESCRIPTION
## Summary

After #210/#211 fixed `demo.solobase.dev`, [a user pointed out](https://github.com/suppers-ai/solobase/issues) that the fix class generalises poorly — the OPFS-pre-create pattern in `solobase-web/src/config.rs` (and the cloned copy in `gizza-ai/src/config.rs`) silently duplicates the admin migration schema; any drift between the two surfaces only on the first `migration_helper::write_state` upsert. The OPFS-wipe-on-recovery I added in #211 also overcorrects for any consumer that stores real user data in OPFS — gizza-ai users have local chat history, generated images, etc. Wiping on a transient self-destruct loop is silent data loss.

This PR restructures the browser init to eliminate both classes:

### 1. Defer seeding to post-admin-init

Mirror the native CLI (`solobase server` via `start_with_priority(&[admin])`) and Cloudflare runner (`init_block(admin)` + `init_all_blocks()` after `seal`):

```
Phase 1: build wafer with EMPTY config_svc + EMPTY BlockSettings + EMPTY StaticConfigSource.
         crypto starts with an empty JWT secret.
Phase 2: seal + init_block(admin)   — admin migrations create the canonical tables.
Phase 3: seed_and_load_variables + load_block_settings  — operate on migration-created tables.
         Publish results into the live services (config_svc.set, block_settings handle write,
         crypto_concrete.set_jwt_secret).
Phase 4: init_all_blocks  — auth reads BOOTSTRAP_ADMIN_{EMAIL,PASSWORD} via config_client and creates the admin user.
```

Admin migration `001_admin_schema.sqlite.sql` is the single source of schema truth from now on; consumers like `solobase-web` and `gizza-ai` no longer pre-create the tables.

### Plumbing

* `solobase-core::features` — add `FeatureConfig` impl for `RwLock<BlockSettings>` so the router's `Arc<dyn FeatureConfig>` observes post-build mutations.
* `solobase-core::builder` — `block_settings` field becomes `Arc<RwLock<BlockSettings>>`. Add `block_settings_handle()` for consumers that need to update the snapshot after `build()`. Native callers that have settings up front keep using `.block_settings(…)` with no semantic change.
* `solobase-browser::crypto::BrowserCryptoService` — `jwt_secret` is now a `RwLock<String>` with a new `set_jwt_secret(&self, new)` setter so the secret can rotate in Phase 3.

### 2. OPFS-wipe-on-recovery becomes opt-in

`loader.js` no longer wipes OPFS unconditionally on the SW self-destruct recovery path. New build-time flag (default **false**) — apps with user data leave it off and surface the error to the user; demo-style throwaway-data deployments opt in.

* `solobase-browser::tools::bundle::AppConfig.opfs_wipe_on_recovery` (default false) → `__OPFS_WIPE_ON_RECOVERY__` template var → `loader.js.tmpl` gates the OPFS sweep behind it.
* `solobase::cli::config::AssetsConfig.opfs_wipe_on_recovery` exposes it via `solobase.toml`. Both `embed_web` and `sealed_web` flows forward the value.
* `solobase-web/solobase.toml` opts in (demo data is throwaway). gizza-ai and any other consumer leave the default off.

A follow-up PR will mirror the restructure into `gizza-ai/src/{lib,config}.rs` so the same drift hazard is eliminated there.

## Test plan

- [x] `cargo check -p solobase-core` + `cargo check -p solobase` — clean.
- [x] `cargo check -p solobase-web --target wasm32-unknown-unknown` + `cargo check -p solobase-browser --target wasm32-unknown-unknown` — clean.
- [x] `solobase build --target web --release` + `solobase serve` on a fresh OPFS (wiped via Playwright) → `POST /b/auth/api/login admin@example.com / admin123` → **200** with `admin`-role JWT.
- [x] Verified the rendered `pkg/loader.js` contains `const OPFS_WIPE_ON_RECOVERY = true;` for the demo build.
- [ ] Auto-deploy via `deploy-demo.yml` republishes `demo.solobase.dev`; clean-browser login still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)