### PR TITLE
refactor(vector): single-source REGISTRY_TABLE const (Wave 29 / TABLE convention sweep)

### DIFF
--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -50,24 +50,11 @@ use wafer_sql_utils::{introspect, query, upsert, Backend};
 
 use super::{
     ingestion::{self, DEFAULT_CHUNK_TOKENS, DEFAULT_OVERLAP_RATIO},
-    service::{self, TABLE_PREFIX},
+    service::{self, REGISTRY_TABLE, TABLE_PREFIX},
 };
 use crate::blocks::helpers::{
     err_bad_request, err_internal, err_internal_no_cause, err_not_found, ok_json,
 };
-
-/// Per-index metadata registry table.
-///
-/// One row per index, keyed by the prefixed (storage) name. Keeping this
-/// separate from `sqlite_master` lets us remember per-index knobs — the
-/// model to re-embed text with, and whether keyword search was enabled —
-/// without spelunking through DDL on every query.
-///
-/// Schema lives in `migrations/001_vector_schema.{sqlite,postgres}.sql` and
-/// is applied at block Init via `apply_if_blessed`. The column layout is:
-/// `(prefixed_name TEXT PK, model TEXT, dimensions INTEGER,
-/// keyword_search INTEGER)`.
-const REGISTRY_TABLE: &str = "suppers_ai__vector__registry";
 
 /// Route dispatcher for the `suppers-ai/vector` block.
 ///

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -30,6 +30,19 @@ pub struct IndexRow {
 /// All tables created for a vector index are named with this prefix.
 pub const TABLE_PREFIX: &str = "suppers_ai__vector__";
 
+/// Per-index metadata registry table.
+///
+/// One row per index, keyed by the prefixed (storage) name. Keeping this
+/// separate from `sqlite_master` lets us remember per-index knobs — the
+/// model to re-embed text with, and whether keyword search was enabled —
+/// without spelunking through DDL on every query.
+///
+/// Schema lives in `migrations/001_vector_schema.{sqlite,postgres}.sql` and
+/// is applied at block Init via `apply_if_blessed`. The column layout is:
+/// `(prefixed_name TEXT PK, model TEXT, dimensions INTEGER,
+/// keyword_search INTEGER)`.
+pub(crate) const REGISTRY_TABLE: &str = "suppers_ai__vector__registry";
+
 /// Convert a user-facing index name (e.g. `"docs"`) into the fully prefixed
 /// name that is actually stored in the database (e.g. `"suppers_ai__vector__docs"`).
 pub fn prefixed_index_name(user_name: &str) -> String {
@@ -150,7 +163,7 @@ async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> 
 pub async fn list_index_rows(ctx: &dyn Context) -> Result<Vec<IndexRow>, WaferError> {
     let records = db::list_sorted(
         ctx,
-        "suppers_ai__vector__registry",
+        REGISTRY_TABLE,
         vec![],
         vec![SortField {
             field: "prefixed_name".to_string(),
@@ -176,7 +189,7 @@ pub async fn get_index_row(
 ) -> Result<Option<IndexRow>, WaferError> {
     let rec = match db::get_by_field(
         ctx,
-        "suppers_ai__vector__registry",
+        REGISTRY_TABLE,
         "prefixed_name",
         serde_json::Value::String(storage_name.to_string()),
     )


### PR DESCRIPTION
## Wave 29 — `TABLE` constant convention sweep

Closes the `TABLE` constant convention sweep item from `audit-design.md`'s Wave 4 (bigger-refactors) list.

### Verification result
The convention (*"each repo module owns its own `pub const TABLE`; no central `*_COLLECTION` constants"*, per `CLAUDE.md`) is already followed across every block — `products`, `admin`, `messages`, `llm`, `auth` (`repo/*::TABLE`), `userportal`, `files`, `legalpages` all own per-table consts used in production, and cross-block reuse works (`userportal/pages/profile.rs` imports `auth::USERS_TABLE`).

The auth `ResourceGrant` literals in `auth/service.rs` are **intentional documented exceptions** — `scripts/audit-wrap-grants.sh`'s const-resolver only follows top-level `super::NAME` paths (not nested `repo::users::TABLE`), so routing them through consts would break the audit. Left as-is.

### The one genuine leftover: vector block
The per-index registry table name had **two sources of truth**:
- a module-private `const REGISTRY_TABLE` in `pages.rs` (route/UI dispatcher), and
- two re-hardcoded string literals in `service.rs` (data-access layer) — which couldn't reach the sibling module's private const.

### Fix
Move the const into `service.rs` (already documented as the "Table-name constants and helpers" module and owner of `TABLE_PREFIX`) as `pub(crate)`, and import it from `pages.rs` alongside `TABLE_PREFIX`. Matches the auth-block convention (data/repo module owns the const, UI imports it) and fixes the inverted layering. **No behavior change.**

### Verification
- `cargo check -p solobase-core` clean.
- `cargo test -p solobase-core --lib` — 693 pass (20 vector tests green).
- `cargo clippy -p solobase-core` — zero findings in the touched files.
- `bash scripts/audit-wrap-grants.sh` — OK, no missing WRAP grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)