### PR TITLE
refactor(solobase): block_settings helper + unified all_block_infos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5720,6 +5720,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5742,6 +5743,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5754,6 +5756,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5765,6 +5768,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5784,6 +5788,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5793,6 +5798,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5808,6 +5814,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5821,6 +5828,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5831,6 +5839,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "serde",
@@ -5842,6 +5851,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5851,6 +5861,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "futures",
@@ -5867,6 +5878,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5884,6 +5896,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5893,6 +5906,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5903,6 +5917,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5917,6 +5932,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5927,6 +5943,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5943,6 +5960,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5954,6 +5972,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5970,6 +5989,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "serde",
  "serde_json",
@@ -5979,6 +5999,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6007,6 +6028,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#31c92f0fe8740d596b65dcd458e36dafdaa54b83"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -1,7 +1,6 @@
 use maud::html;
-use wafer_core::clients::database::{self as db, Filter, FilterOp, ListOptions};
+use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
-use wafer_sql_utils::{query, upsert, value::sea_values_to_json, Backend};
 
 use super::{admin_page, crumb};
 use crate::{
@@ -244,49 +243,11 @@ pub async fn handle_toggle_feature(
     msg: &Message,
     block_name: &str,
 ) -> OutputStream {
-    // Read current state from block_settings
-    let (sql, vals) = query::build_select_columns(
-        BLOCK_SETTINGS,
-        &["enabled"],
-        &ListOptions {
-            filters: vec![Filter {
-                field: "block_name".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(block_name),
-            }],
-            ..Default::default()
-        },
-        None,
-        Backend::Sqlite,
-    );
-    let current_enabled = db::query_raw(ctx, &sql, &sea_values_to_json(vals))
-        .await
-        .ok()
-        .and_then(|rows| {
-            rows.first()
-                .and_then(|r| r.data.get("enabled").and_then(|v| v.as_i64()))
-        })
-        .map(|v| v != 0)
-        .unwrap_or(true);
-
+    // Read current state and toggle via shared helper (audit finding #12).
+    let current_enabled =
+        super::super::settings::block_settings::is_enabled(ctx, block_name).await;
     let new_enabled = !current_enabled;
-    let new_enabled_int = if new_enabled { 1 } else { 0 };
-
-    // Upsert into block_settings
-    let now = chrono::Utc::now().to_rfc3339();
-    let (sql, vals) = upsert::build_upsert(
-        BLOCK_SETTINGS,
-        &[
-            ("block_name".to_string(), serde_json::json!(block_name)),
-            ("enabled".to_string(), serde_json::json!(new_enabled_int)),
-            ("created_at".to_string(), serde_json::json!(&now)),
-            ("updated_at".to_string(), serde_json::json!(&now)),
-        ],
-        &["block_name"],
-        &["enabled", "updated_at"],
-        Backend::Sqlite,
-    );
-    let _ = db::exec_raw(ctx, &sql, &sea_values_to_json(vals)).await;
+    let _ = super::super::settings::block_settings::set_enabled(ctx, block_name, new_enabled).await;
 
     let admin_id = msg.user_id().to_string();
     let ip = msg.remote_addr().to_string();
@@ -311,30 +272,9 @@ pub async fn handle_block_detail(
     let blocks: Vec<wafer_run::BlockInfo> = ctx.registered_blocks();
     let block_opt = blocks.iter().find(|b| b.name == block_name);
 
-    // Check block enabled state from block_settings
-    let (sql, vals) = query::build_select_columns(
-        BLOCK_SETTINGS,
-        &["enabled"],
-        &ListOptions {
-            filters: vec![Filter {
-                field: "block_name".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(block_name),
-            }],
-            ..Default::default()
-        },
-        None,
-        Backend::Sqlite,
-    );
-    let is_enabled = db::query_raw(ctx, &sql, &sea_values_to_json(vals))
-        .await
-        .ok()
-        .and_then(|rows| {
-            rows.first()
-                .and_then(|r| r.data.get("enabled").and_then(|v| v.as_i64()))
-        })
-        .map(|v| v != 0)
-        .unwrap_or(true);
+    // Check block enabled state via shared helper (audit finding #12).
+    let is_enabled =
+        super::super::settings::block_settings::is_enabled(ctx, block_name).await;
 
     let encoded = encode_block_name(block_name);
 

--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -244,8 +244,7 @@ pub async fn handle_toggle_feature(
     block_name: &str,
 ) -> OutputStream {
     // Read current state and toggle via shared helper (audit finding #12).
-    let current_enabled =
-        super::super::settings::block_settings::is_enabled(ctx, block_name).await;
+    let current_enabled = super::super::settings::block_settings::is_enabled(ctx, block_name).await;
     let new_enabled = !current_enabled;
     let _ = super::super::settings::block_settings::set_enabled(ctx, block_name, new_enabled).await;
 
@@ -273,8 +272,7 @@ pub async fn handle_block_detail(
     let block_opt = blocks.iter().find(|b| b.name == block_name);
 
     // Check block enabled state via shared helper (audit finding #12).
-    let is_enabled =
-        super::super::settings::block_settings::is_enabled(ctx, block_name).await;
+    let is_enabled = super::super::settings::block_settings::is_enabled(ctx, block_name).await;
 
     let encoded = encode_block_name(block_name);
 

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -11,6 +11,77 @@ use crate::blocks::helpers::{
     self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
 };
 
+/// Helpers for reading and writing the per-block `enabled` flag in
+/// [`BLOCK_SETTINGS_TABLE`]. Use these instead of inlining the select/upsert
+/// query in every callsite.
+pub mod block_settings {
+    use wafer_core::clients::database as db;
+    use wafer_run::context::Context;
+    use wafer_sql_utils::{query, upsert, value::sea_values_to_json, Backend};
+    use wafer_core::clients::database::{Filter, FilterOp, ListOptions};
+
+    use super::BLOCK_SETTINGS_TABLE as TABLE;
+
+    /// Return whether `block_name` is enabled.
+    ///
+    /// Reads the `enabled` column from [`BLOCK_SETTINGS_TABLE`]. Defaults to
+    /// `true` when no row exists (all blocks are enabled by default).
+    pub async fn is_enabled(ctx: &dyn Context, block_name: &str) -> bool {
+        let (sql, vals) = query::build_select_columns(
+            TABLE,
+            &["enabled"],
+            &ListOptions {
+                filters: vec![Filter {
+                    field: "block_name".into(),
+                    operator: FilterOp::Equal,
+                    value: serde_json::json!(block_name),
+                }],
+                ..Default::default()
+            },
+            None,
+            Backend::Sqlite,
+        );
+        db::query_raw(ctx, &sql, &sea_values_to_json(vals))
+            .await
+            .ok()
+            .and_then(|rows| {
+                rows.first()
+                    .and_then(|r| r.data.get("enabled").and_then(|v| v.as_i64()))
+            })
+            .map(|v| v != 0)
+            .unwrap_or(true)
+    }
+
+    /// Persist the `enabled` flag for `block_name` in [`BLOCK_SETTINGS_TABLE`].
+    ///
+    /// Uses an upsert keyed on `block_name`, so it works whether or not a row
+    /// already exists.
+    pub async fn set_enabled(
+        ctx: &dyn Context,
+        block_name: &str,
+        enabled: bool,
+    ) -> Result<(), String> {
+        let enabled_int: i64 = if enabled { 1 } else { 0 };
+        let now = super::helpers::now_rfc3339();
+        let (sql, vals) = upsert::build_upsert(
+            TABLE,
+            &[
+                ("block_name".to_string(), serde_json::json!(block_name)),
+                ("enabled".to_string(), serde_json::json!(enabled_int)),
+                ("created_at".to_string(), serde_json::json!(&now)),
+                ("updated_at".to_string(), serde_json::json!(&now)),
+            ],
+            &["block_name"],
+            &["enabled", "updated_at"],
+            Backend::Sqlite,
+        );
+        db::exec_raw(ctx, &sql, &sea_values_to_json(vals))
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("block_settings::set_enabled failed: {e}"))
+    }
+}
+
 /// Per-block enable/config settings (one row per block).
 ///
 /// `pub` (not `pub(crate)`) because consumers outside `solobase-core`
@@ -648,6 +719,51 @@ mod tests {
         assert!(
             count > 0,
             "mismatched snapshot hash should still run the seed; got 0 rows"
+        );
+    }
+
+    /// `block_settings::is_enabled` defaults to `true` when no row exists.
+    #[tokio::test]
+    async fn block_settings_is_enabled_defaults_to_true_when_no_row() {
+        let ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        let enabled = block_settings::is_enabled(&ctx, "suppers-ai/nonexistent").await;
+        assert!(
+            enabled,
+            "is_enabled should return true when no block_settings row exists"
+        );
+    }
+
+    /// `block_settings::set_enabled` / `is_enabled` round-trip: write false,
+    /// read back false; write true, read back true.
+    #[tokio::test]
+    async fn block_settings_set_enabled_round_trip() {
+        let ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        let name = "suppers-ai/some-block";
+
+        // Disable then read back.
+        block_settings::set_enabled(&ctx, name, false)
+            .await
+            .expect("set_enabled false");
+        assert!(
+            !block_settings::is_enabled(&ctx, name).await,
+            "is_enabled should return false after set_enabled(false)"
+        );
+
+        // Re-enable then read back.
+        block_settings::set_enabled(&ctx, name, true)
+            .await
+            .expect("set_enabled true");
+        assert!(
+            block_settings::is_enabled(&ctx, name).await,
+            "is_enabled should return true after set_enabled(true)"
         );
     }
 }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -15,10 +15,12 @@ use crate::blocks::helpers::{
 /// [`BLOCK_SETTINGS_TABLE`]. Use these instead of inlining the select/upsert
 /// query in every callsite.
 pub mod block_settings {
-    use wafer_core::clients::database as db;
+    use wafer_core::clients::{
+        database as db,
+        database::{Filter, FilterOp, ListOptions},
+    };
     use wafer_run::context::Context;
     use wafer_sql_utils::{query, upsert, value::sea_values_to_json, Backend};
-    use wafer_core::clients::database::{Filter, FilterOp, ListOptions};
 
     use super::BLOCK_SETTINGS_TABLE as TABLE;
 

--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -42,56 +42,28 @@ pub mod vector;
 
 /// Return `BlockInfo` for every solobase block.
 ///
-/// Sources:
-/// - Auto-registered (zero-arg) blocks via `linkme` — same instances
-///   Wafer::new() will register at runtime.
-/// - LlmBlock — constructed with a throwaway ProviderLlmService since its
-///   info() is declarative and doesn't depend on the real service. Can't
-///   auto-register because its constructor takes Arc<ProviderLlmService>.
+/// This is the single canonical source of truth for both native and wasm32.
+/// Previously, native used `linkme`/`STATIC_BLOCK_REGISTRATIONS` iteration
+/// and wasm32 had a separate manual list — see audit finding #13.
+///
+/// The two lists had diverged: the native linkme sweep also picked up
+/// `wafer-run/*` framework blocks (cors, inspector, etc.) that were never
+/// relevant to `collect_all_config_vars`, and the wasm32 list included the
+/// framework `AuthBlock` whose config vars are declared via
+/// `shared_config_vars()` → `auth_config_vars()` rather than
+/// `BlockInfo::config_keys`, making it redundant there too. This function
+/// enumerates only the solobase feature blocks, consistently on both targets.
 ///
 /// Used by `collect_all_config_vars()` to discover declared config
 /// variables before block registration runs.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
-    #[cfg_attr(not(feature = "llm"), allow(unused_mut))]
-    let mut infos: Vec<_> = wafer_run::STATIC_BLOCK_REGISTRATIONS
-        .iter()
-        .map(|reg| (reg.factory)().info())
-        .collect();
-
-    #[cfg(feature = "llm")]
-    {
-        use wafer_run::block::Block as _;
-        let throwaway = std::sync::Arc::new(llm::providers::ProviderLlmService::new());
-        infos.push(llm::LlmBlock::new(throwaway).info());
-    }
-
-    infos
-}
-
-/// wasm32 fallback: linkme is not supported on wasm32 (wafer-run gates
-/// `StaticBlockRegistration` behind `cfg(not(target_arch = "wasm32"))`), so
-/// enumerate blocks manually. Same content the linkme iteration would
-/// produce on native, plus LlmBlock under `feature = "llm"`.
-#[cfg(target_arch = "wasm32")]
 pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
     use wafer_run::block::Block as _;
 
-    // `unused_mut` fires when every optional feature is off, because no later
+    // `unused_mut` fires when every optional feature is off and no later
     // `.push(...)` exists to mutate the vec.
     #[allow(unused_mut)]
     let mut infos: Vec<wafer_run::block::BlockInfo> = vec![
         admin::AdminBlock::new().info(),
-        // Framework AuthBlock wrapping AuthServiceImpl — not self-registered
-        // because the constructor takes `Arc<dyn AuthService>`. Mirrors the
-        // `register_auth` helper below so wasm config-var collection sees
-        // the same block info native gets.
-        {
-            use std::sync::Arc;
-            let state = auth::service::BlockState::new();
-            let svc = Arc::new(auth::service::AuthServiceImpl::new(state));
-            wafer_core::service_blocks::auth::AuthBlock::new(svc).info()
-        },
         auth_ui::AuthUiBlock::default().info(),
         email::EmailBlock::new().info(),
         system::SystemBlock::new().info(),
@@ -110,9 +82,14 @@ pub fn all_block_infos() -> Vec<wafer_run::block::BlockInfo> {
     #[cfg(feature = "block-vector")]
     infos.push(vector::VectorBlock::new().info());
 
+    // fastembed is native-only: it requires ONNX Runtime which is not
+    // available on wasm32.
     #[cfg(feature = "block-fastembed")]
     infos.push(fastembed::FastembedBlock::new().info());
 
+    // LlmBlock cannot self-register because its constructor takes
+    // Arc<ProviderLlmService>. A throwaway service is enough here since
+    // info() is declarative and doesn't invoke the real provider.
     #[cfg(feature = "llm")]
     {
         use std::sync::Arc;


### PR DESCRIPTION
## Summary
- New `block_settings::is_enabled` / `set_enabled` helpers in `admin/settings.rs`. Replaces two duplicated 9-line snippets in `admin/pages/blocks.rs` and the inlined `upsert+exec_raw` in `handle_toggle_feature`.
- `all_block_infos` in `blocks/mod.rs` is now a single unconditional function for both native and wasm32. Drift fix: native (linkme) was including framework middleware blocks without `config_keys`; wasm32 was including a redundant `AuthBlock`. Both noise items removed.

## Audit
2026-05-20 deep-dive audit, solobase findings #12 and #13.

## Test plan
- [x] `cargo test -p solobase-core --lib` — 656 pass (+2 new for `block_settings`)
- [x] `register_all_static_blocks` (wasm32-only static-block registration) unchanged.