### PR TITLE
refactor(llm): extract shared SseFrameStream from the two SSE decoders (Wave 32)

### DIFF
--- a/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
@@ -15,8 +15,10 @@ use wafer_core::interfaces::llm::service::{
     TokenUsage, ToolDefinition,
 };
 
-use super::config::ProviderConfig;
-use super::sse::{DecodeBatch, SseFrame, SseFrameStream};
+use super::{
+    config::ProviderConfig,
+    sse::{DecodeBatch, SseFrame, SseFrameStream},
+};
 
 pub const ANTHROPIC_VERSION: &str = "2023-06-01";
 

--- a/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
@@ -16,6 +16,7 @@ use wafer_core::interfaces::llm::service::{
 };
 
 use super::config::ProviderConfig;
+use super::sse::{DecodeBatch, SseFrame, SseFrameStream};
 
 pub const ANTHROPIC_VERSION: &str = "2023-06-01";
 
@@ -255,7 +256,7 @@ fn encode_tool(t: &ToolDefinition) -> AnthropicTool<'_> {
 /// - `message_delta` — carries `stop_reason` + incremental usage.
 /// - `message_stop` — terminal.
 pub struct AnthropicSseDecoder {
-    buf: String,
+    frames: SseFrameStream,
     /// Per-content-block index: the tool_use id (if it was a tool_use block).
     /// Keyed by Anthropic's `index`, which is stable within a message.
     tool_blocks: Vec<Option<String>>,
@@ -270,24 +271,21 @@ const MAX_CONTENT_BLOCK_INDEX: u32 = 1024;
 impl AnthropicSseDecoder {
     pub fn new() -> Self {
         Self {
-            buf: String::new(),
+            frames: SseFrameStream::new(),
             tool_blocks: Vec::new(),
         }
     }
 
     pub fn push(&mut self, bytes: &[u8]) -> DecodeBatch {
-        let Ok(text) = std::str::from_utf8(bytes) else {
+        if !self.frames.feed(bytes) {
             tracing::warn!("anthropic sse: non-utf8 bytes — dropping");
             return DecodeBatch::default();
-        };
-        self.buf.push_str(text);
+        }
 
         let mut out = Vec::new();
         let mut done = false;
 
-        while let Some(sep) = self.buf.find("\n\n") {
-            let frame = self.buf[..sep].to_string();
-            self.buf.drain(..=sep + 1);
+        while let Some(frame) = self.frames.next_frame() {
             let (chunks, terminal) = self.decode_frame(&frame);
             out.extend(chunks);
             if terminal {
@@ -299,29 +297,16 @@ impl AnthropicSseDecoder {
         DecodeBatch { chunks: out, done }
     }
 
-    fn decode_frame(&mut self, frame: &str) -> (Vec<ChatChunk>, bool) {
-        let mut event_name = None;
-        let mut data_payload = String::new();
-        for line in frame.lines() {
-            let line = line.trim_start_matches('\u{feff}');
-            if let Some(rest) = line.strip_prefix("event:") {
-                event_name = Some(rest.trim().to_string());
-            } else if let Some(rest) = line.strip_prefix("data:") {
-                let rest = rest.trim_start();
-                if !data_payload.is_empty() {
-                    data_payload.push('\n');
-                }
-                data_payload.push_str(rest);
-            }
-        }
-        let event_name = event_name.unwrap_or_default();
+    fn decode_frame(&mut self, frame: &SseFrame) -> (Vec<ChatChunk>, bool) {
+        let event_name = frame.event.as_deref().unwrap_or_default();
+        let data_payload = frame.data.as_str();
         if data_payload.is_empty() {
             return (Vec::new(), false);
         }
 
-        match event_name.as_str() {
+        match event_name {
             "content_block_start" => {
-                match serde_json::from_str::<AnthropicBlockStart>(&data_payload) {
+                match serde_json::from_str::<AnthropicBlockStart>(data_payload) {
                     Ok(s) => {
                         if !self.ensure_block_slot(s.index) {
                             return (Vec::new(), false);
@@ -341,7 +326,7 @@ impl AnthropicSseDecoder {
                 }
             }
             "content_block_delta" => {
-                match serde_json::from_str::<AnthropicBlockDelta>(&data_payload) {
+                match serde_json::from_str::<AnthropicBlockDelta>(data_payload) {
                     Ok(d) => {
                         if !self.ensure_block_slot(d.index) {
                             return (Vec::new(), false);
@@ -373,7 +358,7 @@ impl AnthropicSseDecoder {
                 }
             }
             "content_block_stop" => {
-                match serde_json::from_str::<AnthropicBlockStop>(&data_payload) {
+                match serde_json::from_str::<AnthropicBlockStop>(data_payload) {
                     Ok(s) => {
                         if let Some(Some(id)) = self.tool_blocks.get(s.index as usize).cloned() {
                             (vec![ChatChunk::tool_call_complete(id)], false)
@@ -384,7 +369,7 @@ impl AnthropicSseDecoder {
                     Err(_) => (Vec::new(), false),
                 }
             }
-            "message_delta" => match serde_json::from_str::<AnthropicMessageDelta>(&data_payload) {
+            "message_delta" => match serde_json::from_str::<AnthropicMessageDelta>(data_payload) {
                 Ok(md) => {
                     let mut chunks = Vec::new();
                     if let Some(reason) = md.delta.stop_reason {
@@ -434,12 +419,6 @@ impl Default for AnthropicSseDecoder {
     fn default() -> Self {
         Self::new()
     }
-}
-
-#[derive(Debug, Default, PartialEq)]
-pub struct DecodeBatch {
-    pub chunks: Vec<ChatChunk>,
-    pub done: bool,
 }
 
 // ---- Wire types for the decoder ----

--- a/crates/solobase-core/src/blocks/llm/providers/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod anthropic;
 pub mod config;
 pub mod openai;
 pub mod openai_compatible;
+pub(crate) mod sse;
 
 use std::{
     collections::HashMap,

--- a/crates/solobase-core/src/blocks/llm/providers/openai.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/openai.rs
@@ -301,6 +301,8 @@ fn encode_response_format(r: &ResponseFormat) -> OpenAiResponseFormat<'_> {
 
 use wafer_core::interfaces::llm::service::{ChatChunk, FinishReason, TokenUsage};
 
+use super::sse::{DecodeBatch, SseFrame, SseFrameStream};
+
 /// Stateful line-by-line SSE decoder. Feed it successive chunks of response
 /// body bytes (they may split inside a frame); it buffers until a blank-line
 /// terminator and emits zero-or-more `ChatChunk`s per chunk of input.
@@ -315,7 +317,7 @@ use wafer_core::interfaces::llm::service::{ChatChunk, FinishReason, TokenUsage};
 ///  - Malformed / unknown frames are skipped silently; tracing::warn logs them
 ///    so operators can notice.
 pub struct OpenAiSseDecoder {
-    buf: String,
+    frames: SseFrameStream,
     /// Tool-call index -> in-flight id. OpenAI streams tool_calls with
     /// `index` + optional `id` + partial `function.name` + partial
     /// `function.arguments`. We emit `ToolCallStart` on first sight of
@@ -332,7 +334,7 @@ pub struct OpenAiSseDecoder {
 impl OpenAiSseDecoder {
     pub fn new() -> Self {
         Self {
-            buf: String::new(),
+            frames: SseFrameStream::new(),
             started: Vec::new(),
         }
     }
@@ -341,20 +343,15 @@ impl OpenAiSseDecoder {
     /// terminated (`[DONE]` seen). Tool-call `Complete` frames for any
     /// in-flight ids are emitted on terminal.
     pub fn push(&mut self, bytes: &[u8]) -> DecodeBatch {
-        let Ok(text) = std::str::from_utf8(bytes) else {
+        if !self.frames.feed(bytes) {
             tracing::warn!("openai sse: non-utf8 bytes — dropping");
             return DecodeBatch::default();
-        };
-        self.buf.push_str(text);
+        }
 
         let mut out = Vec::new();
         let mut done = false;
 
-        // A complete frame ends with `\n\n`. Split off whole frames, leave the
-        // tail for next push.
-        while let Some(sep) = self.buf.find("\n\n") {
-            let frame = self.buf[..sep].to_string();
-            self.buf.drain(..=sep + 1);
+        while let Some(frame) = self.frames.next_frame() {
             if let Some(outcome) = self.decode_frame(&frame) {
                 match outcome {
                     FrameOutcome::Chunks(cs) => out.extend(cs),
@@ -372,30 +369,18 @@ impl OpenAiSseDecoder {
         DecodeBatch { chunks: out, done }
     }
 
-    fn decode_frame(&mut self, frame: &str) -> Option<FrameOutcome> {
-        // Each frame is one or more `key: value` lines. OpenAI uses `data:`.
-        let mut data_payload = String::new();
-        for line in frame.lines() {
-            let line = line.trim_start_matches('\u{feff}'); // BOM guard
-            if let Some(rest) = line.strip_prefix("data:") {
-                let rest = rest.trim_start();
-                if !data_payload.is_empty() {
-                    data_payload.push('\n');
-                }
-                data_payload.push_str(rest);
-            }
-            // Other SSE fields (event:, id:, retry:) — ignored, OpenAI doesn't use them for chat.
-        }
-        if data_payload.is_empty() {
+    fn decode_frame(&mut self, frame: &SseFrame) -> Option<FrameOutcome> {
+        // OpenAI uses only the `data:` field; `event:` is ignored.
+        if frame.data.is_empty() {
             return None;
         }
-        if data_payload == "[DONE]" {
+        if frame.data == "[DONE]" {
             return Some(FrameOutcome::Done);
         }
-        match serde_json::from_str::<OpenAiStreamFrame>(&data_payload) {
-            Ok(frame) => Some(FrameOutcome::Chunks(self.translate(frame))),
+        match serde_json::from_str::<OpenAiStreamFrame>(&frame.data) {
+            Ok(parsed) => Some(FrameOutcome::Chunks(self.translate(parsed))),
             Err(e) => {
-                tracing::warn!(error = %e, payload = %data_payload, "openai sse: decode failed");
+                tracing::warn!(error = %e, payload = %frame.data, "openai sse: decode failed");
                 None
             }
         }
@@ -466,15 +451,6 @@ impl Default for OpenAiSseDecoder {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Result of feeding one chunk of bytes to the decoder.
-#[derive(Debug, Default, PartialEq)]
-pub struct DecodeBatch {
-    pub chunks: Vec<ChatChunk>,
-    /// True if a `[DONE]` sentinel was observed in this batch or a prior one.
-    /// Callers should stop feeding the decoder once this is set.
-    pub done: bool,
 }
 
 enum FrameOutcome {

--- a/crates/solobase-core/src/blocks/llm/providers/sse.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/sse.rs
@@ -1,0 +1,163 @@
+//! Provider-agnostic Server-Sent Events transport parsing.
+//!
+//! The OpenAI and Anthropic streaming decoders share the same wire framing —
+//! accumulate raw bytes, split on the `\n\n` frame separator, and parse each
+//! frame's `event:` / `data:` lines — and differ only in how they interpret a
+//! decoded frame. [`SseFrameStream`] owns the shared transport half; each
+//! provider's decoder layers its own per-frame semantics on top.
+
+use wafer_core::interfaces::llm::service::ChatChunk;
+
+/// One decoded SSE frame: a `\n\n`-terminated block of `key: value` lines.
+///
+/// `event` is the last `event:` value seen in the frame (if any); `data` is the
+/// `data:` lines joined with `\n` (empty when the frame carried none — e.g. a
+/// comment or keepalive).
+pub struct SseFrame {
+    pub event: Option<String>,
+    pub data: String,
+}
+
+/// A batch of decoded chunks plus the terminal flag, returned by each provider
+/// decoder's `push`. Shared so the providers don't each redefine it.
+#[derive(Debug, Default, PartialEq)]
+pub struct DecodeBatch {
+    pub chunks: Vec<ChatChunk>,
+    /// True once the stream has terminated (e.g. OpenAI's `[DONE]` sentinel or
+    /// Anthropic's `message_stop`). Callers should stop feeding once set.
+    pub done: bool,
+}
+
+/// Incremental SSE transport parser: accumulates raw bytes and yields complete
+/// frames on demand. Knows nothing about chunk semantics.
+pub struct SseFrameStream {
+    buf: String,
+}
+
+impl SseFrameStream {
+    pub fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Append raw bytes to the buffer. Returns `false` (buffering nothing) when
+    /// `bytes` is not valid UTF-8, so the caller can emit its provider-tagged
+    /// warning and bail. Keeps this type free of a `tracing` dependency.
+    pub fn feed(&mut self, bytes: &[u8]) -> bool {
+        match std::str::from_utf8(bytes) {
+            Ok(text) => {
+                self.buf.push_str(text);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Pull the next complete `\n\n`-terminated frame, with its `event:` /
+    /// `data:` lines parsed. Returns `None` when no complete frame is buffered
+    /// yet — the partial tail stays for the next [`feed`](Self::feed).
+    pub fn next_frame(&mut self) -> Option<SseFrame> {
+        let sep = self.buf.find("\n\n")?;
+        let raw = self.buf[..sep].to_string();
+        self.buf.drain(..=sep + 1);
+        Some(parse_frame(&raw))
+    }
+}
+
+/// Parse one raw frame body (the text before a `\n\n`) into its `event` / `data`
+/// fields. Strips a leading BOM per line, captures the last `event:` value, and
+/// joins multiple `data:` lines with `\n` (the SSE spec's concatenation rule).
+fn parse_frame(raw: &str) -> SseFrame {
+    let mut event = None;
+    let mut data = String::new();
+    for line in raw.lines() {
+        let line = line.trim_start_matches('\u{feff}');
+        if let Some(rest) = line.strip_prefix("event:") {
+            event = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            let rest = rest.trim_start();
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(rest);
+        }
+        // Other SSE fields (`id:`, `retry:`, comments) are ignored.
+    }
+    SseFrame { event, data }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yields_only_complete_frames() {
+        let mut s = SseFrameStream::new();
+        // Partial frame — no `\n\n` yet.
+        assert!(s.feed(b"data: hello"));
+        assert!(s.next_frame().is_none());
+        // Completing it yields exactly one frame.
+        assert!(s.feed(b"\n\n"));
+        let f = s.next_frame().expect("frame");
+        assert_eq!(f.data, "hello");
+        assert!(s.next_frame().is_none());
+    }
+
+    #[test]
+    fn joins_multiple_data_lines() {
+        let mut s = SseFrameStream::new();
+        s.feed(b"data: line1\ndata: line2\n\n");
+        let f = s.next_frame().expect("frame");
+        assert_eq!(f.data, "line1\nline2");
+    }
+
+    #[test]
+    fn captures_and_trims_event_name() {
+        let mut s = SseFrameStream::new();
+        s.feed(b"event: content_block_delta\ndata: {}\n\n");
+        let f = s.next_frame().expect("frame");
+        assert_eq!(f.event.as_deref(), Some("content_block_delta"));
+        assert_eq!(f.data, "{}");
+    }
+
+    #[test]
+    fn strips_leading_bom() {
+        let mut s = SseFrameStream::new();
+        s.feed("\u{feff}data: x\n\n".as_bytes());
+        let f = s.next_frame().expect("frame");
+        assert_eq!(f.data, "x");
+    }
+
+    #[test]
+    fn comment_or_keepalive_frame_has_empty_data() {
+        let mut s = SseFrameStream::new();
+        s.feed(b": keepalive\n\n");
+        let f = s.next_frame().expect("frame");
+        assert!(f.event.is_none());
+        assert_eq!(f.data, "");
+    }
+
+    #[test]
+    fn non_utf8_feed_returns_false_and_buffers_nothing() {
+        let mut s = SseFrameStream::new();
+        // 0xFF is never valid in UTF-8.
+        assert!(!s.feed(&[0xff, 0xfe]));
+        assert!(s.next_frame().is_none());
+        // A subsequent valid feed still works (buffer wasn't corrupted).
+        assert!(s.feed(b"data: ok\n\n"));
+        assert_eq!(s.next_frame().expect("frame").data, "ok");
+    }
+
+    #[test]
+    fn pull_drains_one_frame_at_a_time_leaving_the_rest() {
+        let mut s = SseFrameStream::new();
+        // Two complete frames plus a partial tail in one buffer.
+        s.feed(b"data: a\n\ndata: b\n\ndata: c");
+        assert_eq!(s.next_frame().expect("first").data, "a");
+        // Pulling one frame must leave the second retrievable...
+        assert_eq!(s.next_frame().expect("second").data, "b");
+        // ...and the partial tail unparsed.
+        assert!(s.next_frame().is_none());
+        s.feed(b"\n\n");
+        assert_eq!(s.next_frame().expect("third").data, "c");
+    }
+}


### PR DESCRIPTION
## Wave 32 — `SseFrameStream` SSE decoder dedupe

Closes the *SSE decoder dedupe (`SseFrameStream`)* item from `audit-design.md`'s "Wave 4 — Bigger refactors" list. Spec: `docs/superpowers/specs/2026-05-30-wave-32-sse-frame-stream-design.md`.

### Problem
`OpenAiSseDecoder` and `AnthropicSseDecoder` each re-implemented identical SSE **transport framing** — a `buf: String`, the `push` byte-accumulation + `\n\n` frame-split loop, and per-frame `event:`/`data:` line parsing (BOM strip, `trim_start`, multi-line `data:` join) — and each defined its own identical `DecodeBatch { chunks, done }`. Only the per-frame *semantics* differ.

### Change
Extract the transport half into a provider-agnostic `providers::sse::SseFrameStream` (`feed` + pull-based `next_frame() -> SseFrame`) and consolidate `DecodeBatch` there. Each decoder now holds `frames: SseFrameStream` and keeps only its semantics (OpenAI: `[DONE]` + JSON; Anthropic: match on event name).

### Why `next_frame` is pull-based (correctness)
A terminal frame stops each provider's loop and **leaves trailing buffered frames in place**. An eager `Vec`-returning parser would drain and lose them. Pull-based `next_frame` preserves the exact drain-on-terminal semantics. `feed` returns a `bool` on non-UTF-8 (no logging) so the transport type stays free of a `tracing` dep; each provider keeps its own tagged warning.

### Behavior guarantee
Byte-identical decode output. The existing provider decoder tests (Anthropic `decodes_*`, OpenAI `[DONE]`/tool-call/malformed-frame) stay green **through the new shared framing** — that's the regression net.

### Tests
Adds 7 `SseFrameStream` transport unit tests: frame split across `feed` calls, multi-line `data:` join, `event:` capture, BOM strip, keepalive (empty data), non-UTF-8 → `false`, and drain-on-pull.

### Verification
- `cargo check -p solobase-core` clean.
- `cargo test -p solobase-core --lib` — **712 pass** (705 + 7 new).
- `cargo clippy -p solobase-core` — no findings in touched files.
- `bash scripts/audit-wrap-grants.sh` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)