### PR TITLE
refactor(routing): drop BlockId enum for &'static str names + RouteAccess (Wave 31)

### DIFF
--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -8,49 +8,53 @@ use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
 use crate::{blocks::helpers, features::FeatureConfig};
 
-/// Block identifier for the routing table.
-///
-/// Most variants map to an HTTP route prefix in [`ROUTES`]; some (e.g. the
-/// embedding blocks) are pure service blocks with no HTTP surface — they
-/// still have a `BlockId` for feature-gating in the dispatch path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum BlockId {
-    System,
-    Inspector,
-    /// `suppers-ai/auth-ui` — owns all `/b/auth/*` HTTP routes (login/signup/
-    /// OAuth/dashboard/orgs/bootstrap/api). The framework `suppers-ai/auth`
-    /// block (wafer-core's AuthBlock wrapping AuthServiceImpl) has no HTTP
-    /// surface — it exposes the `auth@v1` interface only — so it does not
-    /// appear in the routing table.
-    AuthUi,
-    Admin,
-    Files,
-    LegalPages,
-    Products,
-    UserPortal,
-    Messages,
-    Llm,
-    Vector,
-    /// Native ONNX embedding service (no HTTP routes). Feature-gated
-    /// behind `native-embedding` — see `blocks::fastembed`.
-    Fastembed,
-}
-
 /// A single route entry.
+///
+/// `block` is the solobase block name (`{org}/{block}`) used for feature-gating
+/// and the inspector's [`routes_config`] view. `dispatch_to` is the Wafer block
+/// name passed to `ctx.call_block`; it equals `block` for every route except the
+/// inspector, which is feature-gated/displayed as `suppers-ai/inspector` but
+/// dispatches to the `wafer-run/inspector` runtime block.
 pub struct Route {
     pub prefix: &'static str,
-    pub requires_admin: bool,
-    pub block_id: BlockId,
+    pub access: RouteAccess,
+    pub block: &'static str,
+    pub dispatch_to: &'static str,
 }
 
-/// Access tier for a runtime-added [`ExtraRoute`].
+impl Route {
+    /// A route whose dispatch target equals its block name (the common case).
+    const fn new(prefix: &'static str, access: RouteAccess, block: &'static str) -> Route {
+        Route {
+            prefix,
+            access,
+            block,
+            dispatch_to: block,
+        }
+    }
+
+    /// A route whose `ctx.call_block` target differs from its block name. Used
+    /// only by the inspector, which dispatches to the `wafer-run/inspector`
+    /// runtime block while remaining feature-gated as `suppers-ai/inspector`.
+    const fn proxy(
+        prefix: &'static str,
+        access: RouteAccess,
+        block: &'static str,
+        dispatch_to: &'static str,
+    ) -> Route {
+        Route {
+            prefix,
+            access,
+            block,
+            dispatch_to,
+        }
+    }
+}
+
+/// Access tier for a route.
 ///
-/// Checked by [`route_to_block`] before dispatching to the target block.
-///
-/// Built-in [`Route`]s still use the `requires_admin: bool` field —
-/// migrating those to `RouteAccess` would be a wider refactor with no
-/// behavioural change, so the two systems coexist: built-ins as booleans,
-/// extras as declarative tiers.
+/// Checked by [`route_to_block`] (via `check_access`) before dispatching to the
+/// target block, for both built-in [`Route`]s and runtime-added [`ExtraRoute`]s.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RouteAccess {
@@ -65,8 +69,8 @@ pub enum RouteAccess {
 /// A runtime-added route registered by a downstream project via
 /// `SolobaseBuilder::add_route`.
 ///
-/// Dispatches by block name string (not [`BlockId`]) since projects supply
-/// these at build time and cannot extend the closed `BlockId` enum.
+/// Carries an owned `block_name` `String` (rather than the built-in [`Route`]'s
+/// `&'static str`) since projects supply these at build time.
 ///
 /// # Priority
 ///
@@ -88,100 +92,58 @@ pub struct ExtraRoute {
 /// routes outside `/b/`.
 pub const ROUTES: &[Route] = &[
     // System & static assets
-    Route {
-        prefix: "/health",
-        requires_admin: false,
-        block_id: BlockId::System,
-    },
-    Route {
-        prefix: "/b/static/",
-        requires_admin: false,
-        block_id: BlockId::System,
-    },
-    // Inspector — runtime debugging UI (admin only)
-    Route {
-        prefix: "/b/inspector",
-        requires_admin: true,
-        block_id: BlockId::Inspector,
-    },
+    Route::new("/health", RouteAccess::Public, "suppers-ai/system"),
+    Route::new("/b/static/", RouteAccess::Public, "suppers-ai/system"),
+    // Inspector — runtime debugging UI (admin only). Feature-gated as
+    // `suppers-ai/inspector` but dispatches to the `wafer-run/inspector` block.
+    Route::proxy(
+        "/b/inspector",
+        RouteAccess::Admin,
+        "suppers-ai/inspector",
+        "wafer-run/inspector",
+    ),
     // Auth — SSR pages + API under /b/auth/
-    Route {
-        prefix: "/b/auth/",
-        requires_admin: false,
-        block_id: BlockId::AuthUi,
-    },
+    Route::new("/b/auth/", RouteAccess::Public, "suppers-ai/auth-ui"),
     // Admin settings — more specific prefix must come before the /b/admin/ catch-all
-    Route {
-        prefix: "/b/admin/settings",
-        requires_admin: true,
-        block_id: BlockId::Admin,
-    },
+    Route::new("/b/admin/settings", RouteAccess::Admin, "suppers-ai/admin"),
     // Admin — SSR pages + API under /b/admin/
-    Route {
-        prefix: "/b/admin/",
-        requires_admin: true,
-        block_id: BlockId::Admin,
-    },
-    Route {
-        prefix: "/b/admin",
-        requires_admin: true,
-        block_id: BlockId::Admin,
-    },
+    Route::new("/b/admin/", RouteAccess::Admin, "suppers-ai/admin"),
+    Route::new("/b/admin", RouteAccess::Admin, "suppers-ai/admin"),
     // Feature blocks — SSR + API under /b/{block}/
-    Route {
-        prefix: "/b/storage/",
-        requires_admin: false,
-        block_id: BlockId::Files,
-    },
-    Route {
-        prefix: "/b/cloudstorage/",
-        requires_admin: false,
-        block_id: BlockId::Files,
-    },
-    Route {
-        prefix: "/b/products",
-        requires_admin: false,
-        block_id: BlockId::Products,
-    },
+    Route::new("/b/storage/", RouteAccess::Public, "suppers-ai/files"),
+    Route::new("/b/cloudstorage/", RouteAccess::Public, "suppers-ai/files"),
+    Route::new("/b/products", RouteAccess::Public, "suppers-ai/products"),
     // Legalpages — public reads + admin writes/UI.
     // Admin and API prefixes must come BEFORE the bare `/b/legalpages` entry
     // because `route_to_block` matches on first-prefix-hit. Admin handlers
     // inside the block do not re-check `is_admin`, so this gate is the only
     // thing keeping random callers off `/admin/publish` and friends.
-    Route {
-        prefix: "/b/legalpages/admin",
-        requires_admin: true,
-        block_id: BlockId::LegalPages,
-    },
-    Route {
-        prefix: "/b/legalpages/api",
-        requires_admin: true,
-        block_id: BlockId::LegalPages,
-    },
-    Route {
-        prefix: "/b/legalpages",
-        requires_admin: false,
-        block_id: BlockId::LegalPages,
-    },
-    Route {
-        prefix: "/b/userportal",
-        requires_admin: false,
-        block_id: BlockId::UserPortal,
-    },
+    Route::new(
+        "/b/legalpages/admin",
+        RouteAccess::Admin,
+        "suppers-ai/legalpages",
+    ),
+    Route::new(
+        "/b/legalpages/api",
+        RouteAccess::Admin,
+        "suppers-ai/legalpages",
+    ),
+    Route::new(
+        "/b/legalpages",
+        RouteAccess::Public,
+        "suppers-ai/legalpages",
+    ),
+    Route::new(
+        "/b/userportal",
+        RouteAccess::Public,
+        "suppers-ai/userportal",
+    ),
     // Messages — generic thread/message system
     // Route is open; block enforces admin for UI pages, authenticated for API
-    Route {
-        prefix: "/b/messages",
-        requires_admin: false,
-        block_id: BlockId::Messages,
-    },
+    Route::new("/b/messages", RouteAccess::Public, "suppers-ai/messages"),
     // LLM — chat orchestrator
     // Route is open; block enforces admin for UI pages, authenticated for API
-    Route {
-        prefix: "/b/llm",
-        requires_admin: false,
-        block_id: BlockId::Llm,
-    },
+    Route::new("/b/llm", RouteAccess::Public, "suppers-ai/llm"),
     // Vector — similarity search, hybrid retrieval, RAG ingestion.
     //
     // Each endpoint from `VectorBlock::info().endpoints` is registered as a
@@ -191,63 +153,54 @@ pub const ROUTES: &[Route] = &[
     //   - `DELETE /b/vector/api/indexes/{name}` must be listed BEFORE the
     //     generic `DELETE /b/vector/api/{index}/{id}` entry so the specific
     //     "delete index" route wins over the generic "delete vector" route.
-    // All entries dispatch to `BlockId::Vector`; per-method path-param
+    // All entries dispatch to `suppers-ai/vector`; per-method path-param
     // matching happens inside the block's `pages::route` dispatcher.
-    Route {
-        prefix: "/b/vector/api/indexes/{name}",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/indexes",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/upsert",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/query",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/ingest",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/embed",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
-    Route {
-        prefix: "/b/vector/api/stats",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
+    Route::new(
+        "/b/vector/api/indexes/{name}",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/indexes",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/upsert",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/query",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/ingest",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/embed",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
+    Route::new(
+        "/b/vector/api/stats",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
     // Generic `DELETE /b/vector/api/{index}/{id}` — MUST come after the
     // more specific `/b/vector/api/indexes/{name}` entry above so that
     // path-prefix ordering routes index-deletes to the correct handler.
-    Route {
-        prefix: "/b/vector/api/{index}/{id}",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
+    Route::new(
+        "/b/vector/api/{index}/{id}",
+        RouteAccess::Public,
+        "suppers-ai/vector",
+    ),
     // SSR pages and any other /b/vector/* paths.
-    Route {
-        prefix: "/b/vector/",
-        requires_admin: false,
-        block_id: BlockId::Vector,
-    },
+    Route::new("/b/vector/", RouteAccess::Public, "suppers-ai/vector"),
 ];
-
-/// Check if a block's feature is enabled.
-fn is_block_enabled(block_id: BlockId, features: &dyn FeatureConfig) -> bool {
-    features.is_block_enabled(block_id_full_name(block_id))
-}
 
 /// Generate the routing table as JSON config (same format as wafer-run/router).
 /// Used to expose routes to the inspector.
@@ -256,34 +209,24 @@ pub fn routes_config() -> serde_json::Value {
         .iter()
         .map(|r| {
             let path = format!("{}**", r.prefix);
-            serde_json::json!({ "path": path, "block": block_id_full_name(r.block_id) })
+            serde_json::json!({ "path": path, "block": r.block })
         })
         .collect();
     serde_json::json!({ "routes": routes })
 }
 
-/// Full block name in the `{org}/{block}` form used by the feature-flag map
-/// and `routes_config()`'s inspector view.
-///
-/// Returns `&'static str` so per-request routing checks don't allocate a
-/// `String`. Every built-in solobase block lives under `suppers-ai/` —
-/// including `inspector`, which is feature-gated alongside the other
-/// solobase routes even though dispatch hands off to the `wafer-run/inspector`
-/// runtime block.
-fn block_id_full_name(id: BlockId) -> &'static str {
-    match id {
-        BlockId::System => "suppers-ai/system",
-        BlockId::Inspector => "suppers-ai/inspector",
-        BlockId::AuthUi => "suppers-ai/auth-ui",
-        BlockId::Admin => "suppers-ai/admin",
-        BlockId::Files => "suppers-ai/files",
-        BlockId::LegalPages => "suppers-ai/legalpages",
-        BlockId::Products => "suppers-ai/products",
-        BlockId::UserPortal => "suppers-ai/userportal",
-        BlockId::Messages => "suppers-ai/messages",
-        BlockId::Llm => "suppers-ai/llm",
-        BlockId::Vector => "suppers-ai/vector",
-        BlockId::Fastembed => "suppers-ai/fastembed",
+/// Enforce a route's [`RouteAccess`] tier against the request. Returns
+/// `Some(forbidden_response)` when the caller fails the tier, or `None` to
+/// proceed. Shared by the built-in and extra-route dispatch loops.
+fn check_access(access: RouteAccess, msg: &Message) -> Option<OutputStream> {
+    match access {
+        RouteAccess::Public => None,
+        RouteAccess::Authenticated if msg.user_id().is_empty() => {
+            Some(crate::ui::forbidden_response(msg))
+        }
+        RouteAccess::Authenticated => None,
+        RouteAccess::Admin if !helpers::is_admin(msg) => Some(crate::ui::forbidden_response(msg)),
+        RouteAccess::Admin => None,
     }
 }
 
@@ -313,22 +256,17 @@ pub async fn route_to_block(
         }
 
         // Feature gate
-        if !is_block_enabled(route.block_id, features) {
+        if !features.is_block_enabled(route.block) {
             return crate::blocks::helpers::err_not_found("endpoint not found");
         }
 
-        // Admin gate
-        if route.requires_admin && !helpers::is_admin(&msg) {
-            return crate::ui::forbidden_response(&msg);
+        // Access gate
+        if let Some(denied) = check_access(route.access, &msg) {
+            return denied;
         }
 
-        // Dispatch to block via call_block so WRAP sees the correct caller identity
-        if route.block_id == BlockId::Inspector {
-            return ctx.call_block("wafer-run/inspector", msg, input).await;
-        }
-        return ctx
-            .call_block(block_id_full_name(route.block_id), msg, input)
-            .await;
+        // Dispatch via call_block so WRAP sees the correct caller identity.
+        return ctx.call_block(route.dispatch_to, msg, input).await;
     }
 
     // Fall back to project-registered extra routes. Built-ins above win on
@@ -339,18 +277,8 @@ pub async fn route_to_block(
             continue;
         }
 
-        match route.access {
-            RouteAccess::Public => {}
-            RouteAccess::Authenticated => {
-                if msg.user_id().is_empty() {
-                    return crate::ui::forbidden_response(&msg);
-                }
-            }
-            RouteAccess::Admin => {
-                if !helpers::is_admin(&msg) {
-                    return crate::ui::forbidden_response(&msg);
-                }
-            }
+        if let Some(denied) = check_access(route.access, &msg) {
+            return denied;
         }
 
         return ctx.call_block(&route.block_name, msg, input).await;
@@ -385,23 +313,23 @@ mod tests {
     fn route_table_maps_expected_paths() {
         let cases = vec![
             // System endpoints
-            ("/health", BlockId::System),
-            ("/b/static/app.css", BlockId::System),
+            ("/health", "suppers-ai/system"),
+            ("/b/static/app.css", "suppers-ai/system"),
             // Inspector
-            ("/b/inspector", BlockId::Inspector),
-            ("/b/inspector/blocks", BlockId::Inspector),
+            ("/b/inspector", "suppers-ai/inspector"),
+            ("/b/inspector/blocks", "suppers-ai/inspector"),
             // All block routes under /b/
-            ("/b/auth/login", BlockId::AuthUi),
-            ("/b/auth/signup", BlockId::AuthUi),
-            ("/b/auth/api/me", BlockId::AuthUi),
-            ("/b/admin/", BlockId::Admin),
-            ("/b/admin/users", BlockId::Admin),
-            ("/b/admin", BlockId::Admin),
-            ("/b/storage/buckets", BlockId::Files),
-            ("/b/cloudstorage/shares", BlockId::Files),
-            ("/b/products", BlockId::Products),
-            ("/b/legalpages", BlockId::LegalPages),
-            ("/b/userportal", BlockId::UserPortal),
+            ("/b/auth/login", "suppers-ai/auth-ui"),
+            ("/b/auth/signup", "suppers-ai/auth-ui"),
+            ("/b/auth/api/me", "suppers-ai/auth-ui"),
+            ("/b/admin/", "suppers-ai/admin"),
+            ("/b/admin/users", "suppers-ai/admin"),
+            ("/b/admin", "suppers-ai/admin"),
+            ("/b/storage/buckets", "suppers-ai/files"),
+            ("/b/cloudstorage/shares", "suppers-ai/files"),
+            ("/b/products", "suppers-ai/products"),
+            ("/b/legalpages", "suppers-ai/legalpages"),
+            ("/b/userportal", "suppers-ai/userportal"),
         ];
 
         for (path, expected_block) in cases {
@@ -410,9 +338,9 @@ mod tests {
                 .find(|r| path == r.prefix || path.starts_with(r.prefix));
             assert!(matched.is_some(), "path {path} should match a route");
             assert_eq!(
-                matched.unwrap().block_id,
+                matched.unwrap().block,
                 expected_block,
-                "path {path} should route to {expected_block:?}"
+                "path {path} should route to {expected_block}"
             );
         }
     }
@@ -444,8 +372,9 @@ mod tests {
     fn admin_routes_require_admin() {
         for route in ROUTES {
             if route.prefix.starts_with("/b/admin") {
-                assert!(
-                    route.requires_admin,
+                assert_eq!(
+                    route.access,
+                    RouteAccess::Admin,
                     "route {} should require admin",
                     route.prefix
                 );
@@ -473,8 +402,9 @@ mod tests {
                 .iter()
                 .any(|p| route.prefix == *p || route.prefix.starts_with(p))
             {
-                assert!(
-                    !route.requires_admin,
+                assert_ne!(
+                    route.access,
+                    RouteAccess::Admin,
                     "route {} should NOT require admin",
                     route.prefix
                 );
@@ -529,26 +459,31 @@ mod tests {
         }
     }
 
+    /// The block names every built-in route feature-gates against. The
+    /// `route_to_block` feature gate calls `features.is_block_enabled(route.block)`.
+    const GATED_BLOCKS: &[&str] = &[
+        "suppers-ai/auth-ui",
+        "suppers-ai/admin",
+        "suppers-ai/files",
+        "suppers-ai/products",
+        "suppers-ai/legalpages",
+        "suppers-ai/userportal",
+    ];
+
     #[test]
     fn feature_gating_all_enabled() {
         let all = AllEnabled;
-        assert!(is_block_enabled(BlockId::AuthUi, &all));
-        assert!(is_block_enabled(BlockId::Admin, &all));
-        assert!(is_block_enabled(BlockId::Files, &all));
-        assert!(is_block_enabled(BlockId::Products, &all));
-        assert!(is_block_enabled(BlockId::LegalPages, &all));
-        assert!(is_block_enabled(BlockId::UserPortal, &all));
+        for block in GATED_BLOCKS {
+            assert!(all.is_block_enabled(block), "{block} should be enabled");
+        }
     }
 
     #[test]
     fn feature_gating_all_disabled() {
         let none = NoneEnabled;
-        assert!(!is_block_enabled(BlockId::AuthUi, &none));
-        assert!(!is_block_enabled(BlockId::Admin, &none));
-        assert!(!is_block_enabled(BlockId::Files, &none));
-        assert!(!is_block_enabled(BlockId::Products, &none));
-        assert!(!is_block_enabled(BlockId::LegalPages, &none));
-        assert!(!is_block_enabled(BlockId::UserPortal, &none));
+        for block in GATED_BLOCKS {
+            assert!(!none.is_block_enabled(block), "{block} should be disabled");
+        }
     }
 
     #[test]
@@ -557,18 +492,20 @@ mod tests {
             .iter()
             .find(|r| r.prefix == "/b/legalpages/admin")
             .expect("legalpages admin route not declared");
-        assert!(
-            admin_route.requires_admin,
+        assert_eq!(
+            admin_route.access,
+            RouteAccess::Admin,
             "/b/legalpages/admin must require admin"
         );
-        assert!(matches!(admin_route.block_id, BlockId::LegalPages));
+        assert_eq!(admin_route.block, "suppers-ai/legalpages");
 
         let api_route = ROUTES
             .iter()
             .find(|r| r.prefix == "/b/legalpages/api")
             .expect("legalpages api route not declared");
-        assert!(
-            api_route.requires_admin,
+        assert_eq!(
+            api_route.access,
+            RouteAccess::Admin,
             "/b/legalpages/api must require admin"
         );
 
@@ -576,8 +513,9 @@ mod tests {
             .iter()
             .find(|r| r.prefix == "/b/legalpages")
             .expect("public legalpages route not declared");
-        assert!(
-            !public_route.requires_admin,
+        assert_ne!(
+            public_route.access,
+            RouteAccess::Admin,
             "/b/legalpages must remain public"
         );
 
@@ -585,7 +523,7 @@ mod tests {
         let positions: Vec<_> = ROUTES
             .iter()
             .enumerate()
-            .filter(|(_, r)| matches!(r.block_id, BlockId::LegalPages))
+            .filter(|(_, r)| r.block == "suppers-ai/legalpages")
             .map(|(i, r)| (i, r.prefix))
             .collect();
         assert_eq!(
@@ -598,7 +536,7 @@ mod tests {
     #[test]
     fn all_block_routes_are_under_b_prefix() {
         for route in ROUTES {
-            let is_system = matches!(route.block_id, BlockId::System);
+            let is_system = route.block == "suppers-ai/system";
             if !is_system {
                 assert!(
                     route.prefix.starts_with("/b/"),
@@ -607,5 +545,48 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn inspector_dispatch_diverges_from_block_name() {
+        // The inspector is the one route whose dispatch target differs from its
+        // feature/display name: gated as `suppers-ai/inspector`, dispatched to
+        // the `wafer-run/inspector` runtime block.
+        let inspector = ROUTES
+            .iter()
+            .find(|r| r.prefix == "/b/inspector")
+            .expect("inspector route not declared");
+        assert_eq!(inspector.block, "suppers-ai/inspector");
+        assert_eq!(inspector.dispatch_to, "wafer-run/inspector");
+    }
+
+    #[test]
+    fn only_inspector_has_a_dispatch_override() {
+        // Every other route dispatches to its own block name (the `new`
+        // constructor's invariant). Catches a stray `proxy` entry.
+        for route in ROUTES {
+            if route.prefix == "/b/inspector" {
+                continue;
+            }
+            assert_eq!(
+                route.dispatch_to, route.block,
+                "route {} should dispatch to its own block",
+                route.prefix
+            );
+        }
+    }
+
+    #[test]
+    fn routes_config_uses_display_block_name_for_inspector() {
+        // routes_config() must show the inspector as `suppers-ai/inspector`
+        // (the display/feature name), not its `wafer-run/inspector` dispatch
+        // target — the inspector UI keys its feature map on the former.
+        let cfg = super::routes_config();
+        let routes = cfg["routes"].as_array().expect("routes array");
+        let inspector = routes
+            .iter()
+            .find(|r| r["path"] == "/b/inspector**")
+            .expect("inspector route in config");
+        assert_eq!(inspector["block"], "suppers-ai/inspector");
     }
 }


### PR DESCRIPTION
## Wave 31 — `BlockId` routing flattening

Closes the *`BlockId` routing flattening* item from `audit-design.md`'s "Wave 4 — Bigger refactors" list. Spec: `docs/superpowers/specs/2026-05-30-wave-31-blockid-routing-flattening-design.md`.

### Problem
`routing.rs` carried a closed `BlockId` enum paralleling the block-name namespace already expressed as strings everywhere else. It did three jobs — name mapping (`block_id_full_name` match), feature-gating, and dispatch (with a hard-coded `Inspector` special case). The built-in `ROUTES` table also used `requires_admin: bool` while runtime `ExtraRoute`s used `RouteAccess` — two coexisting access models.

### Change
- **Flatten `Route`** to carry the block name directly: `block: &'static str` (feature-flag + `routes_config` display name) and `dispatch_to: &'static str` (the `ctx.call_block` target). They're equal for every route except the **inspector**, which displays/gates as `suppers-ai/inspector` but dispatches to `wafer-run/inspector` — modelled explicitly, no hidden special-case. `const fn` constructors `Route::new` / `Route::proxy` keep the table explicit and non-verbose.
- **Unify access control**: built-ins drop `requires_admin: bool` for `RouteAccess` (`false→Public`, `true→Admin`). A shared `check_access()` gates both dispatch loops (which stay separate — built-ins win on prefix collision + feature-gate).
- Drop the **dead `BlockId::Fastembed`** variant (no route entry; dispatched directly from `vector/pages.rs`).

### Containment
`BlockId` was used nowhere else and is not exported; `route_to_block` / `routes_config` / `RouteAccess` / `ExtraRoute` keep **identical signatures**. The whole change is one file.

### Behavior guarantee
Byte-identical routing: same prefixes, order, feature-flag names, dispatch targets (inspector preserved), and admin gating; `routes_config()` output unchanged.

### Tests
Existing in-file suite updated to the new representation + **3 new pins**: inspector `block`/`dispatch_to` divergence, the `new`-constructor invariant (only inspector overrides dispatch), and `routes_config()` still emitting `suppers-ai/inspector`.

### Verification
- `cargo check -p solobase-core` clean.
- `cargo test -p solobase-core --lib` — **705 pass**.
- `cargo test -p solobase-core --test extra_routes_test` — 7 pass (public-API regression).
- `cargo clippy -p solobase-core` — no findings in touched file.
- `bash scripts/audit-wrap-grants.sh` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)