### PR TITLE
feat(features): hash-gated re-seed for block_settings.enabled defaults

### DIFF
--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -24,7 +24,7 @@ use wafer_core::interfaces::database::service::DatabaseService;
 /// Returns `BlockSettings::default()` on missing collection or query
 /// failure — matches the existing solobase-cloud worker's error tolerance.
 pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockSettings {
-    use solobase_core::features::{BlockState, MigrationState};
+    use solobase_core::features::{BlockState, ExistingRow, MigrationState, SeedOp};
 
     let opts = ListOptions {
         offset: 0,
@@ -32,52 +32,126 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
         skip_count: true,
         ..Default::default()
     };
-    match db.list(BLOCK_SETTINGS_TABLE, &opts).await {
-        Ok(record_list) => {
-            let blocks: HashMap<String, BlockState> = record_list
-                .records
-                .into_iter()
-                .filter_map(|r| {
-                    let name = r.data.get("block_name")?.as_str()?.to_string();
-                    let enabled = r.data.get("enabled")?.as_i64()? != 0;
-                    let current_hash = r
-                        .data
-                        .get("current_hash")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let blessed_hash = r
-                        .data
-                        .get("blessed_hash")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let seed_defaults_hash = r
-                        .data
-                        .get("seed_defaults_hash")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    Some((
-                        name,
-                        BlockState {
-                            enabled,
-                            migration: MigrationState {
-                                current_hash,
-                                blessed_hash,
-                            },
-                            seed_defaults_hash,
-                        },
-                    ))
-                })
-                .collect();
-            BlockSettings::from_blocks(blocks)
-        }
+    let record_list = match db.list(BLOCK_SETTINGS_TABLE, &opts).await {
+        Ok(rl) => rl,
         Err(e) => {
             worker::console_log!("warn: load_block_settings failed: {e}");
-            BlockSettings::default()
+            return BlockSettings::default();
+        }
+    };
+
+    // Build the existing-row map for the hash-gate planner.
+    let existing: HashMap<String, ExistingRow> = record_list
+        .records
+        .iter()
+        .filter_map(|r| {
+            let name = r.data.get("block_name")?.as_str()?.to_string();
+            let enabled = r.data.get("enabled")?.as_i64()? != 0;
+            let hash = r
+                .data
+                .get("seed_defaults_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some((name, ExistingRow { enabled, hash }))
+        })
+        .collect();
+
+    // Plan + apply. Steady state: empty decisions → zero D1 writes.
+    let decisions = solobase_core::features::plan_seed_decisions(&existing);
+    let any_writes = !decisions.is_empty();
+    for d in &decisions {
+        let enabled_val = serde_json::Value::Number(serde_json::Number::from(
+            if d.enabled { 1i64 } else { 0i64 },
+        ));
+        let hash_val = serde_json::Value::String(d.hash.clone());
+        let now = chrono::Utc::now().to_rfc3339();
+        match d.op {
+            SeedOp::Insert => {
+                let id = format!("bs_{}", uuid::Uuid::new_v4());
+                let mut data: HashMap<String, serde_json::Value> = HashMap::new();
+                data.insert("id".into(), serde_json::Value::String(id));
+                data.insert(
+                    "block_name".into(),
+                    serde_json::Value::String(d.block_name.to_string()),
+                );
+                data.insert("enabled".into(), enabled_val);
+                data.insert("seed_defaults_hash".into(), hash_val);
+                data.insert("created_at".into(), serde_json::Value::String(now.clone()));
+                data.insert("updated_at".into(), serde_json::Value::String(now));
+                if let Err(e) = db.create(BLOCK_SETTINGS_TABLE, data).await {
+                    worker::console_log!("warn: seed insert {} failed: {e}", d.block_name);
+                }
+            }
+            SeedOp::Update => {
+                let filters = vec![Filter {
+                    field: "block_name".to_string(),
+                    operator: FilterOp::Equal,
+                    value: serde_json::Value::String(d.block_name.to_string()),
+                }];
+                let mut data: HashMap<String, serde_json::Value> = HashMap::new();
+                data.insert("enabled".into(), enabled_val);
+                data.insert("seed_defaults_hash".into(), hash_val);
+                data.insert("updated_at".into(), serde_json::Value::String(now));
+                if let Err(e) = db.update_where(BLOCK_SETTINGS_TABLE, &filters, data).await {
+                    worker::console_log!("warn: seed update {} failed: {e}", d.block_name);
+                }
+            }
         }
     }
+
+    // If we wrote anything, re-read for the post-seed view. Costs 1 extra
+    // D1 read only when a default actually changed (rare).
+    let final_records = if any_writes {
+        match db.list(BLOCK_SETTINGS_TABLE, &opts).await {
+            Ok(rl) => rl.records,
+            Err(e) => {
+                worker::console_log!("warn: post-seed re-read failed: {e}");
+                record_list.records
+            }
+        }
+    } else {
+        record_list.records
+    };
+
+    let blocks: HashMap<String, BlockState> = final_records
+        .into_iter()
+        .filter_map(|r| {
+            let name = r.data.get("block_name")?.as_str()?.to_string();
+            let enabled = r.data.get("enabled")?.as_i64()? != 0;
+            let current_hash = r
+                .data
+                .get("current_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let blessed_hash = r
+                .data
+                .get("blessed_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let seed_defaults_hash = r
+                .data
+                .get("seed_defaults_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some((
+                name,
+                BlockState {
+                    enabled,
+                    migration: MigrationState {
+                        current_hash,
+                        blessed_hash,
+                    },
+                    seed_defaults_hash,
+                },
+            ))
+        })
+        .collect();
+
+    BlockSettings::from_blocks(blocks)
 }
 
 /// Auto-generate random secrets for every `ConfigVar` declared with

--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -61,9 +61,11 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
     let decisions = solobase_core::features::plan_seed_decisions(&existing);
     let any_writes = !decisions.is_empty();
     for d in &decisions {
-        let enabled_val = serde_json::Value::Number(serde_json::Number::from(
-            if d.enabled { 1i64 } else { 0i64 },
-        ));
+        let enabled_val = serde_json::Value::Number(serde_json::Number::from(if d.enabled {
+            1i64
+        } else {
+            0i64
+        }));
         let hash_val = serde_json::Value::String(d.hash.clone());
         let now = chrono::Utc::now().to_rfc3339();
         match d.op {

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -70,9 +70,15 @@ pub mod block_settings {
                 ("enabled".to_string(), serde_json::json!(enabled_int)),
                 ("created_at".to_string(), serde_json::json!(&now)),
                 ("updated_at".to_string(), serde_json::json!(&now)),
+                // Admin-UI write — mark this row as user-owned so the
+                // boot-time seed never overwrites it.
+                (
+                    "seed_defaults_hash".to_string(),
+                    serde_json::json!(crate::features::USER_EDITED_SENTINEL),
+                ),
             ],
             &["block_name"],
-            &["enabled", "updated_at"],
+            &["enabled", "updated_at", "seed_defaults_hash"],
             Backend::Sqlite,
         );
         db::execute(ctx, &stmt)
@@ -734,6 +740,40 @@ mod tests {
         assert!(
             enabled,
             "is_enabled should return true when no block_settings row exists"
+        );
+    }
+
+    /// `block_settings::set_enabled` stamps `seed_defaults_hash` with the
+    /// [`USER_EDITED_SENTINEL`] so the boot-time seed will never clobber an
+    /// admin-UI toggle. See `plan_seed_decisions` in `features.rs`.
+    #[tokio::test]
+    async fn block_settings_set_enabled_marks_row_user_edited() {
+        let ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        let name = "suppers-ai/some-block";
+        block_settings::set_enabled(&ctx, name, false)
+            .await
+            .expect("set_enabled false");
+
+        let rows = db::list_all(
+            &ctx,
+            BLOCK_SETTINGS_TABLE,
+            vec![Filter {
+                field: "block_name".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(name.to_string()),
+            }],
+        )
+        .await
+        .expect("list block_settings");
+        assert_eq!(rows.len(), 1, "exactly one block_settings row for {name}");
+        assert_eq!(
+            rows[0].str_field("seed_defaults_hash"),
+            crate::features::USER_EDITED_SENTINEL,
+            "set_enabled must stamp seed_defaults_hash with the user-edited sentinel",
         );
     }
 

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -254,11 +254,183 @@ pub enum SeedOp {
     Update,
 }
 
+/// Compute the set of writes needed to bring `block_settings.enabled`
+/// rows in sync with [`ENABLED_DEFAULTS`].
+///
+/// Pure function — no DB access. The caller supplies the already-loaded
+/// `existing` map (keyed by block_name → `ExistingRow`) and applies the
+/// returned decisions in whatever shape its persistence layer prefers
+/// (one upsert per decision, batched, etc.).
+///
+/// Steady-state cost: empty `Vec` returned → caller issues zero writes.
+///
+/// Per-row branching:
+/// - Row absent → `SeedOp::Insert` at the current default.
+/// - Row present with `hash == USER_EDITED_SENTINEL` → skip (admin owns it).
+/// - Row present with empty `hash` → skip (legacy state, preserve).
+/// - Row present with `hash == seed_hash_for(current_default)` → skip
+///   (already at the current seeded default).
+/// - Row present with any other `"seed:..."` hash → `SeedOp::Update`
+///   (stale seed hash; default changed since the row was last seeded).
+pub fn plan_seed_decisions(
+    existing: &HashMap<String, ExistingRow>,
+) -> Vec<SeedDecision> {
+    let mut out = Vec::new();
+    for &(name, default) in ENABLED_DEFAULTS {
+        let want_hash = seed_hash_for(default);
+        match existing.get(name) {
+            None => out.push(SeedDecision {
+                block_name: name,
+                enabled: default,
+                hash: want_hash,
+                op: SeedOp::Insert,
+            }),
+            Some(row) => {
+                if row.hash == USER_EDITED_SENTINEL || row.hash.is_empty() {
+                    continue;
+                }
+                if row.hash == want_hash {
+                    continue;
+                }
+                out.push(SeedDecision {
+                    block_name: name,
+                    enabled: default,
+                    hash: want_hash,
+                    op: SeedOp::Update,
+                });
+            }
+        }
+    }
+    out
+}
+
 /// All features enabled (for testing).
 pub struct AllEnabled;
 
 impl FeatureConfig for AllEnabled {
     fn is_block_enabled(&self, _: &str) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod seed_plan_tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn defaults_count() -> usize {
+        ENABLED_DEFAULTS.len()
+    }
+
+    #[test]
+    fn plan_seed_decisions_inserts_when_row_absent() {
+        let existing: HashMap<String, ExistingRow> = HashMap::new();
+        let decisions = plan_seed_decisions(&existing);
+        assert_eq!(decisions.len(), defaults_count());
+        for d in &decisions {
+            assert_eq!(d.op, SeedOp::Insert);
+            let expected_default = ENABLED_DEFAULTS
+                .iter()
+                .find(|(name, _)| *name == d.block_name)
+                .map(|(_, v)| *v)
+                .expect("decision block name must be in ENABLED_DEFAULTS");
+            assert_eq!(d.enabled, expected_default);
+            assert_eq!(d.hash, seed_hash_for(expected_default));
+        }
+    }
+
+    #[test]
+    fn plan_seed_decisions_skips_when_hash_matches_current() {
+        let mut existing = HashMap::new();
+        for (name, default) in ENABLED_DEFAULTS {
+            existing.insert(
+                (*name).to_string(),
+                ExistingRow {
+                    enabled: *default,
+                    hash: seed_hash_for(*default),
+                },
+            );
+        }
+        let decisions = plan_seed_decisions(&existing);
+        assert!(
+            decisions.is_empty(),
+            "no decisions expected at steady state, got: {decisions:?}",
+        );
+    }
+
+    #[test]
+    fn plan_seed_decisions_updates_when_hash_stale() {
+        let mut existing = HashMap::new();
+        for (name, default) in ENABLED_DEFAULTS {
+            let opposite = !*default;
+            existing.insert(
+                (*name).to_string(),
+                ExistingRow {
+                    enabled: opposite,
+                    hash: seed_hash_for(opposite),
+                },
+            );
+        }
+        let decisions = plan_seed_decisions(&existing);
+        assert_eq!(decisions.len(), defaults_count());
+        for d in &decisions {
+            assert_eq!(d.op, SeedOp::Update);
+            let expected_default = ENABLED_DEFAULTS
+                .iter()
+                .find(|(name, _)| *name == d.block_name)
+                .map(|(_, v)| *v)
+                .expect("decision block name must be in ENABLED_DEFAULTS");
+            assert_eq!(d.enabled, expected_default);
+            assert_eq!(d.hash, seed_hash_for(expected_default));
+        }
+    }
+
+    #[test]
+    fn plan_seed_decisions_skips_user_edited() {
+        let mut existing = HashMap::new();
+        for (name, default) in ENABLED_DEFAULTS {
+            existing.insert(
+                (*name).to_string(),
+                ExistingRow {
+                    enabled: !*default,
+                    hash: USER_EDITED_SENTINEL.to_string(),
+                },
+            );
+        }
+        let decisions = plan_seed_decisions(&existing);
+        assert!(
+            decisions.is_empty(),
+            "user-edited rows must be preserved even when value drifts: {decisions:?}",
+        );
+    }
+
+    #[test]
+    fn plan_seed_decisions_skips_empty_hash_legacy() {
+        let mut existing = HashMap::new();
+        for (name, default) in ENABLED_DEFAULTS {
+            existing.insert(
+                (*name).to_string(),
+                ExistingRow {
+                    enabled: !*default,
+                    hash: String::new(),
+                },
+            );
+        }
+        let decisions = plan_seed_decisions(&existing);
+        assert!(
+            decisions.is_empty(),
+            "legacy empty-hash rows must be preserved: {decisions:?}",
+        );
+    }
+
+    #[test]
+    fn seed_hash_for_is_stable_and_distinct() {
+        let h_true = seed_hash_for(true);
+        let h_false = seed_hash_for(false);
+        assert_ne!(h_true, h_false);
+        assert_eq!(h_true, seed_hash_for(true));
+        assert!(h_true.starts_with("seed:"));
+        assert!(h_false.starts_with("seed:"));
     }
 }

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -198,9 +198,16 @@ impl FeatureConfig for std::sync::RwLock<BlockSettings> {
 /// block module is gated on `feature = "llm"` (wasm32-incompatible) so
 /// the router would dispatch into a void on wasm32 if either was enabled
 /// here. Restored when the LlmService trait refactor lands.
+///
+/// Also excluded: `suppers-ai/admin`. The admin row's `seed_defaults_hash`
+/// column is owned by [`crate::blocks::admin::settings::seed_defaults`]
+/// for the shared-vars-list payload hash (raw hex, no prefix). Two
+/// writers on the same column with different formats would cause an
+/// infinite re-seed loop on every cold start. The admin block is always
+/// enabled by design (FeatureConfig falls back to `true` when the row is
+/// absent), so omitting it from the seed has no behavioural effect.
 pub const ENABLED_DEFAULTS: &[(&str, bool)] = &[
     ("suppers-ai/auth", true),
-    ("suppers-ai/admin", true),
     ("suppers-ai/files", true),
     ("suppers-ai/legalpages", true),
     ("suppers-ai/messages", true),
@@ -432,5 +439,79 @@ mod seed_plan_tests {
         assert_eq!(h_true, seed_hash_for(true));
         assert!(h_true.starts_with("seed:"));
         assert!(h_false.starts_with("seed:"));
+    }
+
+    #[test]
+    fn plan_seed_decisions_handles_mixed_row_states() {
+        // Realistic boot: some rows absent (new blocks), some at the current
+        // seed hash (no-op), some at a stale seed hash (re-seed), some
+        // user-edited (preserve), some legacy empty hash (preserve). The
+        // planner must produce exactly the right decisions, no extras and
+        // no skips.
+        let mut existing = HashMap::new();
+
+        // Pick five blocks from ENABLED_DEFAULTS to stage in different states.
+        // ENABLED_DEFAULTS has 7 entries; assign one to each lane and let the
+        // remaining 2 fall into the "absent → Insert" lane.
+        let names: Vec<&&'static str> = ENABLED_DEFAULTS.iter().map(|(n, _)| n).collect();
+        assert!(names.len() >= 5, "test assumes at least 5 entries in ENABLED_DEFAULTS");
+
+        // Lane A: at-current → skip.
+        let (lane_a_name, lane_a_default) = ENABLED_DEFAULTS[0];
+        existing.insert(
+            lane_a_name.to_string(),
+            ExistingRow { enabled: lane_a_default, hash: seed_hash_for(lane_a_default) },
+        );
+
+        // Lane B: stale seed hash → Update.
+        let (lane_b_name, lane_b_default) = ENABLED_DEFAULTS[1];
+        let lane_b_old = !lane_b_default;
+        existing.insert(
+            lane_b_name.to_string(),
+            ExistingRow { enabled: lane_b_old, hash: seed_hash_for(lane_b_old) },
+        );
+
+        // Lane C: user-edited → skip even if value drifts.
+        let (lane_c_name, lane_c_default) = ENABLED_DEFAULTS[2];
+        existing.insert(
+            lane_c_name.to_string(),
+            ExistingRow { enabled: !lane_c_default, hash: USER_EDITED_SENTINEL.to_string() },
+        );
+
+        // Lane D: legacy empty hash → skip (preserve).
+        let (lane_d_name, lane_d_default) = ENABLED_DEFAULTS[3];
+        existing.insert(
+            lane_d_name.to_string(),
+            ExistingRow { enabled: !lane_d_default, hash: String::new() },
+        );
+
+        // Lanes E and beyond: absent → Insert. ENABLED_DEFAULTS[4..] are all absent.
+
+        let decisions = plan_seed_decisions(&existing);
+
+        // Expected: 1 Update (lane B) + (ENABLED_DEFAULTS.len() - 4) Inserts
+        // (lanes E onward). Lanes A, C, D produce no decisions.
+        let expected_inserts = ENABLED_DEFAULTS.len() - 4;
+        let inserts: Vec<&SeedDecision> =
+            decisions.iter().filter(|d| d.op == SeedOp::Insert).collect();
+        let updates: Vec<&SeedDecision> =
+            decisions.iter().filter(|d| d.op == SeedOp::Update).collect();
+        assert_eq!(
+            inserts.len(),
+            expected_inserts,
+            "expected {expected_inserts} Inserts, got: {inserts:?}",
+        );
+        assert_eq!(updates.len(), 1, "expected 1 Update (lane B), got: {updates:?}");
+        assert_eq!(updates[0].block_name, lane_b_name);
+        assert_eq!(updates[0].enabled, lane_b_default);
+        assert_eq!(updates[0].hash, seed_hash_for(lane_b_default));
+
+        // Confirm none of the skipped lanes (A, C, D) appear in any decision.
+        for skipped in &[lane_a_name, lane_c_name, lane_d_name] {
+            assert!(
+                decisions.iter().all(|d| d.block_name != *skipped),
+                "{skipped} should not be in decisions: {decisions:?}",
+            );
+        }
     }
 }

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -184,6 +184,76 @@ impl FeatureConfig for std::sync::RwLock<BlockSettings> {
     }
 }
 
+/// Canonical defaults for `suppers_ai__admin__block_settings.enabled`.
+/// Consumed by [`plan_seed_decisions`] on every cold start.
+///
+/// Adding a block here: bump the list, ship — every existing row gets the
+/// INSERT path (no row yet → write the new default at the current hash).
+///
+/// Changing an existing default: just edit the bool — the hash gate detects
+/// the change and re-seeds rows still at the old default. Admin-UI edits
+/// (marked [`USER_EDITED_SENTINEL`]) are preserved.
+///
+/// Excluded for now: `suppers-ai/llm` and `suppers-ai/vector`. The LLM
+/// block module is gated on `feature = "llm"` (wasm32-incompatible) so
+/// the router would dispatch into a void on wasm32 if either was enabled
+/// here. Restored when the LlmService trait refactor lands.
+pub const ENABLED_DEFAULTS: &[(&str, bool)] = &[
+    ("suppers-ai/auth", true),
+    ("suppers-ai/admin", true),
+    ("suppers-ai/files", true),
+    ("suppers-ai/legalpages", true),
+    ("suppers-ai/messages", true),
+    ("suppers-ai/products", true),
+    ("suppers-ai/system", true),
+    ("suppers-ai/userportal", true),
+];
+
+/// Stored in `seed_defaults_hash` to mark a row that was last written by
+/// the admin UI's toggle. Such rows are never overwritten by the seed.
+pub const USER_EDITED_SENTINEL: &str = "user-edited";
+
+/// Compute the canonical `"seed:<sha256_hex>"` marker for a default value.
+///
+/// The body of the hash is `sha256_hex(b"true")` or `sha256_hex(b"false")`
+/// — short, deterministic, and stable across builds. The `"seed:"` prefix
+/// distinguishes seed-managed rows from admin-managed rows
+/// ([`USER_EDITED_SENTINEL`]) and from legacy empty-string state.
+pub fn seed_hash_for(default: bool) -> String {
+    let hex = crate::migration_helper::sha256_hex_bytes(default.to_string().as_bytes());
+    format!("seed:{hex}")
+}
+
+/// One row of `suppers_ai__admin__block_settings` as seen by the seed
+/// planner. Decoupled from `BlockState` so the planner stays pure (no
+/// migration-helper dependency, no FeatureConfig trait conversion).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistingRow {
+    pub enabled: bool,
+    pub hash: String,
+}
+
+/// What the planner decided about a given block name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeedDecision {
+    /// Static block name from [`ENABLED_DEFAULTS`].
+    pub block_name: &'static str,
+    /// Value to write.
+    pub enabled: bool,
+    /// `seed_defaults_hash` value to write (always `"seed:<hex>"`).
+    pub hash: String,
+    pub op: SeedOp,
+}
+
+/// INSERT vs UPDATE. Lets the caller pick the right SQL shape (some
+/// callers can collapse both into a single UPSERT statement; others
+/// prefer two distinct paths for logging clarity).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedOp {
+    Insert,
+    Update,
+}
+
 /// All features enabled (for testing).
 pub struct AllEnabled;
 

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -279,9 +279,7 @@ pub enum SeedOp {
 ///   (already at the current seeded default).
 /// - Row present with any other `"seed:..."` hash → `SeedOp::Update`
 ///   (stale seed hash; default changed since the row was last seeded).
-pub fn plan_seed_decisions(
-    existing: &HashMap<String, ExistingRow>,
-) -> Vec<SeedDecision> {
+pub fn plan_seed_decisions(existing: &HashMap<String, ExistingRow>) -> Vec<SeedDecision> {
     let mut out = Vec::new();
     for &(name, default) in ENABLED_DEFAULTS {
         let want_hash = seed_hash_for(default);
@@ -454,13 +452,19 @@ mod seed_plan_tests {
         // ENABLED_DEFAULTS has 7 entries; assign one to each lane and let the
         // remaining 2 fall into the "absent → Insert" lane.
         let names: Vec<&&'static str> = ENABLED_DEFAULTS.iter().map(|(n, _)| n).collect();
-        assert!(names.len() >= 5, "test assumes at least 5 entries in ENABLED_DEFAULTS");
+        assert!(
+            names.len() >= 5,
+            "test assumes at least 5 entries in ENABLED_DEFAULTS"
+        );
 
         // Lane A: at-current → skip.
         let (lane_a_name, lane_a_default) = ENABLED_DEFAULTS[0];
         existing.insert(
             lane_a_name.to_string(),
-            ExistingRow { enabled: lane_a_default, hash: seed_hash_for(lane_a_default) },
+            ExistingRow {
+                enabled: lane_a_default,
+                hash: seed_hash_for(lane_a_default),
+            },
         );
 
         // Lane B: stale seed hash → Update.
@@ -468,21 +472,30 @@ mod seed_plan_tests {
         let lane_b_old = !lane_b_default;
         existing.insert(
             lane_b_name.to_string(),
-            ExistingRow { enabled: lane_b_old, hash: seed_hash_for(lane_b_old) },
+            ExistingRow {
+                enabled: lane_b_old,
+                hash: seed_hash_for(lane_b_old),
+            },
         );
 
         // Lane C: user-edited → skip even if value drifts.
         let (lane_c_name, lane_c_default) = ENABLED_DEFAULTS[2];
         existing.insert(
             lane_c_name.to_string(),
-            ExistingRow { enabled: !lane_c_default, hash: USER_EDITED_SENTINEL.to_string() },
+            ExistingRow {
+                enabled: !lane_c_default,
+                hash: USER_EDITED_SENTINEL.to_string(),
+            },
         );
 
         // Lane D: legacy empty hash → skip (preserve).
         let (lane_d_name, lane_d_default) = ENABLED_DEFAULTS[3];
         existing.insert(
             lane_d_name.to_string(),
-            ExistingRow { enabled: !lane_d_default, hash: String::new() },
+            ExistingRow {
+                enabled: !lane_d_default,
+                hash: String::new(),
+            },
         );
 
         // Lanes E and beyond: absent → Insert. ENABLED_DEFAULTS[4..] are all absent.
@@ -492,16 +505,24 @@ mod seed_plan_tests {
         // Expected: 1 Update (lane B) + (ENABLED_DEFAULTS.len() - 4) Inserts
         // (lanes E onward). Lanes A, C, D produce no decisions.
         let expected_inserts = ENABLED_DEFAULTS.len() - 4;
-        let inserts: Vec<&SeedDecision> =
-            decisions.iter().filter(|d| d.op == SeedOp::Insert).collect();
-        let updates: Vec<&SeedDecision> =
-            decisions.iter().filter(|d| d.op == SeedOp::Update).collect();
+        let inserts: Vec<&SeedDecision> = decisions
+            .iter()
+            .filter(|d| d.op == SeedOp::Insert)
+            .collect();
+        let updates: Vec<&SeedDecision> = decisions
+            .iter()
+            .filter(|d| d.op == SeedOp::Update)
+            .collect();
         assert_eq!(
             inserts.len(),
             expected_inserts,
             "expected {expected_inserts} Inserts, got: {inserts:?}",
         );
-        assert_eq!(updates.len(), 1, "expected 1 Update (lane B), got: {updates:?}");
+        assert_eq!(
+            updates.len(),
+            1,
+            "expected 1 Update (lane B), got: {updates:?}"
+        );
         assert_eq!(updates[0].block_name, lane_b_name);
         assert_eq!(updates[0].enabled, lane_b_default);
         assert_eq!(updates[0].hash, seed_hash_for(lane_b_default));

--- a/crates/solobase-web/src/config.rs
+++ b/crates/solobase-web/src/config.rs
@@ -178,13 +178,14 @@ pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, J
         .map_err(|e| bridge_err("drop stale block_settings table", e))?;
         bridge::db_exec_raw(
             "CREATE TABLE suppers_ai__admin__block_settings (
-                id            TEXT PRIMARY KEY,
-                block_name    TEXT NOT NULL UNIQUE,
-                enabled       INTEGER NOT NULL DEFAULT 1,
-                current_hash  TEXT NOT NULL DEFAULT '',
-                blessed_hash  TEXT NOT NULL DEFAULT '',
-                created_at    TEXT NOT NULL,
-                updated_at    TEXT NOT NULL
+                id                 TEXT PRIMARY KEY,
+                block_name         TEXT NOT NULL UNIQUE,
+                enabled            INTEGER NOT NULL DEFAULT 1,
+                current_hash       TEXT NOT NULL DEFAULT '',
+                blessed_hash       TEXT NOT NULL DEFAULT '',
+                seed_defaults_hash TEXT NOT NULL DEFAULT '',
+                created_at         TEXT NOT NULL,
+                updated_at         TEXT NOT NULL
             )",
             "[]",
         )
@@ -197,31 +198,67 @@ pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, J
         .map_err(|e| bridge_err("recreate block_settings block_name index", e))?;
     }
 
-    // Seed defaults for known blocks. The strict schema demands `id`,
-    // `created_at`, `updated_at` — generate them inline via SQLite builtins
-    // so the seed remains a one-shot SQL statement per block.
-    let defaults: &[(&str, bool)] = &[
-        ("suppers-ai/auth", true),
-        ("suppers-ai/admin", true),
-        ("suppers-ai/files", true),
-        ("suppers-ai/products", true),
-        ("suppers-ai/legalpages", false),
-        ("suppers-ai/userportal", false),
-        ("suppers-ai/system", true),
-    ];
+    // Hash-gated seed: read existing rows including their stored
+    // `seed_defaults_hash`, then ask the planner what (if anything) needs
+    // to change. Steady state is an empty plan → zero writes.
+    let read_json = bridge::db_query_raw(
+        "SELECT block_name, enabled, seed_defaults_hash FROM suppers_ai__admin__block_settings",
+        "[]",
+    )
+    .map_err(|e| bridge_err("read block_settings for hash-gate", e))?;
+    let existing_rows: Vec<serde_json::Value> = serde_json::from_str(&read_json).map_err(|e| {
+        JsValue::from_str(&format!(
+            "solobase-web config: parse block_settings (pre-seed): {e}"
+        ))
+    })?;
 
-    for &(name, default) in defaults {
-        let params = serde_json::json!([name, default as i32]);
-        bridge::db_exec_raw(
-            "INSERT OR IGNORE INTO suppers_ai__admin__block_settings \
-             (id, block_name, enabled, created_at, updated_at) \
-             VALUES (lower(hex(randomblob(16))), ?, ?, datetime('now'), datetime('now'))",
-            &params.to_string(),
-        )
-        .map_err(|e| bridge_err(&format!("seed block_setting {name}"), e))?;
+    let mut existing = HashMap::new();
+    for row in existing_rows {
+        let name = row
+            .get("block_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let enabled = row.get("enabled").and_then(|v| v.as_i64()).unwrap_or(1) != 0;
+        let hash = row
+            .get("seed_defaults_hash")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        existing.insert(name, solobase_core::features::ExistingRow { enabled, hash });
     }
 
-    // Read all settings
+    let decisions = solobase_core::features::plan_seed_decisions(&existing);
+    for d in &decisions {
+        let enabled_int: i64 = if d.enabled { 1 } else { 0 };
+        match d.op {
+            solobase_core::features::SeedOp::Insert => {
+                let params = serde_json::json!([d.block_name, enabled_int, d.hash]);
+                bridge::db_exec_raw(
+                    "INSERT INTO suppers_ai__admin__block_settings \
+                     (id, block_name, enabled, seed_defaults_hash, created_at, updated_at) \
+                     VALUES (lower(hex(randomblob(16))), ?, ?, ?, datetime('now'), datetime('now'))",
+                    &params.to_string(),
+                )
+                .map_err(|e| bridge_err(&format!("seed insert {}", d.block_name), e))?;
+            }
+            solobase_core::features::SeedOp::Update => {
+                let params = serde_json::json!([enabled_int, d.hash, d.block_name]);
+                bridge::db_exec_raw(
+                    "UPDATE suppers_ai__admin__block_settings \
+                     SET enabled = ?, seed_defaults_hash = ?, updated_at = datetime('now') \
+                     WHERE block_name = ?",
+                    &params.to_string(),
+                )
+                .map_err(|e| bridge_err(&format!("seed update {}", d.block_name), e))?;
+            }
+        }
+    }
+
+    // Read post-seed state.
     let json = bridge::db_query_raw(
         "SELECT block_name, enabled FROM suppers_ai__admin__block_settings",
         "[]",


### PR DESCRIPTION
## Summary

Generalises the userportal/legalpages \"endpoint not found\" fix (post-PR #221) into a hash-gated re-seed mechanism on \`suppers_ai__admin__block_settings\`. Future default changes propagate to existing users automatically without overwriting admin-UI toggles. Steady-state cost on D1 is zero writes.

In the same PR, flips \`userportal\`/\`legalpages\` defaults to \`true\` and adds \`messages\` to the seed list — closes the immediate \"endpoint not found\" bug.

## Mechanism

Reuses the existing \`seed_defaults_hash\` column with three sentinel shapes:

| Value | Meaning |
|---|---|
| \`\"seed:<sha256_hex>\"\` | Row was written by seed at this default. |
| \`\"user-edited\"\` | Row was last toggled by the admin UI. |
| \`\"\"\` (empty) | Legacy state — preserved (treated as user-edited). |

Boot-time loop: \`plan_seed_decisions(existing)\` returns Insert decisions for missing rows, Update decisions for stale-hash rows, and skips user-edited + legacy rows. Steady state: empty Vec → zero writes.

Admin UI's \`set_enabled\` now stamps the row with \`\"user-edited\"\` so admin toggles are preserved across future default changes.

## Default value changes shipping in this PR

- \`suppers-ai/userportal\`: false → true
- \`suppers-ai/legalpages\`: false → true
- \`suppers-ai/messages\`: added as true (was relying on FeatureConfig fallback)

## What did NOT change

- **No schema change.** \`seed_defaults_hash\` column already exists from migration 003.
- **\`suppers-ai/admin\` is NOT in ENABLED_DEFAULTS** — the admin row's \`seed_defaults_hash\` column is already owned by \`admin::settings::seed_defaults\` for the shared-vars-list payload hash (raw hex, no \`\"seed:\"\` prefix). Both writers on the same column would cause an infinite re-seed loop. Admin is always-enabled via the FeatureConfig fallback when the row is absent — no behavioural effect. Documented in the rustdoc of \`ENABLED_DEFAULTS\`.
- **LLM and vector blocks excluded** — gated by the LlmService trait refactor (separate concern, currently wasm32-incompatible).
- **No legacy-row migration.** No active users; demo.solobase.dev OPFS is throwaway. Pre-PR rows with empty \`seed_defaults_hash\` get preserved as if user-edited; manual OPFS/D1 wipe gives a clean reset.

## D1 cost (cloudflare)

- **Steady state:** 1 list (unchanged from today).
- **First cold start after a default change:** 1 list + N writes + 1 re-read. N is bounded by ENABLED_DEFAULTS.len() (= 7 today).
- **Subsequent cold starts after the change:** back to 1 list. The hash gate ensures we never write the same row twice.

## Test plan
- [x] \`cargo +nightly fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare\` — no NEW warnings on changed files (pre-existing solobase-browser warnings unchanged)
- [x] \`cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare\` — all suites green; solobase-core lib at 690 passed (was 682 + 7 new planner tests + 1 admin sentinel test)
- [x] \`cargo check -p solobase-web --target wasm32-unknown-unknown\` clean
- [x] \`cargo check -p solobase-cloudflare --target wasm32-unknown-unknown\` clean
- [ ] After deploy: visit demo.solobase.dev after wiping OPFS — \`/b/userportal/\`, \`/b/legalpages/\`, \`/b/messages/\` resolve without \"endpoint not found\"
- [ ] After deploy: visit wafer.run — same admin pages resolve

## Spec
\`docs/superpowers/specs/2026-05-27-block-settings-seed-hash-gate-design.md\` (in the workspace meta-repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)