### PR TITLE
refactor(products): extract purchases + subscriptions repo layer (audit-design Wave 4)

### DIFF
--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -12,7 +12,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{PRICING_TABLE, PURCHASES_TABLE};
+use super::PRICING_TABLE;
 use crate::blocks::{
     crud,
     helpers::{
@@ -899,11 +899,6 @@ async fn handle_stats(ctx: &dyn Context, _msg: &Message) -> OutputStream {
         operator: FilterOp::Equal,
         value: serde_json::Value::String("active".to_string()),
     }];
-    let completed_filter = [Filter {
-        field: "status".to_string(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String("completed".to_string()),
-    }];
 
     // Fan out the 5 independent counts/sums concurrently rather than
     // serializing 5 round-trips on the request path. `futures::join!`
@@ -912,8 +907,8 @@ async fn handle_stats(ctx: &dyn Context, _msg: &Message) -> OutputStream {
     let (total_products, active_products, total_purchases, total_revenue, total_groups) = futures::join!(
         db::count(ctx, PRODUCTS_TABLE, &[]),
         db::count(ctx, PRODUCTS_TABLE, &active_filter),
-        db::count(ctx, PURCHASES_TABLE, &[]),
-        db::sum(ctx, PURCHASES_TABLE, "total_cents", &completed_filter),
+        super::repo::purchases::count_all(ctx),
+        super::repo::purchases::sum_completed_cents(ctx),
         db::count(ctx, GROUPS_TABLE, &[]),
     );
 

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -12,7 +12,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{PRICING_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
+use super::{PRICING_TABLE, PURCHASES_TABLE};
 use crate::blocks::{
     crud,
     helpers::{
@@ -887,56 +887,7 @@ async fn handle_subscription(ctx: &dyn Context, msg: &Message) -> OutputStream {
     if user_id.is_empty() {
         return err_unauthorized("Not authenticated");
     }
-
-    use wafer_sql_utils::{
-        aggregate::{build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig},
-        Backend,
-    };
-
-    // Build COALESCE(addon_*, 0) into the SQL via the aggregate builder so we
-    // don't have to post-process null cells in Rust. group_by is empty —
-    // the row is implicitly grouped by the user_id filter + LIMIT 1.
-    let coalesced = |alias: &str, field: &str| AggregateColumn {
-        func: AggFunc::Coalesce(serde_json::json!(0)),
-        field: Some(field.into()),
-        alias: alias.into(),
-        cast_as: None,
-        inner_expr: None,
-    };
-    let cfg = GroupedQueryConfig {
-        table: SUBSCRIPTIONS_TABLE.into(),
-        select_columns: vec![
-            "id".into(),
-            "plan".into(),
-            "status".into(),
-            "stripe_subscription_id".into(),
-            "grace_period_end".into(),
-            "created_at".into(),
-            "updated_at".into(),
-        ],
-        aggregates: vec![
-            coalesced("addon_projects", "addon_projects"),
-            coalesced("addon_requests", "addon_requests"),
-            coalesced("addon_r2_bytes", "addon_r2_bytes"),
-            coalesced("addon_d1_bytes", "addon_d1_bytes"),
-        ],
-        filters: vec![Filter {
-            field: "user_id".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::json!(user_id),
-        }],
-        group_by: vec![],
-        order_by: vec![],
-        limit: Some(1),
-    };
-    let stmt = build_grouped_query(cfg, Backend::Sqlite);
-    let rows = db::query(ctx, &stmt).await;
-
-    let sub = match rows {
-        Ok(records) if !records.is_empty() => Some(records[0].data.clone()),
-        _ => None,
-    };
-
+    let sub = super::repo::subscriptions::subscription_for_user(ctx, &user_id).await;
     ok_json(&serde_json::json!({"subscription": sub}))
 }
 

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -12,7 +12,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{PRICING_TABLE, PURCHASES_TABLE};
+use super::{PRICING_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
 use crate::blocks::{
     crud,
     helpers::{
@@ -35,9 +35,6 @@ pub(crate) const GROUP_TEMPLATES_TABLE: &str = "suppers_ai__products__group_temp
 
 /// Reusable product template definitions (admin-authored).
 pub(crate) const PRODUCT_TEMPLATES_TABLE: &str = "suppers_ai__products__product_templates";
-
-/// Active subscription rows (one per user subscription).
-pub(crate) const SUBSCRIPTIONS_TABLE: &str = "suppers_ai__products__subscriptions";
 
 async fn user_products_enabled(ctx: &dyn Context) -> bool {
     config::get_default(ctx, "SOLOBASE_SHARED__ALLOW_USER_PRODUCTS", "false").await == "true"

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -14,9 +14,9 @@ mod tests;
 pub(crate) use handlers::{
     GROUPS_TABLE, GROUP_TEMPLATES_TABLE, PRODUCTS_TABLE, PRODUCT_TEMPLATES_TABLE, TYPES_TABLE,
 };
-pub(crate) use repo::subscriptions::SUBSCRIPTIONS_TABLE;
 pub(crate) use pricing::TABLE as PRICING_TABLE;
 pub(crate) use purchase::{LINE_ITEMS_TABLE, PURCHASES_TABLE};
+pub(crate) use repo::subscriptions::SUBSCRIPTIONS_TABLE;
 pub(crate) use variables::TABLE as VARIABLES_TABLE;
 use wafer_run::{
     block::{Block, BlockInfo},

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -15,10 +15,7 @@ pub(crate) use handlers::{
     GROUPS_TABLE, GROUP_TEMPLATES_TABLE, PRODUCTS_TABLE, PRODUCT_TEMPLATES_TABLE, TYPES_TABLE,
 };
 pub(crate) use pricing::TABLE as PRICING_TABLE;
-pub(crate) use repo::{
-    purchases::{LINE_ITEMS_TABLE, PURCHASES_TABLE},
-    subscriptions::SUBSCRIPTIONS_TABLE,
-};
+pub(crate) use repo::purchases::{LINE_ITEMS_TABLE, PURCHASES_TABLE};
 pub(crate) use variables::TABLE as VARIABLES_TABLE;
 use wafer_run::{
     block::{Block, BlockInfo},

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod models;
 mod pages;
 mod pricing;
 mod purchase;
+mod repo;
 mod stripe;
 mod variables;
 
@@ -11,9 +12,9 @@ mod variables;
 mod tests;
 
 pub(crate) use handlers::{
-    GROUPS_TABLE, GROUP_TEMPLATES_TABLE, PRODUCTS_TABLE, PRODUCT_TEMPLATES_TABLE,
-    SUBSCRIPTIONS_TABLE, TYPES_TABLE,
+    GROUPS_TABLE, GROUP_TEMPLATES_TABLE, PRODUCTS_TABLE, PRODUCT_TEMPLATES_TABLE, TYPES_TABLE,
 };
+pub(crate) use repo::subscriptions::SUBSCRIPTIONS_TABLE;
 pub(crate) use pricing::TABLE as PRICING_TABLE;
 pub(crate) use purchase::{LINE_ITEMS_TABLE, PURCHASES_TABLE};
 pub(crate) use variables::TABLE as VARIABLES_TABLE;

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -15,8 +15,10 @@ pub(crate) use handlers::{
     GROUPS_TABLE, GROUP_TEMPLATES_TABLE, PRODUCTS_TABLE, PRODUCT_TEMPLATES_TABLE, TYPES_TABLE,
 };
 pub(crate) use pricing::TABLE as PRICING_TABLE;
-pub(crate) use purchase::{LINE_ITEMS_TABLE, PURCHASES_TABLE};
-pub(crate) use repo::subscriptions::SUBSCRIPTIONS_TABLE;
+pub(crate) use repo::{
+    purchases::{LINE_ITEMS_TABLE, PURCHASES_TABLE},
+    subscriptions::SUBSCRIPTIONS_TABLE,
+};
 pub(crate) use variables::TABLE as VARIABLES_TABLE;
 use wafer_run::{
     block::{Block, BlockInfo},

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -5,7 +5,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 
-use super::{GROUPS_TABLE, PRICING_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE};
+use super::{repo, GROUPS_TABLE, PRICING_TABLE, PRODUCTS_TABLE};
 use crate::{
     blocks::helpers::{err_bad_request, ok_json, RecordExt},
     ui::{
@@ -55,7 +55,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user = UserInfo::from_message(msg);
     let products_count = db::count(ctx, PRODUCTS_TABLE, &[]).await.unwrap_or(0);
     let groups_count = db::count(ctx, GROUPS_TABLE, &[]).await.unwrap_or(0);
-    let purchases_count = db::count(ctx, PURCHASES_TABLE, &[]).await.unwrap_or(0);
+    let purchases_count = repo::purchases::count_all(ctx).await.unwrap_or(0);
     let pricing_count = db::count(ctx, PRICING_TABLE, &[]).await.unwrap_or(0);
 
     let content = html! {
@@ -311,19 +311,7 @@ pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         });
     }
 
-    let sort = vec![SortField {
-        field: "created_at".into(),
-        desc: true,
-    }];
-    let result = db::paginated_list(
-        ctx,
-        PURCHASES_TABLE,
-        page as i64,
-        page_size as i64,
-        filters,
-        sort,
-    )
-    .await;
+    let result = repo::purchases::list_paginated(ctx, filters, page as i64, page_size as i64).await;
 
     let content = html! {
         (components::page_header("Purchases", Some("Track customer orders and payments"), None))
@@ -476,19 +464,7 @@ pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         operator: FilterOp::Equal,
         value: serde_json::Value::String(user_id),
     }];
-    let sort = vec![SortField {
-        field: "created_at".into(),
-        desc: true,
-    }];
-    let result = db::paginated_list(
-        ctx,
-        PURCHASES_TABLE,
-        page as i64,
-        page_size as i64,
-        filters,
-        sort,
-    )
-    .await;
+    let result = repo::purchases::list_paginated(ctx, filters, page as i64, page_size as i64).await;
 
     let content = html! {
         (components::page_header("My Purchases", None, None))

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use wafer_block::db::{Filter, FilterOp, SortField};
+use wafer_block::db::{Filter, FilterOp};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
-use wafer_sql_utils::Backend;
 
-use super::{LINE_ITEMS_TABLE, PRICING_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE};
+use super::{repo, PRICING_TABLE, PRODUCTS_TABLE};
 use crate::blocks::helpers::{
     self, err_bad_request, err_forbidden, err_internal, err_not_found, err_unauthorized, ok_json,
     RecordExt,
@@ -192,7 +191,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
         serde_json::Value::String(now.clone()),
     );
 
-    let purchase = match db::create(ctx, PURCHASES_TABLE, purchase_data).await {
+    let purchase = match repo::purchases::create(ctx, purchase_data).await {
         Ok(p) => p,
         Err(e) => return err_internal("Failed to create purchase", e),
     };
@@ -220,13 +219,13 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
             "created_at".to_string(),
             serde_json::Value::String(now.clone()),
         );
-        if let Err(e) = db::create(ctx, LINE_ITEMS_TABLE, item_data).await {
+        if let Err(e) = repo::purchases::add_line_item(ctx, item_data).await {
             // Roll back: try to delete the purchase first; if delete fails
             // (transient DB error, foreign-key constraints from already-
             // inserted siblings, etc.), fall through to marking it `failed`
             // so it can never proceed to checkout. A dangling `pending`
             // purchase with partial line items is the worst case.
-            if let Err(del_err) = db::delete(ctx, PURCHASES_TABLE, &purchase.id).await {
+            if let Err(del_err) = repo::purchases::delete(ctx, &purchase.id).await {
                 tracing::warn!(
                     error = %del_err,
                     purchase_id = %purchase.id,
@@ -241,9 +240,7 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
                     "updated_at".to_string(),
                     serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
                 );
-                if let Err(mark_err) =
-                    db::update(ctx, PURCHASES_TABLE, &purchase.id, fail_data).await
-                {
+                if let Err(mark_err) = repo::purchases::update(ctx, &purchase.id, fail_data).await {
                     tracing::error!(
                         error = %mark_err,
                         purchase_id = %purchase.id,
@@ -272,21 +269,8 @@ pub async fn handle_list_user(ctx: &dyn Context, msg: &Message) -> OutputStream 
         operator: FilterOp::Equal,
         value: serde_json::Value::String(user_id),
     }];
-    let sort = vec![SortField {
-        field: "created_at".to_string(),
-        desc: true,
-    }];
 
-    match db::paginated_list(
-        ctx,
-        PURCHASES_TABLE,
-        page as i64,
-        page_size as i64,
-        filters,
-        sort,
-    )
-    .await
-    {
+    match repo::purchases::list_paginated(ctx, filters, page as i64, page_size as i64).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -313,21 +297,7 @@ pub async fn handle_list_admin(ctx: &dyn Context, msg: &Message) -> OutputStream
         });
     }
 
-    let sort = vec![SortField {
-        field: "created_at".to_string(),
-        desc: true,
-    }];
-
-    match db::paginated_list(
-        ctx,
-        PURCHASES_TABLE,
-        page as i64,
-        page_size as i64,
-        filters,
-        sort,
-    )
-    .await
-    {
+    match repo::purchases::list_paginated(ctx, filters, page as i64, page_size as i64).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -346,7 +316,7 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
         return err_bad_request("Missing purchase ID");
     }
 
-    let purchase = match db::get(ctx, PURCHASES_TABLE, id).await {
+    let purchase = match repo::purchases::get(ctx, id).await {
         Ok(p) => p,
         Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Purchase not found"),
         Err(e) => return err_internal("Database error", e),
@@ -359,12 +329,7 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Get line items
-    let items_filters = vec![Filter {
-        field: "purchase_id".to_string(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String(id.to_string()),
-    }];
-    let line_items = db::list_all(ctx, LINE_ITEMS_TABLE, items_filters)
+    let line_items = repo::purchases::list_line_items(ctx, id)
         .await
         .unwrap_or_default();
 
@@ -394,7 +359,7 @@ pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream)
     let body: RefundReq = serde_json::from_slice(&raw).unwrap_or_default();
 
     // Verify purchase exists
-    if let Err(e) = db::get(ctx, PURCHASES_TABLE, &id).await {
+    if let Err(e) = repo::purchases::get(ctx, &id).await {
         if e.code == ErrorCode::NotFound {
             return err_not_found("Purchase not found");
         }
@@ -402,34 +367,12 @@ pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream)
     }
 
     // Atomic status transition: completed → refunded (prevents double-refund race)
-    let now = chrono::Utc::now().to_rfc3339();
     let refunded_by = msg.user_id().to_string();
     let reason_val = body.reason.unwrap_or_default();
 
-    let stmt = wafer_sql_utils::query::build_update_where(
-        PURCHASES_TABLE,
-        &[
-            ("status".to_string(), serde_json::json!("refunded")),
-            ("refunded_at".to_string(), serde_json::json!(&now)),
-            ("refunded_by".to_string(), serde_json::json!(&refunded_by)),
-            ("refund_reason".to_string(), serde_json::json!(&reason_val)),
-            ("updated_at".to_string(), serde_json::json!(&now)),
-        ],
-        &[
-            Filter {
-                field: "id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(&id),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("completed"),
-            },
-        ],
-        Backend::Sqlite,
-    );
-    let rows = db::execute(ctx, &stmt).await.unwrap_or(0);
+    let rows = repo::purchases::refund_atomic(ctx, &id, &refunded_by, &reason_val)
+        .await
+        .unwrap_or(0);
 
     if rows == 0 {
         return err_bad_request(
@@ -438,7 +381,7 @@ pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream)
     }
 
     // Fetch the updated record for the response
-    match db::get(ctx, PURCHASES_TABLE, &id).await {
+    match repo::purchases::get(ctx, &id).await {
         Ok(record) => ok_json(&record),
         Err(e) => err_internal("Database error", e),
     }

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -5,17 +5,11 @@ use wafer_core::clients::database as db;
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use wafer_sql_utils::Backend;
 
-use super::{PRICING_TABLE, PRODUCTS_TABLE};
+use super::{LINE_ITEMS_TABLE, PRICING_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE};
 use crate::blocks::helpers::{
     self, err_bad_request, err_forbidden, err_internal, err_not_found, err_unauthorized, ok_json,
     RecordExt,
 };
-
-/// Purchase header table — one row per checkout / order.
-pub(crate) const PURCHASES_TABLE: &str = "suppers_ai__products__purchases";
-
-/// Purchase line-item table — one row per product line in a purchase.
-pub(crate) const LINE_ITEMS_TABLE: &str = "suppers_ai__products__line_items";
 
 pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     #[derive(serde::Deserialize)]

--- a/crates/solobase-core/src/blocks/products/repo/mod.rs
+++ b/crates/solobase-core/src/blocks/products/repo/mod.rs
@@ -1,0 +1,8 @@
+//! Data-access layer for the products block's purchases and subscriptions
+//! domains. Each submodule owns its table name(s) (the canonical
+//! `repo`-module-owns-its-`TABLE` convention) and is the sole place that
+//! issues `db::*` / `wafer_sql_utils` statements against those tables. Block
+//! handlers call these functions and keep all HTTP, authz, logging, and
+//! Stripe-retry policy at the call site.
+
+pub(crate) mod subscriptions;

--- a/crates/solobase-core/src/blocks/products/repo/mod.rs
+++ b/crates/solobase-core/src/blocks/products/repo/mod.rs
@@ -5,4 +5,5 @@
 //! handlers call these functions and keep all HTTP, authz, logging, and
 //! Stripe-retry policy at the call site.
 
+pub(crate) mod purchases;
 pub(crate) mod subscriptions;

--- a/crates/solobase-core/src/blocks/products/repo/purchases.rs
+++ b/crates/solobase-core/src/blocks/products/repo/purchases.rs
@@ -1,0 +1,356 @@
+//! Data access for the purchases header table and its line items.
+
+use std::collections::HashMap;
+
+use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+use wafer_sql_utils::Backend;
+
+/// Purchase header table — one row per checkout / order.
+pub(crate) const PURCHASES_TABLE: &str = "suppers_ai__products__purchases";
+
+/// Purchase line-item table — one row per product line in a purchase.
+pub(crate) const LINE_ITEMS_TABLE: &str = "suppers_ai__products__line_items";
+
+/// Fetch a purchase header by id.
+pub(crate) async fn get(ctx: &dyn Context, id: &str) -> Result<Record, WaferError> {
+    db::get(ctx, PURCHASES_TABLE, id).await
+}
+
+/// Insert a purchase header. Caller supplies the full field map.
+pub(crate) async fn create(
+    ctx: &dyn Context,
+    data: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, PURCHASES_TABLE, data).await
+}
+
+/// Insert a line item. Caller supplies the full field map.
+pub(crate) async fn add_line_item(
+    ctx: &dyn Context,
+    data: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, LINE_ITEMS_TABLE, data).await
+}
+
+/// Delete a purchase header (rollback path).
+pub(crate) async fn delete(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
+    db::delete(ctx, PURCHASES_TABLE, id).await
+}
+
+/// Apply an arbitrary field update to a purchase header by id.
+pub(crate) async fn update(
+    ctx: &dyn Context,
+    id: &str,
+    data: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::update(ctx, PURCHASES_TABLE, id, data).await
+}
+
+/// List a purchase's line items.
+pub(crate) async fn list_line_items(
+    ctx: &dyn Context,
+    purchase_id: &str,
+) -> Result<Vec<Record>, WaferError> {
+    db::list_all(
+        ctx,
+        LINE_ITEMS_TABLE,
+        vec![Filter {
+            field: "purchase_id".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(purchase_id.to_string()),
+        }],
+    )
+    .await
+}
+
+/// Paginated purchase list, newest first, with caller-supplied filters.
+pub(crate) async fn list_paginated(
+    ctx: &dyn Context,
+    filters: Vec<Filter>,
+    page: i64,
+    page_size: i64,
+) -> Result<RecordList, WaferError> {
+    let sort = vec![SortField {
+        field: "created_at".to_string(),
+        desc: true,
+    }];
+    db::paginated_list(ctx, PURCHASES_TABLE, page, page_size, filters, sort).await
+}
+
+/// Atomic checkout-completion: only transitions a purchase still in
+/// `checkout_started`/`pending`. Returns rows affected (0 = already
+/// completed/refunded). `checkout.session.completed`.
+pub(crate) async fn complete_atomic(
+    ctx: &dyn Context,
+    purchase_id: &str,
+    payment_intent: &str,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let stmt = wafer_sql_utils::query::build_update_where(
+        PURCHASES_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("completed")),
+            (
+                "provider_payment_intent_id".to_string(),
+                serde_json::json!(payment_intent),
+            ),
+            ("approved_at".to_string(), serde_json::json!(&now)),
+            ("updated_at".to_string(), serde_json::json!(&now)),
+        ],
+        &[
+            Filter {
+                field: "id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(purchase_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::In,
+                value: serde_json::json!(["checkout_started", "pending"]),
+            },
+        ],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Atomic checkout claim: `pending` -> `checkout_started`. Returns rows
+/// affected (0 = not pending / already in flight).
+pub(crate) async fn claim_for_checkout(
+    ctx: &dyn Context,
+    purchase_id: &str,
+) -> Result<i64, WaferError> {
+    let stmt = wafer_sql_utils::query::build_update_where(
+        PURCHASES_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("checkout_started")),
+            (
+                "updated_at".to_string(),
+                serde_json::json!(chrono::Utc::now().to_rfc3339()),
+            ),
+        ],
+        &[
+            Filter {
+                field: "id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(purchase_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("pending"),
+            },
+        ],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Revert a checkout claim: `checkout_started` -> `pending` (Stripe API error
+/// path). Returns rows affected.
+pub(crate) async fn revert_checkout_claim(
+    ctx: &dyn Context,
+    purchase_id: &str,
+) -> Result<i64, WaferError> {
+    let stmt = wafer_sql_utils::query::build_update_where(
+        PURCHASES_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("pending")),
+            (
+                "updated_at".to_string(),
+                serde_json::json!(chrono::Utc::now().to_rfc3339()),
+            ),
+        ],
+        &[
+            Filter {
+                field: "id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(purchase_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("checkout_started"),
+            },
+        ],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Atomic admin refund: `completed` -> `refunded` with audit fields. Returns
+/// rows affected (0 = not completed / already refunded).
+pub(crate) async fn refund_atomic(
+    ctx: &dyn Context,
+    id: &str,
+    refunded_by: &str,
+    reason: &str,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let stmt = wafer_sql_utils::query::build_update_where(
+        PURCHASES_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("refunded")),
+            ("refunded_at".to_string(), serde_json::json!(&now)),
+            ("refunded_by".to_string(), serde_json::json!(refunded_by)),
+            ("refund_reason".to_string(), serde_json::json!(reason)),
+            ("updated_at".to_string(), serde_json::json!(&now)),
+        ],
+        &[
+            Filter {
+                field: "id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("completed"),
+            },
+        ],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Find a purchase by its provider payment-intent id (`charge.refunded`).
+pub(crate) async fn find_by_payment_intent(
+    ctx: &dyn Context,
+    payment_intent: &str,
+) -> Result<Record, WaferError> {
+    db::get_by_field(
+        ctx,
+        PURCHASES_TABLE,
+        "provider_payment_intent_id",
+        serde_json::Value::String(payment_intent.to_string()),
+    )
+    .await
+}
+
+/// Mark a purchase refunded by id (webhook `charge.refunded` path — sets
+/// status/refunded_at/updated_at, mirrors the original `db::update`).
+pub(crate) async fn mark_refunded(ctx: &dyn Context, id: &str) -> Result<Record, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut data = HashMap::new();
+    data.insert(
+        "status".to_string(),
+        serde_json::Value::String("refunded".to_string()),
+    );
+    data.insert(
+        "refunded_at".to_string(),
+        serde_json::Value::String(now.clone()),
+    );
+    data.insert("updated_at".to_string(), serde_json::Value::String(now));
+    db::update(ctx, PURCHASES_TABLE, id, data).await
+}
+
+/// Select line-item product_ids for a purchase (checkout dependency probe).
+pub(crate) async fn line_item_product_ids(
+    ctx: &dyn Context,
+    purchase_id: &str,
+) -> Result<Vec<Record>, WaferError> {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "purchase_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(purchase_id),
+        }],
+        limit: 1,
+        ..Default::default()
+    };
+    let stmt = wafer_sql_utils::query::build_select_columns(
+        LINE_ITEMS_TABLE,
+        &["product_id"],
+        &opts,
+        None,
+        Backend::Sqlite,
+    );
+    db::query(ctx, &stmt).await
+}
+
+/// Count all purchases (admin stats).
+pub(crate) async fn count_all(ctx: &dyn Context) -> Result<i64, WaferError> {
+    db::count(ctx, PURCHASES_TABLE, &[]).await
+}
+
+/// Sum `total_cents` over completed purchases (admin revenue).
+pub(crate) async fn sum_completed_cents(ctx: &dyn Context) -> Result<f64, WaferError> {
+    db::sum(
+        ctx,
+        PURCHASES_TABLE,
+        "total_cents",
+        &[Filter {
+            field: "status".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String("completed".to_string()),
+        }],
+    )
+    .await
+}
+
+/// Ids of a user's completed purchases (ownership check).
+pub(crate) async fn completed_purchase_ids(
+    ctx: &dyn Context,
+    user_id: &str,
+) -> Result<Vec<Record>, WaferError> {
+    let opts = ListOptions {
+        filters: vec![
+            Filter {
+                field: "user_id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(user_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("completed"),
+            },
+        ],
+        ..Default::default()
+    };
+    let stmt = wafer_sql_utils::query::build_select_columns(
+        PURCHASES_TABLE,
+        &["id"],
+        &opts,
+        None,
+        Backend::Sqlite,
+    );
+    db::query(ctx, &stmt).await
+}
+
+/// Probe whether any of `purchase_ids` contains `product_id` as a line item.
+pub(crate) async fn line_item_exists_for_product(
+    ctx: &dyn Context,
+    purchase_ids: Vec<serde_json::Value>,
+    product_id: &str,
+) -> bool {
+    if purchase_ids.is_empty() {
+        return false;
+    }
+    let opts = ListOptions {
+        filters: vec![
+            Filter {
+                field: "purchase_id".into(),
+                operator: FilterOp::In,
+                value: serde_json::Value::Array(purchase_ids),
+            },
+            Filter {
+                field: "product_id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(product_id),
+            },
+        ],
+        limit: 1,
+        ..Default::default()
+    };
+    let stmt = wafer_sql_utils::query::build_select_columns(
+        LINE_ITEMS_TABLE,
+        &["id"],
+        &opts,
+        None,
+        Backend::Sqlite,
+    );
+    matches!(db::query(ctx, &stmt).await, Ok(rows) if !rows.is_empty())
+}

--- a/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
+++ b/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
@@ -1,0 +1,243 @@
+//! Data access for the platform-billing subscriptions table.
+
+use wafer_block::db::{Filter, FilterOp, ListOptions};
+use wafer_core::clients::database as db;
+use wafer_run::{context::Context, WaferError};
+use wafer_sql_utils::{
+    aggregate::{build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig},
+    Backend,
+};
+
+/// Platform-billing subscription table — one row per user.
+pub(crate) const SUBSCRIPTIONS_TABLE: &str = "suppers_ai__products__subscriptions";
+
+/// Insert-or-update the platform subscription for a user. The row id is the
+/// deterministic `sub_{user_id}` so two webhooks racing for the same user hit
+/// the same primary key and the `user_id`-conflict clause merges them rather
+/// than inserting duplicates. Returns rows affected.
+pub(crate) async fn upsert_platform(
+    ctx: &dyn Context,
+    user_id: &str,
+    stripe_customer_id: &str,
+    stripe_subscription_id: &str,
+    plan: &str,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let sub_id = format!("sub_{user_id}");
+    let stmt = wafer_sql_utils::upsert::build_upsert(
+        SUBSCRIPTIONS_TABLE,
+        &[
+            ("id".to_string(), serde_json::json!(sub_id)),
+            ("user_id".to_string(), serde_json::json!(user_id)),
+            ("stripe_customer_id".to_string(), serde_json::json!(stripe_customer_id)),
+            ("stripe_subscription_id".to_string(), serde_json::json!(stripe_subscription_id)),
+            ("plan".to_string(), serde_json::json!(plan)),
+            ("status".to_string(), serde_json::json!("active")),
+            ("created_at".to_string(), serde_json::json!(&now)),
+            ("updated_at".to_string(), serde_json::json!(&now)),
+        ],
+        &["user_id"],
+        &["stripe_customer_id", "stripe_subscription_id", "plan", "status", "updated_at"],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Sync status (and optionally plan) from a `customer.subscription.updated`
+/// event, matched by Stripe subscription id. Returns rows affected.
+pub(crate) async fn update_status_plan(
+    ctx: &dyn Context,
+    stripe_subscription_id: &str,
+    status: &str,
+    plan: Option<&str>,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut data: Vec<(String, serde_json::Value)> = vec![
+        ("status".to_string(), serde_json::json!(status)),
+        ("updated_at".to_string(), serde_json::json!(&now)),
+    ];
+    if let Some(plan) = plan {
+        data.push(("plan".to_string(), serde_json::json!(plan)));
+    }
+    let stmt = wafer_sql_utils::query::build_update_where(
+        SUBSCRIPTIONS_TABLE,
+        &data,
+        &[Filter {
+            field: "stripe_subscription_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(stripe_subscription_id),
+        }],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Mark a subscription past-due with a 7-day grace window
+/// (`invoice.payment_failed`). Returns rows affected.
+pub(crate) async fn mark_past_due(
+    ctx: &dyn Context,
+    stripe_subscription_id: &str,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now();
+    let grace_end = (now + chrono::Duration::days(7)).to_rfc3339();
+    let now = now.to_rfc3339();
+    let stmt = wafer_sql_utils::query::build_update_where(
+        SUBSCRIPTIONS_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("past_due")),
+            ("grace_period_end".to_string(), serde_json::json!(&grace_end)),
+            ("updated_at".to_string(), serde_json::json!(&now)),
+        ],
+        &[Filter {
+            field: "stripe_subscription_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(stripe_subscription_id),
+        }],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Cancel a subscription and reset every addon column to 0
+/// (`customer.subscription.deleted`). Returns rows affected.
+pub(crate) async fn cancel_and_reset_addons(
+    ctx: &dyn Context,
+    stripe_subscription_id: &str,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let stmt = wafer_sql_utils::query::build_update_where(
+        SUBSCRIPTIONS_TABLE,
+        &[
+            ("status".to_string(), serde_json::json!("cancelled")),
+            ("addon_projects".to_string(), serde_json::json!(0)),
+            ("addon_requests".to_string(), serde_json::json!(0)),
+            ("addon_r2_bytes".to_string(), serde_json::json!(0)),
+            ("addon_d1_bytes".to_string(), serde_json::json!(0)),
+            ("updated_at".to_string(), serde_json::json!(&now)),
+        ],
+        &[Filter {
+            field: "stripe_subscription_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(stripe_subscription_id),
+        }],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Set the addon column totals for a user's active subscription. The caller
+/// (stripe.rs) parses Stripe subscription-item metadata into the four totals;
+/// this writes them. Returns rows affected.
+pub(crate) async fn set_addon_totals(
+    ctx: &dyn Context,
+    user_id: &str,
+    projects: i64,
+    requests: i64,
+    r2_bytes: i64,
+    d1_bytes: i64,
+) -> Result<i64, WaferError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let stmt = wafer_sql_utils::query::build_update_where(
+        SUBSCRIPTIONS_TABLE,
+        &[
+            ("addon_projects".to_string(), serde_json::json!(projects)),
+            ("addon_requests".to_string(), serde_json::json!(requests)),
+            ("addon_r2_bytes".to_string(), serde_json::json!(r2_bytes)),
+            ("addon_d1_bytes".to_string(), serde_json::json!(d1_bytes)),
+            ("updated_at".to_string(), serde_json::json!(now)),
+        ],
+        &[
+            Filter {
+                field: "user_id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(user_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("active"),
+            },
+        ],
+        Backend::Sqlite,
+    );
+    db::execute(ctx, &stmt).await
+}
+
+/// Look up the user_id owning a Stripe subscription. Errors collapse to `None`
+/// (preserves the original `get_user_for_stripe_sub` behaviour).
+pub(crate) async fn find_user_by_stripe_sub(
+    ctx: &dyn Context,
+    stripe_subscription_id: &str,
+) -> Option<String> {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "stripe_subscription_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(stripe_subscription_id),
+        }],
+        limit: 1,
+        ..Default::default()
+    };
+    let stmt = wafer_sql_utils::query::build_select_columns(
+        SUBSCRIPTIONS_TABLE,
+        &["user_id"],
+        &opts,
+        None,
+        Backend::Sqlite,
+    );
+    let rows = db::query(ctx, &stmt).await.ok()?;
+    rows.first()?
+        .data
+        .get("user_id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+/// Fetch a user's subscription row with addon columns coalesced to 0 for the
+/// admin subscription-status endpoint. Errors / no-row collapse to `None`
+/// (preserves the original `handle_subscription` behaviour).
+pub(crate) async fn subscription_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+) -> Option<serde_json::Value> {
+    let coalesced = |alias: &str, field: &str| AggregateColumn {
+        func: AggFunc::Coalesce(serde_json::json!(0)),
+        field: Some(field.into()),
+        alias: alias.into(),
+        cast_as: None,
+        inner_expr: None,
+    };
+    let cfg = GroupedQueryConfig {
+        table: SUBSCRIPTIONS_TABLE.into(),
+        select_columns: vec![
+            "id".into(),
+            "plan".into(),
+            "status".into(),
+            "stripe_subscription_id".into(),
+            "grace_period_end".into(),
+            "created_at".into(),
+            "updated_at".into(),
+        ],
+        aggregates: vec![
+            coalesced("addon_projects", "addon_projects"),
+            coalesced("addon_requests", "addon_requests"),
+            coalesced("addon_r2_bytes", "addon_r2_bytes"),
+            coalesced("addon_d1_bytes", "addon_d1_bytes"),
+        ],
+        filters: vec![Filter {
+            field: "user_id".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(user_id),
+        }],
+        group_by: vec![],
+        order_by: vec![],
+        limit: Some(1),
+    };
+    let stmt = build_grouped_query(cfg, Backend::Sqlite);
+    match db::query(ctx, &stmt).await {
+        Ok(records) if !records.is_empty() => {
+            serde_json::to_value(&records[0].data).ok()
+        }
+        _ => None,
+    }
+}

--- a/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
+++ b/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
@@ -208,6 +208,39 @@ pub(crate) async fn find_user_by_stripe_sub(
         .map(String::from)
 }
 
+/// Whether the user has an `active` subscription whose `plan` equals `plan`.
+pub(crate) async fn active_plan_exists(ctx: &dyn Context, user_id: &str, plan: &str) -> bool {
+    let opts = ListOptions {
+        filters: vec![
+            Filter {
+                field: "user_id".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(user_id),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("active"),
+            },
+            Filter {
+                field: "plan".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(plan),
+            },
+        ],
+        limit: 1,
+        ..Default::default()
+    };
+    let stmt = wafer_sql_utils::query::build_select_columns(
+        SUBSCRIPTIONS_TABLE,
+        &["id"],
+        &opts,
+        None,
+        Backend::Sqlite,
+    );
+    matches!(db::query(ctx, &stmt).await, Ok(rows) if !rows.is_empty())
+}
+
 /// Fetch a user's subscription row with addon columns coalesced to 0 for the
 /// admin subscription-status endpoint. Errors / no-row collapse to `None`
 /// (preserves the original `handle_subscription` behaviour).

--- a/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
+++ b/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
@@ -29,15 +29,27 @@ pub(crate) async fn upsert_platform(
         &[
             ("id".to_string(), serde_json::json!(sub_id)),
             ("user_id".to_string(), serde_json::json!(user_id)),
-            ("stripe_customer_id".to_string(), serde_json::json!(stripe_customer_id)),
-            ("stripe_subscription_id".to_string(), serde_json::json!(stripe_subscription_id)),
+            (
+                "stripe_customer_id".to_string(),
+                serde_json::json!(stripe_customer_id),
+            ),
+            (
+                "stripe_subscription_id".to_string(),
+                serde_json::json!(stripe_subscription_id),
+            ),
             ("plan".to_string(), serde_json::json!(plan)),
             ("status".to_string(), serde_json::json!("active")),
             ("created_at".to_string(), serde_json::json!(&now)),
             ("updated_at".to_string(), serde_json::json!(&now)),
         ],
         &["user_id"],
-        &["stripe_customer_id", "stripe_subscription_id", "plan", "status", "updated_at"],
+        &[
+            "stripe_customer_id",
+            "stripe_subscription_id",
+            "plan",
+            "status",
+            "updated_at",
+        ],
         Backend::Sqlite,
     );
     db::execute(ctx, &stmt).await
@@ -85,7 +97,10 @@ pub(crate) async fn mark_past_due(
         SUBSCRIPTIONS_TABLE,
         &[
             ("status".to_string(), serde_json::json!("past_due")),
-            ("grace_period_end".to_string(), serde_json::json!(&grace_end)),
+            (
+                "grace_period_end".to_string(),
+                serde_json::json!(&grace_end),
+            ),
             ("updated_at".to_string(), serde_json::json!(&now)),
         ],
         &[Filter {
@@ -235,9 +250,7 @@ pub(crate) async fn subscription_for_user(
     };
     let stmt = build_grouped_query(cfg, Backend::Sqlite);
     match db::query(ctx, &stmt).await {
-        Ok(records) if !records.is_empty() => {
-            serde_json::to_value(&records[0].data).ok()
-        }
+        Ok(records) if !records.is_empty() => serde_json::to_value(&records[0].data).ok(),
         _ => None,
     }
 }

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -5,7 +5,7 @@ use wafer_core::clients::{config, database as db, network};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
 use wafer_sql_utils::Backend;
 
-use super::{LINE_ITEMS_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
+use super::{repo, LINE_ITEMS_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
 use crate::blocks::helpers::{
     err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
     err_unauthorized, hex_encode, ok_json,
@@ -392,42 +392,15 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                 .unwrap_or("");
 
             if !user_id.is_empty() && !plan.is_empty() {
-                let now = chrono::Utc::now().to_rfc3339();
-                // Deterministic id keyed only by user_id: two webhooks racing
-                // for the same user must hit the same primary key and the
-                // upsert-on-user_id conflict clause does the right thing.
-                // A timestamp-suffixed id would let them both insert.
-                let sub_id = format!("sub_{user_id}");
-
-                let stmt = wafer_sql_utils::upsert::build_upsert(
-                    SUBSCRIPTIONS_TABLE,
-                    &[
-                        ("id".to_string(), serde_json::json!(sub_id)),
-                        ("user_id".to_string(), serde_json::json!(user_id)),
-                        (
-                            "stripe_customer_id".to_string(),
-                            serde_json::json!(stripe_customer_id),
-                        ),
-                        (
-                            "stripe_subscription_id".to_string(),
-                            serde_json::json!(stripe_sub_id),
-                        ),
-                        ("plan".to_string(), serde_json::json!(plan)),
-                        ("status".to_string(), serde_json::json!("active")),
-                        ("created_at".to_string(), serde_json::json!(&now)),
-                        ("updated_at".to_string(), serde_json::json!(&now)),
-                    ],
-                    &["user_id"],
-                    &[
-                        "stripe_customer_id",
-                        "stripe_subscription_id",
-                        "plan",
-                        "status",
-                        "updated_at",
-                    ],
-                    Backend::Sqlite,
-                );
-                if let Err(e) = db::execute(ctx, &stmt).await {
+                if let Err(e) = repo::subscriptions::upsert_platform(
+                    ctx,
+                    user_id,
+                    stripe_customer_id,
+                    stripe_sub_id,
+                    plan,
+                )
+                .await
+                {
                     tracing::error!(error = %e, user_id = %user_id, "subscription upsert failed");
                 }
 
@@ -452,41 +425,21 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                 .pointer("/items/data/0/price/lookup_key")
                 .or_else(|| data_object.pointer("/items/data/0/price/metadata/plan"))
                 .and_then(|v| v.as_str());
-            let now = chrono::Utc::now().to_rfc3339();
-
+            if let Err(e) =
+                repo::subscriptions::update_status_plan(ctx, stripe_sub_id, status, plan).await
             {
-                let sub_filter = vec![Filter {
-                    field: "stripe_subscription_id".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!(stripe_sub_id),
-                }];
-                let mut data: Vec<(String, serde_json::Value)> = vec![
-                    ("status".to_string(), serde_json::json!(status)),
-                    ("updated_at".to_string(), serde_json::json!(&now)),
-                ];
-                if let Some(plan) = plan {
-                    data.push(("plan".to_string(), serde_json::json!(plan)));
-                }
-                let stmt = wafer_sql_utils::query::build_update_where(
-                    SUBSCRIPTIONS_TABLE,
-                    &data,
-                    &sub_filter,
-                    Backend::Sqlite,
+                tracing::error!(
+                    error = %e,
+                    stripe_sub_id = %stripe_sub_id,
+                    "subscription status/plan sync failed"
                 );
-                if let Err(e) = db::execute(ctx, &stmt).await {
-                    tracing::error!(
-                        error = %e,
-                        stripe_sub_id = %stripe_sub_id,
-                        "subscription status/plan sync failed"
-                    );
-                }
             }
 
             // Sync addon totals from Stripe subscription items metadata.
             // Each addon subscription item has metadata fields: extra_projects,
             // extra_requests, extra_r2_bytes, extra_d1_bytes (set when creating
             // the subscription item via Stripe API).
-            let user_id = get_user_for_stripe_sub(ctx, stripe_sub_id).await;
+            let user_id = repo::subscriptions::find_user_by_stripe_sub(ctx, stripe_sub_id).await;
             if let Some(ref uid) = user_id {
                 if let Some(items) = data_object.get("items") {
                     sync_addon_totals_from_items(ctx, uid, items).await;
@@ -512,27 +465,8 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             if !stripe_sub_id.is_empty() {
-                let now = chrono::Utc::now().to_rfc3339();
-                let grace_end = (chrono::Utc::now() + chrono::Duration::days(7)).to_rfc3339();
-                let stmt = wafer_sql_utils::query::build_update_where(
-                    SUBSCRIPTIONS_TABLE,
-                    &[
-                        ("status".to_string(), serde_json::json!("past_due")),
-                        (
-                            "grace_period_end".to_string(),
-                            serde_json::json!(&grace_end),
-                        ),
-                        ("updated_at".to_string(), serde_json::json!(&now)),
-                    ],
-                    &[Filter {
-                        field: "stripe_subscription_id".into(),
-                        operator: FilterOp::Equal,
-                        value: serde_json::json!(stripe_sub_id),
-                    }],
-                    Backend::Sqlite,
-                );
                 // Billing-critical: surface DB failures so Stripe retries.
-                if let Err(e) = db::execute(ctx, &stmt).await {
+                if let Err(e) = repo::subscriptions::mark_past_due(ctx, stripe_sub_id).await {
                     tracing::error!(
                         error = %e,
                         stripe_sub_id = %stripe_sub_id,
@@ -545,32 +479,12 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
 
         "customer.subscription.deleted" => {
             let stripe_sub_id = data_object.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            let now = chrono::Utc::now().to_rfc3339();
+            let user_id = repo::subscriptions::find_user_by_stripe_sub(ctx, stripe_sub_id).await;
 
-            let user_id = get_user_for_stripe_sub(ctx, stripe_sub_id).await;
-
-            // Cancel subscription and reset all addon columns to 0
-            let stmt = wafer_sql_utils::query::build_update_where(
-                SUBSCRIPTIONS_TABLE,
-                &[
-                    ("status".to_string(), serde_json::json!("cancelled")),
-                    ("addon_projects".to_string(), serde_json::json!(0)),
-                    ("addon_requests".to_string(), serde_json::json!(0)),
-                    ("addon_r2_bytes".to_string(), serde_json::json!(0)),
-                    ("addon_d1_bytes".to_string(), serde_json::json!(0)),
-                    ("updated_at".to_string(), serde_json::json!(&now)),
-                ],
-                &[Filter {
-                    field: "stripe_subscription_id".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!(stripe_sub_id),
-                }],
-                Backend::Sqlite,
-            );
             // Cancellation is billing-critical — make Stripe retry on DB failure
             // so we don't leave a "cancelled in Stripe but still active here"
             // gap that grants free access to a paid user.
-            if let Err(e) = db::execute(ctx, &stmt).await {
+            if let Err(e) = repo::subscriptions::cancel_and_reset_addons(ctx, stripe_sub_id).await {
                 tracing::error!(
                     error = %e,
                     stripe_sub_id = %stripe_sub_id,
@@ -634,31 +548,6 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
     }
 
     ok_json(&serde_json::json!({"received": true}))
-}
-
-async fn get_user_for_stripe_sub(ctx: &dyn Context, stripe_sub_id: &str) -> Option<String> {
-    let opts = ListOptions {
-        filters: vec![Filter {
-            field: "stripe_subscription_id".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::json!(stripe_sub_id),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let stmt = wafer_sql_utils::query::build_select_columns(
-        SUBSCRIPTIONS_TABLE,
-        &["user_id"],
-        &opts,
-        None,
-        Backend::Sqlite,
-    );
-    let rows = db::query(ctx, &stmt).await.ok()?;
-    rows.first()?
-        .data
-        .get("user_id")
-        .and_then(|v| v.as_str())
-        .map(String::from)
 }
 
 /// Fire a webhook for product/billing events.
@@ -947,42 +836,17 @@ async fn sync_addon_totals_from_items(ctx: &dyn Context, user_id: &str, items: &
         }
     }
 
-    let now = chrono::Utc::now().to_rfc3339();
-    let stmt = wafer_sql_utils::query::build_update_where(
-        SUBSCRIPTIONS_TABLE,
-        &[
-            (
-                "addon_projects".to_string(),
-                serde_json::json!(total_projects),
-            ),
-            (
-                "addon_requests".to_string(),
-                serde_json::json!(total_requests),
-            ),
-            ("addon_r2_bytes".to_string(), serde_json::json!(total_r2)),
-            ("addon_d1_bytes".to_string(), serde_json::json!(total_d1)),
-            ("updated_at".to_string(), serde_json::json!(now)),
-        ],
-        &[
-            Filter {
-                field: "user_id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(user_id),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("active"),
-            },
-        ],
-        Backend::Sqlite,
-    );
-    if let Err(e) = db::execute(ctx, &stmt).await {
-        tracing::error!(
-            error = %e,
-            user_id = %user_id,
-            "syncing addon totals failed"
-        );
+    if let Err(e) = repo::subscriptions::set_addon_totals(
+        ctx,
+        user_id,
+        total_projects,
+        total_requests,
+        total_r2,
+        total_d1,
+    )
+    .await
+    {
+        tracing::error!(error = %e, user_id = %user_id, "syncing addon totals failed");
     }
 }
 

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 
-use wafer_block::db::{Filter, FilterOp, ListOptions};
 use wafer_core::clients::{config, database as db, network};
 use wafer_run::{context::Context, types::*, InputStream, OutputStream};
-use wafer_sql_utils::Backend;
 
-use super::{repo, LINE_ITEMS_TABLE, PRODUCTS_TABLE, PURCHASES_TABLE, SUBSCRIPTIONS_TABLE};
+use super::{repo, PRODUCTS_TABLE};
 use crate::blocks::helpers::{
     err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
     err_unauthorized, hex_encode, ok_json,
@@ -30,7 +28,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     };
 
     // Get purchase and verify ownership
-    let purchase = match db::get(ctx, PURCHASES_TABLE, &body.purchase_id).await {
+    let purchase = match repo::purchases::get(ctx, &body.purchase_id).await {
         Ok(p) => p,
         Err(_) => return err_not_found("Purchase not found"),
     };
@@ -53,23 +51,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     }
 
     // Check product dependency (requires field)
-    let line_items_opts = ListOptions {
-        filters: vec![Filter {
-            field: "purchase_id".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::json!(body.purchase_id),
-        }],
-        limit: 1,
-        ..Default::default()
-    };
-    let line_items_stmt = wafer_sql_utils::query::build_select_columns(
-        LINE_ITEMS_TABLE,
-        &["product_id"],
-        &line_items_opts,
-        None,
-        Backend::Sqlite,
-    );
-    let line_items = db::query(ctx, &line_items_stmt).await;
+    let line_items = repo::purchases::line_item_product_ids(ctx, &body.purchase_id).await;
 
     if let Ok(items) = &line_items {
         for item in items {
@@ -100,30 +82,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     }
 
     // Atomic status transition: pending -> checkout_started (prevents double-checkout race)
-    let stmt = wafer_sql_utils::query::build_update_where(
-        PURCHASES_TABLE,
-        &[
-            ("status".to_string(), serde_json::json!("checkout_started")),
-            (
-                "updated_at".to_string(),
-                serde_json::json!(chrono::Utc::now().to_rfc3339()),
-            ),
-        ],
-        &[
-            Filter {
-                field: "id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(body.purchase_id),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("pending"),
-            },
-        ],
-        Backend::Sqlite,
-    );
-    let rows = match db::execute(ctx, &stmt).await {
+    let rows = match repo::purchases::claim_for_checkout(ctx, &body.purchase_id).await {
         Ok(n) => n,
         Err(e) => return err_internal("Failed to claim purchase for checkout", e),
     };
@@ -211,30 +170,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
 
     if resp.status_code >= 400 {
         // Revert status back to pending so user can retry
-        let revert_stmt = wafer_sql_utils::query::build_update_where(
-            PURCHASES_TABLE,
-            &[
-                ("status".to_string(), serde_json::json!("pending")),
-                (
-                    "updated_at".to_string(),
-                    serde_json::json!(chrono::Utc::now().to_rfc3339()),
-                ),
-            ],
-            &[
-                Filter {
-                    field: "id".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!(body.purchase_id),
-                },
-                Filter {
-                    field: "status".into(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::json!("checkout_started"),
-                },
-            ],
-            Backend::Sqlite,
-        );
-        let _ = db::execute(ctx, &revert_stmt).await;
+        let _ = repo::purchases::revert_checkout_claim(ctx, &body.purchase_id).await;
         // SEC-054: log full Stripe response server-side for diagnostics,
         // but never forward Stripe's response body to the client — it can
         // leak account configuration, API keys in error messages, internal
@@ -274,7 +210,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
         "updated_at".to_string(),
         serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
     );
-    if let Err(e) = db::update(ctx, PURCHASES_TABLE, &body.purchase_id, upd).await {
+    if let Err(e) = repo::purchases::update(ctx, &body.purchase_id, upd).await {
         tracing::warn!("Failed to update purchase with Stripe session ID: {e}");
     }
 
@@ -332,33 +268,9 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                     .to_string();
 
                 // Atomic: only complete if still in checkout_started (or pending for backwards compat)
-                let now = chrono::Utc::now().to_rfc3339();
-                let stmt = wafer_sql_utils::query::build_update_where(
-                    PURCHASES_TABLE,
-                    &[
-                        ("status".to_string(), serde_json::json!("completed")),
-                        (
-                            "provider_payment_intent_id".to_string(),
-                            serde_json::json!(payment_intent),
-                        ),
-                        ("approved_at".to_string(), serde_json::json!(&now)),
-                        ("updated_at".to_string(), serde_json::json!(&now)),
-                    ],
-                    &[
-                        Filter {
-                            field: "id".into(),
-                            operator: FilterOp::Equal,
-                            value: serde_json::json!(purchase_id),
-                        },
-                        Filter {
-                            field: "status".into(),
-                            operator: FilterOp::In,
-                            value: serde_json::json!(["checkout_started", "pending"]),
-                        },
-                    ],
-                    Backend::Sqlite,
-                );
-                let rows = match db::execute(ctx, &stmt).await {
+                let rows = match repo::purchases::complete_atomic(ctx, purchase_id, &payment_intent)
+                    .await
+                {
                     Ok(n) => n,
                     // Returning a 500 here makes Stripe retry the webhook —
                     // a transient DB blip mustn't quietly drop the
@@ -513,28 +425,10 @@ pub async fn handle_webhook(ctx: &dyn Context, msg: &Message, input: InputStream
                 .to_string();
 
             if !payment_intent.is_empty() {
-                if let Ok(purchase) = db::get_by_field(
-                    ctx,
-                    PURCHASES_TABLE,
-                    "provider_payment_intent_id",
-                    serde_json::Value::String(payment_intent),
-                )
-                .await
+                if let Ok(purchase) =
+                    repo::purchases::find_by_payment_intent(ctx, &payment_intent).await
                 {
-                    let mut data = HashMap::new();
-                    data.insert(
-                        "status".to_string(),
-                        serde_json::Value::String("refunded".to_string()),
-                    );
-                    data.insert(
-                        "refunded_at".to_string(),
-                        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-                    );
-                    data.insert(
-                        "updated_at".to_string(),
-                        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-                    );
-                    if let Err(e) = db::update(ctx, PURCHASES_TABLE, &purchase.id, data).await {
+                    if let Err(e) = repo::purchases::mark_refunded(ctx, &purchase.id).await {
                         tracing::error!("Failed to mark purchase as refunded: {e}");
                         return err_internal("Failed to update purchase", e);
                     }
@@ -694,103 +588,20 @@ fn is_same_origin(url: &str, expected_origin: &str) -> bool {
 /// references it, or a completed purchase containing it as a line item.
 async fn user_owns_product(ctx: &dyn Context, user_id: &str, product_id: &str) -> bool {
     // Active subscription whose plan references the product.
-    let sub_opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "user_id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(user_id),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("active"),
-            },
-            Filter {
-                field: "plan".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(product_id),
-            },
-        ],
-        limit: 1,
-        ..Default::default()
-    };
-    let sub_stmt = wafer_sql_utils::query::build_select_columns(
-        SUBSCRIPTIONS_TABLE,
-        &["id"],
-        &sub_opts,
-        None,
-        Backend::Sqlite,
-    );
-    if let Ok(rows) = db::query(ctx, &sub_stmt).await {
-        if !rows.is_empty() {
-            return true;
-        }
+    if repo::subscriptions::active_plan_exists(ctx, user_id, product_id).await {
+        return true;
     }
-
-    // Completed purchase containing this product as a line item. Done as two
-    // queries (purchase IDs then line-item probe with IN) because
-    // wafer-sql-utils has no JOIN builder; adding one for a single call site
-    // would be disproportionate. The IN-list stays small in practice (a single
-    // user's completed purchases).
-    let purchase_opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "user_id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(user_id),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("completed"),
-            },
-        ],
-        ..Default::default()
-    };
-    let purchase_stmt = wafer_sql_utils::query::build_select_columns(
-        PURCHASES_TABLE,
-        &["id"],
-        &purchase_opts,
-        None,
-        Backend::Sqlite,
-    );
-    let purchase_ids: Vec<serde_json::Value> = match db::query(ctx, &purchase_stmt).await {
-        Ok(rows) => rows
-            .into_iter()
-            .filter_map(|r| r.data.get("id").and_then(|v| v.as_str()).map(String::from))
-            .map(serde_json::Value::String)
-            .collect(),
-        Err(_) => return false,
-    };
-    if purchase_ids.is_empty() {
-        return false;
-    }
-
-    let line_item_opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "purchase_id".into(),
-                operator: FilterOp::In,
-                value: serde_json::Value::Array(purchase_ids),
-            },
-            Filter {
-                field: "product_id".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(product_id),
-            },
-        ],
-        limit: 1,
-        ..Default::default()
-    };
-    let li_stmt = wafer_sql_utils::query::build_select_columns(
-        LINE_ITEMS_TABLE,
-        &["id"],
-        &line_item_opts,
-        None,
-        Backend::Sqlite,
-    );
-    matches!(db::query(ctx, &li_stmt).await, Ok(rows) if !rows.is_empty())
+    // Completed purchase containing this product as a line item.
+    let purchase_ids: Vec<serde_json::Value> =
+        match repo::purchases::completed_purchase_ids(ctx, user_id).await {
+            Ok(rows) => rows
+                .into_iter()
+                .filter_map(|r| r.data.get("id").and_then(|v| v.as_str()).map(String::from))
+                .map(serde_json::Value::String)
+                .collect(),
+            Err(_) => return false,
+        };
+    repo::purchases::line_item_exists_for_product(ctx, purchase_ids, product_id).await
 }
 
 /// Sync addon column totals from Stripe subscription items.

--- a/crates/solobase-core/src/blocks/products/tests/mod.rs
+++ b/crates/solobase-core/src/blocks/products/tests/mod.rs
@@ -2,4 +2,5 @@ mod handler_tests;
 mod mock_context;
 mod pricing_tests;
 mod purchase_tests;
+mod repo_tests;
 mod stripe_tests;

--- a/crates/solobase-core/src/blocks/products/tests/repo_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/repo_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use wafer_core::clients::database as db;
+
 use super::mock_context::*;
 use crate::blocks::products::repo;
 
@@ -26,7 +28,6 @@ async fn cancel_and_reset_addons_zeroes_addons_and_cancels() {
         .expect("cancel ok");
     assert_eq!(rows, 1, "exactly one subscription row updated");
 
-    use wafer_core::clients::database as db;
     let rec = db::get(&ctx, "suppers_ai__products__subscriptions", "sub_db_1")
         .await
         .expect("row exists");
@@ -50,4 +51,82 @@ async fn cancel_and_reset_addons_zeroes_addons_and_cancels() {
         rec.data.get("addon_d1_bytes").and_then(|v| v.as_i64()),
         Some(0)
     );
+}
+
+/// `complete_atomic` transitions a pending purchase to completed and records
+/// the payment intent; a second call is a 0-row no-op (idempotent).
+#[tokio::test]
+async fn complete_atomic_only_from_pending_or_checkout_started() {
+    let ctx = MockContext::new();
+    let mut pd = HashMap::new();
+    pd.insert("status".to_string(), serde_json::json!("pending"));
+    ctx.seed("suppers_ai__products__purchases", "pur_1", pd);
+
+    let rows = repo::purchases::complete_atomic(&ctx, "pur_1", "pi_abc")
+        .await
+        .expect("complete ok");
+    assert_eq!(rows, 1);
+    let rec = db::get(&ctx, "suppers_ai__products__purchases", "pur_1")
+        .await
+        .unwrap();
+    assert_eq!(
+        rec.data.get("status").and_then(|v| v.as_str()),
+        Some("completed")
+    );
+    assert_eq!(
+        rec.data
+            .get("provider_payment_intent_id")
+            .and_then(|v| v.as_str()),
+        Some("pi_abc")
+    );
+
+    // Second call: already completed -> 0 rows, no change.
+    let rows2 = repo::purchases::complete_atomic(&ctx, "pur_1", "pi_zzz")
+        .await
+        .expect("idempotent ok");
+    assert_eq!(rows2, 0, "completed purchase is not re-completed");
+    let rec2 = db::get(&ctx, "suppers_ai__products__purchases", "pur_1")
+        .await
+        .unwrap();
+    assert_eq!(
+        rec2.data
+            .get("provider_payment_intent_id")
+            .and_then(|v| v.as_str()),
+        Some("pi_abc"),
+        "payment intent not overwritten by the no-op call"
+    );
+}
+
+/// `refund_atomic` only transitions a completed purchase; a pending one is a
+/// 0-row no-op (prevents double-refund / refunding incomplete orders).
+#[tokio::test]
+async fn refund_atomic_only_from_completed() {
+    let ctx = MockContext::new();
+    let mut completed = HashMap::new();
+    completed.insert("status".to_string(), serde_json::json!("completed"));
+    ctx.seed("suppers_ai__products__purchases", "pur_done", completed);
+    let mut pending = HashMap::new();
+    pending.insert("status".to_string(), serde_json::json!("pending"));
+    ctx.seed("suppers_ai__products__purchases", "pur_pending", pending);
+
+    let ok = repo::purchases::refund_atomic(&ctx, "pur_done", "admin_1", "duplicate")
+        .await
+        .expect("refund ok");
+    assert_eq!(ok, 1);
+    let rec = db::get(&ctx, "suppers_ai__products__purchases", "pur_done")
+        .await
+        .unwrap();
+    assert_eq!(
+        rec.data.get("status").and_then(|v| v.as_str()),
+        Some("refunded")
+    );
+    assert_eq!(
+        rec.data.get("refunded_by").and_then(|v| v.as_str()),
+        Some("admin_1")
+    );
+
+    let noop = repo::purchases::refund_atomic(&ctx, "pur_pending", "admin_1", "x")
+        .await
+        .expect("noop ok");
+    assert_eq!(noop, 0, "pending purchase cannot be refunded");
 }

--- a/crates/solobase-core/src/blocks/products/tests/repo_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/repo_tests.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use super::mock_context::*;
+use crate::blocks::products::repo;
+
+/// `cancel_and_reset_addons` flips status to cancelled and zeroes every addon
+/// column for the matched subscription.
+#[tokio::test]
+async fn cancel_and_reset_addons_zeroes_addons_and_cancels() {
+    let ctx = MockContext::new();
+    let mut sd = HashMap::new();
+    sd.insert("user_id".to_string(), serde_json::json!("user_1"));
+    sd.insert(
+        "stripe_subscription_id".to_string(),
+        serde_json::json!("sub_stripe_1"),
+    );
+    sd.insert("status".to_string(), serde_json::json!("active"));
+    sd.insert("addon_projects".to_string(), serde_json::json!(5));
+    sd.insert("addon_requests".to_string(), serde_json::json!(1000));
+    sd.insert("addon_r2_bytes".to_string(), serde_json::json!(42));
+    sd.insert("addon_d1_bytes".to_string(), serde_json::json!(7));
+    ctx.seed("suppers_ai__products__subscriptions", "sub_db_1", sd);
+
+    let rows = repo::subscriptions::cancel_and_reset_addons(&ctx, "sub_stripe_1")
+        .await
+        .expect("cancel ok");
+    assert_eq!(rows, 1, "exactly one subscription row updated");
+
+    use wafer_core::clients::database as db;
+    let rec = db::get(&ctx, "suppers_ai__products__subscriptions", "sub_db_1")
+        .await
+        .expect("row exists");
+    assert_eq!(
+        rec.data.get("status").and_then(|v| v.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        rec.data.get("addon_projects").and_then(|v| v.as_i64()),
+        Some(0)
+    );
+    assert_eq!(
+        rec.data.get("addon_requests").and_then(|v| v.as_i64()),
+        Some(0)
+    );
+    assert_eq!(
+        rec.data.get("addon_r2_bytes").and_then(|v| v.as_i64()),
+        Some(0)
+    );
+    assert_eq!(
+        rec.data.get("addon_d1_bytes").and_then(|v| v.as_i64()),
+        Some(0)
+    );
+}


### PR DESCRIPTION
## Wave 35 — products `repo/` extraction (purchases + subscriptions)

Closes the **Stripe webhook repo extraction** item — the **last solobase item** — on `audit-design.md`'s "Wave 4 — Bigger refactors" list.

### What & why
The `suppers-ai/products` block interleaved Stripe/HTTP protocol with raw data access: `stripe.rs::handle_webhook` (~350 lines) mixed signature verification, event parsing, and dispatch with inline `wafer_sql_utils` statement-building against the purchases/line-items/subscriptions tables, and the same tables were accessed inline from `purchase.rs`, `handlers.rs`, and `pages.rs`. The `TABLE` consts were scattered across `purchase.rs` and `handlers.rs`.

This extracts **all** data access for the two webhook-touched domains — purchases (+ line items) and subscriptions — into a new `products/repo/` module that owns the three `TABLE` consts and is the **sole** data-access path for those tables. Handlers keep protocol, validation, authz, response-shaping, and the Stripe-retry policy (which failures return 500 to force a retry). Unrelated product-catalog tables (products/groups/types/templates/pricing/variables) are out of scope and untouched.

### Structure
- New `repo/purchases.rs` — owns `PURCHASES_TABLE` + `LINE_ITEMS_TABLE`; 18 data-access fns incl. the atomic `complete_atomic` / `claim_for_checkout` / `revert_checkout_claim` / `refund_atomic`.
- New `repo/subscriptions.rs` — owns `SUBSCRIPTIONS_TABLE`; `upsert_platform`, `update_status_plan`, `mark_past_due`, `cancel_and_reset_addons`, `set_addon_totals`, `find_user_by_stripe_sub`, `subscription_for_user`, `active_plan_exists`.
- `stripe.rs` / `purchase.rs` / `handlers.rs` / `pages.rs` now call named repo fns; `mod.rs` re-exports the purchases consts for `CollectionSchema` registration.

### Behaviour
Strictly behaviour-preserving — identical SQL (same columns, same atomic `WHERE status …` guards, same deterministic `sub_{user_id}` upsert key, same 7-day grace window). Two intentional, benign tightenings: `mark_past_due` and `mark_refunded` now capture a single `Utc::now()` instant for their paired timestamp columns instead of calling `now()` twice (was sub-millisecond-apart; now consistent).

### Tests
New `repo_tests.rs` pins the payments-critical atomic invariants with real state assertions: `cancel_and_reset_addons` (status→cancelled + all addon cols→0), `complete_atomic` (pending→completed + idempotent 0-row no-op), `refund_atomic` (completed-only, pending is a no-op).

### Verification
- `cargo test -p solobase-core --lib` — **717 pass** (714 + 3 new repo tests).
- `cargo clippy -p solobase-core` — no findings in touched files.
- `cargo +nightly fmt --check` — clean.
- `bash scripts/audit-wrap-grants.sh` — OK (products tables resolve through the relocated consts).

Spec: `docs/superpowers/specs/2026-05-30-wave-35-stripe-webhook-repo-design.md`. Plan: `docs/superpowers/plans/2026-05-30-wave-35-products-repo-extraction.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)