### PR TITLE
feat(cloudflare): expose block-* as passthrough features

### DIFF
--- a/crates/solobase-cloudflare/Cargo.toml
+++ b/crates/solobase-cloudflare/Cargo.toml
@@ -13,7 +13,27 @@ description = "Cloudflare Workers adapter for solobase (D1, R2, wasm crypto/netw
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+# Default = the full feature-block set wafer.run ships today. Consumers
+# that embed `solobase-cloudflare` can `default-features = false` and
+# re-enable a subset to trim WASM size — e.g. dropping `block-legalpages`
+# strips `pulldown-cmark` + its html5ever transitive subtree entirely.
+default = [
+    "block-files",
+    "block-legalpages",
+    "block-messages",
+    "block-products",
+    "block-userportal",
+]
+# Passthrough block features → forwarded to `solobase-core`. The block
+# register sites in solobase-core are `#[cfg(feature = "block-X")]`-gated
+# (`register_all_static_blocks`), so enabling these here is what makes the
+# corresponding `suppers-ai/<name>` routes resolve. Keep in sync with the
+# `solobase-web/Cargo.toml` block set.
+block-files = ["solobase-core/block-files"]
+block-legalpages = ["solobase-core/block-legalpages"]
+block-messages = ["solobase-core/block-messages"]
+block-products = ["solobase-core/block-products"]
+block-userportal = ["solobase-core/block-userportal"]
 # Reserved for the future wasmi-on-wasm "user-uploaded blocks" feature.
 # Disabled in v1; kept here for parity with solobase-native.
 custom-blocks = []
@@ -25,25 +45,19 @@ wafer-block = { workspace = true }
 wafer-core = { workspace = true }
 
 # Solobase shared core. `default-features = false` strips the native
-# block set (sqlite/storage-local/llm/etc.); the explicit `features`
-# list pulls back in the wasm32-clean feature blocks so
-# `register_all_static_blocks` actually registers them. Without this
-# list every `suppers-ai/<name>` route returns "block not found" — the
-# linkme `register_static_block!` path doesn't emit on wasm32, so the
-# manual register helper is the only registration site, and every
-# entry in it is `#[cfg(feature = "block-X")]`-gated. Keep in sync
-# with `solobase-web/Cargo.toml`.
+# block set (sqlite/storage-local/llm/etc.); the wasm32-clean feature
+# blocks are pulled back in via this crate's own passthrough block
+# features (see `[features]` above), which default-enable the full set.
+# Without an enabled `block-X` every `suppers-ai/<name>` route returns
+# "block not found" — the linkme `register_static_block!` path doesn't
+# emit on wasm32, so `register_all_static_blocks` is the only
+# registration site and every entry there is `#[cfg(feature =
+# "block-X")]`-gated on solobase-core.
 #
 # `block-llm` / `block-vector` are excluded for now — the LlmBlock
 # module is gated on `feature = "llm"`, which pulls in tokio/reqwest
 # and is wasm32-incompatible. Closes via the LlmService trait refactor.
-solobase-core = { path = "../solobase-core", default-features = false, features = [
-    "block-files",
-    "block-legalpages",
-    "block-messages",
-    "block-products",
-    "block-userportal",
-] }
+solobase-core = { path = "../solobase-core", default-features = false }
 
 # Cloudflare Workers SDK
 worker = { workspace = true }


### PR DESCRIPTION
## What

`solobase-cloudflare` hardcoded the full five-block `solobase-core` feature set (`block-files/legalpages/messages/products/userportal`) directly in its dependency table, so every embedder bundled all five with no way to subset.

This replaces the hardcoded `features = [...]` on the `solobase-core` dep with **passthrough features** on this crate:

```toml
block-files     = ["solobase-core/block-files"]
block-legalpages = ["solobase-core/block-legalpages"]
block-messages   = ["solobase-core/block-messages"]
block-products   = ["solobase-core/block-products"]
block-userportal = ["solobase-core/block-userportal"]
```

`default` enables all five, so the **wafer.run build is byte-for-byte unchanged**. Consumers can now `default-features = false` and re-enable a subset.

## Why

Lets embedders trim WASM size by dropping blocks they don't use. The meaningful lever is `block-legalpages` → its `dep:pulldown-cmark` (+ html5ever transitive subtree). Dropping other blocks trims their own code (`maud` stays — it's shared).

> Note: the report's "trims stripe" claim doesn't hold — the products block's Stripe support is a homegrown module over the network service, not a heavy crate. The real size win is `pulldown-cmark` via legalpages.

## Verification

- **Default (all 5):** `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` ✅; `cargo tree -i pulldown-cmark` still present.
- **Subset (drop legalpages):** `--no-default-features --features block-files,block-messages,block-products,block-userportal` compiles wasm32-clean ✅; `cargo tree -i pulldown-cmark` → no match (fully dropped).

Implements claim #5 from the 2026-05-30 Cloudflare request-time D1-trim handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)