### PR TITLE
feat(loader): break recovery loop with manual reset fallback

### DIFF
--- a/crates/solobase-browser/assets/loader.js.tmpl
+++ b/crates/solobase-browser/assets/loader.js.tmpl
@@ -2,12 +2,69 @@
 // so the very next page load hits the recovery path (below) instead of
 // re-registering the SW with the same stale browser-cached modules.
 const SW_RECOVER_KEY = '__solobase_sw_recover';
+// Set once the recovery path has already run in this tab. A second
+// self-destruct after recovery means wiping SW + caches (and OPFS, when
+// allowed) didn't resolve the underlying failure — looping again would
+// just burn another `?_freshen` reload and crash the same way. We surface
+// to the user via `renderRecoveryStuckUI` instead.
+const RECOVERY_DONE_KEY = '__solobase_recovery_done';
 // Whether the recovery path should wipe OPFS. Set per-build via the
 // `opfs_wipe_on_recovery` field on the bundle config (CLI flag
 // `--opfs-wipe-on-recovery`). Demo builds set it true so a schema-drift
 // loop self-resolves; production apps whose OPFS holds user data leave
 // it false and surface the error instead.
 const OPFS_WIPE_ON_RECOVERY = __OPFS_WIPE_ON_RECOVERY__;
+
+// Unregister all SWs, drop Cache Storage, and (if asked) clear OPFS.
+// Used both by automatic recovery and by the manual reset button on the
+// stuck-UI fallback, so the wipe semantics stay in one place.
+async function wipeBrowserState({ wipeOpfs }) {
+    try {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        for (const r of regs) await r.unregister();
+        const keys = await caches.keys();
+        for (const k of keys) await caches.delete(k);
+    } catch (e) {
+        console.error('[__APP_NAME__] cache wipe failed:', e);
+    }
+    if (wipeOpfs) {
+        try {
+            if (navigator.storage && navigator.storage.getDirectory) {
+                const root = await navigator.storage.getDirectory();
+                for await (const [name] of root.entries()) {
+                    await root.removeEntry(name, { recursive: true });
+                }
+            }
+        } catch (e) {
+            console.error('[__APP_NAME__] OPFS wipe failed:', e);
+        }
+    }
+}
+
+// Fallback UI shown when automatic recovery can't break the failure loop.
+// Replaces the loader card with an explanation and a manual reset button.
+// The button does a full wipe including OPFS regardless of
+// OPFS_WIPE_ON_RECOVERY — the user has explicitly opted in by clicking.
+function renderRecoveryStuckUI() {
+    const card = document.querySelector('.loader') || document.body;
+    card.innerHTML =
+        '<div style="max-width:480px;margin:0 auto;text-align:left;padding:1.5rem;font:inherit;line-height:1.5;">' +
+        '<h1 style="margin-top:0;font-size:1.25rem;">__APP_NAME__ couldn\'t start</h1>' +
+        '<p>Your local data is incompatible with the current version of this app, and automatic recovery didn\'t resolve it.</p>' +
+        '<p>Resetting will erase data stored locally in this browser and reload the app.</p>' +
+        '<button id="solobase-reset" style="background:#1f6feb;color:#fff;border:0;border-radius:6px;padding:0.6rem 1rem;font:inherit;cursor:pointer;">Reset local data and reload</button>' +
+        '</div>';
+    document.getElementById('solobase-reset').addEventListener('click', async () => {
+        const btn = document.getElementById('solobase-reset');
+        btn.disabled = true;
+        btn.textContent = 'Resetting…';
+        await wipeBrowserState({ wipeOpfs: true });
+        try { localStorage.clear(); } catch (_) {}
+        try { sessionStorage.clear(); } catch (_) {}
+        // Strip the `?_freshen` query so the next boot starts from a clean URL.
+        window.location.replace(window.location.origin + window.location.pathname);
+    });
+}
 
 async function boot() {
     const status = document.getElementById('status');
@@ -30,27 +87,18 @@ async function boot() {
     // why self-destruct fires in the first place.
     if (sessionStorage.getItem(SW_RECOVER_KEY)) {
         sessionStorage.removeItem(SW_RECOVER_KEY);
+        // Loop guard: a recovery already ran in this tab. The wipe didn't
+        // resolve the boot failure, so retrying would just reload again
+        // with another `?_freshen` and crash the same way. Surface the
+        // error so the user can choose to wipe OPFS (production builds
+        // with OPFS_WIPE_ON_RECOVERY=false can't do it automatically).
+        if (sessionStorage.getItem(RECOVERY_DONE_KEY)) {
+            renderRecoveryStuckUI();
+            return;
+        }
+        sessionStorage.setItem(RECOVERY_DONE_KEY, '1');
         status.textContent = 'Recovering from stale cache...';
-        try {
-            const regs = await navigator.serviceWorker.getRegistrations();
-            for (const r of regs) await r.unregister();
-            const keys = await caches.keys();
-            for (const k of keys) await caches.delete(k);
-        } catch (e) {
-            console.error('[__APP_NAME__] cache wipe failed:', e);
-        }
-        if (OPFS_WIPE_ON_RECOVERY) {
-            try {
-                if (navigator.storage && navigator.storage.getDirectory) {
-                    const root = await navigator.storage.getDirectory();
-                    for await (const [name] of root.entries()) {
-                        await root.removeEntry(name, { recursive: true });
-                    }
-                }
-            } catch (e) {
-                console.error('[__APP_NAME__] OPFS wipe failed:', e);
-            }
-        }
+        await wipeBrowserState({ wipeOpfs: OPFS_WIPE_ON_RECOVERY });
         const url = new URL(window.location.href);
         url.searchParams.set('_freshen', String(Date.now()));
         window.location.replace(url.toString());

--- a/crates/solobase-browser/src/assets.rs
+++ b/crates/solobase-browser/src/assets.rs
@@ -97,4 +97,38 @@ mod tests {
             assert_eq!(got, asset.bytes, "mismatched bytes for {:?}", asset.path);
         }
     }
+
+    // Regression: the loader's recovery path must include a loop-guard that
+    // stops the `self-destruct → wipe → ?_freshen reload → self-destruct`
+    // cycle that traps production builds (OPFS_WIPE_ON_RECOVERY=false) when
+    // initialize() keeps failing after a wipe — and must surface a manual
+    // reset UI instead. Render the actual template and assert the loop-guard
+    // wiring is present.
+    #[test]
+    fn loader_template_renders_with_recovery_loop_guard() {
+        use crate::tools::bundle::template;
+        use std::collections::BTreeMap;
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("loader.js.tmpl");
+        let out = tmp.path().join("loader.js");
+        std::fs::write(&src, include_bytes!("../assets/loader.js.tmpl")).unwrap();
+        let mut vars = BTreeMap::new();
+        vars.insert("APP_NAME".into(), "demo-app".into());
+        vars.insert("BOOT_REDIRECT".into(), "/".into());
+        vars.insert("OPFS_WIPE_ON_RECOVERY".into(), "false".into());
+
+        template::render_to_file(&src, &out, &vars).unwrap();
+        let body = std::fs::read_to_string(&out).unwrap();
+
+        assert!(body.contains("RECOVERY_DONE_KEY"), "missing loop-guard key");
+        assert!(
+            body.contains("renderRecoveryStuckUI"),
+            "missing stuck-UI fallback fn"
+        );
+        assert!(
+            body.contains("Reset local data and reload"),
+            "missing manual reset button label"
+        );
+        assert!(body.contains("const OPFS_WIPE_ON_RECOVERY = false;"));
+    }
 }

--- a/crates/solobase-browser/src/assets.rs
+++ b/crates/solobase-browser/src/assets.rs
@@ -106,8 +106,9 @@ mod tests {
     // wiring is present.
     #[test]
     fn loader_template_renders_with_recovery_loop_guard() {
-        use crate::tools::bundle::template;
         use std::collections::BTreeMap;
+
+        use crate::tools::bundle::template;
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("loader.js.tmpl");
         let out = tmp.path().join("loader.js");


### PR DESCRIPTION
## Summary

The boot recovery path in `solobase-browser`'s loader had no termination condition. When `initialize()` keeps failing after a wipe — for example an OPFS schema-drift bug that a production build (`OPFS_WIPE_ON_RECOVERY=false`) can't auto-fix — every cold start runs the recovery cycle indefinitely:

```
boot → SW activate → initialize() fails → sw-self-destruct
     → recovery wipes SW + caches (NOT OPFS for prod builds)
     → window.location.replace(...?_freshen=NOW)
     → boot → SW activate → same initialize() failure → ...
```

This is what trapped every returning gizza.ai user during the upsert-builder bug fixed in [wafer-run#161](https://github.com/wafer-run/wafer-run/pull/161). The page just spun on `?_freshen` URLs and the only escape was running DevTools console snippets to nuke OPFS by hand.

## What changed

- **Loop guard**: set `RECOVERY_DONE_KEY` in `sessionStorage` on first recovery. If recovery would run again with that key already set, render a fallback UI instead of looping.
- **Manual reset UI**: `renderRecoveryStuckUI()` replaces the loader card with a short explanation and a "Reset local data and reload" button. The button performs the full wipe — OPFS forced, since the user has explicitly opted in by clicking — then redirects to a clean URL.
- **Shared wipe helper**: pulled the SW + caches + OPFS wipe out of the recovery branch into `wipeBrowserState({wipeOpfs})`. Both recovery and the reset button now go through one code path.

## Behaviour matrix

| Path | Before | After |
|---|---|---|
| Initialize succeeds | Boots fine | Boots fine (unchanged) |
| Initialize fails once, recovery fixes it | Recovers + reloads, ✓ | Recovers + reloads, ✓ (unchanged) |
| Initialize keeps failing, `OPFS_WIPE_ON_RECOVERY=true` (demo) | Wipe OPFS, reload, ✓ | Same first pass; if it *still* fails → stuck-UI |
| Initialize keeps failing, `OPFS_WIPE_ON_RECOVERY=false` (prod) | Loops forever | Stuck-UI after one attempt; user can manually reset |
| User opens a new tab | (in loop) | Fresh per-tab `sessionStorage` → one more automatic recovery attempt before stuck-UI |

## Tests

- New `loader_template_renders_with_recovery_loop_guard` in `assets.rs` renders the actual `loader.js.tmpl` through the template engine and asserts the loop-guard symbols (`RECOVERY_DONE_KEY`, `renderRecoveryStuckUI`, the reset-button label) survive substitution. The pre-existing asset-byte tests would not have caught regressions to the inline HTML.
- All 4 `assets::tests::*` pass locally.
- `bundle_integration` tests pass locally.

## Test plan

- [x] `cargo test -p solobase-browser --lib assets`
- [x] `cargo test -p solobase-browser --test bundle_integration`
- [ ] CI green
- [ ] After merge: rebuild + redeploy gizza.ai (or any browser-WASM consumer), confirm normal boot still works and a forced `initialize()` failure surfaces the reset UI on the second pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)