### PR TITLE
feat(solobase): adopt wafer_block::use_static_blocks! macro (c4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "wafer-block",
  "wafer-block-crypto",
  "wafer-block-http-listener",
  "wafer-block-local-storage",
@@ -5811,7 +5812,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5834,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-config"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5847,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5859,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5879,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5889,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5900,13 +5901,12 @@ dependencies = [
  "tracing",
  "wafer-block",
  "wafer-block-macro",
- "wafer-run",
 ]
 
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5932,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-logger"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "serde",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5992,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6002,9 +6002,10 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
+ "serde_json",
  "tracing",
  "wafer-block",
  "wafer-block-macro",
@@ -6013,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6029,7 +6030,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6040,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6060,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6072,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6091,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "serde",
  "serde_json",
@@ -6101,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6131,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "serde",
  "serde_json",
@@ -6140,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#c3151ce3a46bfd98e4decc951d90a6f31bf60bdd"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#362482e171d7b00a80bb87cb3bd9cd3b5af291c7"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -10,12 +10,14 @@ use std::{collections::HashMap, sync::Arc};
 // distributed-slice entries land in the binary. Without these `use as _`
 // anchors the linker excludes the crate's .o file entirely and the
 // register_static_block! entries never appear in STATIC_BLOCK_REGISTRATIONS.
-use wafer_block_cors as _;
-use wafer_block_inspector as _;
-use wafer_block_readonly_guard as _;
-use wafer_block_router as _;
-use wafer_block_security_headers as _;
-use wafer_block_web as _;
+wafer_block::use_static_blocks!(
+    cors,
+    inspector,
+    readonly_guard,
+    router,
+    security_headers,
+    web,
+);
 use wafer_core::interfaces::{
     config::service::ConfigService, crypto::service::CryptoService,
     database::service::DatabaseService, image::service::ImageService, llm::service::LlmService,

--- a/crates/solobase-native/Cargo.toml
+++ b/crates/solobase-native/Cargo.toml
@@ -22,6 +22,9 @@ anyhow = "1"
 wafer-run = { workspace = true, features = ["full"] }
 wafer-core = { workspace = true }
 
+# wafer-block hosts the `use_static_blocks!` macro used in serve.rs.
+wafer-block = { workspace = true }
+
 wafer-block-sqlite = { workspace = true }
 wafer-block-local-storage = { workspace = true }
 wafer-block-network = { workspace = true }

--- a/crates/solobase-native/src/serve.rs
+++ b/crates/solobase-native/src/serve.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 // Force linker inclusion of wafer-block-http-listener so its
 // register_static_block! entry lands in STATIC_BLOCK_REGISTRATIONS.
-use wafer_block_http_listener as _;
+wafer_block::use_static_blocks!(http_listener);
 use wafer_run::Wafer;
 
 /// Register the `wafer-run/http-listener` block on `wafer` and configure


### PR DESCRIPTION
## Summary
- Replaces hand-rolled force-link blocks in `solobase-core/src/builder.rs` (6 lines) and `solobase-native/src/serve.rs` (1 line) with the new `wafer_block::use_static_blocks!` macro shipped in wafer-run #184.
- `solobase-native` gains a direct `wafer-block` dep (already transitive) to host the macro path.
- Cargo.lock bumps every wafer-run-sourced crate from `c3151ce` → `362482e` (the PR 184 merge SHA).
- Closes audit-fixes carry-forward #4 (consumer half).

## Test plan
- [x] `cargo check -p solobase-native` clean (path override off, against post-PR-184 wafer-run).
- [x] `cargo check -p solobase-core` clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` matches CI invocation; warnings only (no errors).
- [ ] CI Tests + Format & Lint + WASM Build + E2E (Playwright) + Security Audit + TypeScript SDK all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)