### PR TITLE
fix(solobase-core/files): move typed Storage grant to admin block (Wave 12 PR B)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -143,6 +143,17 @@ impl Block for AdminBlock {
                 // wants per-op control.
                 wafer_run::ResourceGrant::read_write("*", "*")
                     .typed(wafer_run::types::ResourceType::Crypto),
+                // Typed Storage grant for the files block. The wafer-run
+                // validator rejects typed Storage grants from non-admin blocks
+                // (runtime/lifecycle.rs:36-101), so only admin may declare them.
+                // Scoped to suppers-ai/files specifically (rather than `*/*`
+                // like Network/Crypto above) so other blocks remain Storage
+                // default-deny — preserves least-privilege for the resource
+                // type whose actual production use is concentrated in one
+                // feature block. See spec
+                // docs/superpowers/specs/2026-05-24-wave-12-cors-options-and-files-grant-design.md.
+                wafer_run::ResourceGrant::read_write("suppers-ai/files", "*")
+                    .typed(wafer_run::types::ResourceType::Storage),
             ])
             .category(wafer_run::BlockCategory::Feature)
             .description("Administration panel for managing users, roles, variables, blocks, and logs. Provides SSR dashboard with stats, user management with role assignment, IAM (roles and API keys), environment variables editor, block management with feature toggles, and system/audit log viewer.")
@@ -552,5 +563,31 @@ mod tests {
             .unwrap_or("");
         assert_eq!(status, "308");
         assert_eq!(location, "/b/admin/settings/email");
+    }
+}
+
+#[cfg(test)]
+mod grant_tests {
+    use super::AdminBlock;
+    use wafer_block::types::ResourceType;
+    use wafer_run::block::Block;
+
+    #[test]
+    fn admin_block_declares_typed_storage_grant_for_files() {
+        let admin = AdminBlock::new();
+        let grants = admin.info().grants;
+
+        let storage_grant = grants.iter().find(|g| {
+            g.resource_type == Some(ResourceType::Storage) && g.grantee == "suppers-ai/files"
+        });
+
+        let g = storage_grant.expect(
+            "admin block must declare a typed Storage grant for suppers-ai/files \
+             (validator rejects typed Storage grants from non-admin blocks, so the \
+             files block's own declaration is silently dropped — see \
+             wafer-run/runtime/lifecycle.rs:36-101)",
+        );
+        assert_eq!(g.resource, "*", "files Storage grant must cover all paths");
+        assert!(g.write, "files Storage grant must allow writes");
     }
 }

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -145,7 +145,8 @@ impl Block for AdminBlock {
                     .typed(wafer_run::types::ResourceType::Crypto),
                 // Typed Storage grant for the files block. The wafer-run
                 // validator rejects typed Storage grants from non-admin blocks
-                // (runtime/lifecycle.rs:36-101), so only admin may declare them.
+                // (runtime/lifecycle.rs::validate_and_collect_grants_for_block),
+                // so only admin may declare them.
                 // Scoped to suppers-ai/files specifically (rather than `*/*`
                 // like Network/Crypto above) so other blocks remain Storage
                 // default-deny — preserves least-privilege for the resource
@@ -569,8 +570,8 @@ mod tests {
 #[cfg(test)]
 mod grant_tests {
     use super::AdminBlock;
-    use wafer_block::types::ResourceType;
     use wafer_run::block::Block;
+    use wafer_run::types::ResourceType;
 
     #[test]
     fn admin_block_declares_typed_storage_grant_for_files() {
@@ -585,7 +586,7 @@ mod grant_tests {
             "admin block must declare a typed Storage grant for suppers-ai/files \
              (validator rejects typed Storage grants from non-admin blocks, so the \
              files block's own declaration is silently dropped — see \
-             wafer-run/runtime/lifecycle.rs:36-101)",
+             wafer-run/runtime/lifecycle.rs validate_and_collect_grants_for_block)",
         );
         assert_eq!(g.resource, "*", "files Storage grant must cover all paths");
         assert!(g.write, "files Storage grant must allow writes");

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -569,9 +569,9 @@ mod tests {
 
 #[cfg(test)]
 mod grant_tests {
+    use wafer_run::{block::Block, types::ResourceType};
+
     use super::AdminBlock;
-    use wafer_run::block::Block;
-    use wafer_run::types::ResourceType;
 
     #[test]
     fn admin_block_declares_typed_storage_grant_for_files() {

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -48,21 +48,16 @@ impl FilesBlock {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Block for FilesBlock {
     fn info(&self) -> BlockInfo {
-        use wafer_block::types::{ResourceGrant, ResourceType};
         use wafer_run::{types::CollectionSchema, AuthLevel};
 
         BlockInfo::new("suppers-ai/files", "0.0.1", "http-handler@v1", "File storage, sharing, quotas, and access logging")
             .instance_mode(InstanceMode::Singleton)
             .requires(vec!["wafer-run/database".into(), "wafer-run/storage".into(), "wafer-run/config".into()])
-            // Storage WRAP grant: this block manages user-created buckets at
-            // arbitrary names ({bucket}/{key}). Without an explicit grant,
-            // `wafer-run/local-storage` denies all storage ops with caller
-            // `suppers-ai/files`. Owned by this block — no other block writes
-            // through these paths. (Network/Storage grants skip the owner
-            // check at startup; see `runtime/lifecycle.rs::collect_wrap_grants`.)
-            .grants(vec![
-                ResourceGrant::read_write("suppers-ai/files", "*").typed(ResourceType::Storage),
-            ])
+            // Storage WRAP grant for this block is declared by the admin block
+            // (solobase-core/src/blocks/admin/mod.rs). The wafer-run validator
+            // rejects typed Storage grants from non-admin blocks; only admin
+            // may declare them. See spec
+            // docs/superpowers/specs/2026-05-24-wave-12-cors-options-and-files-grant-design.md.
             .collections(vec![
                 CollectionSchema::new(BUCKETS_TABLE)
                     .field("name", "string")
@@ -283,3 +278,27 @@ impl Block for FilesBlock {
 
 #[cfg(not(target_arch = "wasm32"))]
 ::wafer_block::register_static_block!("suppers-ai/files", FilesBlock);
+
+#[cfg(test)]
+mod grant_tests {
+    use super::FilesBlock;
+    use wafer_block::types::ResourceType;
+    use wafer_run::block::Block;
+
+    #[test]
+    fn files_block_does_not_declare_typed_storage() {
+        let files = FilesBlock::new();
+        let grants = files.info().grants;
+
+        let typed_storage = grants
+            .iter()
+            .find(|g| g.resource_type == Some(ResourceType::Storage));
+
+        assert!(
+            typed_storage.is_none(),
+            "files block must not declare a typed Storage grant — the wafer-run \
+             validator rejects typed Storage grants from non-admin blocks. The \
+             grant belongs in admin/mod.rs's grants list. (got: {typed_storage:?})",
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -281,9 +281,9 @@ impl Block for FilesBlock {
 
 #[cfg(test)]
 mod grant_tests {
+    use wafer_run::{block::Block, types::ResourceType};
+
     use super::FilesBlock;
-    use wafer_run::block::Block;
-    use wafer_run::types::ResourceType;
 
     #[test]
     fn files_block_does_not_declare_typed_storage() {

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -282,8 +282,8 @@ impl Block for FilesBlock {
 #[cfg(test)]
 mod grant_tests {
     use super::FilesBlock;
-    use wafer_block::types::ResourceType;
     use wafer_run::block::Block;
+    use wafer_run::types::ResourceType;
 
     #[test]
     fn files_block_does_not_declare_typed_storage() {


### PR DESCRIPTION
## Summary
- `solobase-core/files` declared `ResourceGrant::read_write("suppers-ai/files", "*").typed(Storage)` in its `BlockInfo`. The wafer-run validator (`runtime/lifecycle.rs:36-101`) rejects typed Storage grants from non-admin blocks with a `tracing::error!`, so the grant was silently dropped at startup. Production has been working only because operators had manually added DB-loaded WRAP grants via the admin UI.
- Wave 11 PR B (`wafer-run/wafer-run#163`) made the web block propagate real storage errors instead of masking as 404, so fresh-install operators now visibly hit `HTTP 403 PermissionDenied` on the file-storage path. This PR closes the gap by declaring the grant where the validator accepts it.
- Grant moves from `files/mod.rs:64` to `admin/mod.rs` (alongside the existing typed Network/Crypto wildcards), scoped specifically to `suppers-ai/files` rather than `*/*` — preserves Storage default-deny for other blocks.

## Wire-behavior change
Fresh-install solobase deployments now have Storage access enabled for the files block by default. Operators who depend on the **absence** of this grant (intentionally disabled file uploads via not granting Storage) can remove the new code-declared grant via the admin UI the same way they would remove any other grant.

Operators with existing DB-loaded Storage grants for `suppers-ai/files` are unaffected — WRAP grant matching is OR-based, so additive grants are harmless and no migration is required.

## Test plan
- [x] `cargo test -p solobase-core` — new introspection tests on both blocks pass; existing suite green
- [x] `cargo clippy -p solobase-core --all-targets -- -D warnings` clean
- [x] `cargo build --workspace` + workspace-wide clippy clean
- [ ] Manual fresh-install smoke: `rm -rf data/ && cargo run`, log in as admin, POST to `/b/storage/api/buckets/{bucket}/objects` returns 200; boot logs contain no `tracing::error!` about rejecting `suppers-ai/files` Storage

## Wave context
Spec: `docs/superpowers/specs/2026-05-24-wave-12-cors-options-and-files-grant-design.md`. Pair PR A (wafer-run/wafer-run) ships the CORS OPTIONS preflight headers-loss fix in parallel; both surfaced by Wave 11 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)