### PR TITLE
ci: check solobase-browser + minimal-browser for wasm32

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -150,6 +150,13 @@ jobs:
       - name: Check solobase-cloudflare (wasm32)
         run: cargo check -p solobase-cloudflare --target wasm32-unknown-unknown
 
+      # Browser-target crates are also wasm-only consumers of wafer-run, and
+      # nothing else in CI builds them for wasm32 — a set_asset_loader
+      # signature break sat silently red on main for 5 days before the
+      # solobase #253 review caught it.
+      - name: Check solobase-browser + minimal-browser (wasm32)
+        run: cargo check -p solobase-browser -p minimal-browser --target wasm32-unknown-unknown
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,13 @@ jobs:
       - name: Check solobase-cloudflare (wasm32)
         run: cargo check -p solobase-cloudflare --target wasm32-unknown-unknown
 
+      # Browser-target crates are also wasm-only consumers of wafer-run, and
+      # nothing else in CI builds them for wasm32 — a set_asset_loader
+      # signature break sat silently red on main for 5 days before the
+      # solobase #253 review caught it.
+      - name: Check solobase-browser + minimal-browser (wasm32)
+        run: cargo check -p solobase-browser -p minimal-browser --target wasm32-unknown-unknown
+
   # E2E is split into a single build stage plus two independent test stages so
   # the browser-WASM smoke tests (port 8080) and the native-server visual
   # baselines (port 8093) run in parallel instead of end-to-end in one job.


### PR DESCRIPTION
## What

Adds `cargo check -p solobase-browser -p minimal-browser --target wasm32-unknown-unknown` to the existing **Cloudflare wasm32 check** job in both `ci.yml` and `ci-main.yml` (job name kept stable in case branch protection pins it; the job already has the wafer-run clone, wasm32 target, and `solobase-web` pkg/ artifact these crates need).

## Why

Nothing in CI built the browser-target crates for wasm32 — their only meaningful target. wafer-run #213 changed `Wafer::set_asset_loader` to take `&Arc<...>` on 2026-06-07 and `minimal-browser` sat silently red on main for 5 days until the adversarial review of #253 caught the gap (suggested there as follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)