### PR TITLE
refactor(migration_helper): apply_migrations() collapses per-block boilerplate (audit #5)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/migrations/mod.rs
@@ -1,19 +1,12 @@
 //! Admin block migrations. Applied from the block's `Init` lifecycle.
 //!
-//! Mirrors the auth block's migration pattern (see `auth/migrations/mod.rs`).
-//! SQL files are embedded with `include_str!`. Backend selection reads the
-//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
-//! Falls back to `sqlite` when the config block is not registered.
-//!
-//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
-//! the helper handles statement splitting + the `current_hash` /
-//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
-//! `suppers_ai__admin__block_settings` once applied. Earlier versions of
-//! this module called `db::ddl` directly in a loop, bypassing the gate
-//! and re-running every DDL on every cold isolate (~2,800 D1 queries/day
-//! on wafer.run — see the 2026-05-14 config-snapshot spec).
+//! SQL files are embedded with `include_str!`. Backend dispatch + concat +
+//! the `current_hash` / `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate
+//! all live in [`crate::migration_helper::apply_migrations`]. Earlier
+//! versions of this module called `db::ddl` directly in a loop, bypassing
+//! the gate and re-running every DDL on every cold isolate (~2,800 D1
+//! queries/day on wafer.run — see the 2026-05-14 config-snapshot spec).
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 const ADMIN_BLOCK_NAME: &str = "suppers-ai/admin";
@@ -25,91 +18,43 @@ const SQL_002_POSTGRES: &str = include_str!("002_variables_block_column.postgres
 const SQL_003_SQLITE: &str = include_str!("003_block_settings_seed_hash.sqlite.sql");
 const SQL_003_POSTGRES: &str = include_str!("003_block_settings_seed_hash.postgres.sql");
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Backend {
-    Sqlite,
-    Postgres,
-}
-
-async fn backend(ctx: &dyn Context) -> Backend {
-    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
-    match raw.to_ascii_lowercase().as_str() {
-        "postgres" => Backend::Postgres,
-        _ => Backend::Sqlite,
-    }
-}
-
-/// Concatenate the per-backend migration scripts into a single blob so
-/// `apply_if_blessed` records one `current_hash` covering both. Mirrors the
-/// auth block's concatenation pattern; `apply_if_blessed`'s splitter handles
-/// the `;\n…` boundary between files.
-fn concatenated_sql(b: Backend) -> String {
-    match b {
-        Backend::Sqlite => format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}\n{SQL_003_SQLITE}"),
-        Backend::Postgres => format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}\n{SQL_003_POSTGRES}"),
-    }
-}
-
 /// Apply all admin migrations through the shared migration-state gate.
 /// Idempotent across cold starts: once the gate stamps a `current_hash` row
 /// in `block_settings`, subsequent boots short-circuit before issuing any
 /// DDL. Schema changes require a `--run-migrations` redeploy (see
 /// `migration-state-workflow` in user memory).
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let b = backend(ctx).await;
-    let sql = concatenated_sql(b);
-    crate::migration_helper::apply_if_blessed(ctx, ADMIN_BLOCK_NAME, &sql).await
+    crate::migration_helper::apply_migrations(
+        ctx,
+        ADMIN_BLOCK_NAME,
+        &[SQL_001_SQLITE, SQL_002_SQLITE, SQL_003_SQLITE],
+        &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES],
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{concatenated_sql, Backend};
+    use super::{
+        SQL_001_POSTGRES, SQL_001_SQLITE, SQL_002_POSTGRES, SQL_002_SQLITE, SQL_003_POSTGRES,
+        SQL_003_SQLITE,
+    };
 
     #[test]
-    fn concatenated_sqlite_contains_all_migrations() {
-        let sql = concatenated_sql(Backend::Sqlite);
-        // Spot-check the 001 schema (the variables UNIQUE INDEX), the
-        // 002 follow-up (ALTER TABLE ADD COLUMN block), and the 003
-        // follow-up (ADD COLUMN seed_defaults_hash) are all present.
-        assert!(
-            sql.contains("suppers_ai__admin__variables_key_uniq"),
-            "missing 001 marker; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("ADD COLUMN block"),
-            "missing 002 ALTER COLUMN; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("suppers_ai__admin__variables_block_idx"),
-            "missing 002 index; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("ADD COLUMN seed_defaults_hash"),
-            "missing 003 ADD COLUMN seed_defaults_hash; got len={}",
-            sql.len()
-        );
+    fn sqlite_migrations_contain_expected_ddl() {
+        // 001 schema (variables UNIQUE INDEX)
+        assert!(SQL_001_SQLITE.contains("suppers_ai__admin__variables_key_uniq"));
+        // 002 follow-up (ALTER TABLE ADD COLUMN block + index)
+        assert!(SQL_002_SQLITE.contains("ADD COLUMN block"));
+        assert!(SQL_002_SQLITE.contains("suppers_ai__admin__variables_block_idx"));
+        // 003 follow-up (ADD COLUMN seed_defaults_hash)
+        assert!(SQL_003_SQLITE.contains("ADD COLUMN seed_defaults_hash"));
     }
 
     #[test]
-    fn concatenated_postgres_contains_all_migrations() {
-        let sql = concatenated_sql(Backend::Postgres);
-        assert!(
-            sql.contains("suppers_ai__admin__variables_key_uniq"),
-            "missing 001 marker; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("ADD COLUMN"),
-            "missing 002/003 ALTER COLUMN; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("seed_defaults_hash"),
-            "missing 003 seed_defaults_hash column; got len={}",
-            sql.len()
-        );
+    fn postgres_migrations_contain_expected_ddl() {
+        assert!(SQL_001_POSTGRES.contains("suppers_ai__admin__variables_key_uniq"));
+        assert!(SQL_002_POSTGRES.contains("ADD COLUMN"));
+        assert!(SQL_003_POSTGRES.contains("seed_defaults_hash"));
     }
 }

--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -4,7 +4,6 @@
 //! `current_hash` in `suppers_ai__admin__block_settings`. Concatenated SQL of
 //! all migration scripts is hashed and tracked.
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -21,13 +20,23 @@ const SQL_005_SQLITE: &str = include_str!("005_jwt_blocklist.sqlite.sql");
 const SQL_005_POSTGRES: &str = include_str!("005_jwt_blocklist.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        format!("{SQL_001_POSTGRES}\n{SQL_002_POSTGRES}\n{SQL_003_POSTGRES}\n{SQL_004_POSTGRES}\n{SQL_005_POSTGRES}")
-    } else {
-        format!("{SQL_001_SQLITE}\n{SQL_002_SQLITE}\n{SQL_003_SQLITE}\n{SQL_004_SQLITE}\n{SQL_005_SQLITE}")
-    };
-    migration_helper::apply_if_blessed(ctx, "suppers-ai/auth", &sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        "suppers-ai/auth",
+        &[
+            SQL_001_SQLITE,
+            SQL_002_SQLITE,
+            SQL_003_SQLITE,
+            SQL_004_SQLITE,
+            SQL_005_SQLITE,
+        ],
+        &[
+            SQL_001_POSTGRES,
+            SQL_002_POSTGRES,
+            SQL_003_POSTGRES,
+            SQL_004_POSTGRES,
+            SQL_005_POSTGRES,
+        ],
+    )
+    .await
 }

--- a/crates/solobase-core/src/blocks/files/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/files/migrations/mod.rs
@@ -1,6 +1,5 @@
 //! Files block migrations. Delegated to `crate::migration_helper`.
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -9,13 +8,11 @@ const SQL_001_SQLITE: &str = include_str!("001_initial_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_initial_schema.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        SQL_001_POSTGRES
-    } else {
-        SQL_001_SQLITE
-    };
-    migration_helper::apply_if_blessed(ctx, "suppers-ai/files", sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        "suppers-ai/files",
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }

--- a/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
@@ -1,6 +1,5 @@
 //! Legalpages block migrations. Delegated to `crate::migration_helper`.
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -9,13 +8,11 @@ const SQL_001_SQLITE: &str = include_str!("001_legalpages_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_legalpages_schema.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        SQL_001_POSTGRES
-    } else {
-        SQL_001_SQLITE
-    };
-    migration_helper::apply_if_blessed(ctx, "suppers-ai/legalpages", sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        "suppers-ai/legalpages",
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }

--- a/crates/solobase-core/src/blocks/llm/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/mod.rs
@@ -30,13 +30,8 @@ const SQL_001_POSTGRES: &str = include_str!("001_llm_schema.postgres.sql");
 /// any DDL. Schema changes require a `--run-migrations` redeploy (see
 /// `migration-state-workflow` in user memory).
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    migration_helper::apply_migrations(
-        ctx,
-        LLM_BLOCK_NAME,
-        &[SQL_001_SQLITE],
-        &[SQL_001_POSTGRES],
-    )
-    .await
+    migration_helper::apply_migrations(ctx, LLM_BLOCK_NAME, &[SQL_001_SQLITE], &[SQL_001_POSTGRES])
+        .await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/llm/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/mod.rs
@@ -1,14 +1,8 @@
 //! LLM block migrations. Applied from the block's `Init` lifecycle.
 //!
-//! Mirrors the files block's migration pattern (see `files/migrations/mod.rs`).
-//! SQL files are embedded with `include_str!`. Backend selection reads the
-//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
-//! Falls back to `sqlite` when the config block is not registered.
-//!
-//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
-//! the helper handles statement splitting + the `current_hash` /
-//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
-//! `suppers_ai__admin__block_settings` once applied. Replaces the implicit
+//! SQL files are embedded with `include_str!`. Backend dispatch + the
+//! `current_hash` / `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate live
+//! in [`crate::migration_helper::apply_migrations`]. Replaces the implicit
 //! `ensure_table` materialisation that previously created these tables on
 //! first insert (TEXT-only columns, no indexes — see solobase
 //! `ensure-table-removal-in-progress`).
@@ -21,7 +15,6 @@
 
 pub(in crate::blocks::llm) mod legacy_providers;
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -31,40 +24,24 @@ const LLM_BLOCK_NAME: &str = "suppers-ai/llm";
 const SQL_001_SQLITE: &str = include_str!("001_llm_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_llm_schema.postgres.sql");
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Backend {
-    Sqlite,
-    Postgres,
-}
-
-async fn backend(ctx: &dyn Context) -> Backend {
-    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
-    match raw.to_ascii_lowercase().as_str() {
-        "postgres" => Backend::Postgres,
-        _ => Backend::Sqlite,
-    }
-}
-
-fn sql_for(b: Backend) -> &'static str {
-    match b {
-        Backend::Sqlite => SQL_001_SQLITE,
-        Backend::Postgres => SQL_001_POSTGRES,
-    }
-}
-
 /// Apply LLM schema migrations through the shared migration-state gate.
 /// Idempotent across cold starts: once the gate stamps a `current_hash`
 /// row in `block_settings`, subsequent boots short-circuit before issuing
 /// any DDL. Schema changes require a `--run-migrations` redeploy (see
 /// `migration-state-workflow` in user memory).
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let b = backend(ctx).await;
-    migration_helper::apply_if_blessed(ctx, LLM_BLOCK_NAME, sql_for(b)).await
+    migration_helper::apply_migrations(
+        ctx,
+        LLM_BLOCK_NAME,
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{sql_for, Backend};
+    use super::{SQL_001_POSTGRES, SQL_001_SQLITE};
 
     fn split_statements(sql: &str) -> usize {
         // Inline mirror of `migration_helper::split_statements`'s
@@ -86,41 +63,38 @@ mod tests {
     #[test]
     fn sqlite_sql_splits_into_expected_chunks() {
         // 2 tables + 3 indexes = 5 executable statements.
-        let count = split_statements(sql_for(Backend::Sqlite));
-        assert_eq!(count, 5, "sqlite llm migration: expected 5 statements");
+        assert_eq!(
+            split_statements(SQL_001_SQLITE),
+            5,
+            "sqlite llm migration: expected 5 statements"
+        );
     }
 
     #[test]
     fn postgres_sql_splits_into_expected_chunks() {
-        let count = split_statements(sql_for(Backend::Postgres));
-        assert_eq!(count, 5, "postgres llm migration: expected 5 statements");
+        assert_eq!(
+            split_statements(SQL_001_POSTGRES),
+            5,
+            "postgres llm migration: expected 5 statements"
+        );
     }
 
     #[test]
     fn sqlite_creates_both_tables() {
-        let sql = sql_for(Backend::Sqlite);
-        assert!(
-            sql.contains("suppers_ai__llm__settings"),
-            "missing settings table"
-        );
-        assert!(
-            sql.contains("suppers_ai__llm__providers"),
-            "missing providers table"
-        );
+        assert!(SQL_001_SQLITE.contains("suppers_ai__llm__settings"));
+        assert!(SQL_001_SQLITE.contains("suppers_ai__llm__providers"));
     }
 
     #[test]
     fn sqlite_declares_required_indexes() {
-        let sql = sql_for(Backend::Sqlite);
-        assert!(sql.contains("suppers_ai__llm__settings_thread_id_idx"));
-        assert!(sql.contains("suppers_ai__llm__providers_name_uniq"));
-        assert!(sql.contains("suppers_ai__llm__providers_enabled_idx"));
+        assert!(SQL_001_SQLITE.contains("suppers_ai__llm__settings_thread_id_idx"));
+        assert!(SQL_001_SQLITE.contains("suppers_ai__llm__providers_name_uniq"));
+        assert!(SQL_001_SQLITE.contains("suppers_ai__llm__providers_enabled_idx"));
     }
 
     #[test]
     fn postgres_creates_both_tables() {
-        let sql = sql_for(Backend::Postgres);
-        assert!(sql.contains("suppers_ai__llm__settings"));
-        assert!(sql.contains("suppers_ai__llm__providers"));
+        assert!(SQL_001_POSTGRES.contains("suppers_ai__llm__settings"));
+        assert!(SQL_001_POSTGRES.contains("suppers_ai__llm__providers"));
     }
 }

--- a/crates/solobase-core/src/blocks/messages/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/migrations/mod.rs
@@ -1,12 +1,6 @@
-//! Messages block migrations. Delegated to `crate::migration_helper`.
-//!
-//! Backend selection mirrors `files/migrations/mod.rs`: read
-//! `SOLOBASE_SHARED__DATABASE__BACKEND` from the config snapshot, fall back
-//! to `sqlite` when the config block is not registered. The actual apply +
-//! gating + statement splitting lives in
-//! [`crate::migration_helper::apply_if_blessed`].
+//! Messages block migrations. Backend dispatch + apply gating live in
+//! [`crate::migration_helper::apply_migrations`].
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -15,15 +9,13 @@ const SQL_001_SQLITE: &str = include_str!("001_messages_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_messages_schema.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        SQL_001_POSTGRES
-    } else {
-        SQL_001_SQLITE
-    };
-    migration_helper::apply_if_blessed(ctx, "suppers-ai/messages", sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        "suppers-ai/messages",
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/products/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/products/migrations/mod.rs
@@ -11,7 +11,6 @@
 //! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
 //! `suppers_ai__admin__block_settings` once applied.
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -22,13 +21,11 @@ const SQL_001_SQLITE: &str = include_str!("001_products_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_products_schema.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        SQL_001_POSTGRES
-    } else {
-        SQL_001_SQLITE
-    };
-    migration_helper::apply_if_blessed(ctx, PRODUCTS_BLOCK_NAME, sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        PRODUCTS_BLOCK_NAME,
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }

--- a/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
@@ -29,15 +29,17 @@ mod tests {
 
     #[test]
     fn sqlite_script_creates_buttons_table_and_sort_order_index() {
-        assert!(SQL_001_SQLITE
-            .contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"));
+        assert!(
+            SQL_001_SQLITE.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons")
+        );
         assert!(SQL_001_SQLITE.contains("suppers_ai__userportal__buttons_sort_order_idx"));
     }
 
     #[test]
     fn postgres_script_creates_buttons_table_and_sort_order_index() {
-        assert!(SQL_001_POSTGRES
-            .contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"));
+        assert!(
+            SQL_001_POSTGRES.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons")
+        );
         assert!(SQL_001_POSTGRES.contains("suppers_ai__userportal__buttons_sort_order_idx"));
     }
 }

--- a/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
@@ -1,16 +1,9 @@
 //! User portal block migrations. Applied from the block's `Init` lifecycle.
 //!
-//! Mirrors the admin/auth/files migration pattern. SQL files are embedded
-//! with `include_str!`. Backend selection reads the
-//! `SOLOBASE_SHARED__DATABASE__BACKEND` config key (`sqlite` | `postgres`).
-//! Falls back to `sqlite` when unset.
-//!
-//! Application is gated by [`crate::migration_helper::apply_if_blessed`]:
-//! the helper handles statement splitting + the `current_hash` /
-//! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
-//! `suppers_ai__admin__block_settings` once applied.
+//! SQL files are embedded with `include_str!`. Backend dispatch + the
+//! `current_hash` / `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate live
+//! in [`crate::migration_helper::apply_migrations`].
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -20,64 +13,31 @@ const USERPORTAL_BLOCK_NAME: &str = "suppers-ai/userportal";
 const SQL_001_SQLITE: &str = include_str!("001_userportal_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_userportal_schema.postgres.sql");
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Backend {
-    Sqlite,
-    Postgres,
-}
-
-async fn backend(ctx: &dyn Context) -> Backend {
-    let raw = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite").await;
-    match raw.to_ascii_lowercase().as_str() {
-        "postgres" => Backend::Postgres,
-        _ => Backend::Sqlite,
-    }
-}
-
-fn concatenated_sql(b: Backend) -> String {
-    match b {
-        Backend::Sqlite => SQL_001_SQLITE.to_string(),
-        Backend::Postgres => SQL_001_POSTGRES.to_string(),
-    }
-}
-
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let b = backend(ctx).await;
-    let sql = concatenated_sql(b);
-    migration_helper::apply_if_blessed(ctx, USERPORTAL_BLOCK_NAME, &sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        USERPORTAL_BLOCK_NAME,
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{concatenated_sql, Backend};
+    use super::{SQL_001_POSTGRES, SQL_001_SQLITE};
 
     #[test]
     fn sqlite_script_creates_buttons_table_and_sort_order_index() {
-        let sql = concatenated_sql(Backend::Sqlite);
-        assert!(
-            sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"),
-            "missing buttons CREATE TABLE; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("suppers_ai__userportal__buttons_sort_order_idx"),
-            "missing sort_order index; got len={}",
-            sql.len()
-        );
+        assert!(SQL_001_SQLITE
+            .contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"));
+        assert!(SQL_001_SQLITE.contains("suppers_ai__userportal__buttons_sort_order_idx"));
     }
 
     #[test]
     fn postgres_script_creates_buttons_table_and_sort_order_index() {
-        let sql = concatenated_sql(Backend::Postgres);
-        assert!(
-            sql.contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"),
-            "missing buttons CREATE TABLE; got len={}",
-            sql.len()
-        );
-        assert!(
-            sql.contains("suppers_ai__userportal__buttons_sort_order_idx"),
-            "missing sort_order index; got len={}",
-            sql.len()
-        );
+        assert!(SQL_001_POSTGRES
+            .contains("CREATE TABLE IF NOT EXISTS suppers_ai__userportal__buttons"));
+        assert!(SQL_001_POSTGRES.contains("suppers_ai__userportal__buttons_sort_order_idx"));
     }
 }

--- a/crates/solobase-core/src/blocks/vector/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/migrations/mod.rs
@@ -13,7 +13,6 @@
 //! and so cannot be expressed as a static SQL migration. See the SQL file
 //! header for the long-form rationale.
 
-use wafer_core::clients::config;
 use wafer_run::context::Context;
 
 use crate::migration_helper;
@@ -22,15 +21,13 @@ const SQL_001_SQLITE: &str = include_str!("001_vector_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_vector_schema.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let sql = if backend == "postgres" {
-        SQL_001_POSTGRES
-    } else {
-        SQL_001_SQLITE
-    };
-    migration_helper::apply_if_blessed(ctx, "suppers-ai/vector", sql).await
+    migration_helper::apply_migrations(
+        ctx,
+        "suppers-ai/vector",
+        &[SQL_001_SQLITE],
+        &[SQL_001_POSTGRES],
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -16,7 +16,7 @@
 //! canonical .sql files don't use either.
 
 use sha2::{Digest, Sha256};
-use wafer_core::clients::database as db;
+use wafer_core::clients::{config, database as db};
 use wafer_run::context::Context;
 
 use crate::features::{BlockSettings, MigrationState, BLOCK_SETTINGS_CONFIG_KEY};
@@ -31,6 +31,48 @@ pub const RUN_MIGRATIONS_KEY: &str = "SOLOBASE_RUN_MIGRATIONS";
 /// Full table name for the block_settings collection. Hardcoded here to
 /// avoid a circular dep on `crate::blocks::admin`.
 const BLOCK_SETTINGS_TABLE: &str = "suppers_ai__admin__block_settings";
+
+/// Read `SOLOBASE_SHARED__DATABASE__BACKEND` from the config snapshot,
+/// concatenate the matching per-backend SQL files, and forward to
+/// [`apply_if_blessed`].
+///
+/// Consolidates the backend dispatch + concatenation boilerplate that
+/// every block's `migrations/mod.rs::apply` previously open-coded:
+///
+/// ```ignore
+/// pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+///     migration_helper::apply_migrations(
+///         ctx,
+///         "suppers-ai/messages",
+///         &[SQL_001_SQLITE],
+///         &[SQL_001_POSTGRES],
+///     )
+///     .await
+/// }
+/// ```
+///
+/// `sqlite_files` and `postgres_files` are joined with `\n` separators —
+/// the same shape `apply_if_blessed`'s statement splitter expects.
+/// Backends other than `"postgres"` (case-insensitive) fall back to
+/// `sqlite_files`, matching the `config::get_default(..., "sqlite")`
+/// behavior every consumer used to spell out.
+pub async fn apply_migrations(
+    ctx: &dyn Context,
+    block_name: &str,
+    sqlite_files: &[&str],
+    postgres_files: &[&str],
+) -> Result<(), String> {
+    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
+        .await
+        .to_ascii_lowercase();
+    let files = if backend == "postgres" {
+        postgres_files
+    } else {
+        sqlite_files
+    };
+    let sql = files.join("\n");
+    apply_if_blessed(ctx, block_name, &sql).await
+}
 
 /// Apply `sql` against `db::ddl` iff the operator has blessed it or
 /// `SOLOBASE_RUN_MIGRATIONS=1`. Idempotent across calls: returns early


### PR DESCRIPTION
## Summary
- Adds `migration_helper::apply_migrations(ctx, block, sqlite_files, postgres_files)` that reads `SOLOBASE_SHARED__DATABASE__BACKEND`, picks the matching file list, joins with `\n`, and forwards to `apply_if_blessed`.
- 9 blocks migrate to the new helper. Each `migrations/mod.rs::apply` shrinks from 8–32 lines to a single 7-line `apply_migrations` call.
- For the four multi-file Pattern B blocks (auth, admin, llm, userportal) the `Backend` enum + `backend()` + `sql_for()` / `concatenated_sql()` helpers go away entirely; tests rewritten to assert against the SQL constants directly.
- Net: **-113 LOC**.
- Closes `audit-design.md` finding #5 — "migration boilerplate to `migration_helper::apply_migrations`".

## Behaviour preservation
The new helper does exactly what every block open-coded:
1. `config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")` — same default.
2. Lowercase compare against `"postgres"` — same case handling.
3. Concatenate files with `\n` separators — same separator `apply_if_blessed`'s splitter expects.
4. Forward to `apply_if_blessed` — same hash-gated apply, same `BLOCK_SETTINGS` stamping.

## Test plan
- [x] `cargo check -p solobase-core` clean.
- [x] `cargo test -p solobase-core --lib` — 693 pass.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — warnings only (no errors), matches baseline.
- [x] `bash scripts/audit-wrap-grants.sh` clean.
- [ ] CI green.

## Out of scope
- The single inline `db::exec_raw("CREATE TABLE IF NOT EXISTS suppers_ai__vector__docs_meta ...")` at `vector/pages_ui.rs:439` — that's a runtime-init guard, not a block-lifecycle migration. Separate cleanup.
- Renaming `apply_if_blessed` to fold under `apply_migrations` — both stay public for now; no caller renames required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)