### PR TITLE
refactor(admin): route-split AdminBlock::handle (lever 2.3)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -206,19 +206,20 @@ impl Block for AdminBlock {
     ) -> OutputStream {
         use route::AdminRoute;
 
-        // For API routes, the existing handler normalizes the meta resource
-        // to `/admin/<api_rest>` so downstream sub-handlers see the legacy
-        // path shape. Mirror exactly.
-        if let Some(api_rest) = msg.path().strip_prefix("/b/admin/api") {
-            let normalized = format!("/admin{}", api_rest);
-            msg.set_meta("req.resource", &normalized);
-        }
-
-        // Capture path + action as owned strings so the borrow of `msg`
-        // ends before the match arms that move `msg` (StorageDelegate,
-        // CloudStorageDelegate, CreateWrapGrant, DeleteWrapGrant).
+        // Capture path + action BEFORE any meta mutation. msg.path() reads from
+        // get_meta("req.resource") which the API normalization below mutates;
+        // without these captures the routing classifier would see the normalized
+        // path and miss the /b/admin/api prefix.
         let path_owned = msg.path().to_string();
         let action_owned = msg.action().to_string();
+
+        // API path normalization: downstream sub-handlers (users::handle,
+        // database::handle, etc.) expect req.resource as /admin/... instead
+        // of /b/admin/api/... — preserve that contract exactly as the
+        // pre-refactor handler did.
+        if let Some(api_rest) = path_owned.strip_prefix("/b/admin/api") {
+            msg.set_meta("req.resource", &format!("/admin{}", api_rest));
+        }
         match route::route(&path_owned, &action_owned) {
             // --- /b/admin/api/... ---
             AdminRoute::UsersApi        => users::handle(ctx, &msg, input).await,
@@ -243,9 +244,11 @@ impl Block for AdminBlock {
             AdminRoute::WaferApi        => wafer_info::handle(ctx, &msg),
             AdminRoute::CustomTablesApi => custom_tables::handle(ctx, &msg, input).await,
             AdminRoute::StorageDelegate => {
-                // Re-set meta to /admin/<api_rest> (already done above; this branch
-                // matches the original which re-set inside the if). Keep parity.
-                let api_rest = msg.path().strip_prefix("/b/admin/api").unwrap_or("");
+                // The original handler re-set req.resource INSIDE the if branch
+                // (to /admin/<api_rest>). The top-of-function normalization already
+                // did this, but the original re-applied; we mirror by deriving
+                // from path_owned (NOT msg.path() which is now normalized).
+                let api_rest = path_owned.strip_prefix("/b/admin/api").unwrap_or("");
                 msg.set_meta("req.resource", &format!("/admin{}", api_rest));
                 ctx.call_block("suppers-ai/files", msg, input).await
             }

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -204,254 +204,104 @@ impl Block for AdminBlock {
         mut msg: Message,
         input: InputStream,
     ) -> OutputStream {
-        let path = msg.path().to_string();
+        use route::AdminRoute;
 
-        // JSON API at /b/admin/api/... — normalize to /admin/... for sub-module compatibility
-        if let Some(api_rest) = path.strip_prefix("/b/admin/api") {
+        // For API routes, the existing handler normalizes the meta resource
+        // to `/admin/<api_rest>` so downstream sub-handlers see the legacy
+        // path shape. Mirror exactly.
+        if let Some(api_rest) = msg.path().strip_prefix("/b/admin/api") {
             let normalized = format!("/admin{}", api_rest);
             msg.set_meta("req.resource", &normalized);
+        }
 
-            if api_rest.starts_with("/users") {
-                return users::handle(ctx, &msg, input).await;
-            }
-            if api_rest.starts_with("/database") {
-                return database::handle(ctx, &msg, input).await;
-            }
-            if api_rest.starts_with("/iam") {
-                return iam::handle(ctx, &msg, input).await;
-            }
-            if api_rest.starts_with("/logs") {
-                return logs::handle(ctx, &msg).await;
-            }
-            if api_rest.starts_with("/settings") {
-                return settings::handle(ctx, &msg, input).await;
-            }
-            if api_rest.starts_with("/extensions") {
+        // Capture path + action as owned strings so the borrow of `msg`
+        // ends before the match arms that move `msg` (StorageDelegate,
+        // CloudStorageDelegate, CreateWrapGrant, DeleteWrapGrant).
+        let path_owned = msg.path().to_string();
+        let action_owned = msg.action().to_string();
+        match route::route(&path_owned, &action_owned) {
+            // --- /b/admin/api/... ---
+            AdminRoute::UsersApi        => users::handle(ctx, &msg, input).await,
+            AdminRoute::DatabaseApi     => database::handle(ctx, &msg, input).await,
+            AdminRoute::IamApi          => iam::handle(ctx, &msg, input).await,
+            AdminRoute::LogsApi         => logs::handle(ctx, &msg).await,
+            AdminRoute::SettingsApi     => settings::handle(ctx, &msg, input).await,
+            AdminRoute::ExtensionsApi   => {
                 let blocks: Vec<_> = ctx
                     .registered_blocks()
                     .into_iter()
-                    .map(|b| {
-                        serde_json::json!({
-                            "name": b.name,
-                            "version": b.version,
-                            "interface": b.interface,
-                            "summary": b.summary,
-                            "enabled": true,
-                        })
-                    })
+                    .map(|b| serde_json::json!({
+                        "name": b.name,
+                        "version": b.version,
+                        "interface": b.interface,
+                        "summary": b.summary,
+                        "enabled": true,
+                    }))
                     .collect();
-                return ok_json(&blocks);
+                ok_json(&blocks)
             }
-            if api_rest.starts_with("/wafer") {
-                return wafer_info::handle(ctx, &msg);
+            AdminRoute::WaferApi        => wafer_info::handle(ctx, &msg),
+            AdminRoute::CustomTablesApi => custom_tables::handle(ctx, &msg, input).await,
+            AdminRoute::StorageDelegate => {
+                // Re-set meta to /admin/<api_rest> (already done above; this branch
+                // matches the original which re-set inside the if). Keep parity.
+                let api_rest = msg.path().strip_prefix("/b/admin/api").unwrap_or("");
+                msg.set_meta("req.resource", &format!("/admin{}", api_rest));
+                ctx.call_block("suppers-ai/files", msg, input).await
             }
-            if api_rest.starts_with("/custom-tables") {
-                return custom_tables::handle(ctx, &msg, input).await;
+            AdminRoute::CloudStorageDelegate { rest } => {
+                msg.set_meta("req.resource", &format!("/admin/b/cloudstorage{}", rest));
+                ctx.call_block("suppers-ai/files", msg, input).await
             }
-            // Delegate admin storage to Files block via call_block so WRAP
-            // sees the call as cross-block (admin → files) instead of an
-            // in-process direct function call. The Files block recognizes
-            // the `/admin/storage/...` path and routes it to its admin
-            // sub-handler.
-            if api_rest.starts_with("/storage") {
-                msg.set_meta("req.resource", format!("/admin{}", api_rest));
-                return ctx.call_block("suppers-ai/files", msg, input).await;
+            AdminRoute::ApiNotFound => err_not_found("not found"),
+
+            // --- /b/admin/settings/... ---
+            AdminRoute::SettingsRedirect    => redirect_308("/b/admin/settings/email"),
+            AdminRoute::SettingsPage { tab } => pages::settings_page(ctx, &msg, tab).await,
+
+            // --- /b/admin/... htmx mutations ---
+            AdminRoute::UserDisable { user_id }     => pages::handle_user_disable(ctx, &msg, user_id).await,
+            AdminRoute::UserEnable  { user_id }     => pages::handle_user_enable(ctx, &msg, user_id).await,
+            AdminRoute::UserDelete  { user_id }     => pages::handle_user_delete(ctx, &msg, user_id).await,
+            AdminRoute::CreateRole                  => pages::handle_create_role(ctx, &msg, input).await,
+            AdminRoute::DeleteRole  { role_id }     => pages::handle_delete_role(ctx, &msg, role_id).await,
+            AdminRoute::BlockDetail { block_name }  => pages::handle_block_detail(ctx, &msg, &block_name).await,
+            AdminRoute::BlockToggle { block_name }  => pages::handle_toggle_feature(ctx, &msg, &block_name).await,
+            AdminRoute::CreateVariable              => pages::handle_create_variable(ctx, &msg, input).await,
+            AdminRoute::EditVariableForm { var_key } => pages::handle_edit_variable_form(ctx, &msg, var_key).await,
+            AdminRoute::UpdateVariable   { var_key } => pages::handle_update_variable(ctx, &msg, input, var_key).await,
+            AdminRoute::NetworkInboundDetail        => pages::network_inbound_detail(ctx, &msg).await,
+            AdminRoute::CreateWrapGrant             => handle_create_wrap_grant(ctx, msg, input).await,
+            AdminRoute::DeleteWrapGrant  { rule_id } => handle_delete_wrap_grant(ctx, msg, rule_id).await,
+            AdminRoute::SaveEmailSettings           => pages::handle_save_email_settings(ctx, &msg, input).await,
+            AdminRoute::DatabaseQuery               => pages::handle_database_query(ctx, &msg, input).await,
+            AdminRoute::CustomBlockInstall          => pages::handle_custom_block_install(ctx, &msg, input).await,
+            AdminRoute::CustomBlockUpload           => pages::handle_custom_block_upload(ctx, &msg, input).await,
+            AdminRoute::CustomBlockDelete { block_name } => pages::handle_custom_block_delete(ctx, &msg, &block_name).await,
+
+            // --- /b/admin/... SSR pages ---
+            AdminRoute::Dashboard      => pages::dashboard(ctx, &msg).await,
+            AdminRoute::UsersPage      => pages::users_page(ctx, &msg).await,
+            AdminRoute::StoragePage    => pages::storage_page(ctx, &msg).await,
+            AdminRoute::BlocksPage     => pages::blocks_page(ctx, &msg).await,
+            AdminRoute::DatabasePage   => pages::database_page(ctx, &msg).await,
+            AdminRoute::LogsPage       => pages::logs_page(ctx, &msg).await,
+            AdminRoute::EmailRedirect      => redirect_308("/b/admin/settings/email"),
+            AdminRoute::NetworkRedirect    => redirect_308("/b/admin/settings/network"),
+            AdminRoute::VariablesRedirect  => redirect_308("/b/admin/settings/variables"),
+            AdminRoute::PermissionsRedirect => {
+                // Carry ?tab= as ?subtab= to preserve deep-links.
+                let old_tab = msg.query("tab");
+                if old_tab.is_empty() {
+                    redirect_308("/b/admin/settings/permissions")
+                } else {
+                    redirect_308(&format!("/b/admin/settings/permissions?subtab={}", old_tab))
+                }
             }
-            // Delegate admin cloud storage to Files block via call_block.
-            if api_rest.starts_with("/cloudstorage") {
-                msg.set_meta(
-                    "req.resource",
-                    format!(
-                        "/admin/b/cloudstorage{}",
-                        api_rest.strip_prefix("/cloudstorage").unwrap_or("")
-                    ),
-                );
-                return ctx.call_block("suppers-ai/files", msg, input).await;
-            }
-            return err_not_found("not found");
+            AdminRoute::GrantsPage   => pages::grants_page(ctx, &msg).await,
+
+            AdminRoute::NotFound => err_not_found("not found"),
         }
-
-        // Settings consolidation: /b/admin/settings/{tab}
-        // Must be checked BEFORE the generic /b/admin handler to avoid the catch-all.
-        if path == "/b/admin/settings" || path == "/b/admin/settings/" {
-            return redirect_308("/b/admin/settings/email");
-        }
-        if path.starts_with("/b/admin/settings/") {
-            let tab = path
-                .strip_prefix("/b/admin/settings/")
-                .unwrap_or("")
-                .split('/')
-                .next()
-                .unwrap_or("");
-            // Whitelist tabs at the dispatch layer so /b/admin/settings/foobar
-            // 404s instead of silently rendering email — easier to catch
-            // typos and broken internal links during the Phase 3-5 ports.
-            match tab {
-                "email" | "network" | "variables" | "permissions" => {
-                    return pages::settings_page(ctx, &msg, tab).await;
-                }
-                _ => return err_not_found("not found"),
-            }
-        }
-
-        // SSR pages + htmx mutations at /b/admin/...
-        if path.starts_with("/b/admin") {
-            let action = msg.action().to_string();
-            let sub = path.strip_prefix("/b/admin").unwrap_or("/").to_string();
-
-            // htmx mutation handlers
-            if action == "create" && sub.ends_with("/disable") {
-                let user_id = sub
-                    .strip_prefix("/users/")
-                    .and_then(|s| s.strip_suffix("/disable"))
-                    .unwrap_or("")
-                    .to_string();
-                if !user_id.is_empty() {
-                    return pages::handle_user_disable(ctx, &msg, &user_id).await;
-                }
-            }
-            if action == "create" && sub.ends_with("/enable") {
-                let user_id = sub
-                    .strip_prefix("/users/")
-                    .and_then(|s| s.strip_suffix("/enable"))
-                    .unwrap_or("")
-                    .to_string();
-                if !user_id.is_empty() {
-                    return pages::handle_user_enable(ctx, &msg, &user_id).await;
-                }
-            }
-            if action == "delete" && sub.starts_with("/users/") {
-                let user_id = sub.strip_prefix("/users/").unwrap_or("").to_string();
-                if !user_id.is_empty() {
-                    return pages::handle_user_delete(ctx, &msg, &user_id).await;
-                }
-            }
-            if action == "create" && sub == "/iam/roles" {
-                return pages::handle_create_role(ctx, &msg, input).await;
-            }
-            if action == "delete" && sub.starts_with("/iam/roles/") {
-                let role_id = sub.strip_prefix("/iam/roles/").unwrap_or("").to_string();
-                if !role_id.is_empty() {
-                    return pages::handle_delete_role(ctx, &msg, &role_id).await;
-                }
-            }
-            // Block detail modal
-            if action == "retrieve" && sub.starts_with("/blocks/") && sub.ends_with("/detail") {
-                let encoded = sub
-                    .strip_prefix("/blocks/")
-                    .and_then(|s| s.strip_suffix("/detail"))
-                    .unwrap_or("")
-                    .to_string();
-                let block_name = encoded.replace("--", "/");
-                if !block_name.is_empty() {
-                    return pages::handle_block_detail(ctx, &msg, &block_name).await;
-                }
-            }
-            // Block feature toggle
-            if action == "create" && sub.starts_with("/blocks/") && sub.ends_with("/toggle") {
-                let encoded = sub
-                    .strip_prefix("/blocks/")
-                    .and_then(|s| s.strip_suffix("/toggle"))
-                    .unwrap_or("")
-                    .to_string();
-                let block_name = encoded.replace("--", "/");
-                if !block_name.is_empty() {
-                    return pages::handle_toggle_feature(ctx, &msg, &block_name).await;
-                }
-            }
-            // Variable mutations
-            if action == "create" && sub == "/variables" {
-                return pages::handle_create_variable(ctx, &msg, input).await;
-            }
-            if action == "retrieve" && sub.ends_with("/edit") && sub.starts_with("/variables/") {
-                let var_key = sub
-                    .strip_prefix("/variables/")
-                    .and_then(|s| s.strip_suffix("/edit"))
-                    .unwrap_or("")
-                    .to_string();
-                if !var_key.is_empty() {
-                    return pages::handle_edit_variable_form(ctx, &msg, &var_key).await;
-                }
-            }
-            if action == "update" && sub.starts_with("/variables/") {
-                let var_key = sub.strip_prefix("/variables/").unwrap_or("").to_string();
-                if !var_key.is_empty() {
-                    return pages::handle_update_variable(ctx, &msg, input, &var_key).await;
-                }
-            }
-
-            // Network detail fragments (htmx)
-            if action == "retrieve" && sub == "/network/detail/inbound" {
-                return pages::network_inbound_detail(ctx, &msg).await;
-            }
-
-            // WRAP grants CRUD (htmx)
-            if action == "create" && sub == "/grants/rules" {
-                return handle_create_wrap_grant(ctx, msg, input).await;
-            }
-            if action == "delete" && sub.starts_with("/grants/rules/") {
-                let rule_id = sub.strip_prefix("/grants/rules/").unwrap_or("").to_string();
-                if !rule_id.is_empty() {
-                    return handle_delete_wrap_grant(ctx, msg, &rule_id).await;
-                }
-            }
-
-            // Email settings save (POST)
-            if action == "create" && sub == "/email" {
-                return pages::handle_save_email_settings(ctx, &msg, input).await;
-            }
-
-            // Database SQL editor (htmx)
-            if action == "create" && sub == "/database/query" {
-                return pages::handle_database_query(ctx, &msg, input).await;
-            }
-
-            // Custom block management
-            if action == "create" && sub == "/custom-blocks/install" {
-                return pages::handle_custom_block_install(ctx, &msg, input).await;
-            }
-            if action == "create" && sub == "/custom-blocks/upload" {
-                return pages::handle_custom_block_upload(ctx, &msg, input).await;
-            }
-            if action == "delete" && sub.starts_with("/custom-blocks/") {
-                let encoded = sub
-                    .strip_prefix("/custom-blocks/")
-                    .unwrap_or("")
-                    .to_string();
-                if !encoded.is_empty() {
-                    let block_name = encoded.replace("--", "/");
-                    return pages::handle_custom_block_delete(ctx, &msg, &block_name).await;
-                }
-            }
-
-            // SSR page handlers (GET)
-            // Note: /email, /network, /variables, /permissions redirect 308 to
-            // /b/admin/settings/{tab} so bookmarks and old links keep working.
-            return match sub.as_str() {
-                "" | "/" => pages::dashboard(ctx, &msg).await,
-                "/users" => pages::users_page(ctx, &msg).await,
-                "/storage" => pages::storage_page(ctx, &msg).await,
-                "/blocks" => pages::blocks_page(ctx, &msg).await,
-                "/database" => pages::database_page(ctx, &msg).await,
-                "/logs" => pages::logs_page(ctx, &msg).await,
-                "/email" => redirect_308("/b/admin/settings/email"),
-                "/network" => redirect_308("/b/admin/settings/network"),
-                "/variables" => redirect_308("/b/admin/settings/variables"),
-                "/permissions" => {
-                    // Preserve ?tab= query string as ?subtab= in the new location.
-                    let old_tab = msg.query("tab");
-                    if old_tab.is_empty() {
-                        redirect_308("/b/admin/settings/permissions")
-                    } else {
-                        redirect_308(&format!("/b/admin/settings/permissions?subtab={}", old_tab))
-                    }
-                }
-                "/grants" => pages::grants_page(ctx, &msg).await,
-                _ => err_not_found("not found"),
-            };
-        }
-
-        err_not_found("not found")
     }
 
     async fn lifecycle(

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -222,26 +222,28 @@ impl Block for AdminBlock {
         }
         match route::route(&path_owned, &action_owned) {
             // --- /b/admin/api/... ---
-            AdminRoute::UsersApi        => users::handle(ctx, &msg, input).await,
-            AdminRoute::DatabaseApi     => database::handle(ctx, &msg, input).await,
-            AdminRoute::IamApi          => iam::handle(ctx, &msg, input).await,
-            AdminRoute::LogsApi         => logs::handle(ctx, &msg).await,
-            AdminRoute::SettingsApi     => settings::handle(ctx, &msg, input).await,
-            AdminRoute::ExtensionsApi   => {
+            AdminRoute::UsersApi => users::handle(ctx, &msg, input).await,
+            AdminRoute::DatabaseApi => database::handle(ctx, &msg, input).await,
+            AdminRoute::IamApi => iam::handle(ctx, &msg, input).await,
+            AdminRoute::LogsApi => logs::handle(ctx, &msg).await,
+            AdminRoute::SettingsApi => settings::handle(ctx, &msg, input).await,
+            AdminRoute::ExtensionsApi => {
                 let blocks: Vec<_> = ctx
                     .registered_blocks()
                     .into_iter()
-                    .map(|b| serde_json::json!({
-                        "name": b.name,
-                        "version": b.version,
-                        "interface": b.interface,
-                        "summary": b.summary,
-                        "enabled": true,
-                    }))
+                    .map(|b| {
+                        serde_json::json!({
+                            "name": b.name,
+                            "version": b.version,
+                            "interface": b.interface,
+                            "summary": b.summary,
+                            "enabled": true,
+                        })
+                    })
                     .collect();
                 ok_json(&blocks)
             }
-            AdminRoute::WaferApi        => wafer_info::handle(ctx, &msg),
+            AdminRoute::WaferApi => wafer_info::handle(ctx, &msg),
             AdminRoute::CustomTablesApi => custom_tables::handle(ctx, &msg, input).await,
             AdminRoute::StorageDelegate => {
                 // The original handler re-set req.resource INSIDE the if branch
@@ -259,39 +261,65 @@ impl Block for AdminBlock {
             AdminRoute::ApiNotFound => err_not_found("not found"),
 
             // --- /b/admin/settings/... ---
-            AdminRoute::SettingsRedirect    => redirect_308("/b/admin/settings/email"),
+            AdminRoute::SettingsRedirect => redirect_308("/b/admin/settings/email"),
             AdminRoute::SettingsPage { tab } => pages::settings_page(ctx, &msg, tab).await,
 
             // --- /b/admin/... htmx mutations ---
-            AdminRoute::UserDisable { user_id }     => pages::handle_user_disable(ctx, &msg, user_id).await,
-            AdminRoute::UserEnable  { user_id }     => pages::handle_user_enable(ctx, &msg, user_id).await,
-            AdminRoute::UserDelete  { user_id }     => pages::handle_user_delete(ctx, &msg, user_id).await,
-            AdminRoute::CreateRole                  => pages::handle_create_role(ctx, &msg, input).await,
-            AdminRoute::DeleteRole  { role_id }     => pages::handle_delete_role(ctx, &msg, role_id).await,
-            AdminRoute::BlockDetail { block_name }  => pages::handle_block_detail(ctx, &msg, &block_name).await,
-            AdminRoute::BlockToggle { block_name }  => pages::handle_toggle_feature(ctx, &msg, &block_name).await,
-            AdminRoute::CreateVariable              => pages::handle_create_variable(ctx, &msg, input).await,
-            AdminRoute::EditVariableForm { var_key } => pages::handle_edit_variable_form(ctx, &msg, var_key).await,
-            AdminRoute::UpdateVariable   { var_key } => pages::handle_update_variable(ctx, &msg, input, var_key).await,
-            AdminRoute::NetworkInboundDetail        => pages::network_inbound_detail(ctx, &msg).await,
-            AdminRoute::CreateWrapGrant             => handle_create_wrap_grant(ctx, msg, input).await,
-            AdminRoute::DeleteWrapGrant  { rule_id } => handle_delete_wrap_grant(ctx, msg, rule_id).await,
-            AdminRoute::SaveEmailSettings           => pages::handle_save_email_settings(ctx, &msg, input).await,
-            AdminRoute::DatabaseQuery               => pages::handle_database_query(ctx, &msg, input).await,
-            AdminRoute::CustomBlockInstall          => pages::handle_custom_block_install(ctx, &msg, input).await,
-            AdminRoute::CustomBlockUpload           => pages::handle_custom_block_upload(ctx, &msg, input).await,
-            AdminRoute::CustomBlockDelete { block_name } => pages::handle_custom_block_delete(ctx, &msg, &block_name).await,
+            AdminRoute::UserDisable { user_id } => {
+                pages::handle_user_disable(ctx, &msg, user_id).await
+            }
+            AdminRoute::UserEnable { user_id } => {
+                pages::handle_user_enable(ctx, &msg, user_id).await
+            }
+            AdminRoute::UserDelete { user_id } => {
+                pages::handle_user_delete(ctx, &msg, user_id).await
+            }
+            AdminRoute::CreateRole => pages::handle_create_role(ctx, &msg, input).await,
+            AdminRoute::DeleteRole { role_id } => {
+                pages::handle_delete_role(ctx, &msg, role_id).await
+            }
+            AdminRoute::BlockDetail { block_name } => {
+                pages::handle_block_detail(ctx, &msg, &block_name).await
+            }
+            AdminRoute::BlockToggle { block_name } => {
+                pages::handle_toggle_feature(ctx, &msg, &block_name).await
+            }
+            AdminRoute::CreateVariable => pages::handle_create_variable(ctx, &msg, input).await,
+            AdminRoute::EditVariableForm { var_key } => {
+                pages::handle_edit_variable_form(ctx, &msg, var_key).await
+            }
+            AdminRoute::UpdateVariable { var_key } => {
+                pages::handle_update_variable(ctx, &msg, input, var_key).await
+            }
+            AdminRoute::NetworkInboundDetail => pages::network_inbound_detail(ctx, &msg).await,
+            AdminRoute::CreateWrapGrant => handle_create_wrap_grant(ctx, msg, input).await,
+            AdminRoute::DeleteWrapGrant { rule_id } => {
+                handle_delete_wrap_grant(ctx, msg, rule_id).await
+            }
+            AdminRoute::SaveEmailSettings => {
+                pages::handle_save_email_settings(ctx, &msg, input).await
+            }
+            AdminRoute::DatabaseQuery => pages::handle_database_query(ctx, &msg, input).await,
+            AdminRoute::CustomBlockInstall => {
+                pages::handle_custom_block_install(ctx, &msg, input).await
+            }
+            AdminRoute::CustomBlockUpload => {
+                pages::handle_custom_block_upload(ctx, &msg, input).await
+            }
+            AdminRoute::CustomBlockDelete { block_name } => {
+                pages::handle_custom_block_delete(ctx, &msg, &block_name).await
+            }
 
             // --- /b/admin/... SSR pages ---
-            AdminRoute::Dashboard      => pages::dashboard(ctx, &msg).await,
-            AdminRoute::UsersPage      => pages::users_page(ctx, &msg).await,
-            AdminRoute::StoragePage    => pages::storage_page(ctx, &msg).await,
-            AdminRoute::BlocksPage     => pages::blocks_page(ctx, &msg).await,
-            AdminRoute::DatabasePage   => pages::database_page(ctx, &msg).await,
-            AdminRoute::LogsPage       => pages::logs_page(ctx, &msg).await,
-            AdminRoute::EmailRedirect      => redirect_308("/b/admin/settings/email"),
-            AdminRoute::NetworkRedirect    => redirect_308("/b/admin/settings/network"),
-            AdminRoute::VariablesRedirect  => redirect_308("/b/admin/settings/variables"),
+            AdminRoute::Dashboard => pages::dashboard(ctx, &msg).await,
+            AdminRoute::UsersPage => pages::users_page(ctx, &msg).await,
+            AdminRoute::StoragePage => pages::storage_page(ctx, &msg).await,
+            AdminRoute::BlocksPage => pages::blocks_page(ctx, &msg).await,
+            AdminRoute::DatabasePage => pages::database_page(ctx, &msg).await,
+            AdminRoute::LogsPage => pages::logs_page(ctx, &msg).await,
+            AdminRoute::EmailRedirect => redirect_308("/b/admin/settings/email"),
+            AdminRoute::NetworkRedirect => redirect_308("/b/admin/settings/network"),
+            AdminRoute::VariablesRedirect => redirect_308("/b/admin/settings/variables"),
             AdminRoute::PermissionsRedirect => {
                 // Carry ?tab= as ?subtab= to preserve deep-links.
                 let old_tab = msg.query("tab");
@@ -301,7 +329,7 @@ impl Block for AdminBlock {
                     redirect_308(&format!("/b/admin/settings/permissions?subtab={}", old_tab))
                 }
             }
-            AdminRoute::GrantsPage   => pages::grants_page(ctx, &msg).await,
+            AdminRoute::GrantsPage => pages::grants_page(ctx, &msg).await,
 
             AdminRoute::NotFound => err_not_found("not found"),
         }

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -4,6 +4,7 @@ mod iam;
 mod logs;
 pub mod migrations;
 mod pages;
+mod route;
 mod settings;
 mod users;
 mod wafer_info;

--- a/crates/solobase-core/src/blocks/admin/route.rs
+++ b/crates/solobase-core/src/blocks/admin/route.rs
@@ -1,0 +1,359 @@
+//! Pure-sync routing for `AdminBlock::handle`.
+//!
+//! `route()` classifies a request by path + action into an `AdminRoute`
+//! variant. It does no I/O, holds no `Context`, and allocates only when
+//! a path-extracted identifier (e.g. a user id) needs to be carried
+//! into the variant. The async `handle()` then dispatches the variant
+//! to the appropriate leaf handler.
+//!
+//! This module is the single source of truth for the AdminBlock's
+//! endpoint table. Every endpoint reachable in `handle()` must appear
+//! as a variant here and be covered by the test table below.
+
+/// Classification of an admin HTTP request.
+///
+/// Lifetime `'a` ties path-extracted slices (user_id, var_key, etc.) to
+/// the caller-owned `path` string, avoiding allocations in the routing
+/// step. Identifiers that need normalization (e.g. block names with
+/// `--` → `/` decoding) own a `String` instead.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum AdminRoute<'a> {
+    // --- /b/admin/api/... (JSON API) ---
+    /// `/b/admin/api/users*`
+    UsersApi,
+    /// `/b/admin/api/database*`
+    DatabaseApi,
+    /// `/b/admin/api/iam*`
+    IamApi,
+    /// `/b/admin/api/logs*`
+    LogsApi,
+    /// `/b/admin/api/settings*`
+    SettingsApi,
+    /// `/b/admin/api/extensions*`
+    ExtensionsApi,
+    /// `/b/admin/api/wafer*` (sync handler)
+    WaferApi,
+    /// `/b/admin/api/custom-tables*`
+    CustomTablesApi,
+    /// `/b/admin/api/storage*` — delegated to `suppers-ai/files`
+    StorageDelegate,
+    /// `/b/admin/api/cloudstorage<rest>` — delegated to `suppers-ai/files`.
+    /// Carries the suffix after `/cloudstorage` because the handler must
+    /// build `/admin/b/cloudstorage<rest>` for the delegated meta.
+    CloudStorageDelegate { rest: &'a str },
+    /// API path under /b/admin/api/ that didn't match any of the above.
+    ApiNotFound,
+
+    // --- /b/admin/settings/... (consolidated settings tabs) ---
+    /// `/b/admin/settings` or `/b/admin/settings/` — redirect to email tab.
+    SettingsRedirect,
+    /// `/b/admin/settings/<tab>` where tab ∈ {email, network, variables, permissions}.
+    SettingsPage { tab: &'a str },
+
+    // --- /b/admin/... (SSR pages + htmx mutations) ---
+    /// action=create, sub=`/users/{user_id}/disable`
+    UserDisable { user_id: &'a str },
+    /// action=create, sub=`/users/{user_id}/enable`
+    UserEnable { user_id: &'a str },
+    /// action=delete, sub=`/users/{user_id}`
+    UserDelete { user_id: &'a str },
+    /// action=create, sub=`/iam/roles`
+    CreateRole,
+    /// action=delete, sub=`/iam/roles/{role_id}`
+    DeleteRole { role_id: &'a str },
+    /// action=retrieve, sub=`/blocks/{encoded}/detail` (block_name = encoded.replace("--", "/"))
+    BlockDetail { block_name: String },
+    /// action=create, sub=`/blocks/{encoded}/toggle`
+    BlockToggle { block_name: String },
+    /// action=create, sub=`/variables`
+    CreateVariable,
+    /// action=retrieve, sub=`/variables/{var_key}/edit`
+    EditVariableForm { var_key: &'a str },
+    /// action=update, sub=`/variables/{var_key}`
+    UpdateVariable { var_key: &'a str },
+    /// action=retrieve, sub=`/network/detail/inbound`
+    NetworkInboundDetail,
+    /// action=create, sub=`/grants/rules`
+    CreateWrapGrant,
+    /// action=delete, sub=`/grants/rules/{rule_id}`
+    DeleteWrapGrant { rule_id: &'a str },
+    /// action=create, sub=`/email`
+    SaveEmailSettings,
+    /// action=create, sub=`/database/query`
+    DatabaseQuery,
+    /// action=create, sub=`/custom-blocks/install`
+    CustomBlockInstall,
+    /// action=create, sub=`/custom-blocks/upload`
+    CustomBlockUpload,
+    /// action=delete, sub=`/custom-blocks/{encoded}`
+    CustomBlockDelete { block_name: String },
+
+    // --- SSR fallthrough (GET) ---
+    Dashboard,
+    UsersPage,
+    StoragePage,
+    BlocksPage,
+    DatabasePage,
+    LogsPage,
+    EmailRedirect,
+    NetworkRedirect,
+    VariablesRedirect,
+    /// `/permissions` — preserves `?tab=` query as `?subtab=` in the new location.
+    PermissionsRedirect,
+    GrantsPage,
+
+    /// Catch-all: path doesn't match any admin route.
+    NotFound,
+}
+
+/// Classify a request by path + action. Pure sync, no allocations
+/// except when an identifier must be normalized (block_name "--" → "/").
+pub(super) fn route<'a>(path: &'a str, action: &str) -> AdminRoute<'a> {
+    // 1) /b/admin/api/... — JSON API, order-sensitive
+    if let Some(api_rest) = path.strip_prefix("/b/admin/api") {
+        // Match by first path segment after /api
+        let first = api_rest.split('/').nth(1).unwrap_or("");
+        return match first {
+            "users"         => AdminRoute::UsersApi,
+            "database"      => AdminRoute::DatabaseApi,
+            "iam"           => AdminRoute::IamApi,
+            "logs"          => AdminRoute::LogsApi,
+            "settings"      => AdminRoute::SettingsApi,
+            "extensions"    => AdminRoute::ExtensionsApi,
+            "wafer"         => AdminRoute::WaferApi,
+            "custom-tables" => AdminRoute::CustomTablesApi,
+            "storage"       => AdminRoute::StorageDelegate,
+            "cloudstorage"  => AdminRoute::CloudStorageDelegate {
+                rest: api_rest.strip_prefix("/cloudstorage").unwrap_or(""),
+            },
+            _ => AdminRoute::ApiNotFound,
+        };
+    }
+
+    // 2) /b/admin/settings (consolidated) — must precede the /b/admin/ catch-all
+    if path == "/b/admin/settings" || path == "/b/admin/settings/" {
+        return AdminRoute::SettingsRedirect;
+    }
+    if let Some(rest) = path.strip_prefix("/b/admin/settings/") {
+        let tab = rest.split('/').next().unwrap_or("");
+        return match tab {
+            "email" | "network" | "variables" | "permissions" => AdminRoute::SettingsPage { tab },
+            _ => AdminRoute::NotFound,
+        };
+    }
+
+    // 3) /b/admin/... (everything else)
+    if let Some(sub) = path.strip_prefix("/b/admin") {
+        // 3a) htmx mutations, action-gated
+        if action == "create" {
+            if let Some(id) = sub
+                .strip_prefix("/users/")
+                .and_then(|s| s.strip_suffix("/disable"))
+            {
+                if !id.is_empty() {
+                    return AdminRoute::UserDisable { user_id: id };
+                }
+            }
+            if let Some(id) = sub
+                .strip_prefix("/users/")
+                .and_then(|s| s.strip_suffix("/enable"))
+            {
+                if !id.is_empty() {
+                    return AdminRoute::UserEnable { user_id: id };
+                }
+            }
+            if sub == "/iam/roles" {
+                return AdminRoute::CreateRole;
+            }
+            if let Some(encoded) = sub
+                .strip_prefix("/blocks/")
+                .and_then(|s| s.strip_suffix("/toggle"))
+            {
+                if !encoded.is_empty() {
+                    return AdminRoute::BlockToggle {
+                        block_name: encoded.replace("--", "/"),
+                    };
+                }
+            }
+            if sub == "/variables" {
+                return AdminRoute::CreateVariable;
+            }
+            if sub == "/grants/rules" {
+                return AdminRoute::CreateWrapGrant;
+            }
+            if sub == "/email" {
+                return AdminRoute::SaveEmailSettings;
+            }
+            if sub == "/database/query" {
+                return AdminRoute::DatabaseQuery;
+            }
+            if sub == "/custom-blocks/install" {
+                return AdminRoute::CustomBlockInstall;
+            }
+            if sub == "/custom-blocks/upload" {
+                return AdminRoute::CustomBlockUpload;
+            }
+        }
+        if action == "delete" {
+            if let Some(id) = sub.strip_prefix("/users/") {
+                if !id.is_empty() {
+                    return AdminRoute::UserDelete { user_id: id };
+                }
+            }
+            if let Some(id) = sub.strip_prefix("/iam/roles/") {
+                if !id.is_empty() {
+                    return AdminRoute::DeleteRole { role_id: id };
+                }
+            }
+            if let Some(id) = sub.strip_prefix("/grants/rules/") {
+                if !id.is_empty() {
+                    return AdminRoute::DeleteWrapGrant { rule_id: id };
+                }
+            }
+            if let Some(encoded) = sub.strip_prefix("/custom-blocks/") {
+                if !encoded.is_empty() {
+                    return AdminRoute::CustomBlockDelete {
+                        block_name: encoded.replace("--", "/"),
+                    };
+                }
+            }
+        }
+        if action == "retrieve" {
+            if let Some(encoded) = sub
+                .strip_prefix("/blocks/")
+                .and_then(|s| s.strip_suffix("/detail"))
+            {
+                if !encoded.is_empty() {
+                    return AdminRoute::BlockDetail {
+                        block_name: encoded.replace("--", "/"),
+                    };
+                }
+            }
+            if let Some(key) = sub
+                .strip_prefix("/variables/")
+                .and_then(|s| s.strip_suffix("/edit"))
+            {
+                if !key.is_empty() {
+                    return AdminRoute::EditVariableForm { var_key: key };
+                }
+            }
+            if sub == "/network/detail/inbound" {
+                return AdminRoute::NetworkInboundDetail;
+            }
+        }
+        if action == "update" {
+            if let Some(key) = sub.strip_prefix("/variables/") {
+                if !key.is_empty() {
+                    return AdminRoute::UpdateVariable { var_key: key };
+                }
+            }
+        }
+
+        // 3b) SSR page fallthrough (GET-ish), action-agnostic at the dispatch layer.
+        // The original code uses `match sub.as_str()` regardless of action; we mirror.
+        return match sub {
+            "" | "/" => AdminRoute::Dashboard,
+            "/users" => AdminRoute::UsersPage,
+            "/storage" => AdminRoute::StoragePage,
+            "/blocks" => AdminRoute::BlocksPage,
+            "/database" => AdminRoute::DatabasePage,
+            "/logs" => AdminRoute::LogsPage,
+            "/email" => AdminRoute::EmailRedirect,
+            "/network" => AdminRoute::NetworkRedirect,
+            "/variables" => AdminRoute::VariablesRedirect,
+            "/permissions" => AdminRoute::PermissionsRedirect,
+            "/grants" => AdminRoute::GrantsPage,
+            _ => AdminRoute::NotFound,
+        };
+    }
+
+    AdminRoute::NotFound
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: each case is (description, path, action, expected_variant).
+    fn cases() -> Vec<(&'static str, &'static str, &'static str, AdminRoute<'static>)> {
+        vec![
+            // /b/admin/api/... — order matters for the longer prefixes
+            ("users api list",       "/b/admin/api/users",                  "retrieve", AdminRoute::UsersApi),
+            ("users api detail",     "/b/admin/api/users/abc",              "retrieve", AdminRoute::UsersApi),
+            ("database api",         "/b/admin/api/database/tables",        "retrieve", AdminRoute::DatabaseApi),
+            ("iam api",              "/b/admin/api/iam/roles",              "retrieve", AdminRoute::IamApi),
+            ("logs api",             "/b/admin/api/logs",                   "retrieve", AdminRoute::LogsApi),
+            ("settings api",         "/b/admin/api/settings/email",         "retrieve", AdminRoute::SettingsApi),
+            ("extensions api",       "/b/admin/api/extensions",             "retrieve", AdminRoute::ExtensionsApi),
+            ("wafer api",            "/b/admin/api/wafer",                  "retrieve", AdminRoute::WaferApi),
+            ("custom-tables api",    "/b/admin/api/custom-tables",          "retrieve", AdminRoute::CustomTablesApi),
+            ("storage delegate",     "/b/admin/api/storage/buckets",        "retrieve", AdminRoute::StorageDelegate),
+            ("cloudstorage delegate","/b/admin/api/cloudstorage/foo",       "retrieve", AdminRoute::CloudStorageDelegate { rest: "/foo" }),
+            ("cloudstorage empty",   "/b/admin/api/cloudstorage",           "retrieve", AdminRoute::CloudStorageDelegate { rest: "" }),
+            ("api unknown",          "/b/admin/api/whatever",               "retrieve", AdminRoute::ApiNotFound),
+
+            // /b/admin/settings — special pre-check
+            ("settings root no slash","/b/admin/settings",                  "retrieve", AdminRoute::SettingsRedirect),
+            ("settings root slash",  "/b/admin/settings/",                  "retrieve", AdminRoute::SettingsRedirect),
+            ("settings email",       "/b/admin/settings/email",             "retrieve", AdminRoute::SettingsPage { tab: "email" }),
+            ("settings network",     "/b/admin/settings/network",           "retrieve", AdminRoute::SettingsPage { tab: "network" }),
+            ("settings variables",   "/b/admin/settings/variables",         "retrieve", AdminRoute::SettingsPage { tab: "variables" }),
+            ("settings permissions", "/b/admin/settings/permissions",       "retrieve", AdminRoute::SettingsPage { tab: "permissions" }),
+            ("settings unknown tab", "/b/admin/settings/foobar",            "retrieve", AdminRoute::NotFound),
+
+            // /b/admin/... htmx mutations
+            ("user disable",         "/b/admin/users/u1/disable",           "create",   AdminRoute::UserDisable { user_id: "u1" }),
+            ("user enable",          "/b/admin/users/u1/enable",            "create",   AdminRoute::UserEnable { user_id: "u1" }),
+            ("user delete",          "/b/admin/users/u1",                   "delete",   AdminRoute::UserDelete { user_id: "u1" }),
+            ("create role",          "/b/admin/iam/roles",                  "create",   AdminRoute::CreateRole),
+            ("delete role",          "/b/admin/iam/roles/r1",               "delete",   AdminRoute::DeleteRole { role_id: "r1" }),
+            ("block detail",         "/b/admin/blocks/suppers-ai--auth/detail",  "retrieve", AdminRoute::BlockDetail { block_name: "suppers-ai/auth".to_string() }),
+            ("block toggle",         "/b/admin/blocks/suppers-ai--auth/toggle",  "create",   AdminRoute::BlockToggle { block_name: "suppers-ai/auth".to_string() }),
+            ("create variable",      "/b/admin/variables",                  "create",   AdminRoute::CreateVariable),
+            ("edit variable form",   "/b/admin/variables/SOLOBASE_SHARED__APP_NAME/edit", "retrieve", AdminRoute::EditVariableForm { var_key: "SOLOBASE_SHARED__APP_NAME" }),
+            ("update variable",      "/b/admin/variables/SOLOBASE_SHARED__APP_NAME", "update", AdminRoute::UpdateVariable { var_key: "SOLOBASE_SHARED__APP_NAME" }),
+            ("network inbound",      "/b/admin/network/detail/inbound",     "retrieve", AdminRoute::NetworkInboundDetail),
+            ("create wrap grant",    "/b/admin/grants/rules",               "create",   AdminRoute::CreateWrapGrant),
+            ("delete wrap grant",    "/b/admin/grants/rules/g1",            "delete",   AdminRoute::DeleteWrapGrant { rule_id: "g1" }),
+            ("save email settings",  "/b/admin/email",                      "create",   AdminRoute::SaveEmailSettings),
+            ("database query",       "/b/admin/database/query",             "create",   AdminRoute::DatabaseQuery),
+            ("custom block install", "/b/admin/custom-blocks/install",      "create",   AdminRoute::CustomBlockInstall),
+            ("custom block upload",  "/b/admin/custom-blocks/upload",       "create",   AdminRoute::CustomBlockUpload),
+            ("custom block delete",  "/b/admin/custom-blocks/suppers-ai--foo", "delete", AdminRoute::CustomBlockDelete { block_name: "suppers-ai/foo".to_string() }),
+
+            // /b/admin/... SSR pages (GET)
+            ("dashboard empty",      "/b/admin",                            "retrieve", AdminRoute::Dashboard),
+            ("dashboard slash",      "/b/admin/",                           "retrieve", AdminRoute::Dashboard),
+            ("users page",           "/b/admin/users",                      "retrieve", AdminRoute::UsersPage),
+            ("storage page",         "/b/admin/storage",                    "retrieve", AdminRoute::StoragePage),
+            ("blocks page",          "/b/admin/blocks",                     "retrieve", AdminRoute::BlocksPage),
+            ("database page",        "/b/admin/database",                   "retrieve", AdminRoute::DatabasePage),
+            ("logs page",            "/b/admin/logs",                       "retrieve", AdminRoute::LogsPage),
+            ("email redirect",       "/b/admin/email",                      "retrieve", AdminRoute::EmailRedirect),
+            ("network redirect",     "/b/admin/network",                    "retrieve", AdminRoute::NetworkRedirect),
+            ("variables redirect",   "/b/admin/variables",                  "retrieve", AdminRoute::VariablesRedirect),
+            ("permissions redirect", "/b/admin/permissions",                "retrieve", AdminRoute::PermissionsRedirect),
+            ("grants page",          "/b/admin/grants",                     "retrieve", AdminRoute::GrantsPage),
+            ("unknown ssr",          "/b/admin/whatever",                   "retrieve", AdminRoute::NotFound),
+
+            // Outside the admin namespace entirely
+            ("outside admin",        "/b/other",                            "retrieve", AdminRoute::NotFound),
+            ("root",                 "/",                                   "retrieve", AdminRoute::NotFound),
+
+            // Empty-id guards: paths that look like mutation patterns but
+            // have empty extracted identifiers must NOT match the mutation
+            // arm (the original handler falls through and returns the
+            // SSR-or-NotFound branch).
+            ("user disable empty id","/b/admin/users//disable",             "create",   AdminRoute::NotFound),
+            ("delete role empty id", "/b/admin/iam/roles/",                 "delete",   AdminRoute::NotFound),
+        ]
+    }
+
+    #[test]
+    fn route_table_classifies_every_endpoint_correctly() {
+        for (desc, path, action, expected) in cases() {
+            let actual = route(path, action);
+            assert_eq!(actual, expected, "case: {desc} (path={path:?}, action={action:?})");
+        }
+    }
+}

--- a/crates/solobase-core/src/blocks/admin/route.rs
+++ b/crates/solobase-core/src/blocks/admin/route.rs
@@ -274,6 +274,12 @@ pub(super) fn route<'a>(path: &'a str, action: &str) -> AdminRoute<'a> {
 mod tests {
     use super::*;
 
+    // NOTE: this module routes purely on the input strings. The real handle() in
+    // mod.rs must capture msg.path() and msg.action() into owned Strings
+    // BEFORE any msg.set_meta("req.resource", ...) call — set_meta mutates
+    // what msg.path() returns. See the API-meta-normalization comment in
+    // handle() for details. Bug surfaced in code review 2026-05-28.
+
     // Helper: each case is (description, path, action, expected_variant).
     fn cases() -> Vec<(&'static str, &'static str, &'static str, AdminRoute<'static>)> {
         vec![

--- a/crates/solobase-core/src/blocks/admin/route.rs
+++ b/crates/solobase-core/src/blocks/admin/route.rs
@@ -40,7 +40,9 @@ pub(super) enum AdminRoute<'a> {
     /// `/b/admin/api/cloudstorage<rest>` — delegated to `suppers-ai/files`.
     /// Carries the suffix after `/cloudstorage` because the handler must
     /// build `/admin/b/cloudstorage<rest>` for the delegated meta.
-    CloudStorageDelegate { rest: &'a str },
+    CloudStorageDelegate {
+        rest: &'a str,
+    },
     /// API path under /b/admin/api/ that didn't match any of the above.
     ApiNotFound,
 
@@ -48,35 +50,55 @@ pub(super) enum AdminRoute<'a> {
     /// `/b/admin/settings` or `/b/admin/settings/` — redirect to email tab.
     SettingsRedirect,
     /// `/b/admin/settings/<tab>` where tab ∈ {email, network, variables, permissions}.
-    SettingsPage { tab: &'a str },
+    SettingsPage {
+        tab: &'a str,
+    },
 
     // --- /b/admin/... (SSR pages + htmx mutations) ---
     /// action=create, sub=`/users/{user_id}/disable`
-    UserDisable { user_id: &'a str },
+    UserDisable {
+        user_id: &'a str,
+    },
     /// action=create, sub=`/users/{user_id}/enable`
-    UserEnable { user_id: &'a str },
+    UserEnable {
+        user_id: &'a str,
+    },
     /// action=delete, sub=`/users/{user_id}`
-    UserDelete { user_id: &'a str },
+    UserDelete {
+        user_id: &'a str,
+    },
     /// action=create, sub=`/iam/roles`
     CreateRole,
     /// action=delete, sub=`/iam/roles/{role_id}`
-    DeleteRole { role_id: &'a str },
+    DeleteRole {
+        role_id: &'a str,
+    },
     /// action=retrieve, sub=`/blocks/{encoded}/detail` (block_name = encoded.replace("--", "/"))
-    BlockDetail { block_name: String },
+    BlockDetail {
+        block_name: String,
+    },
     /// action=create, sub=`/blocks/{encoded}/toggle`
-    BlockToggle { block_name: String },
+    BlockToggle {
+        block_name: String,
+    },
     /// action=create, sub=`/variables`
     CreateVariable,
     /// action=retrieve, sub=`/variables/{var_key}/edit`
-    EditVariableForm { var_key: &'a str },
+    EditVariableForm {
+        var_key: &'a str,
+    },
     /// action=update, sub=`/variables/{var_key}`
-    UpdateVariable { var_key: &'a str },
+    UpdateVariable {
+        var_key: &'a str,
+    },
     /// action=retrieve, sub=`/network/detail/inbound`
     NetworkInboundDetail,
     /// action=create, sub=`/grants/rules`
     CreateWrapGrant,
     /// action=delete, sub=`/grants/rules/{rule_id}`
-    DeleteWrapGrant { rule_id: &'a str },
+    DeleteWrapGrant {
+        rule_id: &'a str,
+    },
     /// action=create, sub=`/email`
     SaveEmailSettings,
     /// action=create, sub=`/database/query`
@@ -86,7 +108,9 @@ pub(super) enum AdminRoute<'a> {
     /// action=create, sub=`/custom-blocks/upload`
     CustomBlockUpload,
     /// action=delete, sub=`/custom-blocks/{encoded}`
-    CustomBlockDelete { block_name: String },
+    CustomBlockDelete {
+        block_name: String,
+    },
 
     // --- SSR fallthrough (GET) ---
     Dashboard,
@@ -114,16 +138,16 @@ pub(super) fn route<'a>(path: &'a str, action: &str) -> AdminRoute<'a> {
         // Match by first path segment after /api
         let first = api_rest.split('/').nth(1).unwrap_or("");
         return match first {
-            "users"         => AdminRoute::UsersApi,
-            "database"      => AdminRoute::DatabaseApi,
-            "iam"           => AdminRoute::IamApi,
-            "logs"          => AdminRoute::LogsApi,
-            "settings"      => AdminRoute::SettingsApi,
-            "extensions"    => AdminRoute::ExtensionsApi,
-            "wafer"         => AdminRoute::WaferApi,
+            "users" => AdminRoute::UsersApi,
+            "database" => AdminRoute::DatabaseApi,
+            "iam" => AdminRoute::IamApi,
+            "logs" => AdminRoute::LogsApi,
+            "settings" => AdminRoute::SettingsApi,
+            "extensions" => AdminRoute::ExtensionsApi,
+            "wafer" => AdminRoute::WaferApi,
             "custom-tables" => AdminRoute::CustomTablesApi,
-            "storage"       => AdminRoute::StorageDelegate,
-            "cloudstorage"  => AdminRoute::CloudStorageDelegate {
+            "storage" => AdminRoute::StorageDelegate,
+            "cloudstorage" => AdminRoute::CloudStorageDelegate {
                 rest: api_rest.strip_prefix("/cloudstorage").unwrap_or(""),
             },
             _ => AdminRoute::ApiNotFound,
@@ -281,77 +305,357 @@ mod tests {
     // handle() for details. Bug surfaced in code review 2026-05-28.
 
     // Helper: each case is (description, path, action, expected_variant).
-    fn cases() -> Vec<(&'static str, &'static str, &'static str, AdminRoute<'static>)> {
+    fn cases() -> Vec<(
+        &'static str,
+        &'static str,
+        &'static str,
+        AdminRoute<'static>,
+    )> {
         vec![
             // /b/admin/api/... — order matters for the longer prefixes
-            ("users api list",       "/b/admin/api/users",                  "retrieve", AdminRoute::UsersApi),
-            ("users api detail",     "/b/admin/api/users/abc",              "retrieve", AdminRoute::UsersApi),
-            ("database api",         "/b/admin/api/database/tables",        "retrieve", AdminRoute::DatabaseApi),
-            ("iam api",              "/b/admin/api/iam/roles",              "retrieve", AdminRoute::IamApi),
-            ("logs api",             "/b/admin/api/logs",                   "retrieve", AdminRoute::LogsApi),
-            ("settings api",         "/b/admin/api/settings/email",         "retrieve", AdminRoute::SettingsApi),
-            ("extensions api",       "/b/admin/api/extensions",             "retrieve", AdminRoute::ExtensionsApi),
-            ("wafer api",            "/b/admin/api/wafer",                  "retrieve", AdminRoute::WaferApi),
-            ("custom-tables api",    "/b/admin/api/custom-tables",          "retrieve", AdminRoute::CustomTablesApi),
-            ("storage delegate",     "/b/admin/api/storage/buckets",        "retrieve", AdminRoute::StorageDelegate),
-            ("cloudstorage delegate","/b/admin/api/cloudstorage/foo",       "retrieve", AdminRoute::CloudStorageDelegate { rest: "/foo" }),
-            ("cloudstorage empty",   "/b/admin/api/cloudstorage",           "retrieve", AdminRoute::CloudStorageDelegate { rest: "" }),
-            ("api unknown",          "/b/admin/api/whatever",               "retrieve", AdminRoute::ApiNotFound),
-
+            (
+                "users api list",
+                "/b/admin/api/users",
+                "retrieve",
+                AdminRoute::UsersApi,
+            ),
+            (
+                "users api detail",
+                "/b/admin/api/users/abc",
+                "retrieve",
+                AdminRoute::UsersApi,
+            ),
+            (
+                "database api",
+                "/b/admin/api/database/tables",
+                "retrieve",
+                AdminRoute::DatabaseApi,
+            ),
+            (
+                "iam api",
+                "/b/admin/api/iam/roles",
+                "retrieve",
+                AdminRoute::IamApi,
+            ),
+            (
+                "logs api",
+                "/b/admin/api/logs",
+                "retrieve",
+                AdminRoute::LogsApi,
+            ),
+            (
+                "settings api",
+                "/b/admin/api/settings/email",
+                "retrieve",
+                AdminRoute::SettingsApi,
+            ),
+            (
+                "extensions api",
+                "/b/admin/api/extensions",
+                "retrieve",
+                AdminRoute::ExtensionsApi,
+            ),
+            (
+                "wafer api",
+                "/b/admin/api/wafer",
+                "retrieve",
+                AdminRoute::WaferApi,
+            ),
+            (
+                "custom-tables api",
+                "/b/admin/api/custom-tables",
+                "retrieve",
+                AdminRoute::CustomTablesApi,
+            ),
+            (
+                "storage delegate",
+                "/b/admin/api/storage/buckets",
+                "retrieve",
+                AdminRoute::StorageDelegate,
+            ),
+            (
+                "cloudstorage delegate",
+                "/b/admin/api/cloudstorage/foo",
+                "retrieve",
+                AdminRoute::CloudStorageDelegate { rest: "/foo" },
+            ),
+            (
+                "cloudstorage empty",
+                "/b/admin/api/cloudstorage",
+                "retrieve",
+                AdminRoute::CloudStorageDelegate { rest: "" },
+            ),
+            (
+                "api unknown",
+                "/b/admin/api/whatever",
+                "retrieve",
+                AdminRoute::ApiNotFound,
+            ),
             // /b/admin/settings — special pre-check
-            ("settings root no slash","/b/admin/settings",                  "retrieve", AdminRoute::SettingsRedirect),
-            ("settings root slash",  "/b/admin/settings/",                  "retrieve", AdminRoute::SettingsRedirect),
-            ("settings email",       "/b/admin/settings/email",             "retrieve", AdminRoute::SettingsPage { tab: "email" }),
-            ("settings network",     "/b/admin/settings/network",           "retrieve", AdminRoute::SettingsPage { tab: "network" }),
-            ("settings variables",   "/b/admin/settings/variables",         "retrieve", AdminRoute::SettingsPage { tab: "variables" }),
-            ("settings permissions", "/b/admin/settings/permissions",       "retrieve", AdminRoute::SettingsPage { tab: "permissions" }),
-            ("settings unknown tab", "/b/admin/settings/foobar",            "retrieve", AdminRoute::NotFound),
-
+            (
+                "settings root no slash",
+                "/b/admin/settings",
+                "retrieve",
+                AdminRoute::SettingsRedirect,
+            ),
+            (
+                "settings root slash",
+                "/b/admin/settings/",
+                "retrieve",
+                AdminRoute::SettingsRedirect,
+            ),
+            (
+                "settings email",
+                "/b/admin/settings/email",
+                "retrieve",
+                AdminRoute::SettingsPage { tab: "email" },
+            ),
+            (
+                "settings network",
+                "/b/admin/settings/network",
+                "retrieve",
+                AdminRoute::SettingsPage { tab: "network" },
+            ),
+            (
+                "settings variables",
+                "/b/admin/settings/variables",
+                "retrieve",
+                AdminRoute::SettingsPage { tab: "variables" },
+            ),
+            (
+                "settings permissions",
+                "/b/admin/settings/permissions",
+                "retrieve",
+                AdminRoute::SettingsPage { tab: "permissions" },
+            ),
+            (
+                "settings unknown tab",
+                "/b/admin/settings/foobar",
+                "retrieve",
+                AdminRoute::NotFound,
+            ),
             // /b/admin/... htmx mutations
-            ("user disable",         "/b/admin/users/u1/disable",           "create",   AdminRoute::UserDisable { user_id: "u1" }),
-            ("user enable",          "/b/admin/users/u1/enable",            "create",   AdminRoute::UserEnable { user_id: "u1" }),
-            ("user delete",          "/b/admin/users/u1",                   "delete",   AdminRoute::UserDelete { user_id: "u1" }),
-            ("create role",          "/b/admin/iam/roles",                  "create",   AdminRoute::CreateRole),
-            ("delete role",          "/b/admin/iam/roles/r1",               "delete",   AdminRoute::DeleteRole { role_id: "r1" }),
-            ("block detail",         "/b/admin/blocks/suppers-ai--auth/detail",  "retrieve", AdminRoute::BlockDetail { block_name: "suppers-ai/auth".to_string() }),
-            ("block toggle",         "/b/admin/blocks/suppers-ai--auth/toggle",  "create",   AdminRoute::BlockToggle { block_name: "suppers-ai/auth".to_string() }),
-            ("create variable",      "/b/admin/variables",                  "create",   AdminRoute::CreateVariable),
-            ("edit variable form",   "/b/admin/variables/SOLOBASE_SHARED__APP_NAME/edit", "retrieve", AdminRoute::EditVariableForm { var_key: "SOLOBASE_SHARED__APP_NAME" }),
-            ("update variable",      "/b/admin/variables/SOLOBASE_SHARED__APP_NAME", "update", AdminRoute::UpdateVariable { var_key: "SOLOBASE_SHARED__APP_NAME" }),
-            ("network inbound",      "/b/admin/network/detail/inbound",     "retrieve", AdminRoute::NetworkInboundDetail),
-            ("create wrap grant",    "/b/admin/grants/rules",               "create",   AdminRoute::CreateWrapGrant),
-            ("delete wrap grant",    "/b/admin/grants/rules/g1",            "delete",   AdminRoute::DeleteWrapGrant { rule_id: "g1" }),
-            ("save email settings",  "/b/admin/email",                      "create",   AdminRoute::SaveEmailSettings),
-            ("database query",       "/b/admin/database/query",             "create",   AdminRoute::DatabaseQuery),
-            ("custom block install", "/b/admin/custom-blocks/install",      "create",   AdminRoute::CustomBlockInstall),
-            ("custom block upload",  "/b/admin/custom-blocks/upload",       "create",   AdminRoute::CustomBlockUpload),
-            ("custom block delete",  "/b/admin/custom-blocks/suppers-ai--foo", "delete", AdminRoute::CustomBlockDelete { block_name: "suppers-ai/foo".to_string() }),
-
+            (
+                "user disable",
+                "/b/admin/users/u1/disable",
+                "create",
+                AdminRoute::UserDisable { user_id: "u1" },
+            ),
+            (
+                "user enable",
+                "/b/admin/users/u1/enable",
+                "create",
+                AdminRoute::UserEnable { user_id: "u1" },
+            ),
+            (
+                "user delete",
+                "/b/admin/users/u1",
+                "delete",
+                AdminRoute::UserDelete { user_id: "u1" },
+            ),
+            (
+                "create role",
+                "/b/admin/iam/roles",
+                "create",
+                AdminRoute::CreateRole,
+            ),
+            (
+                "delete role",
+                "/b/admin/iam/roles/r1",
+                "delete",
+                AdminRoute::DeleteRole { role_id: "r1" },
+            ),
+            (
+                "block detail",
+                "/b/admin/blocks/suppers-ai--auth/detail",
+                "retrieve",
+                AdminRoute::BlockDetail {
+                    block_name: "suppers-ai/auth".to_string(),
+                },
+            ),
+            (
+                "block toggle",
+                "/b/admin/blocks/suppers-ai--auth/toggle",
+                "create",
+                AdminRoute::BlockToggle {
+                    block_name: "suppers-ai/auth".to_string(),
+                },
+            ),
+            (
+                "create variable",
+                "/b/admin/variables",
+                "create",
+                AdminRoute::CreateVariable,
+            ),
+            (
+                "edit variable form",
+                "/b/admin/variables/SOLOBASE_SHARED__APP_NAME/edit",
+                "retrieve",
+                AdminRoute::EditVariableForm {
+                    var_key: "SOLOBASE_SHARED__APP_NAME",
+                },
+            ),
+            (
+                "update variable",
+                "/b/admin/variables/SOLOBASE_SHARED__APP_NAME",
+                "update",
+                AdminRoute::UpdateVariable {
+                    var_key: "SOLOBASE_SHARED__APP_NAME",
+                },
+            ),
+            (
+                "network inbound",
+                "/b/admin/network/detail/inbound",
+                "retrieve",
+                AdminRoute::NetworkInboundDetail,
+            ),
+            (
+                "create wrap grant",
+                "/b/admin/grants/rules",
+                "create",
+                AdminRoute::CreateWrapGrant,
+            ),
+            (
+                "delete wrap grant",
+                "/b/admin/grants/rules/g1",
+                "delete",
+                AdminRoute::DeleteWrapGrant { rule_id: "g1" },
+            ),
+            (
+                "save email settings",
+                "/b/admin/email",
+                "create",
+                AdminRoute::SaveEmailSettings,
+            ),
+            (
+                "database query",
+                "/b/admin/database/query",
+                "create",
+                AdminRoute::DatabaseQuery,
+            ),
+            (
+                "custom block install",
+                "/b/admin/custom-blocks/install",
+                "create",
+                AdminRoute::CustomBlockInstall,
+            ),
+            (
+                "custom block upload",
+                "/b/admin/custom-blocks/upload",
+                "create",
+                AdminRoute::CustomBlockUpload,
+            ),
+            (
+                "custom block delete",
+                "/b/admin/custom-blocks/suppers-ai--foo",
+                "delete",
+                AdminRoute::CustomBlockDelete {
+                    block_name: "suppers-ai/foo".to_string(),
+                },
+            ),
             // /b/admin/... SSR pages (GET)
-            ("dashboard empty",      "/b/admin",                            "retrieve", AdminRoute::Dashboard),
-            ("dashboard slash",      "/b/admin/",                           "retrieve", AdminRoute::Dashboard),
-            ("users page",           "/b/admin/users",                      "retrieve", AdminRoute::UsersPage),
-            ("storage page",         "/b/admin/storage",                    "retrieve", AdminRoute::StoragePage),
-            ("blocks page",          "/b/admin/blocks",                     "retrieve", AdminRoute::BlocksPage),
-            ("database page",        "/b/admin/database",                   "retrieve", AdminRoute::DatabasePage),
-            ("logs page",            "/b/admin/logs",                       "retrieve", AdminRoute::LogsPage),
-            ("email redirect",       "/b/admin/email",                      "retrieve", AdminRoute::EmailRedirect),
-            ("network redirect",     "/b/admin/network",                    "retrieve", AdminRoute::NetworkRedirect),
-            ("variables redirect",   "/b/admin/variables",                  "retrieve", AdminRoute::VariablesRedirect),
-            ("permissions redirect", "/b/admin/permissions",                "retrieve", AdminRoute::PermissionsRedirect),
-            ("grants page",          "/b/admin/grants",                     "retrieve", AdminRoute::GrantsPage),
-            ("unknown ssr",          "/b/admin/whatever",                   "retrieve", AdminRoute::NotFound),
-
+            (
+                "dashboard empty",
+                "/b/admin",
+                "retrieve",
+                AdminRoute::Dashboard,
+            ),
+            (
+                "dashboard slash",
+                "/b/admin/",
+                "retrieve",
+                AdminRoute::Dashboard,
+            ),
+            (
+                "users page",
+                "/b/admin/users",
+                "retrieve",
+                AdminRoute::UsersPage,
+            ),
+            (
+                "storage page",
+                "/b/admin/storage",
+                "retrieve",
+                AdminRoute::StoragePage,
+            ),
+            (
+                "blocks page",
+                "/b/admin/blocks",
+                "retrieve",
+                AdminRoute::BlocksPage,
+            ),
+            (
+                "database page",
+                "/b/admin/database",
+                "retrieve",
+                AdminRoute::DatabasePage,
+            ),
+            (
+                "logs page",
+                "/b/admin/logs",
+                "retrieve",
+                AdminRoute::LogsPage,
+            ),
+            (
+                "email redirect",
+                "/b/admin/email",
+                "retrieve",
+                AdminRoute::EmailRedirect,
+            ),
+            (
+                "network redirect",
+                "/b/admin/network",
+                "retrieve",
+                AdminRoute::NetworkRedirect,
+            ),
+            (
+                "variables redirect",
+                "/b/admin/variables",
+                "retrieve",
+                AdminRoute::VariablesRedirect,
+            ),
+            (
+                "permissions redirect",
+                "/b/admin/permissions",
+                "retrieve",
+                AdminRoute::PermissionsRedirect,
+            ),
+            (
+                "grants page",
+                "/b/admin/grants",
+                "retrieve",
+                AdminRoute::GrantsPage,
+            ),
+            (
+                "unknown ssr",
+                "/b/admin/whatever",
+                "retrieve",
+                AdminRoute::NotFound,
+            ),
             // Outside the admin namespace entirely
-            ("outside admin",        "/b/other",                            "retrieve", AdminRoute::NotFound),
-            ("root",                 "/",                                   "retrieve", AdminRoute::NotFound),
-
+            (
+                "outside admin",
+                "/b/other",
+                "retrieve",
+                AdminRoute::NotFound,
+            ),
+            ("root", "/", "retrieve", AdminRoute::NotFound),
             // Empty-id guards: paths that look like mutation patterns but
             // have empty extracted identifiers must NOT match the mutation
             // arm (the original handler falls through and returns the
             // SSR-or-NotFound branch).
-            ("user disable empty id","/b/admin/users//disable",             "create",   AdminRoute::NotFound),
-            ("delete role empty id", "/b/admin/iam/roles/",                 "delete",   AdminRoute::NotFound),
+            (
+                "user disable empty id",
+                "/b/admin/users//disable",
+                "create",
+                AdminRoute::NotFound,
+            ),
+            (
+                "delete role empty id",
+                "/b/admin/iam/roles/",
+                "delete",
+                AdminRoute::NotFound,
+            ),
         ]
     }
 
@@ -359,7 +663,10 @@ mod tests {
     fn route_table_classifies_every_endpoint_correctly() {
         for (desc, path, action, expected) in cases() {
             let actual = route(path, action);
-            assert_eq!(actual, expected, "case: {desc} (path={path:?}, action={action:?})");
+            assert_eq!(
+                actual, expected,
+                "case: {desc} (path={path:?}, action={action:?})"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Lever 2.3 of the WASM size reduction program (spec: `docs/superpowers/specs/2026-05-28-wasm-size-program-design.md` in the workspace meta-repo). Refactors `AdminBlock::handle` from a fat router (255 lines, 34 awaits, ~26 inline string ops) into a thin async dispatcher backed by a pure-sync `route(path, action) -> AdminRoute` classifier. Brings `AdminBlock::handle` into alignment with the codebase-wide `match (action, path) { … .await }` pattern used by `FilesBlock`, `ProductsBlock`, `products::handle_user`, `files::storage::handle`, and every other block.

## Changes

- **New** `crates/solobase-core/src/blocks/admin/route.rs` — `AdminRoute<'a>` enum + pure-sync `route()` + unit-test table (55 cases) covering every endpoint reachable in the current handler plus empty-id guards.
- **Modified** `crates/solobase-core/src/blocks/admin/mod.rs` — `handle()` body replaced with a flat `match route::route(...) { … .await }` dispatch. Function signature unchanged. Grants, lifecycle, `info()`, and `ui_routes` untouched.

## Correctness (the gate, per amended spec)

Per the spec amendment, Lever 2.3 is correctness-gated, not size-gated. All requirements met:

- All existing `solobase-core` tests pass (691 / 0).
- New unit-test table covers all 44 endpoints from the pre-refactor handler (plus 11 edge cases for empty-id guards and out-of-namespace paths).
- Routing is bit-exact: same paths, same actions, same handler called for each.
- `wasm32-unknown-unknown` release build clean.

## The critical-bug catch (worth highlighting)

During the spec-compliance review pass, a routing regression was caught and fixed (commit `ccbe9a9`): `path_owned` was originally captured AFTER `msg.set_meta("req.resource", ...)` rewrote the path, which made every `/b/admin/api/*` route fall through to `NotFound`. Fixed by capturing path + action before the normalization. The test module in `route.rs` has a comment documenting the invariant so a future refactor doesn't reintroduce it.

## Size impact (recorded, not gating)

Post-bindgen, deployed-equivalent (`wasm-bindgen --target web`):

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Raw | 4,626,956 B | 4,626,324 B | −632 B |
| Gzip | 1,321,895 B | 1,321,777 B | −118 B |

Essentially zero, as expected for a pure refactor that doesn't remove code. The win here is alignment with codebase conventions + testable routing, not bytes.

## Test plan

- [x] `cargo test -p solobase-core --lib` — all 691 tests pass.
- [x] `cargo build -p solobase-web --target wasm32-unknown-unknown --release` — clean.
- [x] `blocks::admin::route::tests::route_table_classifies_every_endpoint_correctly` passes (55/55 cases).
- [ ] Manual spot-check after merge: load the admin UI, confirm each tab (dashboard, users, storage, blocks, database, logs, settings/*, grants) renders without 404 — particularly the JSON API endpoints under /b/admin/api/* since that's where the spec-review catch lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)