### PR TITLE
fix(cloudflare): seed block_settings updates via update-by-id, not update_where

### DIFF
--- a/crates/solobase-cloudflare/src/runner.rs
+++ b/crates/solobase-cloudflare/src/runner.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Arc};
 
 pub(crate) use solobase_core::blocks::admin::BLOCK_SETTINGS_TABLE;
 use solobase_core::{blocks::admin::VARIABLES_TABLE, cache_key, features::BlockSettings};
-use wafer_block::db::{Filter, FilterOp, ListOptions};
+use wafer_block::db::ListOptions;
 use wafer_core::interfaces::database::service::DatabaseService;
 
 /// Read the admin block-settings collection and convert to `BlockSettings`.
@@ -57,6 +57,20 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
         })
         .collect();
 
+    // `block_name` → row `id`, so the `SeedOp::Update` branch can do a
+    // single-row `db.update` (which the KV wrapper invalidates) instead of
+    // `db.update_where` (which hard-errors on cached tables, so a changed
+    // `ENABLED_DEFAULTS` hash would never propagate to existing rows).
+    let id_by_block: HashMap<String, String> = record_list
+        .records
+        .iter()
+        .filter_map(|r| {
+            let name = r.data.get("block_name")?.as_str()?.to_string();
+            let id = r.data.get("id")?.as_str()?.to_string();
+            Some((name, id))
+        })
+        .collect();
+
     // Plan + apply. Steady state: empty decisions → zero D1 writes.
     let decisions = solobase_core::features::plan_seed_decisions(&existing);
     let any_writes = !decisions.is_empty();
@@ -86,16 +100,19 @@ pub(crate) async fn load_block_settings(db: &Arc<dyn DatabaseService>) -> BlockS
                 }
             }
             SeedOp::Update => {
-                let filters = vec![Filter {
-                    field: "block_name".to_string(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::Value::String(d.block_name.to_string()),
-                }];
+                // Update is planned only for rows already present in
+                // `existing`, so the id should always resolve; skip
+                // defensively (rather than fall back to update_where, which
+                // would hard-error) if a row somehow lacks one.
+                let Some(id) = id_by_block.get(d.block_name) else {
+                    worker::console_log!("warn: seed update {} skipped: no row id", d.block_name);
+                    continue;
+                };
                 let mut data: HashMap<String, serde_json::Value> = HashMap::new();
                 data.insert("enabled".into(), enabled_val);
                 data.insert("seed_defaults_hash".into(), hash_val);
                 data.insert("updated_at".into(), serde_json::Value::String(now));
-                if let Err(e) = db.update_where(BLOCK_SETTINGS_TABLE, &filters, data).await {
+                if let Err(e) = db.update(BLOCK_SETTINGS_TABLE, id, data).await {
                     worker::console_log!("warn: seed update {} failed: {e}", d.block_name);
                 }
             }


### PR DESCRIPTION
## Problem (follow-up surfaced by #247)

`runner::load_block_settings`'s `SeedOp::Update` branch wrote via `db.update_where`. But `KvCachedD1DatabaseService` **hard-errors** on `update_where`/`delete_where` for cached tables (to avoid KV mass-invalidation). So on Cloudflare, when a block's `ENABLED_DEFAULTS` hash changes, the re-seed Update silently fails (logged as `warn: seed update … failed`) and the **new default never propagates to existing rows** — masked today only by the wipe-and-redeploy practice (a fresh D1 takes the `Insert` path instead).

This was noted as out-of-scope in #247; this PR fixes it.

## Fix

- Build a `block_name → id` map from the same eager `block_settings` read.
- Switch the `Update` branch to single-row `db.update(id, data)`, which the KV wrapper supports and invalidates correctly (per-block key **and** the full-table all-rows key added in #247).
- Defensively skip-and-log a planned Update with no resolvable id (can't happen — `plan_seed_decisions` only emits Update for rows already in `existing`).
- Inserts were already fine (`db.create`); only the Update path was broken.
- Drop the now-unused `Filter`/`FilterOp` imports (`seed_one` moved to `cache_key::block_list_opts` in #243).

## Verification

`cargo check` + `cargo clippy -p solobase-cloudflare --target wasm32-unknown-unknown` → clean. (The CF crate is wasm32-only and excluded from `cargo test --workspace`; the cache invalidation `db.update` relies on is unit-tested in `solobase-core::cache_key` and exercised by the admin `set_enabled` tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)