### PR TITLE
fix(S1-I): legalpages/messages dedupe — publish_document, crud ports, WaferError

### DIFF
--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -157,6 +157,11 @@ impl LegalPagesBlock {
     }
 
     async fn handle_admin_list(&self, ctx: &dyn Context, msg: &Message) -> OutputStream {
+        // Not a pure-CRUD list: it sorts by `updated_at` desc (editors expect
+        // most-recently-touched first), whereas `crud::crud_list` is fixed to
+        // `created_at` desc. Kept inline rather than widening the shared
+        // helper's signature — `blocks::crud` is owned by the products package.
+        let (_, page_size, offset) = msg.pagination_params(20);
         let doc_type = msg.query("type");
         let mut filters = Vec::new();
         if !doc_type.is_empty() {
@@ -166,11 +171,20 @@ impl LegalPagesBlock {
                 value: serde_json::Value::String(doc_type.to_string()),
             });
         }
-        let sort = vec![SortField {
-            field: "updated_at".to_string(),
-            desc: true,
-        }];
-        crud::crud_list(ctx, msg, COLLECTION, filters, Some(sort)).await
+        let opts = ListOptions {
+            filters,
+            sort: vec![SortField {
+                field: "updated_at".to_string(),
+                desc: true,
+            }],
+            limit: page_size as i64,
+            offset: offset as i64,
+            skip_count: false,
+        };
+        match db::list(ctx, COLLECTION, &opts).await {
+            Ok(result) => ok_json(&result),
+            Err(e) => err_internal("Database error", e),
+        }
     }
 
     async fn handle_admin_create(

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -1,5 +1,6 @@
 mod migrations;
 mod pages;
+mod service;
 
 use std::collections::HashMap;
 
@@ -121,14 +122,7 @@ impl LegalPagesBlock {
                 .get("published_at")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            let version = record
-                .data
-                .get("version")
-                .and_then(|v| {
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
-                .unwrap_or(1);
+            let version = service::doc_version(record).unwrap_or(1);
             let meta = if !published_at.is_empty() {
                 format!(
                     "Last updated: {}",
@@ -263,57 +257,33 @@ impl LegalPagesBlock {
             return err_bad_request("Missing document ID");
         }
 
-        // Get current document
+        // Fetch the document first: its `doc_type` drives version
+        // computation and which published siblings get archived.
         let doc = match db::get(ctx, COLLECTION, id).await {
             Ok(r) => r,
             Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Document not found"),
             Err(e) => return err_internal("Database error", e),
         };
-
         let doc_type = doc
             .data
             .get("doc_type")
             .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+            .unwrap_or("");
 
-        // Unpublish other documents of same type
-        let existing = db::list_all(
+        match service::publish_document(
             ctx,
-            COLLECTION,
-            vec![
-                Filter {
-                    field: "doc_type".to_string(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::Value::String(doc_type),
-                },
-                Filter {
-                    field: "status".to_string(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::Value::String("published".to_string()),
-                },
-            ],
+            service::PublishRequest {
+                doc_type,
+                doc_id: id,
+                title: None,
+                content: None,
+                version: 0,
+                created_by: msg.user_id(),
+            },
         )
-        .await;
-        if let Ok(records) = existing {
-            for r in records {
-                let upd = json_map(serde_json::json!({"status": "archived"}));
-                if let Err(e) = db::update(ctx, COLLECTION, &r.id, upd).await {
-                    tracing::warn!("Failed to archive previous legal page version: {e}");
-                }
-            }
-        }
-
-        // Publish this one
-        let now = helpers::now_rfc3339();
-        let data = json_map(serde_json::json!({
-            "status": "published",
-            "published_at": now,
-            "updated_at": now
-        }));
-
-        match db::update(ctx, COLLECTION, id, data).await {
-            Ok(record) => ok_json(&record),
+        .await
+        {
+            Ok(published) => ok_json(&published.record),
             Err(e) => err_internal("Database error", e),
         }
     }

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -2,8 +2,6 @@ mod migrations;
 mod pages;
 mod service;
 
-use std::collections::HashMap;
-
 use maud::{html, Markup, PreEscaped};
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
@@ -13,8 +11,11 @@ use wafer_run::{
 };
 
 use crate::{
-    blocks::helpers::{
-        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, ResponseBuilder,
+    blocks::{
+        crud,
+        helpers::{
+            self, err_bad_request, err_internal, err_not_found, json_map, ok_json, ResponseBuilder,
+        },
     },
     ui::{self, templates, SiteConfig},
 };
@@ -35,18 +36,22 @@ impl Default for LegalPagesBlock {
 
 pub(crate) const COLLECTION: &str = "suppers_ai__legalpages__documents";
 
-/// Extract document ID from path like `/b/legalpages/api/documents/{id}` or
+/// Path prefix preceding the document id in the JSON API routes.
+const API_DOC_PREFIX: &str = "/b/legalpages/api/documents/";
+
+/// Extract document ID from a publish path like
 /// `/b/legalpages/api/documents/{id}/publish`.
+///
+/// The pure-CRUD routes go through `blocks::crud` (which extracts the id
+/// itself); this stays only for the publish route, which has a trailing
+/// `/publish` segment to strip.
 fn extract_doc_id(msg: &Message) -> &str {
     // Try router-extracted var first (native axum), fall back to path parsing (CF)
     let var = msg.var("id");
     if !var.is_empty() {
         return var;
     }
-    let path = msg.path();
-    let suffix = path
-        .strip_prefix("/b/legalpages/api/documents/")
-        .unwrap_or("");
+    let suffix = msg.path().strip_prefix(API_DOC_PREFIX).unwrap_or("");
     // Strip trailing /publish or /
     suffix.split('/').next().unwrap_or("")
 }
@@ -152,7 +157,6 @@ impl LegalPagesBlock {
     }
 
     async fn handle_admin_list(&self, ctx: &dyn Context, msg: &Message) -> OutputStream {
-        let (_, page_size, offset) = msg.pagination_params(20);
         let doc_type = msg.query("type");
         let mut filters = Vec::new();
         if !doc_type.is_empty() {
@@ -162,32 +166,11 @@ impl LegalPagesBlock {
                 value: serde_json::Value::String(doc_type.to_string()),
             });
         }
-        let opts = ListOptions {
-            filters,
-            sort: vec![SortField {
-                field: "updated_at".to_string(),
-                desc: true,
-            }],
-            limit: page_size as i64,
-            offset: offset as i64,
-            skip_count: false,
-        };
-        match db::list(ctx, COLLECTION, &opts).await {
-            Ok(result) => ok_json(&result),
-            Err(e) => err_internal("Database error", e),
-        }
-    }
-
-    async fn handle_admin_get(&self, ctx: &dyn Context, msg: &Message) -> OutputStream {
-        let id = extract_doc_id(msg);
-        if id.is_empty() {
-            return err_bad_request("Missing document ID");
-        }
-        match db::get(ctx, COLLECTION, id).await {
-            Ok(record) => ok_json(&record),
-            Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
-            Err(e) => err_internal("Database error", e),
-        }
+        let sort = vec![SortField {
+            field: "updated_at".to_string(),
+            desc: true,
+        }];
+        crud::crud_list(ctx, msg, COLLECTION, filters, Some(sort)).await
     }
 
     async fn handle_admin_create(
@@ -220,33 +203,6 @@ impl LegalPagesBlock {
 
         match db::create(ctx, COLLECTION, data).await {
             Ok(record) => ok_json(&record),
-            Err(e) => err_internal("Database error", e),
-        }
-    }
-
-    async fn handle_admin_update(
-        &self,
-        ctx: &dyn Context,
-        msg: &Message,
-        input: InputStream,
-    ) -> OutputStream {
-        let id = extract_doc_id(msg);
-        if id.is_empty() {
-            return err_bad_request("Missing document ID");
-        }
-
-        let raw = input.collect_to_bytes().await;
-        let body: HashMap<String, serde_json::Value> = match serde_json::from_slice(&raw) {
-            Ok(b) => b,
-            Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
-        };
-
-        let mut data = body;
-        helpers::stamp_updated(&mut data);
-
-        match db::update(ctx, COLLECTION, id, data).await {
-            Ok(record) => ok_json(&record),
-            Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
             Err(e) => err_internal("Database error", e),
         }
     }
@@ -284,18 +240,6 @@ impl LegalPagesBlock {
         .await
         {
             Ok(published) => ok_json(&published.record),
-            Err(e) => err_internal("Database error", e),
-        }
-    }
-
-    async fn handle_admin_delete(&self, ctx: &dyn Context, msg: &Message) -> OutputStream {
-        let id = extract_doc_id(msg);
-        if id.is_empty() {
-            return err_bad_request("Missing document ID");
-        }
-        match db::delete(ctx, COLLECTION, id).await {
-            Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-            Err(e) if e.code == ErrorCode::NotFound => err_not_found("Document not found"),
             Err(e) => err_internal("Database error", e),
         }
     }
@@ -577,23 +521,20 @@ impl Block for LegalPagesBlock {
 
             // JSON API at /b/legalpages/api/documents/...
             ("retrieve", "/b/legalpages/api/documents") => self.handle_admin_list(ctx, &msg).await,
-            ("retrieve", _) if path.starts_with("/b/legalpages/api/documents/") => {
-                self.handle_admin_get(ctx, &msg).await
+            ("retrieve", _) if path.starts_with(API_DOC_PREFIX) => {
+                crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
             }
             ("create", "/b/legalpages/api/documents") => {
                 self.handle_admin_create(ctx, &msg, input).await
             }
-            ("update", _)
-                if path.starts_with("/b/legalpages/api/documents/")
-                    && path.ends_with("/publish") =>
-            {
+            ("update", _) if path.starts_with(API_DOC_PREFIX) && path.ends_with("/publish") => {
                 self.handle_admin_publish(ctx, &msg).await
             }
-            ("update", _) if path.starts_with("/b/legalpages/api/documents/") => {
-                self.handle_admin_update(ctx, &msg, input).await
+            ("update", _) if path.starts_with(API_DOC_PREFIX) => {
+                crud::crud_update(ctx, &msg, input, COLLECTION, API_DOC_PREFIX, "Document").await
             }
-            ("delete", _) if path.starts_with("/b/legalpages/api/documents/") => {
-                self.handle_admin_delete(ctx, &msg).await
+            ("delete", _) if path.starts_with(API_DOC_PREFIX) => {
+                crud::crud_delete(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
             }
             _ => ui::not_found_response(&msg),
         }

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -8,11 +8,13 @@
 use maud::{html, Markup, PreEscaped};
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
-use wafer_run::{context::Context, InputStream, Message, OutputStream};
+use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
+use super::service;
 use crate::{
     blocks::helpers::{
-        self, err_bad_request, err_internal, json_map, ok_json, RecordExt, ResponseBuilder,
+        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
+        ResponseBuilder,
     },
     ui::{
         components, icons, nav_groups,
@@ -137,14 +139,7 @@ pub async fn editor_page(ctx: &dyn Context, msg: &Message, doc_type: &str) -> Ou
         Some(d) => {
             let t = d.str_field("title");
             let title = if t.is_empty() { default_title } else { t };
-            let ver = d
-                .data
-                .get("version")
-                .and_then(|v| {
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
-                .unwrap_or(1);
+            let ver = super::service::doc_version(d).unwrap_or(1);
             (
                 d.id.as_str(),
                 title,
@@ -638,95 +633,41 @@ pub async fn handle_save(ctx: &dyn Context, msg: &Message, input: InputStream) -
 }
 
 /// Save and publish a document. Archives any previously published document
-/// of the same type.
+/// of the same type (publish-then-archive ordering lives in
+/// `service::publish_document`).
 pub async fn handle_publish(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     let body: SaveRequest = match serde_json::from_slice(&raw) {
         Ok(b) => b,
-        Err(e) => return ok_json(&serde_json::json!({"error": format!("Invalid request: {e}")})),
+        // Previously returned 200 OK with an `error` key — clients would
+        // still treat that as success. Use the proper 4xx so the caller
+        // can branch on status alone (matches `handle_save`).
+        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
     };
 
-    let now = helpers::now_rfc3339();
-
-    // Use user-provided version if > 0, otherwise auto-increment
-    let next_version = if body.version > 0 {
-        body.version
-    } else {
-        let opts = ListOptions {
-            filters: vec![Filter {
-                field: "doc_type".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(&body.doc_type),
-            }],
-            sort: vec![SortField {
-                field: "version".into(),
-                desc: true,
-            }],
-            limit: 1,
-            ..Default::default()
-        };
-        db::list(ctx, COLLECTION, &opts)
-            .await
-            .ok()
-            .and_then(|r| {
-                r.records.first().and_then(|r| {
-                    let v = r.data.get("version")?;
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
-            })
-            .unwrap_or(0)
-            + 1
+    let published = match service::publish_document(
+        ctx,
+        service::PublishRequest {
+            doc_type: &body.doc_type,
+            doc_id: &body.doc_id,
+            title: Some(&body.title),
+            content: Some(&body.content),
+            version: body.version,
+            created_by: msg.user_id(),
+        },
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) if e.code == ErrorCode::NotFound => return err_not_found("Document not found"),
+        Err(e) => return err_internal("Failed to publish legal page", e),
     };
-
-    // Publish the new/updated doc first, then archive previous published
-    // docs of this type. Archiving up-front would leave the doc-type with
-    // no published version if the publish step then failed.
-    let published_id = if !body.doc_id.is_empty() {
-        let data = json_map(serde_json::json!({
-            "title": body.title,
-            "content": body.content,
-            "status": "published",
-            "version": next_version,
-            "published_at": now,
-            "updated_at": now
-        }));
-        match db::update(ctx, COLLECTION, &body.doc_id, data).await {
-            Ok(_) => body.doc_id.clone(),
-            Err(e) => {
-                return err_bad_request(&format!("Failed to publish: {e}"));
-            }
-        }
-    } else {
-        let data = json_map(serde_json::json!({
-            "doc_type": body.doc_type,
-            "title": body.title,
-            "content": body.content,
-            "status": "published",
-            "version": next_version,
-            "created_at": now,
-            "updated_at": now,
-            "published_at": now,
-            "created_by": msg.user_id()
-        }));
-        match db::create(ctx, COLLECTION, data).await {
-            Ok(record) => record.id,
-            Err(e) => {
-                return err_bad_request(&format!("Failed to publish: {e}"));
-            }
-        }
-    };
-
-    // New doc is live; safe to archive earlier published siblings now.
-    // `published_id` (and not just `doc_id_for_archive`) ensures we don't
-    // archive the doc we just created.
-    archive_published(ctx, &body.doc_type, &published_id).await;
 
     ok_json(&serde_json::json!({
-        "doc_id": published_id,
+        "doc_id": published.record.id,
         "status": "published",
-        "version": next_version,
-        "message": format!("Published as v{}", next_version)
+        "version": published.version,
+        "message": format!("Published as v{}", published.version)
     }))
 }
 
@@ -888,36 +829,6 @@ pub async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> Outp
     }
 
     ok_json(&serde_json::json!({"message": "Settings saved"}))
-}
-
-/// Archive all published documents of a given type, except the specified ID.
-async fn archive_published(ctx: &dyn Context, doc_type: &str, except_id: &str) {
-    let existing = db::list_all(
-        ctx,
-        COLLECTION,
-        vec![
-            Filter {
-                field: "doc_type".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!(doc_type),
-            },
-            Filter {
-                field: "status".into(),
-                operator: FilterOp::Equal,
-                value: serde_json::json!("published"),
-            },
-        ],
-    )
-    .await;
-    if let Ok(records) = existing {
-        for r in records {
-            if r.id == except_id {
-                continue;
-            }
-            let upd = json_map(serde_json::json!({"status": "archived"}));
-            let _ = db::update(ctx, COLLECTION, &r.id, upd).await;
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/legalpages/service.rs
+++ b/crates/solobase-core/src/blocks/legalpages/service.rs
@@ -1,0 +1,320 @@
+//! Publish/archive business logic for the legalpages block.
+//!
+//! Plain async functions — no HTTP awareness (mirrors the messages block's
+//! service layering). Both publish surfaces route through
+//! [`publish_document`]:
+//!
+//! - the JSON API handler (`POST /b/legalpages/api/documents/{id}/publish`)
+//! - the admin-UI editor handler (`POST /b/legalpages/admin/publish`)
+//!
+//! so the publish-then-archive ordering and version handling exist exactly
+//! once.
+
+use std::collections::HashMap;
+
+use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database as db;
+use wafer_run::{context::Context, WaferError};
+
+use super::COLLECTION;
+use crate::blocks::helpers::{self, json_map};
+
+/// Inputs for [`publish_document`].
+pub(super) struct PublishRequest<'a> {
+    /// Document type (`terms` / `privacy`); drives version computation and
+    /// which previously published siblings get archived.
+    pub doc_type: &'a str,
+    /// Existing document to publish; empty string = create a new one.
+    pub doc_id: &'a str,
+    /// New title from the editor; `None` keeps the stored value
+    /// (JSON API publish path).
+    pub title: Option<&'a str>,
+    /// New content from the editor; `None` keeps the stored value.
+    pub content: Option<&'a str>,
+    /// Explicit version when `> 0`, otherwise auto-increment past the
+    /// highest existing version for this `doc_type`.
+    pub version: i64,
+    /// Recorded as `created_by` when a new document is created.
+    pub created_by: &'a str,
+}
+
+/// Outcome of a successful [`publish_document`] call.
+pub(super) struct Published {
+    /// The published document as stored.
+    pub record: db::Record,
+    /// The version it was published as.
+    pub version: i64,
+}
+
+/// Publish a document, then archive previously published documents of the
+/// same type.
+///
+/// Ordering matters: the new doc goes live first, and the archive pass
+/// excludes it. Archiving up-front would leave the doc-type with no
+/// published version if the publish step then failed.
+pub(super) async fn publish_document(
+    ctx: &dyn Context,
+    req: PublishRequest<'_>,
+) -> Result<Published, WaferError> {
+    let version = if req.version > 0 {
+        req.version
+    } else {
+        latest_version(ctx, req.doc_type).await + 1
+    };
+
+    let now = helpers::now_rfc3339();
+    let record = if req.doc_id.is_empty() {
+        let mut data = json_map(serde_json::json!({
+            "doc_type": req.doc_type,
+            "status": "published",
+            "version": version,
+            "created_at": now,
+            "updated_at": now,
+            "published_at": now,
+            "created_by": req.created_by,
+        }));
+        insert_opt(&mut data, "title", req.title);
+        insert_opt(&mut data, "content", req.content);
+        db::create(ctx, COLLECTION, data).await?
+    } else {
+        let mut data = json_map(serde_json::json!({
+            "status": "published",
+            "version": version,
+            "published_at": now,
+            "updated_at": now,
+        }));
+        insert_opt(&mut data, "title", req.title);
+        insert_opt(&mut data, "content", req.content);
+        db::update(ctx, COLLECTION, req.doc_id, data).await?
+    };
+
+    // New doc is live; safe to archive earlier published siblings now.
+    archive_published(ctx, req.doc_type, &record.id).await;
+
+    Ok(Published { record, version })
+}
+
+/// Read a document's `version` field, tolerating integer or string storage.
+pub(super) fn doc_version(record: &db::Record) -> Option<i64> {
+    let v = record.data.get("version")?;
+    v.as_i64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// Highest version recorded for any document of `doc_type` (0 when none).
+async fn latest_version(ctx: &dyn Context, doc_type: &str) -> i64 {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "doc_type".into(),
+            operator: FilterOp::Equal,
+            value: serde_json::json!(doc_type),
+        }],
+        sort: vec![SortField {
+            field: "version".into(),
+            desc: true,
+        }],
+        limit: 1,
+        ..Default::default()
+    };
+    db::list(ctx, COLLECTION, &opts)
+        .await
+        .ok()
+        .and_then(|r| r.records.first().and_then(doc_version))
+        .unwrap_or(0)
+}
+
+/// Archive all published documents of a given type, except `except_id`
+/// (the document that was just published).
+async fn archive_published(ctx: &dyn Context, doc_type: &str, except_id: &str) {
+    let existing = db::list_all(
+        ctx,
+        COLLECTION,
+        vec![
+            Filter {
+                field: "doc_type".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!(doc_type),
+            },
+            Filter {
+                field: "status".into(),
+                operator: FilterOp::Equal,
+                value: serde_json::json!("published"),
+            },
+        ],
+    )
+    .await;
+    if let Ok(records) = existing {
+        for r in records {
+            if r.id == except_id {
+                continue;
+            }
+            let upd = json_map(serde_json::json!({"status": "archived"}));
+            if let Err(e) = db::update(ctx, COLLECTION, &r.id, upd).await {
+                tracing::warn!("Failed to archive previous legal page version: {e}");
+            }
+        }
+    }
+}
+
+fn insert_opt(data: &mut HashMap<String, serde_json::Value>, key: &str, value: Option<&str>) {
+    if let Some(v) = value {
+        data.insert(key.to_string(), serde_json::Value::String(v.to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    async fn ctx_with_schema() -> TestContext {
+        let ctx = TestContext::with_admin().await;
+        super::super::migrations::apply(&ctx)
+            .await
+            .expect("apply legalpages migrations");
+        ctx
+    }
+
+    async fn seed_doc(
+        ctx: &TestContext,
+        doc_type: &str,
+        title: &str,
+        status: &str,
+        version: i64,
+    ) -> db::Record {
+        let now = helpers::now_rfc3339();
+        let data = json_map(serde_json::json!({
+            "doc_type": doc_type,
+            "title": title,
+            "content": "body",
+            "status": status,
+            "version": version,
+            "created_at": now,
+            "updated_at": now,
+            "created_by": "seed",
+        }));
+        db::create(ctx, COLLECTION, data).await.expect("seed doc")
+    }
+
+    #[tokio::test]
+    async fn publish_existing_doc_auto_increments_and_archives_previous() {
+        let ctx = ctx_with_schema().await;
+        let live = seed_doc(&ctx, "terms", "Old Terms", "published", 3).await;
+        let draft = seed_doc(&ctx, "terms", "New Terms", "draft", 1).await;
+
+        let published = publish_document(
+            &ctx,
+            PublishRequest {
+                doc_type: "terms",
+                doc_id: &draft.id,
+                title: None,
+                content: None,
+                version: 0,
+                created_by: "admin_1",
+            },
+        )
+        .await
+        .expect("publish draft");
+
+        // Auto-increment past the highest existing version (3 → 4).
+        assert_eq!(published.version, 4);
+        assert_eq!(published.record.id, draft.id);
+
+        // The just-published doc must NOT be archived (except_id guard) and
+        // keeps its stored title (JSON publish path passes None).
+        let now_live = db::get(&ctx, COLLECTION, &draft.id).await.expect("get");
+        assert_eq!(
+            now_live.data.get("status").and_then(|v| v.as_str()),
+            Some("published")
+        );
+        assert_eq!(doc_version(&now_live), Some(4));
+        assert_eq!(
+            now_live.data.get("title").and_then(|v| v.as_str()),
+            Some("New Terms")
+        );
+
+        // The previously published sibling is archived.
+        let archived = db::get(&ctx, COLLECTION, &live.id).await.expect("get");
+        assert_eq!(
+            archived.data.get("status").and_then(|v| v.as_str()),
+            Some("archived")
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_new_doc_creates_published_and_archives_previous() {
+        let ctx = ctx_with_schema().await;
+        let live = seed_doc(&ctx, "privacy", "Old Policy", "published", 1).await;
+
+        let published = publish_document(
+            &ctx,
+            PublishRequest {
+                doc_type: "privacy",
+                doc_id: "",
+                title: Some("New Policy"),
+                content: Some("fresh body"),
+                version: 0,
+                created_by: "admin_1",
+            },
+        )
+        .await
+        .expect("publish new doc");
+
+        assert_eq!(published.version, 2);
+        assert_ne!(published.record.id, live.id);
+
+        let created = db::get(&ctx, COLLECTION, &published.record.id)
+            .await
+            .expect("get created");
+        assert_eq!(
+            created.data.get("status").and_then(|v| v.as_str()),
+            Some("published")
+        );
+        assert_eq!(
+            created.data.get("title").and_then(|v| v.as_str()),
+            Some("New Policy")
+        );
+        assert_eq!(
+            created.data.get("created_by").and_then(|v| v.as_str()),
+            Some("admin_1")
+        );
+
+        let archived = db::get(&ctx, COLLECTION, &live.id).await.expect("get");
+        assert_eq!(
+            archived.data.get("status").and_then(|v| v.as_str()),
+            Some("archived")
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_respects_explicit_version_and_other_doc_types_untouched() {
+        let ctx = ctx_with_schema().await;
+        let other_type = seed_doc(&ctx, "terms", "Terms", "published", 1).await;
+        let draft = seed_doc(&ctx, "privacy", "Policy", "draft", 1).await;
+
+        let published = publish_document(
+            &ctx,
+            PublishRequest {
+                doc_type: "privacy",
+                doc_id: &draft.id,
+                title: Some("Policy"),
+                content: Some("body"),
+                version: 7,
+                created_by: "admin_1",
+            },
+        )
+        .await
+        .expect("publish with explicit version");
+
+        assert_eq!(published.version, 7);
+
+        // Archiving is scoped to the published doc_type.
+        let untouched = db::get(&ctx, COLLECTION, &other_type.id)
+            .await
+            .expect("get");
+        assert_eq!(
+            untouched.data.get("status").and_then(|v| v.as_str()),
+            Some("published")
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/messages/a2a.rs
+++ b/crates/solobase-core/src/blocks/messages/a2a.rs
@@ -166,7 +166,7 @@ async fn handle_send_message(
 
         service::create_context(ctx, "task", &title, "", "", None, None)
             .await
-            .map_err(|e| (-32000, e))?
+            .map_err(|e| (-32000, format!("Database error: {e}")))?
     };
 
     let parts_meta = if parts.is_empty() {
@@ -185,7 +185,7 @@ async fn handle_send_message(
         parts_meta,
     )
     .await
-    .map_err(|e| (-32000, e))?;
+    .map_err(|e| (-32000, format!("Database error: {e}")))?;
 
     if context_id.is_none() {
         let mut updates = std::collections::HashMap::new();
@@ -226,7 +226,7 @@ async fn handle_list_tasks(
 
     let result = service::list_contexts(ctx, &list_params)
         .await
-        .map_err(|e| (-32000, e))?;
+        .map_err(|e| (-32000, format!("Database error: {e}")))?;
 
     let total_count = result.total_count;
     // Consume the records — each task carries metadata/parent_id we'd

--- a/crates/solobase-core/src/blocks/messages/rest.rs
+++ b/crates/solobase-core/src/blocks/messages/rest.rs
@@ -135,6 +135,7 @@ pub async fn delete_context(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
     match service::delete_context(ctx, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
+        Err(e) if e.code == ErrorCode::NotFound => err_not_found("Context not found"),
         Err(e) => err_internal("delete_context failed", e),
     }
 }

--- a/crates/solobase-core/src/blocks/messages/rest.rs
+++ b/crates/solobase-core/src/blocks/messages/rest.rs
@@ -1,11 +1,22 @@
 //! REST endpoint handlers for the messages block.
 //!
 //! Thin layer: parse HTTP request → call service → format JSON response.
+//! Pure-CRUD shells (get context/entry, delete entry) go through the shared
+//! `blocks::crud` helpers instead.
 
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
 use super::service::{self, ListContextsParams, ListEntriesParams};
-use crate::blocks::helpers::{err_bad_request, err_internal, err_not_found, ok_json};
+use crate::blocks::{
+    crud,
+    helpers::{err_bad_request, err_internal, err_not_found, ok_json},
+};
+
+/// Path prefix preceding the context id in the REST routes.
+const CONTEXTS_PREFIX: &str = "/b/messages/api/contexts/";
+
+/// Path prefix preceding the entry id in the REST routes.
+const ENTRIES_PREFIX: &str = "/b/messages/api/entries/";
 
 /// Convert empty string to None (msg.query() returns "" for missing params).
 fn non_empty(s: &str) -> Option<String> {
@@ -27,19 +38,7 @@ fn extract_context_id(msg: &Message) -> &str {
     if !var.is_empty() {
         return var;
     }
-    let path = msg.path();
-    let suffix = path.strip_prefix("/b/messages/api/contexts/").unwrap_or("");
-    suffix.split('/').next().unwrap_or("")
-}
-
-/// Extract entry ID from paths like `/b/messages/api/entries/{id}`.
-fn extract_entry_id(msg: &Message) -> &str {
-    let var = msg.var("id");
-    if !var.is_empty() {
-        return var;
-    }
-    let path = msg.path();
-    let suffix = path.strip_prefix("/b/messages/api/entries/").unwrap_or("");
+    let suffix = msg.path().strip_prefix(CONTEXTS_PREFIX).unwrap_or("");
     suffix.split('/').next().unwrap_or("")
 }
 
@@ -99,15 +98,14 @@ pub async fn create_context(ctx: &dyn Context, input: InputStream) -> OutputStre
 }
 
 pub async fn get_context(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let id = extract_context_id(msg);
-    if id.is_empty() {
-        return err_bad_request("Missing context ID");
-    }
-    match service::get_context(ctx, id).await {
-        Ok(record) => ok_json(&record),
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("Context not found"),
-        Err(e) => err_internal("Database error", e),
-    }
+    crud::crud_get(
+        ctx,
+        msg,
+        service::CONTEXTS_TABLE,
+        CONTEXTS_PREFIX,
+        "Context",
+    )
+    .await
 }
 
 pub async fn update_context(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
@@ -206,25 +204,9 @@ pub async fn add_entry(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
 }
 
 pub async fn get_entry(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let id = extract_entry_id(msg);
-    if id.is_empty() {
-        return err_bad_request("Missing entry ID");
-    }
-    match service::get_entry(ctx, id).await {
-        Ok(record) => ok_json(&record),
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("Entry not found"),
-        Err(e) => err_internal("Database error", e),
-    }
+    crud::crud_get(ctx, msg, service::ENTRIES_TABLE, ENTRIES_PREFIX, "Entry").await
 }
 
 pub async fn delete_entry(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let id = extract_entry_id(msg);
-    if id.is_empty() {
-        return err_bad_request("Missing entry ID");
-    }
-    match service::delete_entry(ctx, id).await {
-        Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("Entry not found"),
-        Err(e) => err_internal("Database error", e),
-    }
+    crud::crud_delete(ctx, msg, service::ENTRIES_TABLE, ENTRIES_PREFIX, "Entry").await
 }

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -38,7 +38,7 @@ pub async fn create_context(
     recipient_id: &str,
     parent_id: Option<&str>,
     metadata: Option<serde_json::Value>,
-) -> Result<db::Record, String> {
+) -> Result<db::Record, WaferError> {
     let metadata = metadata.unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
 
     let mut data = json_map(serde_json::json!({
@@ -56,9 +56,7 @@ pub async fn create_context(
 
     helpers::stamp_created(&mut data);
 
-    db::create(ctx, CONTEXTS_TABLE, data)
-        .await
-        .map_err(|e| format!("Database error: {e}"))
+    db::create(ctx, CONTEXTS_TABLE, data).await
 }
 
 pub async fn get_context(ctx: &dyn Context, id: &str) -> Result<db::Record, WaferError> {
@@ -77,7 +75,7 @@ pub struct ListContextsParams {
 pub async fn list_contexts(
     ctx: &dyn Context,
     params: &ListContextsParams,
-) -> Result<db::RecordList, String> {
+) -> Result<db::RecordList, WaferError> {
     let filters = [
         ("type", params.context_type.as_deref()),
         ("status", params.status.as_deref()),
@@ -99,9 +97,7 @@ pub async fn list_contexts(
         skip_count: false,
     };
 
-    db::list(ctx, CONTEXTS_TABLE, &opts)
-        .await
-        .map_err(|e| format!("Database error: {e}"))
+    db::list(ctx, CONTEXTS_TABLE, &opts).await
 }
 
 pub async fn update_context(
@@ -121,7 +117,7 @@ pub async fn update_context(
     db::update(ctx, CONTEXTS_TABLE, id, data).await
 }
 
-pub async fn delete_context(ctx: &dyn Context, id: &str) -> Result<(), String> {
+pub async fn delete_context(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
     // Cascade delete entries first
     let filters = vec![Filter {
         field: "context_id".to_string(),
@@ -132,9 +128,7 @@ pub async fn delete_context(ctx: &dyn Context, id: &str) -> Result<(), String> {
         tracing::warn!("Failed to cascade delete entries for context {id}: {e}");
     }
 
-    db::delete(ctx, CONTEXTS_TABLE, id)
-        .await
-        .map_err(|e| format!("Database error: {e}"))
+    db::delete(ctx, CONTEXTS_TABLE, id).await
 }
 
 // ---------------------------------------------------------------------------
@@ -150,7 +144,7 @@ pub async fn add_entry(
     content: &str,
     content_type: Option<&str>,
     metadata: Option<serde_json::Value>,
-) -> Result<db::Record, String> {
+) -> Result<db::Record, WaferError> {
     let metadata = metadata.unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
     let content_type = content_type.unwrap_or("text/plain");
 
@@ -167,9 +161,7 @@ pub async fn add_entry(
         "created_at": now,
     }));
 
-    let record = db::create(ctx, ENTRIES_TABLE, data)
-        .await
-        .map_err(|e| format!("Database error: {e}"))?;
+    let record = db::create(ctx, ENTRIES_TABLE, data).await?;
 
     // Bump parent context's updated_at
     let mut context_update = std::collections::HashMap::new();
@@ -196,7 +188,7 @@ pub async fn list_entries(
     ctx: &dyn Context,
     context_id: &str,
     params: &ListEntriesParams,
-) -> Result<db::RecordList, String> {
+) -> Result<db::RecordList, WaferError> {
     let mut filters = vec![Filter {
         field: "context_id".to_string(),
         operator: FilterOp::Equal,
@@ -229,9 +221,7 @@ pub async fn list_entries(
         skip_count: false,
     };
 
-    db::list(ctx, ENTRIES_TABLE, &opts)
-        .await
-        .map_err(|e| format!("Database error: {e}"))
+    db::list(ctx, ENTRIES_TABLE, &opts).await
 }
 
 pub async fn delete_entry(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -1,7 +1,8 @@
 //! Service layer for the messages block.
 //!
-//! Plain async functions — no HTTP awareness. Both REST and A2A handlers
-//! call these. All database interactions live here.
+//! Plain async functions — no HTTP awareness. Shared by the REST, A2A,
+//! and SSR-page handlers. Pure-CRUD REST shells with no business logic
+//! (get context/entry, delete entry) go through `blocks::crud` instead.
 
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
@@ -173,10 +174,6 @@ pub async fn add_entry(
     Ok(record)
 }
 
-pub async fn get_entry(ctx: &dyn Context, id: &str) -> Result<db::Record, WaferError> {
-    db::get(ctx, ENTRIES_TABLE, id).await
-}
-
 pub struct ListEntriesParams {
     pub kind: Option<String>,
     pub role: Option<String>,
@@ -222,8 +219,4 @@ pub async fn list_entries(
     };
 
     db::list(ctx, ENTRIES_TABLE, &opts).await
-}
-
-pub async fn delete_entry(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
-    db::delete(ctx, ENTRIES_TABLE, id).await
 }


### PR DESCRIPTION
S1-I: legalpages/messages dedupe (solobase quality-fix program, phase 2, wave 1). Resumed + verified preserved Wave-1 work.

## Findings addressed (S1-I plan section)
- [x] **[high/duplication] legalpages publish/archive business logic implemented twice with divergent semantics** — extracted `legalpages/service.rs::publish_document` with the CORRECT semantics (publish-then-archive-with-`except_id` ordering + version auto-increment). Both the JSON API (`POST /api/documents/{id}/publish`) and the admin-UI (`POST /admin/publish`) handlers route through it. Inline `archive_published` loops deleted from `mod.rs` and `pages.rs`. 4 pinning tests on real in-memory SQLite (auto-increment, except_id archiving, explicit version, doc_type scoping).
- [x] **[medium/duplication] crud.rs only used by products; legalpages and messages hand-roll the same handlers** — ported the pure-CRUD shells onto the EXISTING `blocks::crud` API: legalpages JSON `get/update/delete` dispatch arms call `crud_get/crud_update/crud_delete` directly; messages `rest::get_context/get_entry/delete_entry` are now thin crud wrappers. Dead `handle_admin_get/update/delete`, `service::get_entry/delete_entry` passthroughs, and `extract_entry_id` deleted. `handle_admin_create` keeps its typed/validated body; `handle_admin_list` stays inline (sorts by `updated_at`, see crud.rs note below).
- [x] **[medium/code-smell] messages service layer mixes Result<_, String> and Result<_, WaferError>** — all `service.rs` functions now return `Result<_, WaferError>` (dropped the `format!("Database error: {e}")` wrapping). `rest::update_context/delete_context` get uniform `ErrorCode::NotFound -> 404` handling; `a2a.rs` maps to the JSON-RPC `(-32000, ...)` tuple at its boundary (the only String consumer).
- [x] **[low/code-smell] Residual 200-OK-with-error-key responses** — legalpages `handle_publish` parse-failure arm now returns `err_bad_request` (matches `handle_save`). **The userportal `handle_save_settings` hunk is OWNED BY S1-J** per the plan (3-line hunk in a file S1-J also touches; S1-J is running concurrently) — intentionally NOT in this PR.

## Decisions made
- **crud.rs ownership ceded to S1-E:** this PR delivers ZERO crud.rs changes. An earlier preserved commit routed `handle_admin_list` through a `crud_list(..., Some(sort))` extension; since that extension belongs to S1-E (the only intentional shared file in wave 1), the final commit reverts `handle_admin_list` to an inline `db::list` call (documented in-code). legalpages/messages consume only the `crud_get/crud_update/crud_delete` API already on main. No rebase against S1-E needed.
- **a2a.rs kept:** the `/a2a` removal branch `fix/messages-remove-a2a` (`1ddaa75`, from the 2026-06-05 review program) is unmerged and a2a.rs is still on main. Per the plan sequencing note, kept a2a.rs and its JSON-RPC tuple mapping at the boundary rather than pulling an out-of-program security removal into this PR.

## Deferred
- userportal `handle_save_settings` err_bad_request hunk -> S1-J (see above).

## Verification (local, CI-mirror; CI is the final gate)
- `cargo +nightly fmt --all -- --check`: clean
- `bash scripts/grep-guard-html.sh`: OK; `bash scripts/audit-wrap-grants.sh`: OK — no missing WRAP grants (the 4 "unresolved" messages_schema constants are a pre-existing static-analysis note on the re-export; script exits 0, unchanged from main)
- `cargo clippy -p solobase-core --all-targets`: no NEW warnings in touched files (the 4 clippy hits in legalpages/messages — needless_lifetimes, uninlined_format_args, 2x too_many_arguments — are all pre-existing on main on lines this PR did not change; `add_entry` had the same 8 args on main)
- `cargo test -p solobase-core`: 729 lib tests + integration suites pass (16 legalpages, 11 messages incl. 4 new publish_document tests). The single failure `lockfile_e2e::lockfile_loads_remote_block` is environmental — "wafer-run was compiled without the wasmi feature" in the shared local worktree — and unrelated (this PR touches zero test/Cargo/feature files; it passes on CI with the correct feature set).
- Scope confirmed: only `legalpages/{mod,pages,service}.rs` + `messages/{a2a,rest,service}.rs` touched.

## Migrations
No block-SQL/migration changes — `SOLOBASE_RUN_MIGRATIONS=1` NOT required.

Do not merge (orchestrator handles merge).
