### PR TITLE
fix(S1-J): userportal + email block cleanups

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/pages/orgs.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/orgs.rs
@@ -6,7 +6,7 @@ use maud::{html, Markup};
 use wafer_run::{context::Context, Message, OutputStream};
 
 use crate::{
-    blocks::{auth::repo::orgs, helpers::ResponseBuilder},
+    blocks::{auth::repo::orgs, helpers::redirect},
     ui::{self, SiteConfig},
 };
 
@@ -14,10 +14,7 @@ use crate::{
 pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
     if user_id.is_empty() {
-        return ResponseBuilder::new()
-            .status(302)
-            .set_header("Location", "/b/auth/login")
-            .body(Vec::new(), "text/plain");
+        return redirect(302, "/b/auth/login");
     }
 
     let orgs_list = orgs::list_for_user(ctx, &user_id).await.unwrap_or_default();

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -241,13 +241,12 @@ async fn handle_send_template(
             );
             (
                 format!("Verify your {app_name} email"),
-                format!(
-                    r#"<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:500px;margin:0 auto;padding:2rem">
-<h2 style="color:#1e293b">Verify your email</h2>
-<p style="color:#64748b;line-height:1.6">Click the button below to verify your email address. This link expires in 24 hours.</p>
-<a href="{url}" style="display:inline-block;background:#0ea5e9;color:white;padding:0.75rem 1.5rem;border-radius:8px;text-decoration:none;font-weight:600;margin:1rem 0">Verify Email</a>
-<p style="color:#94a3b8;font-size:0.813rem">If you didn't create an account, you can ignore this email.</p>
-</div>"#
+                email_shell(
+                    "Verify your email",
+                    "#1e293b",
+                    r#"<p style="color:#64748b;line-height:1.6">Click the button below to verify your email address. This link expires in 24 hours.</p>"#,
+                    Some((&url, "Verify Email", "#0ea5e9")),
+                    Some("If you didn't create an account, you can ignore this email."),
                 ),
                 format!("Verify your {app_name} email: {url}"),
             )
@@ -261,13 +260,12 @@ async fn handle_send_template(
             );
             (
                 format!("Reset your {app_name} password"),
-                format!(
-                    r#"<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:500px;margin:0 auto;padding:2rem">
-<h2 style="color:#1e293b">Reset your password</h2>
-<p style="color:#64748b;line-height:1.6">Click the button below to reset your password. This link expires in 1 hour.</p>
-<a href="{url}" style="display:inline-block;background:#0ea5e9;color:white;padding:0.75rem 1.5rem;border-radius:8px;text-decoration:none;font-weight:600;margin:1rem 0">Reset Password</a>
-<p style="color:#94a3b8;font-size:0.813rem">If you didn't request a password reset, you can ignore this email.</p>
-</div>"#
+                email_shell(
+                    "Reset your password",
+                    "#1e293b",
+                    r#"<p style="color:#64748b;line-height:1.6">Click the button below to reset your password. This link expires in 1 hour.</p>"#,
+                    Some((&url, "Reset Password", "#0ea5e9")),
+                    Some("If you didn't request a password reset, you can ignore this email."),
                 ),
                 format!("Reset your {app_name} password: {url}"),
             )
@@ -275,19 +273,20 @@ async fn handle_send_template(
         "payment_failed" => {
             let days = req.days_remaining.unwrap_or(7);
             let settings_url = format!("{base_url}/b/admin/#settings");
+            let body = format!(
+                r#"<p style="color:#64748b;line-height:1.6">We were unable to process your subscription payment. Your service will remain active for <strong>{days} more days</strong>. After that, your projects will be suspended.</p>"#
+            );
             (
                 format!("{app_name}: Payment failed — action required"),
-                format!(
-                    r#"<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:500px;margin:0 auto;padding:2rem">
-<h2 style="color:#dc2626">Payment failed</h2>
-<p style="color:#64748b;line-height:1.6">We were unable to process your subscription payment. Your service will remain active for <strong>{days} more days</strong>. After that, your projects will be suspended.</p>
-<a href="{settings_url}" style="display:inline-block;background:#dc2626;color:white;padding:0.75rem 1.5rem;border-radius:8px;text-decoration:none;font-weight:600;margin:1rem 0">Update Payment Method</a>
-<p style="color:#94a3b8;font-size:0.813rem">If you've already updated your payment method, you can ignore this email.</p>
-</div>"#
+                email_shell(
+                    "Payment failed",
+                    "#dc2626",
+                    &body,
+                    Some((&settings_url, "Update Payment Method", "#dc2626")),
+                    Some("If you've already updated your payment method, you can ignore this email."),
                 ),
                 format!(
-                    "Your {app_name} payment failed. Update your payment method within {} days.",
-                    days
+                    "Your {app_name} payment failed. Update your payment method within {days} days."
                 ),
             )
         }
@@ -301,19 +300,17 @@ async fn handle_send_template(
             let pricing_url = format!("{site_url}/pricing/");
             let dashboard_url = format!("{base_url}/b/admin/");
             let docs_url = format!("{site_url}/docs/");
-            (
-                format!("Welcome to {app_name}!"),
-                format!(
-                    r#"<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:500px;margin:0 auto;padding:2rem">
-<h2 style="color:#1e293b">{greeting}</h2>
-<p style="color:#64748b;line-height:1.6">Your {app_name} account is ready. Here's how to get started:</p>
+            let body = format!(
+                r#"<p style="color:#64748b;line-height:1.6">Your {app_name} account is ready. Here's how to get started:</p>
 <ol style="color:#64748b;line-height:1.8">
 <li>Choose a plan on the <a href="{pricing_url}" style="color:#0ea5e9">pricing page</a></li>
 <li>Create your first project from the <a href="{dashboard_url}" style="color:#0ea5e9">dashboard</a></li>
 <li>Read the <a href="{docs_url}" style="color:#0ea5e9">documentation</a></li>
-</ol>
-</div>"#
-                ),
+</ol>"#
+            );
+            (
+                format!("Welcome to {app_name}!"),
+                email_shell(&greeting, "#1e293b", &body, None, None),
                 format!("Welcome to {app_name}! Get started: {dashboard_url}"),
             )
         }
@@ -324,6 +321,40 @@ async fn handle_send_template(
 
     let sent = send_email(ctx, &req.to, &subject, &html, Some(&text)).await;
     ok_json(&SendResp { sent })
+}
+
+/// Shared HTML wrapper for the templated emails: the outer card `div`
+/// (font stack, max-width, padding), a colored `<h2>` heading, the
+/// caller-provided body HTML, an optional CTA button
+/// (`(url, label, background-color)`), and an optional small-print footnote.
+/// Keeps the repeated inline-style markup in one place so each template arm
+/// only supplies its content.
+fn email_shell(
+    heading: &str,
+    heading_color: &str,
+    body_html: &str,
+    cta: Option<(&str, &str, &str)>,
+    footnote: Option<&str>,
+) -> String {
+    let mut out = format!(
+        r#"<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:500px;margin:0 auto;padding:2rem">
+<h2 style="color:{heading_color}">{heading}</h2>
+{body_html}"#
+    );
+    if let Some((url, label, background)) = cta {
+        out.push('\n');
+        out.push_str(&format!(
+            r#"<a href="{url}" style="display:inline-block;background:{background};color:white;padding:0.75rem 1.5rem;border-radius:8px;text-decoration:none;font-weight:600;margin:1rem 0">{label}</a>"#
+        ));
+    }
+    if let Some(note) = footnote {
+        out.push('\n');
+        out.push_str(&format!(
+            r#"<p style="color:#94a3b8;font-size:0.813rem">{note}</p>"#
+        ));
+    }
+    out.push_str("\n</div>");
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -349,7 +380,13 @@ async fn send_email(
     };
 
     if api_key.is_empty() || domain.is_empty() {
-        // Email not configured — log but don't fail
+        // Email not configured — don't fail the caller, but make the
+        // resulting {"sent": false} diagnosable from the logs.
+        tracing::warn!(
+            to = %to,
+            "email not sent: Mailgun is not configured (SUPPERS_AI__EMAIL__MAILGUN_API_KEY \
+             and/or SUPPERS_AI__EMAIL__MAILGUN_DOMAIN unset)"
+        );
         return false;
     }
 
@@ -390,8 +427,21 @@ async fn send_email(
     );
 
     match net::do_request(ctx, "POST", &url, &headers, Some(body.as_bytes())).await {
-        Ok(resp) => (200..300).contains(&resp.status_code),
-        Err(_) => false,
+        Ok(resp) => {
+            let sent = (200..300).contains(&resp.status_code);
+            if !sent {
+                tracing::warn!(
+                    status = resp.status_code,
+                    to = %to,
+                    "email not sent: Mailgun returned non-2xx status"
+                );
+            }
+            sent
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, to = %to, "email not sent: Mailgun request failed");
+            false
+        }
     }
 }
 
@@ -644,6 +694,37 @@ mod tests {
         assert_eq!(
             resolve_base_url("https://api.mailgun.net/"),
             "https://api.mailgun.net"
+        );
+    }
+
+    // ---- email_shell ----------------------------------------------------------
+
+    #[test]
+    fn email_shell_renders_heading_body_cta_and_footnote() {
+        let html = email_shell(
+            "Test heading",
+            "#1e293b",
+            "<p>body content</p>",
+            Some(("https://x.test/go", "Go Now", "#0ea5e9")),
+            Some("Small print."),
+        );
+        assert!(html.starts_with(r#"<div style="font-family:"#));
+        assert!(html.ends_with("</div>"));
+        assert!(html.contains(r##"<h2 style="color:#1e293b">Test heading</h2>"##));
+        assert!(html.contains("<p>body content</p>"));
+        assert!(html.contains(r#"<a href="https://x.test/go""#));
+        assert!(html.contains("background:#0ea5e9"));
+        assert!(html.contains(">Go Now</a>"));
+        assert!(html.contains("Small print."));
+    }
+
+    #[test]
+    fn email_shell_omits_cta_and_footnote_when_absent() {
+        let html = email_shell("H", "#1e293b", "<p>b</p>", None, None);
+        assert!(!html.contains("<a href="), "no CTA expected: {html}");
+        assert!(
+            !html.contains("font-size:0.813rem"),
+            "no footnote expected: {html}"
         );
     }
 

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -283,7 +283,9 @@ async fn handle_send_template(
                     "#dc2626",
                     &body,
                     Some((&settings_url, "Update Payment Method", "#dc2626")),
-                    Some("If you've already updated your payment method, you can ignore this email."),
+                    Some(
+                        "If you've already updated your payment method, you can ignore this email.",
+                    ),
                 ),
                 format!(
                     "Your {app_name} payment failed. Update your payment method within {days} days."

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -237,6 +237,16 @@ pub fn ok_empty() -> OutputStream {
     OutputStream::respond(vec![])
 }
 
+/// Build a redirect `OutputStream` with the given status (302, 303, …) and
+/// `Location` header. Single source of truth for the redirect response shape
+/// (status + `Location` + empty `text/plain` body) used by page handlers.
+pub fn redirect(status: u16, location: &str) -> OutputStream {
+    ResponseBuilder::new()
+        .status(status)
+        .set_header("Location", location)
+        .body(Vec::new(), "text/plain")
+}
+
 /// Return a 400 Bad Request `OutputStream`.
 pub fn err_bad_request(message: &str) -> OutputStream {
     OutputStream::error(WaferError {

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -10,9 +10,8 @@ use super::helpers::{self, parse_form_body, stamp_updated, RecordExt};
 use crate::{
     blocks::helpers::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json},
     ui::{
-        self, components, icons, nav_groups,
+        components, icons, nav_groups,
         shell::{Crumb, Topbar},
-        sidebar::nav_icon,
         SiteConfig, UserInfo,
     },
 };
@@ -21,24 +20,6 @@ pub(crate) mod migrations;
 mod pages;
 
 const TABLE: &str = "suppers_ai__userportal__buttons";
-
-/// Known icon names available for button configuration.
-const ICON_OPTIONS: &[(&str, &str)] = &[
-    ("package", "Package"),
-    ("shopping-cart", "Shopping Cart"),
-    ("folder", "Folder"),
-    ("key", "Key"),
-    ("server", "Server"),
-    ("globe", "Globe"),
-    ("users", "Users"),
-    ("user", "User"),
-    ("settings", "Settings"),
-    ("shield", "Shield"),
-    ("file-text", "File"),
-    ("bar-chart", "Chart"),
-    ("dollar-sign", "Dollar"),
-    ("dashboard", "Dashboard"),
-];
 
 pub struct UserPortalBlock;
 
@@ -205,8 +186,10 @@ impl UserPortalBlock {
         match (action, sub) {
             ("retrieve", "/admin/settings") => admin_settings_page(ctx, &msg).await,
             ("create", "/admin/settings") => handle_save_settings(ctx, input).await,
-            ("retrieve", "/admin/buttons") => admin_buttons_page(ctx, &msg).await,
-            ("create", "/admin/buttons") => handle_create_button(ctx, input).await,
+            ("retrieve", "/admin/buttons") => pages::admin_buttons::admin_buttons_page(ctx, &msg).await,
+            ("create", "/admin/buttons") => {
+                pages::admin_buttons::handle_create_button(ctx, input).await
+            }
             ("retrieve", s) if s.starts_with("/admin/buttons/") && s.ends_with("/edit") => {
                 let id = s
                     .strip_prefix("/admin/buttons/")
@@ -215,21 +198,21 @@ impl UserPortalBlock {
                 if id.is_empty() {
                     return err_not_found("not found");
                 }
-                handle_edit_button_form(ctx, id).await
+                pages::admin_buttons::handle_edit_button_form(ctx, id).await
             }
             ("update", s) if s.starts_with("/admin/buttons/") => {
                 let id = s.strip_prefix("/admin/buttons/").unwrap_or("");
                 if id.is_empty() {
                     return err_not_found("not found");
                 }
-                handle_update_button(ctx, input, id).await
+                pages::admin_buttons::handle_update_button(ctx, input, id).await
             }
             ("delete", s) if s.starts_with("/admin/buttons/") => {
                 let id = s.strip_prefix("/admin/buttons/").unwrap_or("");
                 if id.is_empty() {
                     return err_not_found("not found");
                 }
-                handle_delete_button(ctx, id).await
+                pages::admin_buttons::handle_delete_button(ctx, id).await
             }
             _ => err_not_found("not found"),
         }
@@ -321,311 +304,6 @@ async fn handle_update_profile(
     // Plain form POST → 303 See Other so the browser follows up with a GET
     // and the back/forward stack stays clean.
     helpers::redirect(303, "/b/userportal/profile")
-}
-
-// ---------------------------------------------------------------------------
-// Admin: Buttons management page
-// ---------------------------------------------------------------------------
-
-async fn admin_buttons_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let buttons = load_buttons(ctx).await;
-
-    let content = html! {
-        (components::page_header(
-            "Portal Buttons",
-            Some("Configure navigation buttons shown on the user profile page"),
-            None,
-        ))
-
-        // Add button form
-        div .card style="margin-bottom:1.5rem;padding:1.25rem" {
-            h3 style="margin:0 0 1rem;font-size:1rem" { "Add Button" }
-            form
-                hx-post="/b/userportal/admin/buttons"
-                hx-target="#buttons-table"
-                hx-swap="outerHTML"
-                style="display:grid;grid-template-columns:1fr 1fr 1fr auto auto;gap:0.75rem;align-items:end"
-            {
-                div .form-group style="margin:0" {
-                    label .form-label for="label" { "Label" }
-                    input .form-input #label type="text" name="label"
-                        placeholder="e.g. My Products" required;
-                }
-                div .form-group style="margin:0" {
-                    label .form-label for="path" { "Path" }
-                    input .form-input #path type="text" name="path"
-                        placeholder="e.g. /b/products/mine" required;
-                }
-                div .form-group style="margin:0" {
-                    label .form-label for="icon" { "Icon" }
-                    select .form-input #icon name="icon" {
-                        @for &(value, display) in ICON_OPTIONS {
-                            option value=(value) { (display) }
-                        }
-                    }
-                }
-                div .form-group style="margin:0" {
-                    label .form-label for="sort_order" { "Order" }
-                    input .form-input #sort_order type="number" name="sort_order"
-                        value="0" style="width:5rem";
-                }
-                button .btn .btn-primary type="submit" style="white-space:nowrap" {
-                    (icons::plus()) " Add"
-                }
-            }
-        }
-
-        // Buttons table
-        (render_buttons_table(&buttons))
-    };
-
-    render_page(
-        "Portal Buttons",
-        &site_config,
-        "/b/userportal/admin/buttons",
-        user.as_ref(),
-        "Portal Buttons",
-        content,
-        msg,
-    )
-}
-
-fn render_buttons_table(buttons: &[wafer_core::clients::database::Record]) -> maud::Markup {
-    html! {
-        div #buttons-table {
-            @if buttons.is_empty() {
-                (components::empty_state(
-                    icons::package(),
-                    "No buttons configured",
-                    "Add a button above to show navigation links on the user profile page.",
-                    None,
-                ))
-            } @else {
-                div .table-container {
-                    table .table {
-                        thead {
-                            tr {
-                                th { "Label" }
-                                th { "Icon" }
-                                th { "Path" }
-                                th { "Order" }
-                                th style="width:6rem" { "Actions" }
-                            }
-                        }
-                        tbody {
-                            @for btn in buttons {
-                                tr {
-                                    td .font-medium { (btn.str_field("label")) }
-                                    td {
-                                        span .nav-icon style="display:inline-flex" {
-                                            (nav_icon(btn.str_field("icon")))
-                                        }
-                                        " "
-                                        span .text-muted .text-sm { (btn.str_field("icon")) }
-                                    }
-                                    td { code { (btn.str_field("path")) } }
-                                    td { (btn.i64_field("sort_order")) }
-                                    td {
-                                        div style="display:flex;gap:0.25rem" {
-                                            button .btn .btn-ghost .btn-sm
-                                                hx-get=(format!("/b/userportal/admin/buttons/{}/edit", btn.id))
-                                                hx-target=(format!("#edit-modal-{}", btn.id))
-                                                hx-swap="innerHTML"
-                                                title="Edit"
-                                            {
-                                                (icons::edit())
-                                            }
-                                            button .btn .btn-ghost .btn-sm
-                                                hx-delete=(format!("/b/userportal/admin/buttons/{}", btn.id))
-                                                hx-target="#buttons-table"
-                                                hx-swap="outerHTML"
-                                                hx-confirm="Delete this button?"
-                                                title="Delete"
-                                                style="color:var(--danger)"
-                                            {
-                                                (icons::trash())
-                                            }
-                                        }
-                                        div id=(format!("edit-modal-{}", btn.id)) {}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Admin: Button CRUD handlers
-// ---------------------------------------------------------------------------
-
-async fn handle_create_button(ctx: &dyn Context, input: InputStream) -> OutputStream {
-    let raw = input.collect_to_bytes().await;
-    let body = parse_form_body(&raw);
-
-    let label = body.get("label").map(|s| s.as_str()).unwrap_or("").trim();
-    let path = body.get("path").map(|s| s.as_str()).unwrap_or("").trim();
-    let icon = body
-        .get("icon")
-        .map(|s| s.as_str())
-        .unwrap_or("package")
-        .trim();
-    let sort_order: i64 = body
-        .get("sort_order")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-
-    if label.is_empty() || path.is_empty() {
-        return err_bad_request("Label and path are required");
-    }
-
-    let mut data = super::helpers::json_map(serde_json::json!({
-        "label": label,
-        "path": path,
-        "icon": icon,
-        "sort_order": sort_order,
-    }));
-    super::helpers::stamp_created(&mut data);
-
-    if let Err(e) = db::create(ctx, TABLE, data).await {
-        return err_internal("Failed to create button", e.message);
-    }
-
-    // Re-render buttons table
-    let buttons = load_buttons(ctx).await;
-    ui::html_response(render_buttons_table(&buttons))
-}
-
-/// Validate that `id` is safe to interpolate into inline HTML/JS strings
-/// (DOM IDs, `getElementById` arguments, etc.). Rejects anything outside
-/// `[A-Za-z0-9_-]` and any string longer than 64 chars or empty.
-///
-/// Used by SEC-058: the userportal edit-button form inlines the record ID
-/// into a `script` block via `PreEscaped`, so it must not contain quotes,
-/// angle brackets, backslashes, or any other JS-syntax-significant chars.
-fn is_safe_dom_id(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= 64
-        && id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-}
-
-async fn handle_edit_button_form(ctx: &dyn Context, id: &str) -> OutputStream {
-    // SEC-058: the modal auto-show script below uses `PreEscaped(format!(...))`
-    // to inject the record ID into inline JS. A record returned from
-    // `db::get` should always have a well-formed ID (UUIDv7), but defensively
-    // reject any caller-supplied path segment that isn't strict
-    // `[a-zA-Z0-9_-]{1,64}` so the JS string interpolation can never be
-    // poisoned even if a future code path looks the record up by a
-    // non-validated identifier.
-    if !is_safe_dom_id(id) {
-        return err_not_found("Button not found");
-    }
-    let record = match db::get(ctx, TABLE, id).await {
-        Ok(r) => r,
-        Err(_) => return err_not_found("Button not found"),
-    };
-
-    let current_icon = record.str_field("icon");
-
-    let markup = html! {
-        (components::modal(&format!("edit-btn-{id}"), "Edit Button", html! {
-            form
-                hx-put=(format!("/b/userportal/admin/buttons/{id}"))
-                hx-target="#buttons-table"
-                hx-swap="outerHTML"
-                style="display:flex;flex-direction:column;gap:0.75rem"
-            {
-                div .form-group style="margin:0" {
-                    label .form-label { "Label" }
-                    input .form-input type="text" name="label"
-                        value=(record.str_field("label")) required;
-                }
-                div .form-group style="margin:0" {
-                    label .form-label { "Path" }
-                    input .form-input type="text" name="path"
-                        value=(record.str_field("path")) required;
-                }
-                div .form-group style="margin:0" {
-                    label .form-label { "Icon" }
-                    select .form-input name="icon" {
-                        @for &(value, display) in ICON_OPTIONS {
-                            option value=(value) selected[value == current_icon] { (display) }
-                        }
-                    }
-                }
-                div .form-group style="margin:0" {
-                    label .form-label { "Order" }
-                    input .form-input type="number" name="sort_order"
-                        value=(record.i64_field("sort_order"));
-                }
-                div style="display:flex;gap:0.5rem;justify-content:flex-end" {
-                    button .btn .btn-secondary type="button"
-                        onclick=(format!("document.getElementById('edit-btn-{id}').style.display='none'"))
-                    { "Cancel" }
-                    button .btn .btn-primary type="submit" { "Save" }
-                }
-            }
-        }))
-        // Auto-show the modal
-        script { (maud::PreEscaped(format!(
-            "document.getElementById('edit-btn-{id}').style.display='flex';"
-        ))) }
-    };
-
-    ui::html_response(markup)
-}
-
-async fn handle_update_button(ctx: &dyn Context, input: InputStream, id: &str) -> OutputStream {
-    let raw = input.collect_to_bytes().await;
-    let body = parse_form_body(&raw);
-
-    let label = body.get("label").map(|s| s.as_str()).unwrap_or("").trim();
-    let path = body.get("path").map(|s| s.as_str()).unwrap_or("").trim();
-    let icon = body
-        .get("icon")
-        .map(|s| s.as_str())
-        .unwrap_or("package")
-        .trim();
-    let sort_order: i64 = body
-        .get("sort_order")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-
-    if label.is_empty() || path.is_empty() {
-        return err_bad_request("Label and path are required");
-    }
-
-    let mut data = super::helpers::json_map(serde_json::json!({
-        "label": label,
-        "path": path,
-        "icon": icon,
-        "sort_order": sort_order,
-    }));
-    stamp_updated(&mut data);
-
-    if let Err(e) = db::update(ctx, TABLE, id, data).await {
-        return err_internal("Failed to update button", e.message);
-    }
-
-    // Re-render buttons table
-    let buttons = load_buttons(ctx).await;
-    ui::html_response(render_buttons_table(&buttons))
-}
-
-async fn handle_delete_button(ctx: &dyn Context, id: &str) -> OutputStream {
-    if let Err(e) = db::delete(ctx, TABLE, id).await {
-        return err_internal("Failed to delete button", e.message);
-    }
-
-    let buttons = load_buttons(ctx).await;
-    ui::html_response(render_buttons_table(&buttons))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -186,7 +186,9 @@ impl UserPortalBlock {
         match (action, sub) {
             ("retrieve", "/admin/settings") => admin_settings_page(ctx, &msg).await,
             ("create", "/admin/settings") => handle_save_settings(ctx, input).await,
-            ("retrieve", "/admin/buttons") => pages::admin_buttons::admin_buttons_page(ctx, &msg).await,
+            ("retrieve", "/admin/buttons") => {
+                pages::admin_buttons::admin_buttons_page(ctx, &msg).await
+            }
             ("create", "/admin/buttons") => {
                 pages::admin_buttons::handle_create_button(ctx, input).await
             }

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -320,10 +320,7 @@ async fn handle_update_profile(
 
     // Plain form POST → 303 See Other so the browser follows up with a GET
     // and the back/forward stack stays clean.
-    crate::blocks::helpers::ResponseBuilder::new()
-        .status(303)
-        .set_header("Location", "/b/userportal/profile")
-        .body(Vec::new(), "text/plain")
+    helpers::redirect(303, "/b/userportal/profile")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -756,13 +756,16 @@ async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> OutputSt
     let raw = input.collect_to_bytes().await;
     let body: std::collections::HashMap<String, String> = match serde_json::from_slice(&raw) {
         Ok(b) => b,
-        Err(e) => {
-            return ok_json(&serde_json::json!({"error": format!("Invalid request: {e}")}));
-        }
+        // Previously returned 200 OK with an `error` key — clients would
+        // still treat that as success. Use the proper 4xx so the caller can
+        // branch on status alone (matches legalpages handle_save).
+        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
     };
     for &(key, _, _, _, _) in portal_settings_keys().iter() {
         if let Some(value) = body.get(key) {
-            let _ = config::set(ctx, key, value).await;
+            if let Err(e) = config::set(ctx, key, value).await {
+                tracing::warn!(error = %e, key = key, "userportal: failed to set config value");
+            }
         }
     }
     ok_json(&serde_json::json!({"message": "Settings saved"}))

--- a/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
@@ -8,7 +8,11 @@ use maud::html;
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
-use super::super::{load_buttons, render_page, TABLE};
+use super::super::{load_buttons, render_page};
+// Crate-rooted path (rather than `super::super::TABLE`) so the WRAP-grant
+// audit (scripts/audit-wrap-grants.sh) can statically resolve the constant
+// to this block's table.
+use crate::blocks::userportal::TABLE;
 use crate::{
     blocks::helpers::{
         err_bad_request, err_internal, err_not_found, json_map, parse_form_body, stamp_created,

--- a/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
@@ -1,0 +1,326 @@
+//! `/b/userportal/admin/buttons` — admin management UI for the portal
+//! navigation buttons: add form + table, htmx edit modal, and the
+//! create/update/delete handlers that re-render the table fragment.
+
+use std::collections::HashMap;
+
+use maud::html;
+use wafer_core::clients::database as db;
+use wafer_run::{context::Context, InputStream, Message, OutputStream};
+
+use super::super::{load_buttons, render_page, TABLE};
+use crate::{
+    blocks::helpers::{
+        err_bad_request, err_internal, err_not_found, json_map, parse_form_body, stamp_created,
+        stamp_updated, RecordExt,
+    },
+    ui::{self, components, icons, sidebar::nav_icon, SiteConfig, UserInfo},
+};
+
+/// Known icon names available for button configuration.
+const ICON_OPTIONS: &[(&str, &str)] = &[
+    ("package", "Package"),
+    ("shopping-cart", "Shopping Cart"),
+    ("folder", "Folder"),
+    ("key", "Key"),
+    ("server", "Server"),
+    ("globe", "Globe"),
+    ("users", "Users"),
+    ("user", "User"),
+    ("settings", "Settings"),
+    ("shield", "Shield"),
+    ("file-text", "File"),
+    ("bar-chart", "Chart"),
+    ("dollar-sign", "Dollar"),
+    ("dashboard", "Dashboard"),
+];
+
+pub async fn admin_buttons_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
+    let site_config = SiteConfig::load(ctx).await;
+    let user = UserInfo::from_message(msg);
+    let buttons = load_buttons(ctx).await;
+
+    let content = html! {
+        (components::page_header(
+            "Portal Buttons",
+            Some("Configure navigation buttons shown on the user profile page"),
+            None,
+        ))
+
+        // Add button form
+        div .card style="margin-bottom:1.5rem;padding:1.25rem" {
+            h3 style="margin:0 0 1rem;font-size:1rem" { "Add Button" }
+            form
+                hx-post="/b/userportal/admin/buttons"
+                hx-target="#buttons-table"
+                hx-swap="outerHTML"
+                style="display:grid;grid-template-columns:1fr 1fr 1fr auto auto;gap:0.75rem;align-items:end"
+            {
+                div .form-group style="margin:0" {
+                    label .form-label for="label" { "Label" }
+                    input .form-input #label type="text" name="label"
+                        placeholder="e.g. My Products" required;
+                }
+                div .form-group style="margin:0" {
+                    label .form-label for="path" { "Path" }
+                    input .form-input #path type="text" name="path"
+                        placeholder="e.g. /b/products/mine" required;
+                }
+                div .form-group style="margin:0" {
+                    label .form-label for="icon" { "Icon" }
+                    select .form-input #icon name="icon" {
+                        @for &(value, display) in ICON_OPTIONS {
+                            option value=(value) { (display) }
+                        }
+                    }
+                }
+                div .form-group style="margin:0" {
+                    label .form-label for="sort_order" { "Order" }
+                    input .form-input #sort_order type="number" name="sort_order"
+                        value="0" style="width:5rem";
+                }
+                button .btn .btn-primary type="submit" style="white-space:nowrap" {
+                    (icons::plus()) " Add"
+                }
+            }
+        }
+
+        // Buttons table
+        (render_buttons_table(&buttons))
+    };
+
+    render_page(
+        "Portal Buttons",
+        &site_config,
+        "/b/userportal/admin/buttons",
+        user.as_ref(),
+        "Portal Buttons",
+        content,
+        msg,
+    )
+}
+
+fn render_buttons_table(buttons: &[db::Record]) -> maud::Markup {
+    html! {
+        div #buttons-table {
+            @if buttons.is_empty() {
+                (components::empty_state(
+                    icons::package(),
+                    "No buttons configured",
+                    "Add a button above to show navigation links on the user profile page.",
+                    None,
+                ))
+            } @else {
+                div .table-container {
+                    table .table {
+                        thead {
+                            tr {
+                                th { "Label" }
+                                th { "Icon" }
+                                th { "Path" }
+                                th { "Order" }
+                                th style="width:6rem" { "Actions" }
+                            }
+                        }
+                        tbody {
+                            @for btn in buttons {
+                                tr {
+                                    td .font-medium { (btn.str_field("label")) }
+                                    td {
+                                        span .nav-icon style="display:inline-flex" {
+                                            (nav_icon(btn.str_field("icon")))
+                                        }
+                                        " "
+                                        span .text-muted .text-sm { (btn.str_field("icon")) }
+                                    }
+                                    td { code { (btn.str_field("path")) } }
+                                    td { (btn.i64_field("sort_order")) }
+                                    td {
+                                        div style="display:flex;gap:0.25rem" {
+                                            button .btn .btn-ghost .btn-sm
+                                                hx-get=(format!("/b/userportal/admin/buttons/{}/edit", btn.id))
+                                                hx-target=(format!("#edit-modal-{}", btn.id))
+                                                hx-swap="innerHTML"
+                                                title="Edit"
+                                            {
+                                                (icons::edit())
+                                            }
+                                            button .btn .btn-ghost .btn-sm
+                                                hx-delete=(format!("/b/userportal/admin/buttons/{}", btn.id))
+                                                hx-target="#buttons-table"
+                                                hx-swap="outerHTML"
+                                                hx-confirm="Delete this button?"
+                                                title="Delete"
+                                                style="color:var(--danger)"
+                                            {
+                                                (icons::trash())
+                                            }
+                                        }
+                                        div id=(format!("edit-modal-{}", btn.id)) {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Re-load the buttons and render the `#buttons-table` fragment — the htmx
+/// swap target every mutating handler responds with.
+async fn buttons_table_response(ctx: &dyn Context) -> OutputStream {
+    let buttons = load_buttons(ctx).await;
+    ui::html_response(render_buttons_table(&buttons))
+}
+
+/// Parse + validate the create/update button form (shared by both handlers):
+/// extracts `label`/`path`/`icon`/`sort_order` with the same defaults and
+/// trimming, rejects empty label/path, and returns the data map ready for
+/// `db::create`/`db::update` (callers add their own timestamp stamp).
+fn parse_button_form(raw: &[u8]) -> Result<HashMap<String, serde_json::Value>, OutputStream> {
+    let body = parse_form_body(raw);
+
+    let label = body.get("label").map(|s| s.as_str()).unwrap_or("").trim();
+    let path = body.get("path").map(|s| s.as_str()).unwrap_or("").trim();
+    let icon = body
+        .get("icon")
+        .map(|s| s.as_str())
+        .unwrap_or("package")
+        .trim();
+    let sort_order: i64 = body
+        .get("sort_order")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    if label.is_empty() || path.is_empty() {
+        return Err(err_bad_request("Label and path are required"));
+    }
+
+    Ok(json_map(serde_json::json!({
+        "label": label,
+        "path": path,
+        "icon": icon,
+        "sort_order": sort_order,
+    })))
+}
+
+pub async fn handle_create_button(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    let raw = input.collect_to_bytes().await;
+    let mut data = match parse_button_form(&raw) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    stamp_created(&mut data);
+
+    if let Err(e) = db::create(ctx, TABLE, data).await {
+        return err_internal("Failed to create button", e.message);
+    }
+
+    buttons_table_response(ctx).await
+}
+
+/// Validate that `id` is safe to interpolate into inline HTML/JS strings
+/// (DOM IDs, `getElementById` arguments, etc.). Rejects anything outside
+/// `[A-Za-z0-9_-]` and any string longer than 64 chars or empty.
+///
+/// Used by SEC-058: the userportal edit-button form inlines the record ID
+/// into a `script` block via `PreEscaped`, so it must not contain quotes,
+/// angle brackets, backslashes, or any other JS-syntax-significant chars.
+fn is_safe_dom_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+pub async fn handle_edit_button_form(ctx: &dyn Context, id: &str) -> OutputStream {
+    // SEC-058: the modal auto-show script below uses `PreEscaped(format!(...))`
+    // to inject the record ID into inline JS. A record returned from
+    // `db::get` should always have a well-formed ID (UUIDv7), but defensively
+    // reject any caller-supplied path segment that isn't strict
+    // `[a-zA-Z0-9_-]{1,64}` so the JS string interpolation can never be
+    // poisoned even if a future code path looks the record up by a
+    // non-validated identifier.
+    if !is_safe_dom_id(id) {
+        return err_not_found("Button not found");
+    }
+    let record = match db::get(ctx, TABLE, id).await {
+        Ok(r) => r,
+        Err(_) => return err_not_found("Button not found"),
+    };
+
+    let current_icon = record.str_field("icon");
+
+    let markup = html! {
+        (components::modal(&format!("edit-btn-{id}"), "Edit Button", html! {
+            form
+                hx-put=(format!("/b/userportal/admin/buttons/{id}"))
+                hx-target="#buttons-table"
+                hx-swap="outerHTML"
+                style="display:flex;flex-direction:column;gap:0.75rem"
+            {
+                div .form-group style="margin:0" {
+                    label .form-label { "Label" }
+                    input .form-input type="text" name="label"
+                        value=(record.str_field("label")) required;
+                }
+                div .form-group style="margin:0" {
+                    label .form-label { "Path" }
+                    input .form-input type="text" name="path"
+                        value=(record.str_field("path")) required;
+                }
+                div .form-group style="margin:0" {
+                    label .form-label { "Icon" }
+                    select .form-input name="icon" {
+                        @for &(value, display) in ICON_OPTIONS {
+                            option value=(value) selected[value == current_icon] { (display) }
+                        }
+                    }
+                }
+                div .form-group style="margin:0" {
+                    label .form-label { "Order" }
+                    input .form-input type="number" name="sort_order"
+                        value=(record.i64_field("sort_order"));
+                }
+                div style="display:flex;gap:0.5rem;justify-content:flex-end" {
+                    button .btn .btn-secondary type="button"
+                        onclick=(format!("document.getElementById('edit-btn-{id}').style.display='none'"))
+                    { "Cancel" }
+                    button .btn .btn-primary type="submit" { "Save" }
+                }
+            }
+        }))
+        // Auto-show the modal
+        script { (maud::PreEscaped(format!(
+            "document.getElementById('edit-btn-{id}').style.display='flex';"
+        ))) }
+    };
+
+    ui::html_response(markup)
+}
+
+pub async fn handle_update_button(ctx: &dyn Context, input: InputStream, id: &str) -> OutputStream {
+    let raw = input.collect_to_bytes().await;
+    let mut data = match parse_button_form(&raw) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    stamp_updated(&mut data);
+
+    if let Err(e) = db::update(ctx, TABLE, id, data).await {
+        return err_internal("Failed to update button", e.message);
+    }
+
+    buttons_table_response(ctx).await
+}
+
+pub async fn handle_delete_button(ctx: &dyn Context, id: &str) -> OutputStream {
+    if let Err(e) = db::delete(ctx, TABLE, id).await {
+        return err_internal("Failed to delete button", e.message);
+    }
+
+    buttons_table_response(ctx).await
+}

--- a/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
@@ -11,8 +11,8 @@ use wafer_core::clients::database::Record;
 use wafer_run::{context::Context, Message, OutputStream};
 
 use crate::{
-    blocks::helpers::{RecordExt, ResponseBuilder},
-    ui::{self, icons, sidebar::nav_icon, SiteConfig, UserInfo},
+    blocks::helpers::{redirect, RecordExt},
+    ui::{icons, sidebar::nav_icon, SiteConfig, UserInfo},
 };
 
 struct DashboardButton {
@@ -25,10 +25,7 @@ struct DashboardButton {
 pub async fn dashboard_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
     if user_id.is_empty() {
-        return ResponseBuilder::new()
-            .status(302)
-            .set_header("Location", "/b/auth/login")
-            .body(Vec::new(), "text/plain");
+        return redirect(302, "/b/auth/login");
     }
 
     let buttons = load_buttons(ctx).await;
@@ -56,19 +53,7 @@ pub async fn dashboard_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    let markup = ui::layout::page(
-        "Account",
-        &config,
-        ui::templates::account_card_page(
-            ui::templates::AccountCard {
-                logo_url: &config.logo_url,
-                title: "Account",
-                back_href: None,
-            },
-            body,
-        ),
-    );
-    ui::html_response(markup)
+    super::account_page(&config, "Account", None, body)
 }
 
 fn nav_link(href: &str, icon: Markup, label: &str) -> Markup {

--- a/crates/solobase-core/src/blocks/userportal/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_buttons;
 pub mod dashboard;
 pub mod profile;
 pub mod security;

--- a/crates/solobase-core/src/blocks/userportal/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/mod.rs
@@ -2,3 +2,33 @@ pub mod dashboard;
 pub mod profile;
 pub mod security;
 pub mod sessions;
+
+use maud::Markup;
+use wafer_run::OutputStream;
+
+use crate::ui::{self, SiteConfig};
+
+/// Render a page in the shared single-card account layout —
+/// `ui::layout::page` + `ui::templates::account_card_page` +
+/// `ui::html_response`. `title` doubles as the document title and the card
+/// heading (every account page uses the same string for both).
+fn account_page(
+    config: &SiteConfig,
+    title: &str,
+    back_href: Option<&str>,
+    body: Markup,
+) -> OutputStream {
+    let markup = ui::layout::page(
+        title,
+        config,
+        ui::templates::account_card_page(
+            ui::templates::AccountCard {
+                logo_url: &config.logo_url,
+                title,
+                back_href,
+            },
+            body,
+        ),
+    );
+    ui::html_response(markup)
+}

--- a/crates/solobase-core/src/blocks/userportal/pages/profile.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/profile.rs
@@ -9,18 +9,15 @@ use wafer_run::{context::Context, Message, OutputStream};
 use crate::{
     blocks::{
         auth::USERS_TABLE,
-        helpers::{RecordExt, ResponseBuilder},
+        helpers::{redirect, RecordExt},
     },
-    ui::{self, components, SiteConfig, UserInfo},
+    ui::{components, SiteConfig, UserInfo},
 };
 
 pub async fn profile_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
     if user_id.is_empty() {
-        return ResponseBuilder::new()
-            .status(302)
-            .set_header("Location", "/b/auth/login")
-            .body(Vec::new(), "text/plain");
+        return redirect(302, "/b/auth/login");
     }
 
     let site_config = SiteConfig::load(ctx).await;
@@ -72,19 +69,7 @@ pub async fn profile_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    let markup = ui::layout::page(
-        "Profile",
-        &site_config,
-        ui::templates::account_card_page(
-            ui::templates::AccountCard {
-                logo_url: &site_config.logo_url,
-                title: "Profile",
-                back_href: Some("/b/userportal/"),
-            },
-            body,
-        ),
-    );
-    ui::html_response(markup)
+    super::account_page(&site_config, "Profile", Some("/b/userportal/"), body)
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/userportal/pages/security.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/security.rs
@@ -7,18 +7,15 @@ use wafer_run::{context::Context, Message, OutputStream};
 use crate::{
     blocks::{
         auth::repo::{provider_links, users},
-        helpers::ResponseBuilder,
+        helpers::redirect,
     },
-    ui::{self, SiteConfig},
+    ui::SiteConfig,
 };
 
 pub async fn security_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
     if user_id.is_empty() {
-        return ResponseBuilder::new()
-            .status(302)
-            .set_header("Location", "/b/auth/login")
-            .body(Vec::new(), "text/plain");
+        return redirect(302, "/b/auth/login");
     }
 
     let links = provider_links::list_for_user(ctx, &user_id)
@@ -110,19 +107,7 @@ pub async fn security_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
 
     let config = SiteConfig::load(ctx).await;
-    let markup = ui::layout::page(
-        "Security",
-        &config,
-        ui::templates::account_card_page(
-            ui::templates::AccountCard {
-                logo_url: &config.logo_url,
-                title: "Security",
-                back_href: Some("/b/userportal/"),
-            },
-            body,
-        ),
-    );
-    ui::html_response(markup)
+    super::account_page(&config, "Security", Some("/b/userportal/"), body)
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/sessions.rs
@@ -6,10 +6,9 @@ use wafer_run::{context::Context, Message, OutputStream};
 use crate::{
     blocks::{
         auth::{repo::sessions, service::hash_token},
-        helpers::{hex_encode, ResponseBuilder},
+        helpers::{hex_encode, redirect, ResponseBuilder},
     },
     ui::{
-        self,
         components::{badge, BadgeVariant},
         SiteConfig,
     },
@@ -18,10 +17,7 @@ use crate::{
 pub async fn sessions_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
     if user_id.is_empty() {
-        return ResponseBuilder::new()
-            .status(302)
-            .set_header("Location", "/b/auth/login")
-            .body(Vec::new(), "text/plain");
+        return redirect(302, "/b/auth/login");
     }
 
     // DB errors are tracing::warn'd (per repo convention) and we render the
@@ -44,19 +40,7 @@ pub async fn sessions_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
 
     let config = SiteConfig::load(ctx).await;
-    let markup = ui::layout::page(
-        "Sessions",
-        &config,
-        ui::templates::account_card_page(
-            ui::templates::AccountCard {
-                logo_url: &config.logo_url,
-                title: "Sessions",
-                back_href: Some("/b/userportal/"),
-            },
-            body,
-        ),
-    );
-    ui::html_response(markup)
+    super::account_page(&config, "Sessions", Some("/b/userportal/"), body)
 }
 
 fn decode_hex(s: &str) -> Option<Vec<u8>> {


### PR DESCRIPTION
fix(S1-J): userportal + email block cleanups — Wave 1, phase 2 of the solobase quality-fix program.

Resumed and verified 6 preserved commits (+524/−454, 10 files). All findings from the plan's S1-J section are addressed and verified locally.

## S1-J findings addressed (all verified)

- [x] **userportal pages repeat the anonymous-redirect block and account-card wrapper 4x each** — added `blocks::helpers::redirect(status, location)` (single source for the status+Location+empty-body redirect shape; replaces 5 anonymous-redirect copies incl. `auth_ui/pages/orgs.rs` + the 303 in `handle_update_profile`) and `userportal::pages::account_page(config, title, back_href, body)` wrapping layout+account_card_page+html_response (replaces 4 identical ~13-line tails).
- [x] **userportal button create/update handlers duplicate the 30-line form-parse/validate block** — extracted `parse_button_form` (parse+validate+json_map) and `buttons_table_response` (htmx table re-render tail); create/update/delete handlers shrink to ~8 lines each.
- [x] **email.rs: four inline HTML templates duplicate layout markup; send_email swallows failures silently** — extracted `email_shell(heading, heading_color, body_html, cta, footnote)`; the 4 template arms now supply content only. Added `tracing::warn!` in all three silent `{"sent":false}` branches (unconfigured Mailgun, request error, non-2xx response). Two unit tests lock the shell shape.
- [x] **userportal/mod.rs god module (scoped slice)** — moved the admin-buttons UI (`admin_buttons_page`, `render_buttons_table`, the CRUD handlers, the SEC-058 `is_safe_dom_id` guard, `ICON_OPTIONS`) into `pages/admin_buttons.rs`. mod.rs: 860 → 529 lines. Branding-settings page intentionally LEFT in mod.rs (S2-M absorbs it into the shared settings-form component — moving it now would churn the same lines twice).
- [x] **Residual 200-OK-with-error-key (userportal arm; coordinated with S1-I)** — `handle_save_settings` parse-failure arm now returns `err_bad_request` (400) instead of `ok_json({"error": ...})`; `config::set` failures are now `tracing::warn!`'d instead of discarded. Per the plan's ownership note, S1-J carries the userportal hunk; S1-I carries the legalpages hunk.

## Decisions made

- The WRAP-grant audit could not statically resolve `super::super::TABLE`, so the const import in `admin_buttons.rs` uses the crate-rooted `crate::blocks::userportal::TABLE` form (matches the auditor's Phase 1.6 resolution and the rest of the codebase). Commit `7ab3e46`.
- `email_shell` adds a third `tracing::warn!` for non-2xx Mailgun responses (the plan named the two silent branches; the non-2xx case was equally silent and `{"sent":false}` — warning it too makes every false result diagnosable).
- Branding-settings page deliberately not moved (deferred to S2-M per plan Instructions).

## Local verification (CI is the final gate)

- `cargo +nightly fmt --all -- --check` — clean
- `cargo check -p solobase-core` — clean; `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean (solobase-core compiles on wasm32 with these changes)
- `cargo clippy -p solobase-core` — 0 errors; **0 new warnings** (the pre-existing warnings in `email.rs`/`helpers.rs` are on lines outside this diff; the `admin_buttons.rs:254` let-else warning is on MOVED code that warned identically as `mod.rs:533` on main)
- `cargo test -p solobase-core` — 728 lib + 38 userportal + 19 email (incl. 2 new `email_shell_*`) tests pass. One **pre-existing, environment-only** failure: `lockfile_e2e::lockfile_loads_remote_block` panics with "wafer-run was compiled without the 'wasmi' feature" — a local feature-resolution gap unrelated to this diff (touches zero Cargo.toml/feature/build/lockfile files); passes on CI.
- Guard scripts: `grep-guard-html.sh` OK; `audit-wrap-grants.sh` OK — no missing WRAP grants (the userportal `TABLE` now resolves correctly post-`7ab3e46`).

No block-SQL/seed changes → no `SOLOBASE_RUN_MIGRATIONS=1` deploy requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)