### PR TITLE
fix(cloudflare): wire SOLOBASE_RUN_MIGRATIONS --var into the config snapshot

### DIFF
--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -210,6 +210,25 @@ where
         solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY.to_string(),
         block_settings.to_config_json(),
     );
+    // The deploy threads `--run-migrations` into the Worker as a wrangler
+    // `--var SOLOBASE_RUN_MIGRATIONS:1` text binding (see
+    // `cli/flows/embed_cloudflare.rs`). Mirror native `server.rs`: fan it
+    // into the config snapshot so `migration_helper::apply_if_blessed` can
+    // gate on it via `ctx.config_get`. Without this, `run_requested` is
+    // always `false` on CF and a `--run-migrations` deploy against an
+    // existing (non-wiped) D1 silently no-ops.
+    if env
+        .var(solobase_core::migration_helper::RUN_MIGRATIONS_KEY)
+        .ok()
+        .map(|v| v.to_string())
+        .as_deref()
+        == Some("1")
+    {
+        cfg_svc_map.insert(
+            solobase_core::migration_helper::RUN_MIGRATIONS_KEY.to_string(),
+            "1".to_string(),
+        );
+    }
 
     // 4. Construct remaining services.
     let bucket: Arc<dyn StorageService> = make_r2_storage_service(&env, runner::R2_BINDING)


### PR DESCRIPTION
## Problem (#244)

The CF deploy threads `--run-migrations` into the Worker as a wrangler `--var SOLOBASE_RUN_MIGRATIONS:1` text binding (`cli/flows/embed_cloudflare.rs`), with an explicit comment that `apply_if_blessed` should see it via `ctx.config_get`. But `run_inner` only loaded `PROTECTED_ENV_KEYS` + `BLOCK_SETTINGS_CONFIG_KEY` into the config snapshot → `migration_helper::run_requested` was always `false` on CF.

**Footgun:** a `--run-migrations` deploy against an existing (non-wiped) D1 silently no-ops. Masked today only by the wipe-and-redeploy practice (`is_fresh` short-circuits the gate on a brand-new DB).

## Fix

Mirror native `crates/solobase/src/cli/server.rs`: read `env.var(RUN_MIGRATIONS_KEY)` and, when `"1"`, insert it into `cfg_svc_map` **before** the `snapshot = cfg_svc_map.clone()` so both the async `ConfigService` and the synchronous `ctx.config_get` snapshot carry it. `apply_if_blessed`'s `run_requested = ctx.config_get(RUN_MIGRATIONS_KEY) == Some("1")` then gates correctly.

~19 lines, standalone. Verified with `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown`.

Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)