### PR TITLE
refactor(solobase): centralize urlencoding/now_rfc3339/hex_encode helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5720,7 +5720,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5743,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5768,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5788,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5828,7 +5828,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "serde",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "futures",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5896,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5906,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5932,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5943,7 +5943,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5989,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "serde",
  "serde_json",
@@ -5999,7 +5999,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6028,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#9146ebaacb97ec7f266df9bd25dfa2fd9bcc2e32"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -17,6 +17,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Headers, ResponseInit};
 
+use crate::helpers::urlencoding_decode;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -29,25 +31,6 @@ fn http_method_to_action(method: &str) -> &'static str {
         "DELETE" => "delete",
         _ => "execute",
     }
-}
-
-fn urlencoding_decode(s: &str) -> String {
-    let mut bytes = Vec::with_capacity(s.len());
-    let mut chars = s.bytes();
-    while let Some(b) = chars.next() {
-        if b == b'+' {
-            bytes.push(b' ');
-        } else if b == b'%' {
-            let h1 = chars.next().and_then(|c| (c as char).to_digit(16));
-            let h2 = chars.next().and_then(|c| (c as char).to_digit(16));
-            if let (Some(h1), Some(h2)) = (h1, h2) {
-                bytes.push((h1 * 16 + h2) as u8);
-            }
-        } else {
-            bytes.push(b);
-        }
-    }
-    String::from_utf8(bytes).unwrap_or_else(|_| s.to_string())
 }
 
 fn error_code_to_http_status(code: &ErrorCode) -> u16 {

--- a/crates/solobase-browser/src/database.rs
+++ b/crates/solobase-browser/src/database.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use wafer_core::interfaces::database::service::*;
 
-use crate::bridge;
+use crate::{bridge, helpers::now_rfc3339};
 
 /// Browser-side DatabaseService backed by sql.js via the JS bridge.
 ///
@@ -155,11 +155,6 @@ fn parse_rows(json: &str) -> Result<Vec<Record>, DatabaseError> {
 /// Parse the rows-modified count string returned by `db_exec_raw`.
 fn parse_rows_modified(json: &str) -> i64 {
     json.trim().parse::<i64>().unwrap_or(0)
-}
-
-/// Return current UTC timestamp as an RFC 3339 string.
-fn now_rfc3339() -> String {
-    chrono::Utc::now().to_rfc3339()
 }
 
 /// Generate a random hex ID using `getrandom`.

--- a/crates/solobase-browser/src/helpers.rs
+++ b/crates/solobase-browser/src/helpers.rs
@@ -1,0 +1,35 @@
+//! Shared helpers for the browser adapter crates (wasm32-only).
+//!
+//! These are thin wrappers kept here — rather than duplicated in `convert.rs`
+//! and `database.rs` — because `solobase-browser` does not depend on
+//! `solobase-core`. When the dependency is ever added, these can be deleted and
+//! callers switched to `solobase_core::blocks::helpers::*`.
+
+/// Current UTC time as RFC 3339 string.
+pub(crate) fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Decode a percent-encoded (URL-encoded) string.
+///
+/// Decodes `+` as a space (form-urlencoding semantics) and `%XX` hex
+/// sequences. Matches the canonical implementation in
+/// `solobase_core::blocks::helpers::urlencoding_decode`.
+pub(crate) fn urlencoding_decode(s: &str) -> String {
+    let s = s.replace('+', " ");
+    let mut result = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                result.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&result).into_owned()
+}

--- a/crates/solobase-browser/src/lib.rs
+++ b/crates/solobase-browser/src/lib.rs
@@ -35,6 +35,8 @@ pub mod crypto;
 #[cfg(target_arch = "wasm32")]
 pub mod database;
 #[cfg(target_arch = "wasm32")]
+mod helpers;
+#[cfg(target_arch = "wasm32")]
 pub mod logger;
 #[cfg(target_arch = "wasm32")]
 pub mod network;

--- a/crates/solobase-cloudflare/src/convert.rs
+++ b/crates/solobase-cloudflare/src/convert.rs
@@ -4,6 +4,7 @@
 //! `OutputStream` → `worker::Response`. Mirrors the native axum adapter
 //! in `wafer-block-http-listener` and the browser adapter in `solobase-web`.
 
+use solobase_core::blocks::helpers::urlencoding_decode;
 use wafer_run::{meta::*, types::*, InputStream, OutputStream, TerminalNotResponse};
 use worker::{Request, Response, Result};
 
@@ -254,23 +255,4 @@ fn apply_meta_headers(headers: &mut worker::Headers, meta: &[MetaEntry]) -> Resu
         }
     }
     Ok(())
-}
-
-fn urlencoding_decode(s: &str) -> String {
-    let mut bytes = Vec::with_capacity(s.len());
-    let mut chars = s.bytes();
-    while let Some(b) = chars.next() {
-        if b == b'+' {
-            bytes.push(b' ');
-        } else if b == b'%' {
-            let h1 = chars.next().and_then(|c| (c as char).to_digit(16));
-            let h2 = chars.next().and_then(|c| (c as char).to_digit(16));
-            if let (Some(h1), Some(h2)) = (h1, h2) {
-                bytes.push((h1 * 16 + h2) as u8);
-            }
-        } else {
-            bytes.push(b);
-        }
-    }
-    String::from_utf8(bytes).unwrap_or_else(|_| s.to_string())
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -349,14 +349,6 @@ pub(crate) mod helpers {
             if secure { "; Secure" } else { "" }
         )
     }
-
-    pub(crate) fn urlencode(s: &str) -> String {
-        // `byte_serialize` percent-encodes everything that isn't the
-        // application/x-www-form-urlencoded "safe set" (unreserved chars).
-        // Equivalent to the previous hand-rolled implementation but
-        // shares an audited path with the rest of the workspace.
-        url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
-    }
 }
 
 /// Authenticate a request using an API key.

--- a/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/bootstrap_tokens.rs
@@ -9,6 +9,7 @@ use wafer_core::clients::database as db;
 use wafer_run::context::Context;
 
 use super::RepoError;
+use crate::blocks::helpers::hex_encode;
 
 pub const TABLE: &str = "suppers_ai__auth__bootstrap_tokens";
 
@@ -40,15 +41,6 @@ pub async fn insert(
         .await
         .map_err(|e| RepoError::Db(format!("bootstrap_tokens insert: {e}")))?;
     Ok(())
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        let _ = write!(s, "{b:02x}");
-    }
-    s
 }
 
 /// Returns true iff an unexpired row exists with the given hash.

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -29,6 +29,7 @@ use wafer_core::clients::database as db;
 use wafer_run::context::Context;
 
 use super::RepoError;
+use crate::blocks::helpers::hex_encode;
 
 pub const TABLE: &str = "suppers_ai__auth__sessions";
 
@@ -50,10 +51,6 @@ pub struct NewSession {
 
 fn now_iso() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 fn decode_hex(s: &str) -> Option<Vec<u8>> {

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -8,15 +8,13 @@ use wafer_run::{context::Context, types::Message, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{
-            build_auth_cookie, ensure_admin_role, generate_tokens, store_refresh_token, urlencode,
-        },
+        helpers::{build_auth_cookie, ensure_admin_role, generate_tokens, store_refresh_token},
         repo::{oauth_pkce, provider_links, users},
         USERS_TABLE,
     },
     auth_ui::redirect::is_safe_local_redirect,
     helpers::{
-        err_bad_request, err_forbidden, err_internal, err_internal_no_cause, json_map,
+        err_bad_request, err_forbidden, err_internal, err_internal_no_cause, json_map, urlencode,
         ResponseBuilder,
     },
 };

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
@@ -5,11 +5,8 @@ use wafer_core::clients::config;
 use wafer_run::{context::Context, types::Message, OutputStream};
 
 use crate::blocks::{
-    auth::{
-        helpers::urlencode,
-        repo::oauth_pkce::{self, NewPkceState},
-    },
-    helpers::{err_bad_request, err_forbidden, err_internal, ok_json},
+    auth::repo::oauth_pkce::{self, NewPkceState},
+    helpers::{err_bad_request, err_forbidden, err_internal, ok_json, urlencode},
 };
 
 /// PKCE state TTL: 10 minutes. OAuth round-trips complete in seconds; this

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -130,6 +130,14 @@ pub fn url_path_encode(s: &str) -> String {
         .collect()
 }
 
+/// Percent-encode a string for use as an OAuth / `application/x-www-form-urlencoded`
+/// query parameter. Delegates to [`url::form_urlencoded::byte_serialize`] which
+/// encodes spaces as `+` and everything outside the unreserved set as `%XX`.
+/// Prefer this over hand-rolling percent-encoding in OAuth / form-body contexts.
+pub fn urlencode(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
 /// Percent-encode a string for use as an `application/x-www-form-urlencoded`
 /// value. Same alphabet as [`url_path_encode`] but spaces become `+` (per the
 /// form-encoding convention) rather than `%20`. Use this for HTTP form bodies
@@ -424,6 +432,36 @@ impl Default for ResponseBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn urlencoding_decode_plus_to_space() {
+        assert_eq!(urlencoding_decode("a+b"), "a b");
+    }
+
+    #[test]
+    fn urlencoding_decode_percent() {
+        assert_eq!(urlencoding_decode("a%2Fb"), "a/b");
+    }
+
+    #[test]
+    fn now_rfc3339_parses() {
+        let s = now_rfc3339();
+        let _: chrono::DateTime<chrono::Utc> = s.parse().expect("rfc3339 round-trip");
+    }
+
+    #[test]
+    fn urlencode_space_becomes_plus() {
+        assert_eq!(urlencode("a b"), "a+b");
+    }
+
+    #[test]
+    fn urlencode_special_chars() {
+        // Slash and ampersand must be percent-encoded in form values.
+        let encoded = urlencode("a/b&c=d");
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains('&'));
+        assert!(!encoded.contains('='));
+    }
 
     #[test]
     fn url_path_encode_basic() {

--- a/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
@@ -6,7 +6,7 @@ use wafer_run::{context::Context, types::Message, OutputStream};
 use crate::{
     blocks::{
         auth::{repo::sessions, service::hash_token},
-        helpers::ResponseBuilder,
+        helpers::{hex_encode, ResponseBuilder},
     },
     ui::{
         self,
@@ -57,10 +57,6 @@ pub async fn sessions_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         ),
     );
     ui::html_response(markup)
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 fn decode_hex(s: &str) -> Option<Vec<u8>> {


### PR DESCRIPTION
## Summary
- Three implementations of `urlencoding_decode` and two of `now_rfc3339` consolidated to `solobase-core::blocks::helpers`.
- New `urlencode` thin wrapper around `url::form_urlencoded::byte_serialize` replaces inline OAuth code in `auth_ui/oauth/{callback,start}.rs`.
- Three local `hex_encode` duplicates in `auth/repo/{sessions,bootstrap_tokens}.rs` and `userportal/pages/sessions.rs` switched to `crate::blocks::helpers::hex_encode`.
- `solobase-cloudflare/src/convert.rs` local `urlencoding_decode` removed; imports the canonical helper.
- `solobase-browser/src/helpers.rs` is a new wasm32-only file that mirrors `now_rfc3339` + `urlencoding_decode` locally, because `solobase-browser` does not currently depend on `solobase-core`. The file documents this as a TODO — when the dep is added, the file can be deleted.

## Audit
2026-05-20 deep-dive audit, solobase finding #10.

## Test plan
- [x] `cargo test -p solobase-core --lib` — 659 pass (+5 new helpers tests)