### PR TITLE
perf(cloudflare): KV-cache the eager block_settings read + invalidate on toggle

### DIFF
--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -80,6 +80,26 @@ impl KvCachedD1DatabaseService {
     pub fn new(inner: Arc<dyn DatabaseService>, kv: Arc<dyn KvBackend>) -> Self {
         Self { inner, kv }
     }
+
+    /// Delete every cache key in `keys`, logging (but never failing on) KV
+    /// errors. The underlying mutation has already committed by the time this
+    /// runs; a failed invalidation just leaves the stale entry to expire on
+    /// its 24 h TTL. `op` names the originating write for log correlation.
+    async fn invalidate_all(&self, collection: &str, keys: &[String], op: &str) {
+        for key in keys {
+            if let Err(e) = self.kv.delete(key).await {
+                tracing::warn!(
+                    table = %collection,
+                    key = %key,
+                    error = %e,
+                    op,
+                    "kv invalidate failed; relying on TTL"
+                );
+            } else {
+                tracing::debug!(table = %collection, key = %key, op, "cache_invalidate");
+            }
+        }
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -251,27 +271,19 @@ impl DatabaseService for KvCachedD1DatabaseService {
         data: HashMap<String, serde_json::Value>,
     ) -> Result<Record, DatabaseError> {
         let cached = cache_key::classify_table(collection);
-        let invalidate_key = cached.and_then(|t| cache_key::write_key(t, &data));
+        let invalidate = cached
+            .map(|t| cache_key::invalidate_keys(t, &data))
+            .unwrap_or_default();
 
         let record = self.inner.create(collection, data).await?;
 
-        if let Some(key) = invalidate_key {
-            if let Err(e) = self.kv.delete(&key).await {
-                tracing::warn!(
-                    table = %collection,
-                    key = %key,
-                    error = %e,
-                    "kv invalidate after create failed; relying on TTL"
-                );
-            } else {
-                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_create");
-            }
-        } else if cached.is_some() {
+        if invalidate.is_empty() && cached.is_some() {
             tracing::warn!(
                 table = %collection,
                 "cached table write with no extractable cache-key column; relying on TTL"
             );
         }
+        self.invalidate_all(collection, &invalidate, "create").await;
 
         Ok(record)
     }
@@ -283,9 +295,9 @@ impl DatabaseService for KvCachedD1DatabaseService {
         data: HashMap<String, serde_json::Value>,
     ) -> Result<Record, DatabaseError> {
         let cached = cache_key::classify_table(collection);
-        let invalidate_key = if let Some(t) = cached {
+        let invalidate = if let Some(t) = cached {
             match self.inner.get(collection, id).await {
-                Ok(row) => cache_key::write_key(t, &row.data),
+                Ok(row) => cache_key::invalidate_keys(t, &row.data),
                 Err(e) => {
                     tracing::warn!(
                         table = %collection,
@@ -293,36 +305,25 @@ impl DatabaseService for KvCachedD1DatabaseService {
                         error = %e,
                         "pre-read for cache-key failed; skipping invalidation"
                     );
-                    None
+                    Vec::new()
                 }
             }
         } else {
-            None
+            Vec::new()
         };
 
         let record = self.inner.update(collection, id, data).await?;
 
-        if let Some(key) = invalidate_key {
-            if let Err(e) = self.kv.delete(&key).await {
-                tracing::warn!(
-                    table = %collection,
-                    key = %key,
-                    error = %e,
-                    "kv invalidate after update failed; relying on TTL"
-                );
-            } else {
-                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_update");
-            }
-        }
+        self.invalidate_all(collection, &invalidate, "update").await;
 
         Ok(record)
     }
 
     async fn delete(&self, collection: &str, id: &str) -> Result<(), DatabaseError> {
         let cached = cache_key::classify_table(collection);
-        let invalidate_key = if let Some(t) = cached {
+        let invalidate = if let Some(t) = cached {
             match self.inner.get(collection, id).await {
-                Ok(row) => cache_key::write_key(t, &row.data),
+                Ok(row) => cache_key::invalidate_keys(t, &row.data),
                 Err(e) => {
                     tracing::warn!(
                         table = %collection,
@@ -330,27 +331,16 @@ impl DatabaseService for KvCachedD1DatabaseService {
                         error = %e,
                         "pre-read for cache-key failed; skipping invalidation"
                     );
-                    None
+                    Vec::new()
                 }
             }
         } else {
-            None
+            Vec::new()
         };
 
         self.inner.delete(collection, id).await?;
 
-        if let Some(key) = invalidate_key {
-            if let Err(e) = self.kv.delete(&key).await {
-                tracing::warn!(
-                    table = %collection,
-                    key = %key,
-                    error = %e,
-                    "kv invalidate after delete failed; relying on TTL"
-                );
-            } else {
-                tracing::debug!(table = %collection, key = %key, "cache_invalidate_after_delete");
-            }
-        }
+        self.invalidate_all(collection, &invalidate, "delete").await;
 
         Ok(())
     }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -18,7 +18,7 @@ pub mod block_settings {
     use wafer_block::db::{Filter, FilterOp, ListOptions};
     use wafer_core::clients::database as db;
     use wafer_run::context::Context;
-    use wafer_sql_utils::{query, upsert, Backend};
+    use wafer_sql_utils::{query, Backend};
 
     use super::BLOCK_SETTINGS_TABLE as TABLE;
 
@@ -56,35 +56,41 @@ pub mod block_settings {
     ///
     /// Uses an upsert keyed on `block_name`, so it works whether or not a row
     /// already exists.
+    ///
+    /// Routes through the structured [`db::upsert`] (get-by-field →
+    /// `update` | `create`) rather than a raw `db::execute(build_upsert(...))`.
+    /// The structured path hits `DatabaseService::{create,update}`, which the
+    /// Cloudflare `KvCachedD1DatabaseService` invalidates — so toggling a block
+    /// clears the cached `block_settings` read (both the per-block key and the
+    /// full-table all-rows key). A raw `EXECUTE` bypasses that invalidation and
+    /// would leave the eager `load_block_settings` cache stale until its TTL.
+    /// `created_at` is intentionally omitted: it is preserved on update and
+    /// synthesized by the backend on insert.
     pub async fn set_enabled(
         ctx: &dyn Context,
         block_name: &str,
         enabled: bool,
     ) -> Result<(), String> {
         let enabled_int: i64 = if enabled { 1 } else { 0 };
-        let now = super::helpers::now_rfc3339();
-        let stmt = upsert::build_upsert(
+        let mut data = super::json_map(serde_json::json!({
+            "block_name": block_name,
+            "enabled": enabled_int,
+            // Admin-UI write — mark this row as user-owned so the boot-time
+            // seed never overwrites it.
+            "seed_defaults_hash": crate::features::USER_EDITED_SENTINEL,
+        }));
+        super::helpers::stamp_updated(&mut data);
+
+        db::upsert(
+            ctx,
             TABLE,
-            &[
-                ("block_name".to_string(), serde_json::json!(block_name)),
-                ("enabled".to_string(), serde_json::json!(enabled_int)),
-                ("created_at".to_string(), serde_json::json!(&now)),
-                ("updated_at".to_string(), serde_json::json!(&now)),
-                // Admin-UI write — mark this row as user-owned so the
-                // boot-time seed never overwrites it.
-                (
-                    "seed_defaults_hash".to_string(),
-                    serde_json::json!(crate::features::USER_EDITED_SENTINEL),
-                ),
-            ],
-            &["block_name"],
-            &["enabled", "updated_at", "seed_defaults_hash"],
-            Backend::Sqlite,
-        );
-        db::execute(ctx, &stmt)
-            .await
-            .map(|_| ())
-            .map_err(|e| format!("block_settings::set_enabled failed: {e}"))
+            "block_name",
+            serde_json::json!(block_name),
+            data,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("block_settings::set_enabled failed: {e}"))
     }
 }
 

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -33,6 +33,12 @@ use wafer_block::db::{Filter, FilterOp, ListOptions};
 /// treated as paginated and bypasses cache.
 const FULL_LIMIT_THRESHOLD: i64 = 10_000;
 
+/// Reserved cache-key value for the full-table `block_settings` read —
+/// `runner::load_block_settings`'s eager filterless list. Real block names
+/// are always `{org}/{block}` (slash-delimited), so this slash-free
+/// sentinel can never collide with a per-block key.
+const ALL_ROWS_SENTINEL: &str = "__all__";
+
 /// The block-identifying column for each cached table's canonical list
 /// query. Single source of truth shared by [`read_key`] (the classifier)
 /// and [`block_list_opts`] (the constructor) so the two can't drift.
@@ -64,26 +70,43 @@ pub fn block_list_opts(table: CachedTable, value: &str) -> ListOptions {
     }
 }
 
-/// Returns Some(kv_key) iff `opts` matches the canonical
-/// "load all rows for one block" shape.
+/// Returns Some(kv_key) iff `opts` matches a cacheable read shape:
+/// either the canonical "load all rows for one block" single-filter shape,
+/// or — for `block_settings` only — the eager filterless full-table read
+/// (`runner::load_block_settings`).
 pub fn read_key(table: CachedTable, opts: &ListOptions) -> Option<String> {
-    if opts.filters.len() != 1
-        || !opts.skip_count
+    // Shape gate shared by both read kinds: an unsorted, unpaginated,
+    // count-skipping "give me every matching row" list.
+    if !opts.skip_count
         || opts.offset != 0
         || opts.limit < FULL_LIMIT_THRESHOLD
         || !opts.sort.is_empty()
     {
         return None;
     }
-    let f = &opts.filters[0];
-    if !matches!(f.operator, FilterOp::Equal) {
-        return None;
+    match opts.filters.len() {
+        // Full-table read. Only `block_settings` issues this (the eager
+        // `load_block_settings` list with no filter); cache it under the
+        // all-rows sentinel. Variables is always read per-block, so a
+        // filterless variables list is not a recognized shape.
+        0 => match table {
+            CachedTable::BlockSettings => Some(format_key(table, ALL_ROWS_SENTINEL)),
+            CachedTable::Variables => None,
+        },
+        // Per-block read keyed on the table's identity column.
+        1 => {
+            let f = &opts.filters[0];
+            if !matches!(f.operator, FilterOp::Equal) {
+                return None;
+            }
+            if f.field != key_column(table) {
+                return None;
+            }
+            let value_str = f.value.as_str()?;
+            Some(format_key(table, value_str))
+        }
+        _ => None,
     }
-    if f.field != key_column(table) {
-        return None;
-    }
-    let value_str = f.value.as_str()?;
-    Some(format_key(table, value_str))
 }
 
 fn format_key(table: CachedTable, value: &str) -> String {
@@ -101,6 +124,32 @@ use std::collections::HashMap;
 pub fn write_key(table: CachedTable, row: &HashMap<String, serde_json::Value>) -> Option<String> {
     let value_str = row.get(key_column(table))?.as_str()?;
     Some(format_key(table, value_str))
+}
+
+/// All KV keys a single-row write (create / update / delete) to `row` in
+/// `table` must invalidate.
+///
+/// Always includes the per-row key when the identity column is extractable.
+/// For `block_settings` it additionally includes the all-rows key, because
+/// `load_block_settings`'s cached full-table read depends on every row — so
+/// any insert / toggle / delete must drop it. The all-rows key is emitted
+/// unconditionally for `block_settings` (even when the per-row key can't be
+/// extracted) so the full-table cache can never be left stale.
+pub fn invalidate_keys(
+    table: CachedTable,
+    row: &HashMap<String, serde_json::Value>,
+) -> Vec<String> {
+    let mut keys = Vec::new();
+    if let Some(k) = write_key(table, row) {
+        keys.push(k);
+    }
+    if table == CachedTable::BlockSettings {
+        let all = format_key(table, ALL_ROWS_SENTINEL);
+        if !keys.contains(&all) {
+            keys.push(all);
+        }
+    }
+    keys
 }
 
 #[cfg(test)]
@@ -300,5 +349,112 @@ mod tests {
     fn write_key_empty_row_returns_none() {
         let r: HashMap<String, serde_json::Value> = HashMap::new();
         assert_eq!(write_key(CachedTable::Variables, &r), None);
+    }
+
+    // --- Full-table block_settings read (the eager `load_block_settings`) ---
+
+    /// The shape `load_block_settings` actually issues: no filter, full
+    /// limit, skip_count, no offset, no sort.
+    fn full_table_opts() -> ListOptions {
+        ListOptions {
+            offset: 0,
+            limit: 10_000,
+            skip_count: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn read_key_block_settings_full_table_shape() {
+        assert_eq!(
+            read_key(CachedTable::BlockSettings, &full_table_opts()),
+            Some("cfg:v1:block_settings:__all__".to_string())
+        );
+    }
+
+    #[test]
+    fn read_key_variables_full_table_returns_none() {
+        // Variables is always read per-block; a filterless variables list is
+        // not a recognized cache shape.
+        assert_eq!(read_key(CachedTable::Variables, &full_table_opts()), None);
+    }
+
+    #[test]
+    fn read_key_full_table_bad_shape_returns_none() {
+        for mutate in [
+            |o: &mut ListOptions| o.skip_count = false,
+            |o: &mut ListOptions| o.offset = 100,
+            |o: &mut ListOptions| o.limit = 50,
+            |o: &mut ListOptions| {
+                o.sort.push(wafer_block::db::SortField {
+                    field: "block_name".into(),
+                    desc: false,
+                })
+            },
+        ] {
+            let mut opts = full_table_opts();
+            mutate(&mut opts);
+            assert_eq!(read_key(CachedTable::BlockSettings, &opts), None);
+        }
+    }
+
+    /// The all-rows sentinel must never collide with a real per-block key,
+    /// because block names are slash-delimited and the sentinel is not.
+    #[test]
+    fn full_table_key_distinct_from_per_block_keys() {
+        let all = read_key(CachedTable::BlockSettings, &full_table_opts());
+        let per_block = read_key(
+            CachedTable::BlockSettings,
+            &canonical_opts("block_name", "suppers-ai/admin"),
+        );
+        assert!(all.is_some() && per_block.is_some());
+        assert_ne!(all, per_block);
+    }
+
+    // --- invalidate_keys ---
+
+    #[test]
+    fn invalidate_keys_variables_only_per_row() {
+        let r = row(
+            "block",
+            serde_json::Value::String("SUPPERS_AI__AUTH".into()),
+        );
+        assert_eq!(
+            invalidate_keys(CachedTable::Variables, &r),
+            vec!["cfg:v1:variables:SUPPERS_AI__AUTH".to_string()]
+        );
+    }
+
+    #[test]
+    fn invalidate_keys_variables_missing_column_is_empty() {
+        let r = row("key", serde_json::Value::String("JWT_SECRET".into()));
+        assert!(invalidate_keys(CachedTable::Variables, &r).is_empty());
+    }
+
+    #[test]
+    fn invalidate_keys_block_settings_includes_per_row_and_all() {
+        let r = row(
+            "block_name",
+            serde_json::Value::String("wafer-run/registry".into()),
+        );
+        assert_eq!(
+            invalidate_keys(CachedTable::BlockSettings, &r),
+            vec![
+                "cfg:v1:block_settings:wafer-run/registry".to_string(),
+                "cfg:v1:block_settings:__all__".to_string(),
+            ]
+        );
+    }
+
+    /// Even when the per-row key can't be extracted, the full-table key must
+    /// still be invalidated so the cached `load_block_settings` read can't go
+    /// stale.
+    #[test]
+    fn invalidate_keys_block_settings_missing_column_still_drops_all() {
+        let r = row("id", serde_json::Value::String("bs_123".into()));
+        assert_eq!(
+            invalidate_keys(CachedTable::BlockSettings, &r),
+            vec!["cfg:v1:block_settings:__all__".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## Problem (handoff claim #2 remainder)

`runner::load_block_settings` issues a **filterless full-table** list of `block_settings` on every Cloudflare request. The KV cache (`cache_key::read_key`) only recognized the **per-block single-filter** shape, so this eager read always missed the cache → 1 uncached D1 read/request.

Naively caching it is unsafe without invalidation: the admin enable/disable write (`block_settings::set_enabled`) went through `db::execute(build_upsert(...))` → host `exec_raw`, which the KV wrapper passes through **without invalidating anything**. So a cached full-table read would go stale on every block toggle until its 24h TTL.

## Change

**1. `cache_key.rs` — recognize + invalidate the full-table read**
- `read_key` now recognizes the filterless full-table shape **for `block_settings` only** → `cfg:v1:block_settings:__all__`. Block names are `{org}/{block}` (slash-delimited), so the slash-free `__all__` sentinel can never collide with a per-block key. Variables is always read per-block, so a filterless variables list stays uncached.
- New `invalidate_keys(table, row)` returns **every** key a single-row write must drop: the per-row key, plus — for `block_settings` — the all-rows key. The all-rows key is emitted **unconditionally** for block_settings (even if the row lacks an extractable `block_name`), so a write can never leave the full-table cache stale.

**2. `kv_cached_db.rs` — invalidate the full key set**
- `create`/`update`/`delete` now call `invalidate_keys` and drop every returned key via a shared `invalidate_all` helper (was: a single `write_key`).

**3. `admin/settings.rs` `set_enabled` — make the write actually invalidate (root cause)**
- Route the enable/disable write through the structured `db::upsert` (get_by_field → `update` | `create`) instead of `db::execute(build_upsert(...))`. The structured path hits `DatabaseService::{create,update}`, which the KV wrapper invalidates. Mirrors the variables `handle_set` pattern. `created_at` is dropped from the payload (preserved on update, synthesized by the backend on insert).

## Result

Steady-state CF cost for the block_settings read: **1 D1 read → 0** (KV hit on warm isolates), invalidated immediately on any block toggle or seed insert.

## Verification

- `cargo test -p solobase-core --lib cache_key` → 28 pass (new: full-table read shape, bad-shape rejection, sentinel-distinctness, `invalidate_keys` for both tables incl. missing-column → still drops `__all__`).
- `cargo test -p solobase-core --lib blocks::admin` → 25 pass (incl. `set_enabled` round-trip + user-edited-sentinel, now exercising the structured upsert path).
- `cargo check/clippy -p solobase-cloudflare --target wasm32-unknown-unknown` → clean.

## Out of scope (pre-existing, noted for follow-up)

The seed loop's `SeedOp::Update` path uses `db.update_where`, which **hard-errors on cached tables** — so a changed `ENABLED_DEFAULTS` hash doesn't propagate to existing CF rows. Independent of this change (the cache stays consistent because the failed write doesn't mutate). Worth a separate fix (e.g. update-by-id in the seed loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)