### PR TITLE
perf(cloudflare): make auto-gen secret seeding hit the KV config cache

### DIFF
--- a/crates/solobase-cloudflare/src/config_source.rs
+++ b/crates/solobase-cloudflare/src/config_source.rs
@@ -15,11 +15,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use solobase_core::blocks::admin::VARIABLES_TABLE;
-use wafer_block::{
-    db::{Filter, FilterOp, ListOptions},
-    ConfigVar,
-};
+use solobase_core::{blocks::admin::VARIABLES_TABLE, cache_key};
+use wafer_block::ConfigVar;
 use wafer_core::interfaces::database::service::DatabaseService;
 use wafer_run::{ConfigError, ConfigSource, EnvBlockConfig};
 
@@ -81,8 +78,8 @@ impl D1ConfigSource {
     }
 
     /// Fetch all rows in the variables table whose `block` column equals
-    /// `screaming_block`. Uses [`DatabaseService::list`] with a single
-    /// [`FilterOp::Equal`] filter; the new index on `(block)` (migration
+    /// `screaming_block`. Uses the canonical KV-cacheable list shape from
+    /// [`cache_key::block_list_opts`]; the index on `(block)` (migration
     /// 002) makes this an indexed lookup, not a scan.
     ///
     /// Tolerates `no such column: block` on pre-migration-002 D1s (fresh
@@ -94,17 +91,7 @@ impl D1ConfigSource {
         &self,
         screaming_block: &str,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error + Send + Sync>> {
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "block".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(screaming_block.to_string()),
-            }],
-            limit: 10_000,
-            offset: 0,
-            skip_count: true,
-            ..Default::default()
-        };
+        let opts = cache_key::block_list_opts(cache_key::CachedTable::Variables, screaming_block);
         let rows = match self.db.list(VARIABLES_TABLE, &opts).await {
             Ok(rows) => rows,
             Err(e) if e.to_string().contains("no such column: block") => {

--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -15,7 +15,7 @@ pub(crate) const KV_BINDING: &str = "CONFIG_CACHE";
 use std::{collections::HashMap, sync::Arc};
 
 pub(crate) use solobase_core::blocks::admin::BLOCK_SETTINGS_TABLE;
-use solobase_core::{blocks::admin::VARIABLES_TABLE, features::BlockSettings};
+use solobase_core::{blocks::admin::VARIABLES_TABLE, cache_key, features::BlockSettings};
 use wafer_block::db::{Filter, FilterOp, ListOptions};
 use wafer_core::interfaces::database::service::DatabaseService;
 
@@ -199,18 +199,26 @@ async fn seed_one(
     block_name: &str,
     var: &wafer_block::ConfigVar,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let exists_opts = ListOptions {
-        filters: vec![Filter {
-            field: "key".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(var.key.clone()),
-        }],
-        limit: 1,
-        skip_count: true,
-        ..Default::default()
-    };
+    // `block` column matches what admin migration 002 backfills from `key`
+    // (key's first two `__`-delimited segments). We compute it from the
+    // block name via the canonical helper so both paths converge on the
+    // same SCREAMING_SNAKE prefix even if a key were ever introduced with
+    // a non-matching shape. Computed up front so the existence check below
+    // can filter on it.
+    let block_col = crate::config_source::D1ConfigSource::screaming_block(block_name);
+
+    // Existence check via the per-block list shape the KV cache recognizes
+    // (`cache_key::block_list_opts`). This shares the cache entry
+    // `D1ConfigSource` populates for this block on init, so on a warm isolate
+    // it's a KV hit instead of an uncached `key`-filtered D1 read on every
+    // request. We then match `var.key` in memory.
+    let exists_opts = cache_key::block_list_opts(cache_key::CachedTable::Variables, &block_col);
     let listed = db.list(VARIABLES_TABLE, &exists_opts).await?;
-    if !listed.records.is_empty() {
+    if listed
+        .records
+        .iter()
+        .any(|r| r.data.get("key").and_then(|v| v.as_str()) == Some(var.key.as_str()))
+    {
         return Ok(());
     }
 
@@ -218,12 +226,6 @@ async fn seed_one(
     getrandom::getrandom(&mut bytes).map_err(|e| format!("getrandom: {e}"))?;
     let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
 
-    // `block` column matches what admin migration 002 backfills from `key`
-    // (key's first two `__`-delimited segments). We compute it from the
-    // block name via the canonical helper so both paths converge on the
-    // same SCREAMING_SNAKE prefix even if a key were ever introduced with
-    // a non-matching shape.
-    let block_col = crate::config_source::D1ConfigSource::screaming_block(block_name);
     let now = chrono::Utc::now().to_rfc3339();
     let id = format!("var_{}", uuid::Uuid::new_v4());
 

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -26,12 +26,43 @@ pub fn classify_table(table: &str) -> Option<CachedTable> {
     }
 }
 
-use wafer_block::db::{FilterOp, ListOptions};
+use wafer_block::db::{Filter, FilterOp, ListOptions};
 
 /// Minimum `limit` value treated as "all matching rows". Matches the
 /// `D1ConfigSource` and admin block list shapes. Anything smaller is
 /// treated as paginated and bypasses cache.
 const FULL_LIMIT_THRESHOLD: i64 = 10_000;
+
+/// The block-identifying column for each cached table's canonical list
+/// query. Single source of truth shared by [`read_key`] (the classifier)
+/// and [`block_list_opts`] (the constructor) so the two can't drift.
+fn key_column(table: CachedTable) -> &'static str {
+    match table {
+        CachedTable::Variables => "block",
+        CachedTable::BlockSettings => "block_name",
+    }
+}
+
+/// Build the canonical "load all rows for one block" [`ListOptions`] that
+/// [`read_key`] recognizes as cacheable.
+///
+/// Single source of truth for the cached query shape: callers that want a
+/// KV-cached per-block read (the `D1ConfigSource`, the Cloudflare auto-gen
+/// secret seeder) construct their `ListOptions` here instead of open-coding
+/// the shape, so they can't silently drift out of cache coverage.
+pub fn block_list_opts(table: CachedTable, value: &str) -> ListOptions {
+    ListOptions {
+        filters: vec![Filter {
+            field: key_column(table).to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(value.to_string()),
+        }],
+        limit: FULL_LIMIT_THRESHOLD,
+        offset: 0,
+        skip_count: true,
+        ..Default::default()
+    }
+}
 
 /// Returns Some(kv_key) iff `opts` matches the canonical
 /// "load all rows for one block" shape.
@@ -48,11 +79,7 @@ pub fn read_key(table: CachedTable, opts: &ListOptions) -> Option<String> {
     if !matches!(f.operator, FilterOp::Equal) {
         return None;
     }
-    let expected_col = match table {
-        CachedTable::Variables => "block",
-        CachedTable::BlockSettings => "block_name",
-    };
-    if f.field != expected_col {
+    if f.field != key_column(table) {
         return None;
     }
     let value_str = f.value.as_str()?;
@@ -139,6 +166,21 @@ mod tests {
             read_key(CachedTable::BlockSettings, &opts),
             Some("cfg:v1:block_settings:wafer-run/registry".to_string())
         );
+    }
+
+    #[test]
+    fn block_list_opts_roundtrips_through_read_key() {
+        // The constructor must always produce a shape the classifier
+        // recognizes — this is the contract that keeps cached callers (the
+        // D1 config source, the CF auto-gen seeder) on the cache fast path.
+        for table in [CachedTable::Variables, CachedTable::BlockSettings] {
+            let opts = block_list_opts(table, "SUPPERS_AI__AUTH");
+            assert_eq!(
+                read_key(table, &opts),
+                Some(format_key(table, "SUPPERS_AI__AUTH")),
+                "block_list_opts must round-trip through read_key for {table:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -99,11 +99,7 @@ use std::collections::HashMap;
 /// Pulls the cache-key column from a row payload. Returns Some(kv_key)
 /// when the column is present and string-typed.
 pub fn write_key(table: CachedTable, row: &HashMap<String, serde_json::Value>) -> Option<String> {
-    let col = match table {
-        CachedTable::Variables => "block",
-        CachedTable::BlockSettings => "block_name",
-    };
-    let value_str = row.get(col)?.as_str()?;
+    let value_str = row.get(key_column(table))?.as_str()?;
     Some(format_key(table, value_str))
 }
 


### PR DESCRIPTION
## Summary

`seed_auto_generated` runs in the per-request Cloudflare entry path (`run_inner`), and its existence check `seed_one` listed the variables table filtered by `key` with `limit: 1` — a shape `cache_key::read_key` does **not** recognize, so it bypassed the KV cache and hit D1 on every request (one read per auto-generate key; today that's `SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET`).

This switches the check to the canonical per-block list shape (`block` filter, full limit) that `D1ConfigSource` already uses, so it shares the same KV cache entry (`cfg:v1:variables:<SCREAMING_BLOCK>`) and becomes a **KV hit on warm isolates** instead of a D1 read. The exact-key match moves in-memory.

This is Part 2 of trimming the CF request-time D1 reads (Part 1 = #241, products template seeding → migration). It does **not** touch runtime caching, which isn't safely retrofittable given services are embedded in request-scoped backend blocks.

### Why not gate behind `--run-migrations` instead
That was the other candidate. Rejected because `solobase-cloudflare` never reads `SOLOBASE_RUN_MIGRATIONS` into the config snapshot (the deploy threads it as a `wrangler --var`, but `run_inner` only loads `PROTECTED_ENV_KEYS` + `BLOCK_SETTINGS_CONFIG_KEY`), so there's nothing to gate on without new plumbing — and gating would add a permanent-fail footgun if a deploy ever skipped the flag. The cache approach needs no deploy-contract change.

### Avoiding implicit drift
The cacheability of the query *silently* depends on matching `read_key`'s recognized shape — change a field and the cache disappears with no error. To keep that explicit (per the repo's no-magic rule), this adds `cache_key::block_list_opts` next to the `read_key` classifier as the single source of truth, extracts a shared `key_column`, and routes **both** callers (`D1ConfigSource::fetch_block_variables` and `seed_one`) through it. A round-trip test pins the constructor to the classifier.

### Changes
- `cache_key.rs`: new `block_list_opts` constructor + extracted `key_column`; `read_key` uses `key_column`; round-trip test.
- `config_source.rs`: `fetch_block_variables` uses the constructor (drops the open-coded `ListOptions`).
- `runner.rs`: `seed_one` existence check uses the constructor + in-memory key match.

## Test plan
- [x] `cargo test -p solobase-core --lib` (715) green, incl. `block_list_opts_roundtrips_through_read_key`
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean
- [x] `cargo +nightly fmt --all --check` clean
- [x] Verified `seed_one`'s new opts are byte-identical in shape to `D1ConfigSource::fetch_block_variables` (same `screaming_block` value), so they share one KV entry

> Note: the live KV-hit behavior can't be exercised host-side (needs a Worker + KV runtime); it's verified by construction — both callers go through the same constructor, and the round-trip test proves that shape is cache-recognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)