### PR TITLE
fix: adapt to wafer-run rust-best-practices audit API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,6 +5904,7 @@ dependencies = [
  "async-trait",
  "parking_lot",
  "percent-encoding",
+ "serde",
  "serde_json",
  "tracing",
  "wafer-block",
@@ -5938,6 +5939,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -5955,7 +5957,6 @@ dependencies = [
  "tracing",
  "wafer-block-macro",
  "wafer-core",
- "wafer-run",
 ]
 
 [[package]]
@@ -6064,6 +6065,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio-util",
  "tracing",
+ "url",
  "wafer-block",
  "wafer-block-macro",
  "wafer-schema",
@@ -6099,7 +6101,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "url",
  "wafer-block",
  "wafer-block-macro",
  "wafer-flow",
@@ -6114,6 +6115,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6122,6 +6124,7 @@ version = "0.1.0"
 dependencies = [
  "sea-query",
  "serde_json",
+ "thiserror 2.0.18",
  "wafer-block",
  "wafer-schema",
 ]

--- a/crates/solobase-browser/src/asset_loader.rs
+++ b/crates/solobase-browser/src/asset_loader.rs
@@ -129,7 +129,7 @@ fn lookup_manifest(asset_id: &str) -> Option<ExternalAsset> {
 
 /// Factory: returns an `Arc<dyn LoadAssetCallback>` that bridges `load_asset`
 /// calls to the Service Worker via postMessage. Install via
-/// `wafer.set_asset_loader(solobase_browser::make_sw_asset_loader())`
+/// `wafer.set_asset_loader(&solobase_browser::make_sw_asset_loader())`
 /// before calling `wafer.seal()`.
 pub fn make_sw_asset_loader() -> std::sync::Arc<dyn wafer_run::LoadAssetCallback> {
     std::sync::Arc::new(SwAssetLoader::new())

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -11,7 +11,7 @@ use wafer_block::{
         input::InputStream,
         output::{OutputStream, TerminalNotResponse},
     },
-    ErrorCode, Message, MetaAccess, MetaEntry,
+    ErrorCode, Message, MetaGet, MetaEntry,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -198,12 +198,12 @@ fn apply_response_meta(headers: &Headers, meta: &[wafer_block::MetaEntry]) -> Re
 }
 
 fn get_status_code(meta: &[wafer_block::MetaEntry], default_code: u16) -> u16 {
-    if let Some(code) = MetaAccess::get(meta, META_RESP_STATUS) {
+    if let Some(code) = MetaGet::get(meta, META_RESP_STATUS) {
         if let Ok(n) = code.parse::<u16>() {
             return n;
         }
     }
-    if let Some(code) = MetaAccess::get(meta, "http.status") {
+    if let Some(code) = MetaGet::get(meta, "http.status") {
         if let Ok(n) = code.parse::<u16>() {
             return n;
         }
@@ -357,8 +357,8 @@ pub async fn output_to_response(mut output: OutputStream) -> Result<web_sys::Res
     // them and the loop below falls through to `collect_buffered`.
     let (leading_meta, next_event) = drain_leading_meta(&mut output).await;
 
-    let leading_ct = MetaAccess::get(&leading_meta, META_RESP_CONTENT_TYPE)
-        .or_else(|| MetaAccess::get(&leading_meta, "Content-Type"));
+    let leading_ct = MetaGet::get(&leading_meta, META_RESP_CONTENT_TYPE)
+        .or_else(|| MetaGet::get(&leading_meta, "Content-Type"));
 
     if let (Some(ct), Some(StreamEvent::Chunk(first))) = (leading_ct, &next_event) {
         if is_streaming_content_type(ct) {
@@ -442,8 +442,8 @@ fn finalise_buffered(
             let headers = Headers::new()?;
             apply_response_meta(&headers, &buf.meta)?;
 
-            let has_ct = MetaAccess::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
-                || MetaAccess::contains_key(&buf.meta, "Content-Type");
+            let has_ct = MetaGet::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
+                || MetaGet::contains_key(&buf.meta, "Content-Type");
             if !has_ct {
                 headers.set("Content-Type", "application/json")?;
             }
@@ -499,8 +499,8 @@ fn finalise_buffered(
             let headers = Headers::new()?;
             apply_response_meta(&headers, &buf.meta)?;
 
-            let has_ct = MetaAccess::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
-                || MetaAccess::contains_key(&buf.meta, "Content-Type");
+            let has_ct = MetaGet::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
+                || MetaGet::contains_key(&buf.meta, "Content-Type");
             if !has_ct {
                 headers.set("Content-Type", "application/json")?;
             }
@@ -522,8 +522,8 @@ fn build_streaming_response(
     let headers = Headers::new()?;
     apply_response_meta(&headers, &leading_meta)?;
 
-    let has_ct = MetaAccess::contains_key(&leading_meta, META_RESP_CONTENT_TYPE)
-        || MetaAccess::contains_key(&leading_meta, "Content-Type");
+    let has_ct = MetaGet::contains_key(&leading_meta, META_RESP_CONTENT_TYPE)
+        || MetaGet::contains_key(&leading_meta, "Content-Type");
     if !has_ct {
         // Streaming bodies without an explicit Content-Type fall back to
         // octet-stream rather than the JSON default the buffered path uses.

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -11,7 +11,7 @@ use wafer_block::{
         input::InputStream,
         output::{OutputStream, TerminalNotResponse},
     },
-    ErrorCode, Message, MetaGet, MetaEntry,
+    ErrorCode, Message, MetaEntry, MetaGet,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;

--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -85,8 +85,12 @@ async fn daily_counts_30d(
     }];
     filters.extend(extra_filters);
 
-    let stmt = aggregate::build_daily_count(table, "created_at", &filters, Backend::Sqlite);
-    let rows = db::query(ctx, &stmt).await.unwrap_or_default();
+    let rows = match aggregate::build_daily_count(table, "created_at", &filters, Backend::Sqlite) {
+        Ok(stmt) => db::query(ctx, &stmt).await.unwrap_or_default(),
+        // `date_field` is the constant "created_at", so a build error is
+        // unreachable here; fall back to an empty series defensively.
+        Err(_) => Vec::new(),
+    };
 
     let counts: HashMap<String, i64> = rows
         .iter()

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -12,8 +12,9 @@ use wafer_core::clients::{
     database as db,
     llm::{
         self as llm_client, ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole,
-        ChunkDelta, LoadModelRequest, NativeTypedFrameStream, StatusRequest, UnloadModelRequest,
+        ChunkDelta, LoadModelRequest, StatusRequest, UnloadModelRequest,
     },
+    NativeTypedFrameStream,
 };
 use wafer_run::{
     context::Context,

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -115,7 +115,7 @@ pub async fn initialize() -> Result<(), JsValue> {
     let (mut wafer, storage_block) = builder
         .build()
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    wafer.set_asset_loader(solobase_browser::make_sw_asset_loader());
+    wafer.set_asset_loader(&solobase_browser::make_sw_asset_loader());
 
     wafer
         .seal()


### PR DESCRIPTION
Consumer follow-up to the wafer-run rust-best-practices audit (wafer-run #209-#214, all merged to main). solobase builds against wafer-run `main`, so these changes are required to keep it compiling.

## Changes
- **`MetaAccess` → `MetaGet`** (wafer-run #210 split the trait into `MetaGet` (read, slice+Vec) / `MetaSet` (write, Vec)). `solobase-browser/convert.rs` is read-only.
- **`build_daily_count` now returns `Result`** (#210 SQL error propagation). `dashboard.rs` handles it — `date_field` is the constant `"created_at"` so the error arm is unreachable; falls back to an empty series defensively.
- **`NativeTypedFrameStream` import path** (#210 deduped it into `clients::`, the `clients::llm::` re-export is now private). Imported from `wafer_core::clients::` directly.
- **`Cargo.lock`** tracks the new wafer-run dependency graph.

`build_grouped_query` stays by-value (wafer-run #214 restored that signature — `GroupedQueryConfig` is `!Send`, so by-value lets async callers drop it before awaiting), so those call sites are unchanged.

## Verification (against local wafer-run main)
- `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — clean
- `cargo check -p solobase-browser --target wasm32-unknown-unknown` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)