### PR TITLE
feat: KV-cached D1 config source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "solobase-core",
+ "tracing",
  "uuid",
  "wafer-block",
  "wafer-core",
@@ -5720,6 +5721,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5742,6 +5744,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5754,6 +5757,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5765,6 +5769,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5784,6 +5789,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5793,6 +5799,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -5809,6 +5816,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5822,6 +5830,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5833,6 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "serde",
@@ -5844,6 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5853,6 +5864,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "futures",
@@ -5870,6 +5882,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5889,6 +5902,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5898,6 +5912,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5908,6 +5923,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5923,6 +5939,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5933,6 +5950,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5952,6 +5970,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "tracing",
@@ -5963,6 +5982,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5981,6 +6001,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "serde",
  "serde_json",
@@ -5990,6 +6011,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6019,6 +6041,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "serde",
  "serde_json",
@@ -6027,6 +6050,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#e282f2696d665a6d23e2841f201190cdb3fde788"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/Cargo.toml
+++ b/crates/solobase-cloudflare/Cargo.toml
@@ -49,6 +49,9 @@ chrono = { workspace = true }
 # Async
 async-trait = { workspace = true }
 
+# Observability
+tracing = { workspace = true }
+
 # Templating
 maud = { workspace = true }
 

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -251,7 +251,30 @@ impl DatabaseService for KvCachedD1DatabaseService {
         collection: &str,
         data: HashMap<String, serde_json::Value>,
     ) -> Result<Record, DatabaseError> {
-        self.inner.create(collection, data).await
+        let cached = cache_key::classify_table(collection);
+        let invalidate_key = cached.and_then(|t| cache_key::write_key(t, &data));
+
+        let record = self.inner.create(collection, data).await?;
+
+        if let Some(key) = invalidate_key {
+            if let Err(e) = self.kv.delete(&key).await {
+                tracing::warn!(
+                    table = %collection,
+                    key = %key,
+                    error = %e,
+                    "kv invalidate after create failed; relying on TTL"
+                );
+            } else {
+                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_create");
+            }
+        } else if cached.is_some() {
+            tracing::warn!(
+                table = %collection,
+                "cached table write with no extractable cache-key column; relying on TTL"
+            );
+        }
+
+        Ok(record)
     }
 
     async fn update(

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -178,13 +178,72 @@ impl DatabaseService for KvCachedD1DatabaseService {
         self.inner.update_where(collection, filters, data).await
     }
 
-    // Cache-aware methods filled in by subsequent commits — placeholder pass-through for now.
     async fn list(
         &self,
         collection: &str,
         opts: &ListOptions,
     ) -> Result<RecordList, DatabaseError> {
-        self.inner.list(collection, opts).await
+        let cache_key_opt = cache_key::classify_table(collection)
+            .and_then(|t| cache_key::read_key(t, opts));
+
+        let Some(key) = cache_key_opt else {
+            return self.inner.list(collection, opts).await;
+        };
+
+        // Try cache hit.
+        match self.kv.get(&key).await {
+            Ok(Some(body)) => match serde_json::from_str::<Vec<Record>>(&body) {
+                Ok(records) => {
+                    let page_size = opts.limit;
+                    let total_count = records.len() as i64;
+                    tracing::debug!(table = %collection, key = %key, "cache_hit");
+                    return Ok(RecordList {
+                        records,
+                        total_count,
+                        page: 1,
+                        page_size,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        table = %collection,
+                        key = %key,
+                        error = %e,
+                        "cache value deserialize failed; falling through"
+                    );
+                }
+            },
+            Ok(None) => {
+                tracing::debug!(table = %collection, key = %key, "cache_miss");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    table = %collection,
+                    key = %key,
+                    error = %e,
+                    "kv get failed; falling through"
+                );
+            }
+        }
+
+        // Fall through to D1 and populate cache.
+        let result = self.inner.list(collection, opts).await?;
+        let payload = match serde_json::to_string(&result.records) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "cache payload serialize failed; skipping put");
+                return Ok(result);
+            }
+        };
+        if let Err(e) = self.kv.put_with_ttl(&key, &payload, CACHE_TTL_SECS).await {
+            tracing::warn!(
+                table = %collection,
+                key = %key,
+                error = %e,
+                "kv put failed; cache stays cold"
+            );
+        }
+        Ok(result)
     }
 
     async fn create(

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -57,8 +57,7 @@ impl KvBackend for WorkerKvBackend {
 // KvCachedD1DatabaseService
 // ---------------------------------------------------------------------------
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use solobase_core::cache_key;
 use wafer_block::db::{Filter, ListOptions};
@@ -183,8 +182,8 @@ impl DatabaseService for KvCachedD1DatabaseService {
         collection: &str,
         opts: &ListOptions,
     ) -> Result<RecordList, DatabaseError> {
-        let cache_key_opt = cache_key::classify_table(collection)
-            .and_then(|t| cache_key::read_key(t, opts));
+        let cache_key_opt =
+            cache_key::classify_table(collection).and_then(|t| cache_key::read_key(t, opts));
 
         let Some(key) = cache_key_opt else {
             return self.inner.list(collection, opts).await;

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -283,7 +283,40 @@ impl DatabaseService for KvCachedD1DatabaseService {
         id: &str,
         data: HashMap<String, serde_json::Value>,
     ) -> Result<Record, DatabaseError> {
-        self.inner.update(collection, id, data).await
+        let cached = cache_key::classify_table(collection);
+        let invalidate_key = if let Some(t) = cached {
+            match self.inner.get(collection, id).await {
+                Ok(row) => cache_key::write_key(t, &row.data),
+                Err(e) => {
+                    tracing::warn!(
+                        table = %collection,
+                        id = %id,
+                        error = %e,
+                        "pre-read for cache-key failed; skipping invalidation"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let record = self.inner.update(collection, id, data).await?;
+
+        if let Some(key) = invalidate_key {
+            if let Err(e) = self.kv.delete(&key).await {
+                tracing::warn!(
+                    table = %collection,
+                    key = %key,
+                    error = %e,
+                    "kv invalidate after update failed; relying on TTL"
+                );
+            } else {
+                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_update");
+            }
+        }
+
+        Ok(record)
     }
 
     async fn delete(&self, collection: &str, id: &str) -> Result<(), DatabaseError> {

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -320,6 +320,39 @@ impl DatabaseService for KvCachedD1DatabaseService {
     }
 
     async fn delete(&self, collection: &str, id: &str) -> Result<(), DatabaseError> {
-        self.inner.delete(collection, id).await
+        let cached = cache_key::classify_table(collection);
+        let invalidate_key = if let Some(t) = cached {
+            match self.inner.get(collection, id).await {
+                Ok(row) => cache_key::write_key(t, &row.data),
+                Err(e) => {
+                    tracing::warn!(
+                        table = %collection,
+                        id = %id,
+                        error = %e,
+                        "pre-read for cache-key failed; skipping invalidation"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        self.inner.delete(collection, id).await?;
+
+        if let Some(key) = invalidate_key {
+            if let Err(e) = self.kv.delete(&key).await {
+                tracing::warn!(
+                    table = %collection,
+                    key = %key,
+                    error = %e,
+                    "kv invalidate after delete failed; relying on TTL"
+                );
+            } else {
+                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_delete");
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -1,0 +1,54 @@
+//! `KvCachedD1DatabaseService` — wraps a `DatabaseService` with a
+//! Cloudflare KV cache for the per-block config-var hot path.
+//!
+//! See `docs/superpowers/specs/2026-05-22-kv-cached-d1-config-source-design.md`.
+//!
+//! Pure cache-key derivation lives in `solobase_core::cache_key` so it can
+//! be unit-tested on host (this crate is excluded from `cargo test --workspace`).
+
+use wafer_block::{MaybeSend, MaybeSync};
+
+/// Pluggable KV backend. Production uses `worker::kv::KvStore` via
+/// `WorkerKvBackend`; tests use `MockKvBackend` (see `tests/support`).
+///
+/// All errors are returned as `String` and never propagate as a hard
+/// failure to callers — `KvCachedD1DatabaseService` treats every KV
+/// error as a cache miss and falls through to the underlying database.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait KvBackend: MaybeSend + MaybeSync {
+    /// Returns `Ok(Some(value))` on cache hit, `Ok(None)` on miss,
+    /// `Err(msg)` on KV transport error.
+    async fn get(&self, key: &str) -> Result<Option<String>, String>;
+
+    /// Writes `value` under `key` with the given TTL (seconds).
+    async fn put_with_ttl(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), String>;
+
+    /// Deletes `key`. Deleting a non-existent key is not an error.
+    async fn delete(&self, key: &str) -> Result<(), String>;
+}
+
+/// Production `KvBackend` backed by `worker::kv::KvStore`.
+pub struct WorkerKvBackend(pub worker::kv::KvStore);
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl KvBackend for WorkerKvBackend {
+    async fn get(&self, key: &str) -> Result<Option<String>, String> {
+        self.0.get(key).text().await.map_err(|e| e.to_string())
+    }
+
+    async fn put_with_ttl(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), String> {
+        self.0
+            .put(key, value)
+            .map_err(|e| e.to_string())?
+            .expiration_ttl(ttl_secs)
+            .execute()
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), String> {
+        self.0.delete(key).await.map_err(|e| e.to_string())
+    }
+}

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -52,3 +52,159 @@ impl KvBackend for WorkerKvBackend {
         self.0.delete(key).await.map_err(|e| e.to_string())
     }
 }
+
+// ---------------------------------------------------------------------------
+// KvCachedD1DatabaseService
+// ---------------------------------------------------------------------------
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use solobase_core::cache_key;
+use wafer_block::db::{Filter, ListOptions};
+use wafer_core::interfaces::database::service::{
+    Column, DatabaseError, DatabaseService, Record, RecordList, Table,
+};
+
+/// KV TTL applied to every cache PUT (24 h).
+const CACHE_TTL_SECS: u64 = 86_400;
+
+/// Wraps a [`DatabaseService`] with a write-through-invalidated KV cache
+/// for the `variables` and `block_settings` per-block read paths.
+pub struct KvCachedD1DatabaseService {
+    inner: Arc<dyn DatabaseService>,
+    kv: Arc<dyn KvBackend>,
+}
+
+impl KvCachedD1DatabaseService {
+    /// Wrap `inner` with a KV-backed cache using `kv`.
+    pub fn new(inner: Arc<dyn DatabaseService>, kv: Arc<dyn KvBackend>) -> Self {
+        Self { inner, kv }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl DatabaseService for KvCachedD1DatabaseService {
+    async fn get(&self, collection: &str, id: &str) -> Result<Record, DatabaseError> {
+        self.inner.get(collection, id).await
+    }
+
+    async fn count(&self, collection: &str, filters: &[Filter]) -> Result<i64, DatabaseError> {
+        self.inner.count(collection, filters).await
+    }
+
+    async fn sum(
+        &self,
+        collection: &str,
+        field: &str,
+        filters: &[Filter],
+    ) -> Result<f64, DatabaseError> {
+        self.inner.sum(collection, field, filters).await
+    }
+
+    async fn query_raw(
+        &self,
+        query: &str,
+        args: &[serde_json::Value],
+    ) -> Result<Vec<Record>, DatabaseError> {
+        self.inner.query_raw(query, args).await
+    }
+
+    async fn exec_raw(
+        &self,
+        query: &str,
+        args: &[serde_json::Value],
+    ) -> Result<i64, DatabaseError> {
+        self.inner.exec_raw(query, args).await
+    }
+
+    async fn increment_field_where(
+        &self,
+        collection: &str,
+        col: &str,
+        delta: i64,
+        filters: &[Filter],
+    ) -> Result<i64, DatabaseError> {
+        // MUST override — trait default returns Err(Internal).
+        self.inner
+            .increment_field_where(collection, col, delta, filters)
+            .await
+    }
+
+    async fn ensure_schema_table(&self, table: &Table) -> Result<(), DatabaseError> {
+        self.inner.ensure_schema_table(table).await
+    }
+
+    async fn schema_table_exists(&self, name: &str) -> Result<bool, DatabaseError> {
+        self.inner.schema_table_exists(name).await
+    }
+
+    async fn schema_drop_table(&self, name: &str) -> Result<(), DatabaseError> {
+        self.inner.schema_drop_table(name).await
+    }
+
+    async fn schema_add_column(&self, table: &str, column: &Column) -> Result<(), DatabaseError> {
+        self.inner.schema_add_column(table, column).await
+    }
+
+    // Bulk-write ops on cached tables hard-error to avoid silent stale-cache footguns.
+    async fn delete_where(
+        &self,
+        collection: &str,
+        filters: &[Filter],
+    ) -> Result<(), DatabaseError> {
+        if cache_key::classify_table(collection).is_some() {
+            return Err(DatabaseError::Internal(format!(
+                "bulk delete_where not supported on cached table `{collection}` \
+                 (would require KV mass-invalidation)"
+            )));
+        }
+        self.inner.delete_where(collection, filters).await
+    }
+
+    async fn update_where(
+        &self,
+        collection: &str,
+        filters: &[Filter],
+        data: HashMap<String, serde_json::Value>,
+    ) -> Result<(), DatabaseError> {
+        if cache_key::classify_table(collection).is_some() {
+            return Err(DatabaseError::Internal(format!(
+                "bulk update_where not supported on cached table `{collection}` \
+                 (would require KV mass-invalidation)"
+            )));
+        }
+        self.inner.update_where(collection, filters, data).await
+    }
+
+    // Cache-aware methods filled in by subsequent commits — placeholder pass-through for now.
+    async fn list(
+        &self,
+        collection: &str,
+        opts: &ListOptions,
+    ) -> Result<RecordList, DatabaseError> {
+        self.inner.list(collection, opts).await
+    }
+
+    async fn create(
+        &self,
+        collection: &str,
+        data: HashMap<String, serde_json::Value>,
+    ) -> Result<Record, DatabaseError> {
+        self.inner.create(collection, data).await
+    }
+
+    async fn update(
+        &self,
+        collection: &str,
+        id: &str,
+        data: HashMap<String, serde_json::Value>,
+    ) -> Result<Record, DatabaseError> {
+        self.inner.update(collection, id, data).await
+    }
+
+    async fn delete(&self, collection: &str, id: &str) -> Result<(), DatabaseError> {
+        self.inner.delete(collection, id).await
+    }
+}

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -47,6 +47,30 @@ pub fn make_d1_database_service(
     Ok(Arc::new(database::D1DatabaseService::new(db)))
 }
 
+/// Construct a [`DatabaseService`] backed by D1 with a Cloudflare KV cache
+/// layered on top of the per-block read paths (`variables WHERE block=?`
+/// and `block_settings WHERE block_name=?`).
+///
+/// The KV binding name must match a `[[kv_namespaces]]` entry in the
+/// consumer's `wrangler.toml` (canonical name: `"CONFIG_CACHE"`).
+///
+/// Fails fast if the KV binding is missing — silent degradation would
+/// mask a config-drift outage.
+///
+/// Spec: `docs/superpowers/specs/2026-05-22-kv-cached-d1-config-source-design.md`.
+pub fn make_kv_cached_database_service(
+    env: &worker::Env,
+    d1_binding: &str,
+    kv_binding: &str,
+) -> Result<Arc<dyn DatabaseService>, worker::Error> {
+    let inner = make_d1_database_service(env, d1_binding)?;
+    let kv_store = env.kv(kv_binding)?;
+    let backend = Arc::new(kv_cached_db::WorkerKvBackend(kv_store));
+    Ok(Arc::new(kv_cached_db::KvCachedD1DatabaseService::new(
+        inner, backend,
+    )))
+}
+
 /// Construct an R2-backed [`StorageService`] from a worker `Env` and the R2
 /// bucket binding name.
 ///
@@ -145,9 +169,9 @@ where
         Arc<dyn StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
-    // 1. Construct D1 service first — env vars live in D1.
-    let db = make_d1_database_service(&env, runner::D1_BINDING)
-        .map_err(|e| format!("D1 binding {:?}: {e}", runner::D1_BINDING))?;
+    // 1. Construct D1 service (with KV cache) first — env vars live in D1.
+    let db = make_kv_cached_database_service(&env, runner::D1_BINDING, runner::KV_BINDING)
+        .map_err(|e| format!("DB/KV bindings (D1={:?}, KV={:?}): {e}", runner::D1_BINDING, runner::KV_BINDING))?;
 
     // 2. Load block settings (enablement + migration state) eagerly —
     //    this is the only D1 read at cold start now. The per-block

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -14,6 +14,7 @@ pub mod convert;
 pub mod crypto_service;
 pub mod database;
 pub mod helpers;
+pub mod kv_cached_db;
 pub mod logger_service;
 pub mod network_service;
 mod runner;

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -171,7 +171,13 @@ where
 {
     // 1. Construct D1 service (with KV cache) first — env vars live in D1.
     let db = make_kv_cached_database_service(&env, runner::D1_BINDING, runner::KV_BINDING)
-        .map_err(|e| format!("DB/KV bindings (D1={:?}, KV={:?}): {e}", runner::D1_BINDING, runner::KV_BINDING))?;
+        .map_err(|e| {
+            format!(
+                "DB/KV bindings (D1={:?}, KV={:?}): {e}",
+                runner::D1_BINDING,
+                runner::KV_BINDING
+            )
+        })?;
 
     // 2. Load block settings (enablement + migration state) eagerly —
     //    this is the only D1 read at cold start now. The per-block

--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -10,6 +10,7 @@
 
 pub(crate) const D1_BINDING: &str = "DB";
 pub(crate) const R2_BINDING: &str = "STORAGE";
+pub(crate) const KV_BINDING: &str = "CONFIG_CACHE";
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -26,6 +26,47 @@ pub fn classify_table(table: &str) -> Option<CachedTable> {
     }
 }
 
+use wafer_block::db::{FilterOp, ListOptions};
+
+/// Minimum `limit` value treated as "all matching rows". Matches the
+/// `D1ConfigSource` and admin block list shapes. Anything smaller is
+/// treated as paginated and bypasses cache.
+const FULL_LIMIT_THRESHOLD: i64 = 10_000;
+
+/// Returns Some(kv_key) iff `opts` matches the canonical
+/// "load all rows for one block" shape.
+pub fn read_key(table: CachedTable, opts: &ListOptions) -> Option<String> {
+    if opts.filters.len() != 1
+        || !opts.skip_count
+        || opts.offset != 0
+        || opts.limit < FULL_LIMIT_THRESHOLD
+        || !opts.sort.is_empty()
+    {
+        return None;
+    }
+    let f = &opts.filters[0];
+    if !matches!(f.operator, FilterOp::Equal) {
+        return None;
+    }
+    let expected_col = match table {
+        CachedTable::Variables => "block",
+        CachedTable::BlockSettings => "block_name",
+    };
+    if f.field != expected_col {
+        return None;
+    }
+    let value_str = f.value.as_str()?;
+    Some(format_key(table, value_str))
+}
+
+fn format_key(table: CachedTable, value: &str) -> String {
+    let tag = match table {
+        CachedTable::Variables => "variables",
+        CachedTable::BlockSettings => "block_settings",
+    };
+    format!("cfg:v1:{tag}:{value}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,5 +92,101 @@ mod tests {
         assert_eq!(classify_table("suppers_ai__auth__users"), None);
         assert_eq!(classify_table(""), None);
         assert_eq!(classify_table("variables"), None);
+    }
+
+    use wafer_block::db::{Filter, FilterOp, ListOptions};
+
+    fn canonical_opts(field: &str, value: &str) -> ListOptions {
+        ListOptions {
+            filters: vec![Filter {
+                field: field.into(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(value.into()),
+            }],
+            limit: 10_000,
+            offset: 0,
+            skip_count: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn read_key_variables_canonical_shape() {
+        let opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        assert_eq!(
+            read_key(CachedTable::Variables, &opts),
+            Some("cfg:v1:variables:SUPPERS_AI__AUTH".to_string())
+        );
+    }
+
+    #[test]
+    fn read_key_block_settings_canonical_shape() {
+        let opts = canonical_opts("block_name", "wafer-run/registry");
+        assert_eq!(
+            read_key(CachedTable::BlockSettings, &opts),
+            Some("cfg:v1:block_settings:wafer-run/registry".to_string())
+        );
+    }
+
+    #[test]
+    fn read_key_wrong_column_returns_none() {
+        let opts = canonical_opts("key", "SOME_VAR");
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_multiple_filters_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.filters.push(Filter {
+            field: "key".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String("JWT_SECRET".into()),
+        });
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_no_filters_returns_none() {
+        let opts = ListOptions {
+            limit: 10_000,
+            skip_count: true,
+            ..Default::default()
+        };
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_non_equal_op_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.filters[0].operator = FilterOp::NotEqual;
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_skip_count_false_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.skip_count = false;
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_nonzero_offset_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.offset = 100;
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_small_limit_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.limit = 50;
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    #[test]
+    fn read_key_non_string_value_returns_none() {
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.filters[0].value = serde_json::Value::Number(42.into());
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
     }
 }

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -206,6 +206,14 @@ mod tests {
         assert_eq!(read_key(CachedTable::Variables, &opts), None);
     }
 
+    #[test]
+    fn read_key_sort_set_returns_none() {
+        use wafer_block::db::SortField;
+        let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
+        opts.sort.push(SortField { field: "key".into(), desc: false });
+        assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
     use std::collections::HashMap;
 
     fn row(field: &str, value: serde_json::Value) -> HashMap<String, serde_json::Value> {

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -71,10 +71,7 @@ use std::collections::HashMap;
 
 /// Pulls the cache-key column from a row payload. Returns Some(kv_key)
 /// when the column is present and string-typed.
-pub fn write_key(
-    table: CachedTable,
-    row: &HashMap<String, serde_json::Value>,
-) -> Option<String> {
+pub fn write_key(table: CachedTable, row: &HashMap<String, serde_json::Value>) -> Option<String> {
     let col = match table {
         CachedTable::Variables => "block",
         CachedTable::BlockSettings => "block_name",
@@ -210,7 +207,10 @@ mod tests {
     fn read_key_sort_set_returns_none() {
         use wafer_block::db::SortField;
         let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
-        opts.sort.push(SortField { field: "key".into(), desc: false });
+        opts.sort.push(SortField {
+            field: "key".into(),
+            desc: false,
+        });
         assert_eq!(read_key(CachedTable::Variables, &opts), None);
     }
 
@@ -224,7 +224,10 @@ mod tests {
 
     #[test]
     fn write_key_variables_extracts_block() {
-        let r = row("block", serde_json::Value::String("SUPPERS_AI__AUTH".into()));
+        let r = row(
+            "block",
+            serde_json::Value::String("SUPPERS_AI__AUTH".into()),
+        );
         assert_eq!(
             write_key(CachedTable::Variables, &r),
             Some("cfg:v1:variables:SUPPERS_AI__AUTH".to_string())
@@ -233,7 +236,10 @@ mod tests {
 
     #[test]
     fn write_key_block_settings_extracts_block_name() {
-        let r = row("block_name", serde_json::Value::String("wafer-run/registry".into()));
+        let r = row(
+            "block_name",
+            serde_json::Value::String("wafer-run/registry".into()),
+        );
         assert_eq!(
             write_key(CachedTable::BlockSettings, &r),
             Some("cfg:v1:block_settings:wafer-run/registry".to_string())

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -67,6 +67,22 @@ fn format_key(table: CachedTable, value: &str) -> String {
     format!("cfg:v1:{tag}:{value}")
 }
 
+use std::collections::HashMap;
+
+/// Pulls the cache-key column from a row payload. Returns Some(kv_key)
+/// when the column is present and string-typed.
+pub fn write_key(
+    table: CachedTable,
+    row: &HashMap<String, serde_json::Value>,
+) -> Option<String> {
+    let col = match table {
+        CachedTable::Variables => "block",
+        CachedTable::BlockSettings => "block_name",
+    };
+    let value_str = row.get(col)?.as_str()?;
+    Some(format_key(table, value_str))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +204,49 @@ mod tests {
         let mut opts = canonical_opts("block", "SUPPERS_AI__AUTH");
         opts.filters[0].value = serde_json::Value::Number(42.into());
         assert_eq!(read_key(CachedTable::Variables, &opts), None);
+    }
+
+    use std::collections::HashMap;
+
+    fn row(field: &str, value: serde_json::Value) -> HashMap<String, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert(field.into(), value);
+        m
+    }
+
+    #[test]
+    fn write_key_variables_extracts_block() {
+        let r = row("block", serde_json::Value::String("SUPPERS_AI__AUTH".into()));
+        assert_eq!(
+            write_key(CachedTable::Variables, &r),
+            Some("cfg:v1:variables:SUPPERS_AI__AUTH".to_string())
+        );
+    }
+
+    #[test]
+    fn write_key_block_settings_extracts_block_name() {
+        let r = row("block_name", serde_json::Value::String("wafer-run/registry".into()));
+        assert_eq!(
+            write_key(CachedTable::BlockSettings, &r),
+            Some("cfg:v1:block_settings:wafer-run/registry".to_string())
+        );
+    }
+
+    #[test]
+    fn write_key_missing_column_returns_none() {
+        let r = row("key", serde_json::Value::String("JWT_SECRET".into()));
+        assert_eq!(write_key(CachedTable::Variables, &r), None);
+    }
+
+    #[test]
+    fn write_key_non_string_value_returns_none() {
+        let r = row("block", serde_json::Value::Number(42.into()));
+        assert_eq!(write_key(CachedTable::Variables, &r), None);
+    }
+
+    #[test]
+    fn write_key_empty_row_returns_none() {
+        let r: HashMap<String, serde_json::Value> = HashMap::new();
+        assert_eq!(write_key(CachedTable::Variables, &r), None);
     }
 }

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -1,0 +1,55 @@
+//! Pure functions translating `(table, ListOptions)` and `(table, row)`
+//! into KV cache keys. Determines which `DatabaseService` calls qualify
+//! for caching and how to derive their key.
+//!
+//! Consumed by `solobase-cloudflare::kv_cached_db`. Pure data-mapping
+//! logic lives here so it's host-testable; `solobase-cloudflare` is
+//! excluded from `cargo test --workspace`.
+
+use crate::blocks::admin::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE};
+
+/// Tables that this wrapper caches in KV.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachedTable {
+    /// `suppers_ai__admin__variables` — config var rows, keyed by `block` column.
+    Variables,
+    /// `suppers_ai__admin__block_settings` — per-block migration state, keyed by `block_name` column.
+    BlockSettings,
+}
+
+/// Returns Some when `table` is one of the cached tables.
+pub fn classify_table(table: &str) -> Option<CachedTable> {
+    match table {
+        t if t == VARIABLES_TABLE => Some(CachedTable::Variables),
+        t if t == BLOCK_SETTINGS_TABLE => Some(CachedTable::BlockSettings),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_table_variables() {
+        assert_eq!(
+            classify_table("suppers_ai__admin__variables"),
+            Some(CachedTable::Variables)
+        );
+    }
+
+    #[test]
+    fn classify_table_block_settings() {
+        assert_eq!(
+            classify_table("suppers_ai__admin__block_settings"),
+            Some(CachedTable::BlockSettings)
+        );
+    }
+
+    #[test]
+    fn classify_table_unknown_returns_none() {
+        assert_eq!(classify_table("suppers_ai__auth__users"), None);
+        assert_eq!(classify_table(""), None);
+        assert_eq!(classify_table("variables"), None);
+    }
+}

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod blocks;
 pub mod builder;
 pub mod cache;
+pub mod cache_key;
 pub mod config_source;
 pub mod config_vars;
 pub mod crypto;


### PR DESCRIPTION
## Summary

Wraps `D1DatabaseService` with a write-through-invalidated, KV-backed cache for the `variables` and `block_settings` per-block read paths.

- **Spec:** `workspace/docs/superpowers/specs/2026-05-22-kv-cached-d1-config-source-design.md`
- **Plan:** `workspace/docs/superpowers/plans/2026-05-22-kv-cached-d1-config-source.md`
- **Motivation report:** `workspace/docs/superpowers/measurements/2026-05-18-phase-1-d1-read-drop.md`

Filter-shape inspection on `list()`; pre-read on `update`/`delete`; 24h TTL backstop; KV failures degrade to D1 fall-through (warnings only, never errors). Cross-platform `DatabaseService` trait shape unchanged; native and browser-WASM bypass entirely.

## What landed

- **`solobase-core::cache_key`** (host-testable, 18 unit tests + 1 adversarial sort-guard test = 19 total): `CachedTable` enum, `classify_table`, `read_key` (filter-shape inspection), `write_key` (row inspection).
- **`solobase-cloudflare::kv_cached_db`** (wasm32-only): `KvBackend` trait, `WorkerKvBackend` production impl, `KvCachedD1DatabaseService` wrapper.
- **`solobase-cloudflare::make_kv_cached_database_service`** helper + wiring in `run_inner` + new `runner::KV_BINDING` constant.

Bulk-write ops on cached tables (`delete_where`/`update_where`) hard-error to avoid silent stale-cache footguns. No caller writes to these tables in bulk today (audited 2026-05-22).

## Companion PR

`site/` needs the matching wrangler-config change to bind `CONFIG_CACHE`. See https://github.com/wafer-run/site/pull/?? (to be opened).

## Deploy notes

One-time operator setup before merging:

```
wrangler kv namespace create CONFIG_CACHE --preview false
```

Capture the namespace id and substitute it for the `REPLACE_WITH_REAL_NAMESPACE_ID` placeholder in `site/wrangler.overrides.toml`.

After deploy, KV starts empty — first ~5–10 minutes of cold starts pay full D1 cost as the cache warms. Steady state shows the cache hit path.

## ⚠️ CI status

CI will fail on the pre-existing `register_static_block` breakage in `solobase-core/src/blocks/{admin,auth_ui,email,system}/mod.rs` — fallout from wafer-run Wave 4 PR-A that hasn't been swept through solobase yet (the in-flight Wave 6 work). This PR introduces no new compile errors; wasm32 target builds clean (`cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` passes).

Reviewable now, mergeable after Wave 6 lands.

## Integration tests deferred

`solobase-cloudflare` is excluded from `cargo test --workspace` (it's wasm32-only) and `wasm-pack test --node` is not set up in CI. The wrapper's behavior is verified by:

1. The 19 pure-function tests in `solobase-core::cache_key` covering the tricky filter-shape/row-key derivation logic.
2. Code review (two-stage: spec compliance + code quality, both ✅).
3. Post-deploy `wrangler d1 insights wafer-site-prod --time-period 2d` re-measurement 24h after deploy. **Success criterion:** `variables WHERE block=?` runs/day drops from ~1,665 toward ≤200/day.

Setting up wasm-pack-test CI is a separate future task.

## Test plan

- [x] `cargo test -p solobase-core --lib cache_key::` — 19 tests pass (3 classify + 11 read_key + 5 write_key)
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- [ ] CI green (blocked on Wave 6)
- [ ] Post-deploy: `wrangler d1 insights wafer-site-prod --time-period 2d`, expect `variables WHERE block=?` runs/day drop ≥5× vs current baseline
- [ ] Document the post-deploy number as a follow-up in `workspace/docs/superpowers/measurements/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)