### PR TITLE
refactor(auth-ui): consolidate OAuth provider dispatch into OAuthProviderSpec (Wave 30)

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -14,7 +14,7 @@ use crate::blocks::{
     },
     auth_ui::redirect::is_safe_local_redirect,
     helpers::{
-        err_bad_request, err_forbidden, err_internal, err_internal_no_cause, json_map, urlencode,
+        err_bad_request, err_forbidden, err_internal, err_internal_no_cause, json_map,
         ResponseBuilder,
     },
 };
@@ -47,6 +47,11 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // match check passes even if the live config changed mid-flow.
     let redirect_uri = pkce_row.redirect_uri.clone();
 
+    let spec = match super::spec::lookup(&provider) {
+        Some(s) => s,
+        None => return err_bad_request("Unsupported OAuth provider"),
+    };
+
     let client_id = config::get_default(
         ctx,
         &format!(
@@ -71,24 +76,14 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Exchange code for token (URL-encode all values, include PKCE verifier)
-    let (token_url, token_body_str) = match provider.as_str() {
-        "google" => (
-            "https://oauth2.googleapis.com/token".to_string(),
-            format!("code={}&client_id={}&client_secret={}&redirect_uri={}&grant_type=authorization_code&code_verifier={}",
-                urlencode(code), urlencode(&client_id), urlencode(&client_secret), urlencode(&redirect_uri), urlencode(&code_verifier)),
-        ),
-        "github" => (
-            "https://github.com/login/oauth/access_token".to_string(),
-            format!("code={}&client_id={}&client_secret={}&redirect_uri={}",
-                urlencode(code), urlencode(&client_id), urlencode(&client_secret), urlencode(&redirect_uri)),
-        ),
-        "microsoft" => (
-            "https://login.microsoftonline.com/common/oauth2/v2.0/token".to_string(),
-            format!("code={}&client_id={}&client_secret={}&redirect_uri={}&grant_type=authorization_code&code_verifier={}",
-                urlencode(code), urlencode(&client_id), urlencode(&client_secret), urlencode(&redirect_uri), urlencode(&code_verifier)),
-        ),
-        _ => return err_bad_request("Unsupported OAuth provider"),
-    };
+    let token_url = spec.token_url;
+    let token_body_str = spec.build_token_body(
+        code,
+        &client_id,
+        &client_secret,
+        &redirect_uri,
+        &code_verifier,
+    );
 
     let mut headers = HashMap::new();
     headers.insert(
@@ -98,12 +93,18 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     headers.insert("Accept".to_string(), "application/json".to_string());
 
     let token_body_bytes = token_body_str.into_bytes();
-    let token_resp =
-        match network::do_request(ctx, "POST", &token_url, &headers, Some(&token_body_bytes)).await
-        {
-            Ok(r) => r,
-            Err(e) => return err_internal("Token exchange failed", e),
-        };
+    let token_resp = match network::do_request(
+        ctx,
+        "POST",
+        token_url,
+        &headers,
+        Some(&token_body_bytes),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return err_internal("Token exchange failed", e),
+    };
 
     let token_data: serde_json::Value = match serde_json::from_slice(&token_resp.body) {
         Ok(d) => d,
@@ -119,21 +120,8 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Get user info
-    let (userinfo_url, auth_header) = match provider.as_str() {
-        "google" => (
-            "https://www.googleapis.com/oauth2/v2/userinfo".to_string(),
-            format!("Bearer {}", access_token_oauth),
-        ),
-        "github" => (
-            "https://api.github.com/user".to_string(),
-            format!("token {}", access_token_oauth),
-        ),
-        "microsoft" => (
-            "https://graph.microsoft.com/v1.0/me".to_string(),
-            format!("Bearer {}", access_token_oauth),
-        ),
-        _ => return err_internal_no_cause("Unsupported provider"),
-    };
+    let userinfo_url = spec.userinfo_url;
+    let auth_header = spec.userinfo_auth_header(access_token_oauth);
 
     let mut info_headers = HashMap::new();
     info_headers.insert("Authorization".to_string(), auth_header);
@@ -145,8 +133,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
     );
 
-    let info_resp = match network::do_request(ctx, "GET", &userinfo_url, &info_headers, None).await
-    {
+    let info_resp = match network::do_request(ctx, "GET", userinfo_url, &info_headers, None).await {
         Ok(r) => r,
         Err(e) => return err_internal("User info request failed", e),
     };
@@ -192,26 +179,21 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // GitHub's /user endpoint returns a null `email` for users who have
     // their primary email set to private. The authoritative list lives at
     // /user/emails — which is only returned when the `user:email` scope
-    // was granted. Pick the first primary verified address.
-    if email.is_empty() && provider == "github" {
+    // was granted. Pick the first primary verified address. Only providers
+    // with an `emails_url` (GitHub) carry this fallback.
+    if let (true, Some(emails_url)) = (email.is_empty(), spec.emails_url) {
         let mut emails_headers = HashMap::new();
         emails_headers.insert(
             "Authorization".to_string(),
-            format!("token {}", access_token_oauth),
+            spec.userinfo_auth_header(access_token_oauth),
         );
         emails_headers.insert("Accept".to_string(), "application/json".to_string());
         emails_headers.insert(
             "User-Agent".to_string(),
             concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
         );
-        if let Ok(emails_resp) = network::do_request(
-            ctx,
-            "GET",
-            "https://api.github.com/user/emails",
-            &emails_headers,
-            None,
-        )
-        .await
+        if let Ok(emails_resp) =
+            network::do_request(ctx, "GET", emails_url, &emails_headers, None).await
         {
             if let Ok(arr) = serde_json::from_slice::<serde_json::Value>(&emails_resp.body) {
                 if let Some(entries) = arr.as_array() {

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod callback;
 pub mod providers;
+pub(crate) mod spec;
 pub mod start;

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/providers.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/providers.rs
@@ -9,14 +9,14 @@ use crate::blocks::helpers::ok_json;
 pub async fn handle(ctx: &dyn Context) -> OutputStream {
     let mut providers = Vec::new();
 
-    for provider_name in &["google", "github", "microsoft"] {
+    for spec in super::spec::OAUTH_PROVIDERS {
         let client_id_key = format!(
             "SUPPERS_AI__AUTH_UI__OAUTH_{}_CLIENT_ID",
-            provider_name.to_uppercase()
+            spec.name.to_uppercase()
         );
         if config::get(ctx, &client_id_key).await.is_ok() {
             providers.push(serde_json::json!({
-                "name": provider_name,
+                "name": spec.name,
                 "enabled": true
             }));
         }

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/spec.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/spec.rs
@@ -1,0 +1,247 @@
+//! Per-provider OAuth wiring as static data + a generic driver.
+//!
+//! All three supported providers run the same flow — build an authorize URL,
+//! exchange the code for a token, fetch userinfo, and (for GitHub) fall back to
+//! `/user/emails` for a verified address. Only the *data* differs between them,
+//! so each provider is one [`OAuthProviderSpec`] row and the flow handlers in
+//! `start.rs` / `callback.rs` read these fields instead of matching on the
+//! provider name. Adding a provider is a single table row.
+
+use crate::blocks::helpers::urlencode;
+
+/// Authorization-header scheme for the userinfo request. Providers differ only
+/// in the scheme word.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UserinfoAuth {
+    /// `Authorization: Bearer <token>` — Google, Microsoft (OIDC).
+    Bearer,
+    /// `Authorization: token <token>` — GitHub REST API.
+    Token,
+}
+
+/// Static OAuth wiring for one provider.
+///
+/// One row per supported provider in [`OAUTH_PROVIDERS`]. The generic flow in
+/// `start.rs` / `callback.rs` reads these fields rather than branching on the
+/// provider name.
+pub struct OAuthProviderSpec {
+    /// Provider key as it appears in config-var names
+    /// (`SUPPERS_AI__AUTH_UI__OAUTH_{NAME}_CLIENT_ID`) and the
+    /// `provider_links.provider` column.
+    pub name: &'static str,
+    /// Authorization endpoint (the user-facing redirect target).
+    pub authorize_url: &'static str,
+    /// Token-exchange endpoint.
+    pub token_url: &'static str,
+    /// Userinfo endpoint.
+    pub userinfo_url: &'static str,
+    /// OAuth scope, stored in its exact on-the-wire form and interpolated
+    /// verbatim into the authorize URL.
+    ///
+    /// It is deliberately *not* routed through [`urlencode`]: Google/Microsoft
+    /// use a pre-encoded `openid%20email%20profile`, while GitHub uses
+    /// `user:email` with a raw colon. `urlencode` (form-urlencoded) would
+    /// render the space as `+` and the colon as `%3A`, changing both URLs.
+    pub scope: &'static str,
+    /// Whether the flow uses PKCE + OIDC `response_type=code` /
+    /// `grant_type=authorization_code` / `code_verifier`. Google and Microsoft
+    /// do; GitHub's legacy OAuth2 flow does not.
+    pub uses_pkce: bool,
+    /// Authorization-header scheme for the userinfo request.
+    pub userinfo_auth: UserinfoAuth,
+    /// Optional fallback endpoint for a verified primary email when the
+    /// userinfo payload omits one (GitHub `/user/emails`). `None` for providers
+    /// that always return an email.
+    pub emails_url: Option<&'static str>,
+}
+
+impl OAuthProviderSpec {
+    /// Build the provider's authorize URL. All `*_enc` arguments are expected
+    /// already-`urlencode`d by the caller; [`scope`](Self::scope) is
+    /// interpolated verbatim (see its docs).
+    pub fn build_authorize_url(
+        &self,
+        client_id_enc: &str,
+        redirect_uri_enc: &str,
+        state_enc: &str,
+        challenge_enc: &str,
+    ) -> String {
+        if self.uses_pkce {
+            format!(
+                "{}?client_id={client_id_enc}&redirect_uri={redirect_uri_enc}&response_type=code&scope={}&state={state_enc}&code_challenge={challenge_enc}&code_challenge_method=S256",
+                self.authorize_url, self.scope
+            )
+        } else {
+            format!(
+                "{}?client_id={client_id_enc}&redirect_uri={redirect_uri_enc}&scope={}&state={state_enc}",
+                self.authorize_url, self.scope
+            )
+        }
+    }
+
+    /// Build the `application/x-www-form-urlencoded` token-exchange request
+    /// body. Every value is `urlencode`d; PKCE providers additionally send
+    /// `grant_type=authorization_code` and the `code_verifier`.
+    pub fn build_token_body(
+        &self,
+        code: &str,
+        client_id: &str,
+        client_secret: &str,
+        redirect_uri: &str,
+        code_verifier: &str,
+    ) -> String {
+        let base = format!(
+            "code={}&client_id={}&client_secret={}&redirect_uri={}",
+            urlencode(code),
+            urlencode(client_id),
+            urlencode(client_secret),
+            urlencode(redirect_uri),
+        );
+        if self.uses_pkce {
+            format!(
+                "{base}&grant_type=authorization_code&code_verifier={}",
+                urlencode(code_verifier)
+            )
+        } else {
+            base
+        }
+    }
+
+    /// Build the `Authorization` header value for the userinfo request.
+    pub fn userinfo_auth_header(&self, access_token: &str) -> String {
+        match self.userinfo_auth {
+            UserinfoAuth::Bearer => format!("Bearer {access_token}"),
+            UserinfoAuth::Token => format!("token {access_token}"),
+        }
+    }
+}
+
+/// All supported OAuth providers. The enabled-provider list endpoint and the
+/// login/callback flow both iterate or look up against this table.
+pub const OAUTH_PROVIDERS: &[OAuthProviderSpec] = &[
+    OAuthProviderSpec {
+        name: "google",
+        authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+        token_url: "https://oauth2.googleapis.com/token",
+        userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo",
+        scope: "openid%20email%20profile",
+        uses_pkce: true,
+        userinfo_auth: UserinfoAuth::Bearer,
+        emails_url: None,
+    },
+    OAuthProviderSpec {
+        name: "github",
+        authorize_url: "https://github.com/login/oauth/authorize",
+        token_url: "https://github.com/login/oauth/access_token",
+        userinfo_url: "https://api.github.com/user",
+        scope: "user:email",
+        uses_pkce: false,
+        userinfo_auth: UserinfoAuth::Token,
+        emails_url: Some("https://api.github.com/user/emails"),
+    },
+    OAuthProviderSpec {
+        name: "microsoft",
+        authorize_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        userinfo_url: "https://graph.microsoft.com/v1.0/me",
+        scope: "openid%20email%20profile",
+        uses_pkce: true,
+        userinfo_auth: UserinfoAuth::Bearer,
+        emails_url: None,
+    },
+];
+
+/// Look up a provider spec by its `name`. Returns `None` for unsupported
+/// providers.
+pub fn lookup(name: &str) -> Option<&'static OAuthProviderSpec> {
+    OAUTH_PROVIDERS.iter().find(|p| p.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str) -> &'static OAuthProviderSpec {
+        lookup(name).expect("provider exists")
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(lookup("twitter").is_none());
+        assert!(lookup("").is_none());
+    }
+
+    // --- authorize URL: pinned byte-for-byte against the pre-refactor literals ---
+
+    #[test]
+    fn authorize_url_google() {
+        assert_eq!(
+            spec("google").build_authorize_url("CID", "RURI", "STATE", "CHAL"),
+            "https://accounts.google.com/o/oauth2/v2/auth?client_id=CID&redirect_uri=RURI&response_type=code&scope=openid%20email%20profile&state=STATE&code_challenge=CHAL&code_challenge_method=S256"
+        );
+    }
+
+    #[test]
+    fn authorize_url_github() {
+        // GitHub: no response_type, no PKCE challenge, raw `:` in scope.
+        assert_eq!(
+            spec("github").build_authorize_url("CID", "RURI", "STATE", "CHAL"),
+            "https://github.com/login/oauth/authorize?client_id=CID&redirect_uri=RURI&scope=user:email&state=STATE"
+        );
+    }
+
+    #[test]
+    fn authorize_url_microsoft() {
+        assert_eq!(
+            spec("microsoft").build_authorize_url("CID", "RURI", "STATE", "CHAL"),
+            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=CID&redirect_uri=RURI&response_type=code&scope=openid%20email%20profile&state=STATE&code_challenge=CHAL&code_challenge_method=S256"
+        );
+    }
+
+    // --- token body: pinned against the pre-refactor literals (values are urlencoded) ---
+
+    #[test]
+    fn token_body_google_includes_pkce() {
+        assert_eq!(
+            spec("google").build_token_body("CODE", "cid", "secret", "https://app/cb", "VERIFIER"),
+            "code=CODE&client_id=cid&client_secret=secret&redirect_uri=https%3A%2F%2Fapp%2Fcb&grant_type=authorization_code&code_verifier=VERIFIER"
+        );
+    }
+
+    #[test]
+    fn token_body_github_omits_pkce() {
+        assert_eq!(
+            spec("github").build_token_body("CODE", "cid", "secret", "https://app/cb", "VERIFIER"),
+            "code=CODE&client_id=cid&client_secret=secret&redirect_uri=https%3A%2F%2Fapp%2Fcb"
+        );
+    }
+
+    #[test]
+    fn token_body_microsoft_includes_pkce() {
+        assert_eq!(
+            spec("microsoft").build_token_body("CODE", "cid", "secret", "https://app/cb", "VERIFIER"),
+            "code=CODE&client_id=cid&client_secret=secret&redirect_uri=https%3A%2F%2Fapp%2Fcb&grant_type=authorization_code&code_verifier=VERIFIER"
+        );
+    }
+
+    // --- userinfo auth header: Bearer (OIDC) vs token (GitHub) ---
+
+    #[test]
+    fn userinfo_auth_header_schemes() {
+        assert_eq!(spec("google").userinfo_auth_header("TOK"), "Bearer TOK");
+        assert_eq!(spec("microsoft").userinfo_auth_header("TOK"), "Bearer TOK");
+        assert_eq!(spec("github").userinfo_auth_header("TOK"), "token TOK");
+    }
+
+    // --- endpoints + emails fallback pinned ---
+
+    #[test]
+    fn endpoints_and_emails_fallback() {
+        let g = spec("github");
+        assert_eq!(g.token_url, "https://github.com/login/oauth/access_token");
+        assert_eq!(g.userinfo_url, "https://api.github.com/user");
+        assert_eq!(g.emails_url, Some("https://api.github.com/user/emails"));
+        assert_eq!(spec("google").emails_url, None);
+        assert_eq!(spec("microsoft").emails_url, None);
+    }
+}

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
@@ -101,17 +101,14 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let redirect_uri_enc = urlencode(&redirect_uri);
     let state_enc = urlencode(&state_id);
     let challenge_enc = urlencode(&code_challenge);
-    let auth_url = match provider {
-        "google" => format!(
-            "https://accounts.google.com/o/oauth2/v2/auth?client_id={client_id_enc}&redirect_uri={redirect_uri_enc}&response_type=code&scope=openid%20email%20profile&state={state_enc}&code_challenge={challenge_enc}&code_challenge_method=S256"
+    let auth_url = match super::spec::lookup(provider) {
+        Some(spec) => spec.build_authorize_url(
+            &client_id_enc,
+            &redirect_uri_enc,
+            &state_enc,
+            &challenge_enc,
         ),
-        "github" => format!(
-            "https://github.com/login/oauth/authorize?client_id={client_id_enc}&redirect_uri={redirect_uri_enc}&scope=user:email&state={state_enc}"
-        ),
-        "microsoft" => format!(
-            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id={client_id_enc}&redirect_uri={redirect_uri_enc}&response_type=code&scope=openid%20email%20profile&state={state_enc}&code_challenge={challenge_enc}&code_challenge_method=S256"
-        ),
-        _ => return err_bad_request(&format!("Unsupported provider: {provider}")),
+        None => return err_bad_request(&format!("Unsupported provider: {provider}")),
     };
 
     ok_json(&serde_json::json!({


### PR DESCRIPTION
## Wave 30 — `OAuthProviderSpec` consolidation

Closes the *OAuth provider dispatch consolidation* item from `audit-design.md`'s "Wave 4 — Bigger refactors" list. Spec: `docs/superpowers/specs/2026-05-30-wave-30-oauth-provider-spec-design.md`.

### Problem
Provider-specific OAuth wiring for `google`/`github`/`microsoft` was scattered across **four `match provider` blocks + one hardcoded list** in `auth_ui/oauth/`:
- `start.rs` — authorize URL + scope + PKCE params
- `callback.rs` — token endpoint + body, userinfo endpoint + auth-header scheme, GitHub `/user/emails` fallback
- `providers.rs` — `["google","github","microsoft"]` enabled-list literal

### Change
Across all three the flow is identical and only the *data* differs, so the scattered match arms become a single `OAuthProviderSpec` data table + generic driver (`spec.rs`). Each provider is one row; the handlers read the spec instead of branching on the provider name. Adding a provider is one table row.

### Byte-identical guarantee
Authorize URL, token body, userinfo URL, and auth header stay **byte-for-byte identical** per provider; all error messages preserved. The `scope` is stored in exact wire form and interpolated **verbatim** (not via `urlencode`), because the pre-refactor code left GitHub's `user:email` colon raw while pre-encoding Google/Microsoft's `openid%20email%20profile` — `urlencode` (form-encoded) would render the space as `+` and the colon as `%3A`, changing both URLs.

### Tests
Adds pin-down unit tests asserting the exact generated string for all 3 providers across the 3 builders (authorize URL, token body, userinfo header). **None existed before** — OAuth flows can't be E2E-tested in CI (no real provider endpoints), so these are the regression net.

### Verification
- `cargo check -p solobase-core` clean.
- `cargo test -p solobase-core --lib` — **702 pass** (693 + 9 new spec tests).
- `cargo clippy -p solobase-core` — no findings in touched files.
- `bash scripts/audit-wrap-grants.sh` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)