### PR TITLE
perf(products): seed default templates via migration, not per-request Init

### DIFF
--- a/crates/solobase-core/src/blocks/products/migrations/002_default_templates.postgres.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/002_default_templates.postgres.sql
@@ -1,0 +1,15 @@
+-- Default group/product templates. See `002_default_templates.sqlite.sql` for
+-- the full rationale (static FK-parent rows moved out of the per-request
+-- runtime seed into this hash-gated migration). Idempotent via
+-- `ON CONFLICT (id) DO NOTHING`.
+INSERT INTO suppers_ai__products__group_templates
+    (id, name, display_name, created_at, updated_at)
+VALUES
+    ('default', 'default', 'Default', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO suppers_ai__products__product_templates
+    (id, name, display_name, created_at, updated_at)
+VALUES
+    ('default', 'default', 'Default', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;

--- a/crates/solobase-core/src/blocks/products/migrations/002_default_templates.sqlite.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/002_default_templates.sqlite.sql
@@ -1,0 +1,19 @@
+-- Default group/product templates — static FK-parent rows the groups and
+-- products tables require. Previously seeded at runtime in
+-- `ProductsBlock::lifecycle(Init)` via a per-request existence check + insert
+-- (two `db::list_all` reads on every request, uncached). Moved here so the
+-- seed is hash-gated like every other migration and costs zero D1 reads per
+-- request in steady state. Idempotent via `INSERT OR IGNORE` on the PK.
+--
+-- Lookups resolve the default by `name = 'default'` (see
+-- `handlers::default_template_id`), so the `id` value is arbitrary as long as
+-- it is stable; we use the literal `default`.
+INSERT OR IGNORE INTO suppers_ai__products__group_templates
+    (id, name, display_name, created_at, updated_at)
+VALUES
+    ('default', 'default', 'Default', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z');
+
+INSERT OR IGNORE INTO suppers_ai__products__product_templates
+    (id, name, display_name, created_at, updated_at)
+VALUES
+    ('default', 'default', 'Default', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z');

--- a/crates/solobase-core/src/blocks/products/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/products/migrations/mod.rs
@@ -19,13 +19,15 @@ const PRODUCTS_BLOCK_NAME: &str = "suppers-ai/products";
 
 const SQL_001_SQLITE: &str = include_str!("001_products_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_products_schema.postgres.sql");
+const SQL_002_SQLITE: &str = include_str!("002_default_templates.sqlite.sql");
+const SQL_002_POSTGRES: &str = include_str!("002_default_templates.postgres.sql");
 
 pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
     migration_helper::apply_migrations(
         ctx,
         PRODUCTS_BLOCK_NAME,
-        &[SQL_001_SQLITE],
-        &[SQL_001_POSTGRES],
+        &[SQL_001_SQLITE, SQL_002_SQLITE],
+        &[SQL_001_POSTGRES, SQL_002_POSTGRES],
     )
     .await
 }

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -272,60 +272,17 @@ impl Block for ProductsBlock {
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
         if event.event_type == LifecycleType::Init {
-            // Apply block-owned schema migrations before any seeding so the
-            // default-template inserts below land on a known column set.
+            // Apply block-owned schema migrations. Migration 002 seeds the
+            // default group/product templates (the static FK-parent rows the
+            // groups/products tables require) via idempotent INSERTs, so there
+            // is no longer a per-request runtime existence-check + seed here —
+            // the hash-gate short-circuits in memory once applied.
             migrations::apply(ctx).await.map_err(|e| {
                 WaferError::new(
                     wafer_run::ErrorCode::Internal,
                     format!("products migrations: {e}"),
                 )
             })?;
-
-            // Seed default templates if they don't exist — these are required by FK constraints
-            // on the groups and products tables.
-            use wafer_core::clients::database as db;
-
-            // Default group template
-            match db::list_all(ctx, GROUP_TEMPLATES_TABLE, vec![]).await {
-                Ok(records) if records.is_empty() => {
-                    let mut data = std::collections::HashMap::new();
-                    data.insert(
-                        "name".to_string(),
-                        serde_json::Value::String("default".to_string()),
-                    );
-                    data.insert(
-                        "display_name".to_string(),
-                        serde_json::Value::String("Default".to_string()),
-                    );
-                    match db::create(ctx, GROUP_TEMPLATES_TABLE, data).await {
-                        Ok(_) => tracing::info!("seeded default group template"),
-                        Err(e) => tracing::warn!("failed to seed group template: {e}"),
-                    }
-                }
-                Ok(_) => {} // already has records
-                Err(e) => tracing::warn!("failed to list group templates: {e}"),
-            }
-
-            // Default product template
-            match db::list_all(ctx, PRODUCT_TEMPLATES_TABLE, vec![]).await {
-                Ok(records) if records.is_empty() => {
-                    let mut data = std::collections::HashMap::new();
-                    data.insert(
-                        "name".to_string(),
-                        serde_json::Value::String("default".to_string()),
-                    );
-                    data.insert(
-                        "display_name".to_string(),
-                        serde_json::Value::String("Default".to_string()),
-                    );
-                    match db::create(ctx, PRODUCT_TEMPLATES_TABLE, data).await {
-                        Ok(_) => tracing::info!("seeded default product template"),
-                        Err(e) => tracing::warn!("failed to seed product template: {e}"),
-                    }
-                }
-                Ok(_) => {}
-                Err(e) => tracing::warn!("failed to list product templates: {e}"),
-            }
         }
         Ok(())
     }

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -488,6 +488,27 @@ mod tests {
             postgres_count, 19,
             "products postgres migration: expected 19 statements, got {postgres_count}"
         );
+
+        // 002 seeds the two default templates (one INSERT each) per backend.
+        for (label, sql) in [
+            (
+                "sqlite",
+                include_str!("blocks/products/migrations/002_default_templates.sqlite.sql"),
+            ),
+            (
+                "postgres",
+                include_str!("blocks/products/migrations/002_default_templates.postgres.sql"),
+            ),
+        ] {
+            let count = split_statements(sql)
+                .into_iter()
+                .filter(|s| has_executable_content(s))
+                .count();
+            assert_eq!(
+                count, 2,
+                "products {label} migration 002: expected 2 statements, got {count}"
+            );
+        }
     }
 
     /// Reproduces the prod failure mode this commit fixes: a block's


### PR DESCRIPTION
## Summary

`ProductsBlock::lifecycle(Init)` seeded the default group/product templates (static FK-parent rows) with an existence-check + insert. On the Cloudflare target the `Wafer` runtime is rebuilt **per request**, so this `Init` runs on every request, firing **two uncached `db::list_all` reads against D1 each time** (the template tables aren't KV-cached).

This moves the seed into a new hash-gated migration `002_default_templates`, mirroring the existing `auth/002_reserved_orgs` data-seed pattern, and removes the runtime seed block. In steady state the migration short-circuits in memory via the `current_hash` gate, so the per-request cost of both reads drops to **zero**. The native target benefits too (same `Init` path).

This is the safe, high-value slice from a broader review of the `solobase-cloudflare` request-time orchestration. It does **not** touch runtime caching (which isn't safe to retrofit given services are embedded in request-scoped backend blocks).

### Changes
- New `blocks/products/migrations/002_default_templates.{sqlite,postgres}.sql` — idempotent `INSERT OR IGNORE` / `ON CONFLICT (id) DO NOTHING` for the two default templates.
- Register `002` in `products/migrations/mod.rs`.
- Drop the per-request existence-check + seed from `products/mod.rs` `lifecycle(Init)`; keep `migrations::apply`.
- Extend the products migration-split test to cover `002`.

### Notes
- Lookups resolve the default by `name = 'default'` (`handlers::default_template_id`), so the fixed `id = 'default'` is lookup-irrelevant.
- On existing (already-runtime-seeded) deployments, a `--run-migrations` deploy adds the `id='default'` row alongside any prior uuid-id `name='default'` row; both carry identical content and lookups still resolve, and the dev/prod DBs here are wipeable. Fresh installs get exactly one.

## Test plan
- [x] `cargo check -p solobase-core` clean
- [x] `cargo test -p solobase-core --lib products` (120) + extended migration-split test green
- [x] Fresh `--run-migrations` boot seeds exactly **one** row per template table (`('default','default','Default')`); old runtime-seed log lines gone
- [x] Second `--run-migrations` boot stays at one row each (hash-gate + `INSERT OR IGNORE`)
- [x] `cargo +nightly fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)