### PR TITLE
fix(S1-A): rewrite HTTP codec consumers onto wafer_block::http_codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,6 +5808,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5831,6 +5832,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5842,6 +5844,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5862,6 +5865,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5871,6 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5884,6 +5889,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5897,6 +5903,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5908,6 +5915,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5918,6 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5934,6 +5943,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5954,6 +5964,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5963,6 +5974,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5974,6 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5989,6 +6002,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5998,6 +6012,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6018,6 +6033,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6029,6 +6045,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6050,6 +6067,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6059,6 +6077,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6088,6 +6107,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6097,6 +6117,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5832,7 +5831,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5844,7 +5842,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5865,7 +5862,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5875,7 +5871,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5889,7 +5884,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5903,7 +5897,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5915,7 +5908,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5926,7 +5918,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5943,7 +5934,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5964,7 +5954,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5974,7 +5963,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5986,7 +5974,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6002,7 +5989,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6012,7 +5998,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6033,7 +6018,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6045,7 +6029,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6067,7 +6050,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6077,7 +6059,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6107,7 +6088,6 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6117,7 +6097,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -1,59 +1,27 @@
+//! HTTP ↔ Message conversion for the browser Service Worker adapter.
+//!
+//! Thin platform glue: the protocol mapping (method→action table, request
+//! meta layout, response-meta classification, `ErrorCode`→status table) lives
+//! in `wafer_block::http_codec` — the same implementation the native axum
+//! listener and the Cloudflare adapter use. Only `web_sys` I/O lives here:
+//! reading the request body/headers, the Service-Worker cookie re-injection,
+//! and building `web_sys::Response` (buffered or `ReadableStream`-backed).
+
 use futures::{SinkExt, StreamExt};
 use js_sys::{ArrayBuffer, Uint8Array};
 use wafer_block::{
-    meta::{
-        META_REQ_ACTION, META_REQ_CLIENT_IP, META_REQ_CONTENT_TYPE, META_REQ_QUERY_PREFIX,
-        META_REQ_RESOURCE, META_RESP_CONTENT_TYPE, META_RESP_COOKIE_PREFIX,
-        META_RESP_HEADER_PREFIX, META_RESP_STATUS,
-    },
+    http_codec::{self, ResponseMetaPart},
+    meta::META_RESP_CONTENT_TYPE,
     stream::StreamEvent,
     streams::{
         input::InputStream,
-        output::{OutputStream, TerminalNotResponse},
+        output::{BufferedResponse, OutputStream, TerminalNotResponse},
     },
-    ErrorCode, Message, MetaEntry, MetaGet,
+    Message, MetaEntry, MetaGet,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Headers, ResponseInit};
-
-use crate::helpers::urlencoding_decode;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn http_method_to_action(method: &str) -> &'static str {
-    match method.to_uppercase().as_str() {
-        "GET" | "HEAD" => "retrieve",
-        "POST" => "create",
-        "PUT" | "PATCH" => "update",
-        "DELETE" => "delete",
-        _ => "execute",
-    }
-}
-
-fn error_code_to_http_status(code: &ErrorCode) -> u16 {
-    match code {
-        ErrorCode::Ok => 200,
-        ErrorCode::Cancelled => 499,
-        ErrorCode::InvalidArgument => 400,
-        ErrorCode::DeadlineExceeded => 504,
-        ErrorCode::NotFound => 404,
-        ErrorCode::AlreadyExists => 409,
-        ErrorCode::PermissionDenied => 403,
-        ErrorCode::ResourceExhausted => 429,
-        ErrorCode::FailedPrecondition => 412,
-        ErrorCode::Aborted => 409,
-        ErrorCode::OutOfRange => 400,
-        ErrorCode::Unimplemented => 501,
-        ErrorCode::Internal => 500,
-        ErrorCode::Unavailable => 503,
-        ErrorCode::DataLoss => 500,
-        ErrorCode::Unauthenticated => 401,
-        _ => 500,
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Request conversion
@@ -61,9 +29,11 @@ fn error_code_to_http_status(code: &ErrorCode) -> u16 {
 
 /// Convert a browser `web_sys::Request` into a WAFER `(Message, InputStream)` pair.
 ///
-/// Mirrors `http_to_message()` from `wafer-block-http-listener`.  The remote
-/// address is always `"127.0.0.1"` — in a Service Worker the request comes
-/// from the same device.
+/// The protocol mapping (kind, `http.*` / `req.*` meta, method→action, header
+/// and query decoding) is delegated to `http_codec::build_http_message`; only
+/// the `web_sys` body/header reads and the Service-Worker cookie re-injection
+/// are browser-specific. The remote address is always `"127.0.0.1"` — in a
+/// Service Worker the request comes from the same device.
 pub async fn request_to_message(
     request: &web_sys::Request,
 ) -> Result<(Message, InputStream), JsValue> {
@@ -94,68 +64,42 @@ pub async fn request_to_message(
         arr.to_vec()
     };
 
-    let mut msg = Message::new(format!("{}:{}", method, path));
-
-    // HTTP-specific meta (mirrors the native listener).
-    msg.set_meta("http.method", method.clone());
-    msg.set_meta("http.path", path.clone());
-    msg.set_meta("http.raw_query", raw_query.clone());
-    msg.set_meta("http.remote_addr", "127.0.0.1");
-
-    // Collect headers into meta.
+    // Collect headers into (name, value) pairs for the codec.
+    let mut header_pairs: Vec<(String, String)> = Vec::new();
     let headers: Headers = request.headers();
-    // Iterate the headers JS iterator.
     let iter =
         js_sys::try_iter(&headers)?.ok_or_else(|| JsValue::from_str("headers not iterable"))?;
-    let mut content_type = String::new();
-    let mut host = String::new();
     for item in iter {
         let item = item?;
         // Each entry is a JS Array [name, value].
         let arr: js_sys::Array = item.dyn_into()?;
-        let key = arr.get(0).as_string().unwrap_or_default().to_lowercase();
+        let key = arr.get(0).as_string().unwrap_or_default();
         let val = arr.get(1).as_string().unwrap_or_default();
-        if key == "content-type" {
-            content_type = val.clone();
-        }
-        if key == "host" {
-            host = val.clone();
-        }
-        msg.set_meta(format!("http.header.{}", key), val);
+        header_pairs.push((key, val));
     }
-
-    msg.set_meta("http.content_type", content_type.clone());
-    msg.set_meta("http.host", host);
 
     // Re-inject the `Cookie` header from the SW's CookieStore.
     // `FetchEvent.request.headers` filters `Cookie` out per the SW spec, so
-    // the header-iteration loop above never sees it even though the browser
-    // sends cookies on same-origin requests. CookieStore is the only way to
-    // read them back inside the SW.
+    // the header iteration above never sees it even though the browser sends
+    // cookies on same-origin requests. CookieStore is the only way to read
+    // them back inside the SW.
     let cookie_val = crate::bridge::read_cookie_header().await;
     if let Some(s) = cookie_val.as_string() {
         if !s.is_empty() {
-            msg.set_meta("http.header.cookie", s);
+            header_pairs.push(("cookie".to_string(), s));
         }
     }
 
-    // Normalised request meta.
-    msg.set_meta(META_REQ_ACTION, http_method_to_action(&method));
-    msg.set_meta(META_REQ_RESOURCE, path.clone());
-    msg.set_meta(META_REQ_CLIENT_IP, "127.0.0.1");
-    msg.set_meta(META_REQ_CONTENT_TYPE, content_type);
-
-    // Decode query parameters into both `http.query.*` and `req.query.*`.
-    if !raw_query.is_empty() {
-        for pair in raw_query.split('&') {
-            let mut parts = pair.splitn(2, '=');
-            if let (Some(key), Some(val)) = (parts.next(), parts.next()) {
-                let decoded_val = urlencoding_decode(val);
-                msg.set_meta(format!("http.query.{}", key), decoded_val.clone());
-                msg.set_meta(format!("{}{}", META_REQ_QUERY_PREFIX, key), decoded_val);
-            }
-        }
-    }
+    // `build_http_message` builds `kind`, `http.*` and normalized `req.*` meta
+    // from the method+path. The browser serves paths as-received (no `/api`
+    // prefix to strip, unlike the Cloudflare adapter), so no post-fixup.
+    let msg = http_codec::build_http_message(
+        &method,
+        &path,
+        &raw_query,
+        "127.0.0.1",
+        header_pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+    );
 
     Ok((msg, InputStream::from_bytes(body)))
 }
@@ -164,65 +108,26 @@ pub async fn request_to_message(
 // Response conversion
 // ---------------------------------------------------------------------------
 
-/// Apply response meta entries to a `web_sys::Headers` object.
-///
-/// Mirrors `apply_response_meta()` from the native listener.
-fn apply_response_meta(headers: &Headers, meta: &[wafer_block::MetaEntry]) -> Result<(), JsValue> {
-    for entry in meta {
-        let k = entry.key.as_str();
-        let v = &entry.value;
-        match k {
-            k if k == META_RESP_STATUS || k == "http.status" => {
-                // Status is handled separately; skip.
-            }
-            k if k.starts_with(META_RESP_COOKIE_PREFIX)
-                || k.starts_with("http.resp.set-cookie.") =>
-            {
-                headers.append("Set-Cookie", v)?;
-            }
-            k if k.starts_with(META_RESP_HEADER_PREFIX) => {
-                let header_name = &k[META_RESP_HEADER_PREFIX.len()..];
-                headers.set(header_name, v)?;
-            }
-            k if k.starts_with("http.resp.header.") => {
-                let header_name = &k[17..];
-                headers.set(header_name, v)?;
-            }
-            k if k == META_RESP_CONTENT_TYPE || k == "Content-Type" => {
-                headers.set("Content-Type", v)?;
-            }
-            _ => {}
+/// Apply classified response-meta parts to a `web_sys::Headers`. Status parts
+/// are resolved separately (see `http_codec::resolve_status`) and skipped here.
+/// Only the canonical `resp.*` meta keys are honored — legacy aliases
+/// (`http.status`, `http.resp.header.*`, `http.resp.set-cookie.*`, a literal
+/// `Content-Type` meta key) are ignored by `http_codec`.
+fn apply_response_meta(headers: &Headers, meta: &[MetaEntry]) -> Result<(), JsValue> {
+    for part in http_codec::response_meta_parts(meta) {
+        match part {
+            ResponseMetaPart::Status(_) => {}
+            ResponseMetaPart::Header { name, value } => headers.set(name, value)?,
+            ResponseMetaPart::SetCookie(v) => headers.append("Set-Cookie", v)?,
+            ResponseMetaPart::ContentType(v) => headers.set("Content-Type", v)?,
         }
     }
     Ok(())
 }
 
-fn get_status_code(meta: &[wafer_block::MetaEntry], default_code: u16) -> u16 {
-    if let Some(code) = MetaGet::get(meta, META_RESP_STATUS) {
-        if let Ok(n) = code.parse::<u16>() {
-            return n;
-        }
-    }
-    if let Some(code) = MetaGet::get(meta, "http.status") {
-        if let Ok(n) = code.parse::<u16>() {
-            return n;
-        }
-    }
-    default_code
-}
-
-fn get_error_status_code(
-    error: Option<&wafer_block::WaferError>,
-    meta: &[wafer_block::MetaEntry],
-) -> u16 {
-    let from_meta = get_status_code(meta, 0);
-    if from_meta > 0 {
-        return from_meta;
-    }
-    if let Some(err) = error {
-        return error_code_to_http_status(&err.code);
-    }
-    500
+/// True when `meta` carries an explicit `resp.content_type` entry.
+fn has_content_type(meta: &[MetaEntry]) -> bool {
+    MetaGet::contains_key(meta, META_RESP_CONTENT_TYPE)
 }
 
 /// Build a `web_sys::Response` from raw bytes, a status code, and a
@@ -247,14 +152,6 @@ fn make_response(
     }
 }
 
-/// True for content-types that should stream body chunks to the browser as
-/// they're produced rather than buffer the entire response. Today: SSE and
-/// generic byte streams (which feature blocks use for downloads / archives).
-fn is_streaming_content_type(ct: &str) -> bool {
-    let lower = ct.to_ascii_lowercase();
-    lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
-}
-
 /// Pull `Meta` events off the front of an `OutputStream`, stopping at the
 /// first non-Meta event. Returns the accumulated meta and the next event
 /// (if any). Used by `output_to_response` to peek the response's headers
@@ -270,14 +167,6 @@ async fn drain_leading_meta(output: &mut OutputStream) -> (Vec<MetaEntry>, Optio
     (meta, None)
 }
 
-/// Build a `ReadableStream` body that pipes remaining `Chunk` events from an
-/// `OutputStream` to the browser. The first chunk (already pulled from the
-/// stream) is pushed first, then the loop drains the rest.
-///
-/// Terminal events (`Complete`, `Error`, `Drop`, `Continue`) close the stream.
-/// `Error` after we've already started writing the body is the stream just
-/// being aborted — there's no way to flip the HTTP status mid-response, so
-/// we close the stream and let the browser surface the truncation.
 /// Build a JS `ReadableStream` that yields `first_chunk` and then every
 /// subsequent `Chunk` event from `remaining`. Mid-body `Meta` is dropped
 /// (too late to apply to HTTP headers); any terminal closes the stream.
@@ -338,193 +227,168 @@ fn make_streaming_body(
 /// Convert a WAFER `OutputStream` into a browser `web_sys::Response`.
 ///
 /// Two paths:
-/// 1. **Buffered** (default) — for blocks that emit `Chunk(bytes), Complete{meta}`
-///    via `respond_with_meta`. Status, headers, and body all live in the
-///    terminal `Complete{meta}` for those blocks, so we have to read the
-///    whole stream before we can build the `Response`. Same behaviour as
-///    before this commit.
-/// 2. **Streaming** — for blocks that emit leading `Meta` events declaring
+/// 1. **Streaming** — for blocks that emit leading `Meta` events declaring
 ///    `Content-Type: text/event-stream` (or `application/octet-stream`)
-///    BEFORE the first `Chunk`. We build a `Response` with a `ReadableStream`
-///    body and pipe subsequent chunks straight to the browser, so a
-///    multi-minute SSE response doesn't get held back behind a buffer that
-///    flushes at the very end (which Chrome's idle keep-alive treats as a
-///    hung fetch and drops with `net::ERR_FAILED`).
+///    BEFORE the first `Chunk`. We classify the leading meta with
+///    `http_codec::response_meta_parts` and apply status + headers to a
+///    `Response` backed by a `ReadableStream`, piping subsequent chunks
+///    straight to the browser — so a multi-minute SSE response isn't held
+///    back behind a buffer that flushes at the very end (which Chrome's idle
+///    keep-alive treats as a hung fetch and drops with `net::ERR_FAILED`).
+///    The meta is applied *before the body finishes*, so this path must NOT
+///    route through `collect_http_response` (which buffers).
+/// 2. **Buffered** (default) — for blocks that emit `Chunk(bytes),
+///    Complete{meta}` via `respond_with_meta`. Status, headers, and body all
+///    live in the terminal, so we read the whole stream before building the
+///    `Response`. The terminal-event mapping mirrors
+///    `http_codec::collect_http_response` (whose drift decisions —
+///    `Continue` → empty `200`, default `Content-Type: application/json`,
+///    `Ok`/`Halt` identical — are pinned by the codec's tests).
 pub async fn output_to_response(mut output: OutputStream) -> Result<web_sys::Response, JsValue> {
-    // Peek leading Meta events without consuming Chunks. The streaming path
-    // is signalled by an early Content-Type meta; buffered blocks send no
-    // Meta before their first Chunk, so this just returns an empty vec for
-    // them and the loop below falls through to `collect_buffered`.
+    // Peek leading Meta events without consuming Chunks. The streaming path is
+    // signalled by an early Content-Type meta; buffered blocks send no Meta
+    // before their first Chunk, so this returns an empty vec for them and the
+    // buffered branch below handles the terminal.
     let (leading_meta, next_event) = drain_leading_meta(&mut output).await;
 
-    let leading_ct = MetaGet::get(&leading_meta, META_RESP_CONTENT_TYPE)
-        .or_else(|| MetaGet::get(&leading_meta, "Content-Type"));
+    let leading_ct = http_codec::response_meta_parts(&leading_meta).find_map(|part| match part {
+        ResponseMetaPart::ContentType(ct) => Some(ct.to_string()),
+        _ => None,
+    });
 
     if let (Some(ct), Some(StreamEvent::Chunk(first))) = (leading_ct, &next_event) {
-        if is_streaming_content_type(ct) {
+        if is_streaming_content_type(&ct) {
             return build_streaming_response(leading_meta, first.clone(), output);
         }
     }
 
-    // Buffered path — drain the rest, prepending whatever we've already
-    // pulled (leading meta + the next event we peeked).
-    let (terminal_result, mut prelude_meta, mut prelude_body) = match next_event {
-        Some(StreamEvent::Chunk(b)) => {
-            // Continue collecting from where we are. Build a synthetic stream
-            // that yields the rest of `output` and replays the chunk we just
-            // peeked at the front.
-            (output.collect_buffered().await, leading_meta, b)
-        }
-        Some(StreamEvent::Complete { meta }) => {
-            // Terminal landed before any chunk — this is a header-only OK.
-            // Combine prelude + terminal meta and emit an empty body.
-            let mut all_meta = leading_meta;
-            all_meta.extend(meta);
-            return finalise_buffered(Ok(buffered_view(Vec::new(), all_meta)));
-        }
-        Some(StreamEvent::Error(err)) => {
-            return finalise_buffered(Err(TerminalNotResponse::Error(*err)));
-        }
-        Some(StreamEvent::Drop) => {
-            return finalise_buffered(Err(TerminalNotResponse::Drop));
-        }
-        Some(StreamEvent::Continue(msg)) => {
-            return finalise_buffered(Err(TerminalNotResponse::Continue(msg)));
-        }
-        Some(StreamEvent::Meta(_)) => unreachable!("drain_leading_meta consumes Meta events"),
-        Some(StreamEvent::Halt { body, meta }) => {
-            // Halt before any chunk — short-circuit terminal carrying its
-            // own body+meta. Combine the prelude meta we drained with the
-            // Halt's meta and finalise as a buffered Halt terminal.
-            use wafer_run::streams::output::BufferedResponse;
-            let mut all_meta = leading_meta;
-            all_meta.extend(meta);
-            return finalise_buffered(Err(TerminalNotResponse::Halt(BufferedResponse {
-                body,
-                meta: all_meta,
-            })));
-        }
-        None => {
-            // Stream ended after meta-only with no terminal — malformed.
-            return finalise_buffered(Err(TerminalNotResponse::Malformed));
-        }
-    };
+    // Buffered path — drain the remainder, prepending the leading meta + the
+    // event we peeked, then map the terminal to a response exactly as
+    // `http_codec::collect_http_response` would for a non-peeked stream.
+    let terminal = collect_buffered_with_prelude(output, leading_meta, next_event).await;
+    finalise_buffered(terminal)
+}
 
-    match terminal_result {
-        Ok(buf) => {
-            // Merge the leading meta we drained earlier with the buffered tail.
-            prelude_meta.extend(buf.meta);
-            prelude_body.extend(buf.body);
-            finalise_buffered(Ok(buffered_view(prelude_body, prelude_meta)))
+/// True for content-types that should stream body chunks to the browser as
+/// they're produced rather than buffer the entire response. Today: SSE and
+/// generic byte streams (which feature blocks use for downloads / archives).
+fn is_streaming_content_type(ct: &str) -> bool {
+    let lower = ct.to_ascii_lowercase();
+    lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
+}
+
+/// Drain the remaining stream into a buffered terminal, prepending the
+/// already-peeked leading meta + next event. Mirrors the contract of
+/// `OutputStream::collect_buffered` (a `Halt` terminal replaces any streamed
+/// prelude), reproduced here because `solobase-browser` cannot depend on
+/// `solobase-core`'s `pipeline::collect_buffered_with_prelude`.
+async fn collect_buffered_with_prelude(
+    rest: OutputStream,
+    leading_meta: Vec<MetaEntry>,
+    next_event: Option<StreamEvent>,
+) -> Result<BufferedResponse, TerminalNotResponse> {
+    match next_event {
+        Some(StreamEvent::Chunk(first)) => match rest.collect_buffered().await {
+            Ok(buf) => {
+                let mut body = first;
+                body.extend(buf.body);
+                let mut meta = leading_meta;
+                meta.extend(buf.meta);
+                Ok(BufferedResponse { body, meta })
+            }
+            Err(terminal) => Err(terminal),
+        },
+        Some(StreamEvent::Meta(_)) => unreachable!("drain_leading_meta consumes Meta events"),
+        Some(StreamEvent::Complete { meta }) => {
+            let mut all_meta = leading_meta;
+            all_meta.extend(meta);
+            Ok(BufferedResponse {
+                body: Vec::new(),
+                meta: all_meta,
+            })
         }
-        Err(other) => finalise_buffered(Err(other)),
+        Some(StreamEvent::Halt { body, meta }) => {
+            // Halt carries a complete response; per the `collect_buffered`
+            // contract any prior streamed events — the prelude included — are
+            // replaced by its payload.
+            Err(TerminalNotResponse::Halt(BufferedResponse { body, meta }))
+        }
+        Some(StreamEvent::Error(err)) => Err(TerminalNotResponse::Error(*err)),
+        Some(StreamEvent::Drop) => Err(TerminalNotResponse::Drop),
+        Some(StreamEvent::Continue(msg)) => Err(TerminalNotResponse::Continue(msg)),
+        None => Err(TerminalNotResponse::Malformed),
     }
 }
 
-/// Local mirror of `wafer_block::streams::output::BufferedOutput` so we can
-/// re-enter the buffered finaliser with a synthetic value built from the
-/// leading-meta drain. Carries body bytes + accumulated meta.
-struct BufferedView {
-    body: Vec<u8>,
-    meta: Vec<MetaEntry>,
-}
-
-fn buffered_view(body: Vec<u8>, meta: Vec<MetaEntry>) -> BufferedView {
-    BufferedView { body, meta }
-}
-
+/// Map a buffered terminal to a `web_sys::Response`, mirroring
+/// `http_codec::collect_http_response`'s terminal handling (the codec maps to
+/// transport-neutral parts; we apply them to `web_sys` types here).
 fn finalise_buffered(
-    result: Result<BufferedView, TerminalNotResponse>,
+    result: Result<BufferedResponse, TerminalNotResponse>,
 ) -> Result<web_sys::Response, JsValue> {
     match result {
-        Ok(buf) => {
-            let status = get_status_code(&buf.meta, 200);
+        // Ok and Halt are the single buffered code path (codec finding 55).
+        Ok(buf) | Err(TerminalNotResponse::Halt(buf)) => {
+            let status = http_codec::resolve_status(&buf.meta, 200);
             let headers = Headers::new()?;
             apply_response_meta(&headers, &buf.meta)?;
-
-            let has_ct = MetaGet::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
-                || MetaGet::contains_key(&buf.meta, "Content-Type");
-            if !has_ct {
-                headers.set("Content-Type", "application/json")?;
+            if !has_content_type(&buf.meta) {
+                headers.set("Content-Type", http_codec::DEFAULT_RESPONSE_CONTENT_TYPE)?;
             }
-
             make_response(buf.body, status, headers)
         }
 
         Err(TerminalNotResponse::Error(err)) => {
-            let status = get_error_status_code(Some(&err), &err.meta);
+            let status = http_codec::resolve_error_status(&err);
             let headers = Headers::new()?;
             apply_response_meta(&headers, &err.meta)?;
-            headers.set("Content-Type", "application/json")?;
-
+            // Error bodies ARE JSON; a `resp.content_type` on the error meta is
+            // superseded (exactly one Content-Type, matching the codec).
+            headers.set("Content-Type", http_codec::DEFAULT_RESPONSE_CONTENT_TYPE)?;
             let body = serde_json::json!({
                 "error": err.code,
                 "message": err.message,
             })
             .to_string()
             .into_bytes();
-
             make_response(body, status, headers)
         }
 
-        Err(TerminalNotResponse::Drop) => {
-            let headers = Headers::new()?;
-            make_response(Vec::new(), 204, headers)
-        }
+        Err(TerminalNotResponse::Drop) => make_response(Vec::new(), 204, Headers::new()?),
 
-        Err(TerminalNotResponse::Continue(_msg)) => {
+        Err(TerminalNotResponse::Continue(msg)) => {
+            // Codec drift: `Continue` at the HTTP boundary → empty-body 200
+            // with the message's response meta applied (nowhere to forward).
             let headers = Headers::new()?;
-            headers.set("Content-Type", "application/json")?;
-            make_response(
-                b"{\"error\":\"continue not supported by listener\"}".to_vec(),
-                500,
-                headers,
-            )
+            apply_response_meta(&headers, &msg.meta)?;
+            headers.set("Content-Type", http_codec::DEFAULT_RESPONSE_CONTENT_TYPE)?;
+            make_response(Vec::new(), 200, headers)
         }
 
         Err(TerminalNotResponse::Malformed) => {
+            web_sys::console::error_1(
+                &"solobase-browser: stream ended without terminal event".into(),
+            );
             let headers = Headers::new()?;
-            headers.set("Content-Type", "application/json")?;
-            make_response(
-                b"{\"error\":\"stream ended without terminal event\"}".to_vec(),
-                500,
-                headers,
-            )
-        }
-
-        Err(TerminalNotResponse::Halt(buf)) => {
-            // Halt is a successful short-circuit terminal — the body+meta
-            // ARE the response. Same wire shape as the Ok arm.
-            let status = get_status_code(&buf.meta, 200);
-            let headers = Headers::new()?;
-            apply_response_meta(&headers, &buf.meta)?;
-
-            let has_ct = MetaGet::contains_key(&buf.meta, META_RESP_CONTENT_TYPE)
-                || MetaGet::contains_key(&buf.meta, "Content-Type");
-            if !has_ct {
-                headers.set("Content-Type", "application/json")?;
-            }
-
-            make_response(buf.body, status, headers)
+            make_response(b"internal server error".to_vec(), 500, headers)
         }
     }
 }
 
 /// Build a streaming `web_sys::Response` from the leading meta (carrying
-/// status + headers) and an `OutputStream` whose remaining events should be
-/// piped into the body.
+/// status + headers) and an `OutputStream` whose remaining events are piped
+/// into the body. Meta is classified and applied *before* the body finishes —
+/// the whole point of the streaming path.
 fn build_streaming_response(
     leading_meta: Vec<MetaEntry>,
     first_chunk: Vec<u8>,
     remaining: OutputStream,
 ) -> Result<web_sys::Response, JsValue> {
-    let status = get_status_code(&leading_meta, 200);
+    let status = http_codec::resolve_status(&leading_meta, 200);
     let headers = Headers::new()?;
     apply_response_meta(&headers, &leading_meta)?;
 
-    let has_ct = MetaGet::contains_key(&leading_meta, META_RESP_CONTENT_TYPE)
-        || MetaGet::contains_key(&leading_meta, "Content-Type");
-    if !has_ct {
+    if !has_content_type(&leading_meta) {
         // Streaming bodies without an explicit Content-Type fall back to
         // octet-stream rather than the JSON default the buffered path uses.
         headers.set("Content-Type", "application/octet-stream")?;

--- a/crates/solobase-browser/src/helpers.rs
+++ b/crates/solobase-browser/src/helpers.rs
@@ -1,35 +1,11 @@
 //! Shared helpers for the browser adapter crates (wasm32-only).
 //!
-//! These are thin wrappers kept here — rather than duplicated in `convert.rs`
-//! and `database.rs` — because `solobase-browser` does not depend on
-//! `solobase-core`. When the dependency is ever added, these can be deleted and
-//! callers switched to `solobase_core::blocks::helpers::*`.
+//! Thin wrappers kept here — rather than duplicated in `database.rs` — because
+//! `solobase-browser` does not depend on `solobase-core`. When the dependency
+//! is ever added, these can be deleted and callers switched to
+//! `solobase_core::blocks::helpers::*`.
 
 /// Current UTC time as RFC 3339 string.
 pub(crate) fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
-}
-
-/// Decode a percent-encoded (URL-encoded) string.
-///
-/// Decodes `+` as a space (form-urlencoding semantics) and `%XX` hex
-/// sequences. Matches the canonical implementation in
-/// `solobase_core::blocks::helpers::urlencoding_decode`.
-pub(crate) fn urlencoding_decode(s: &str) -> String {
-    let s = s.replace('+', " ");
-    let mut result = Vec::new();
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
-                result.push(byte);
-                i += 3;
-                continue;
-            }
-        }
-        result.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8_lossy(&result).into_owned()
 }

--- a/crates/solobase-cloudflare/src/convert.rs
+++ b/crates/solobase-cloudflare/src/convert.rs
@@ -49,7 +49,8 @@ pub async fn worker_request_to_message(req: &Request) -> Result<(Message, InputS
         .or_else(|| req.headers().get("x-forwarded-for").ok().flatten())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let mut msg = http_codec::build_http_message(&method, &path, &query, &remote_addr, req.headers());
+    let mut msg =
+        http_codec::build_http_message(&method, &path, &query, &remote_addr, req.headers());
     // The message kind and normalized `req.resource` use the /api-stripped
     // path; `http.path` keeps the path as received on the wire.
     msg.set_meta(META_HTTP_PATH, raw_path);

--- a/crates/solobase-cloudflare/src/convert.rs
+++ b/crates/solobase-cloudflare/src/convert.rs
@@ -1,16 +1,12 @@
-//! HTTP ↔ Message conversion for Cloudflare Workers (streaming protocol).
+//! HTTP ↔ Message conversion for Cloudflare Workers.
 //!
-//! Converts `worker::Request` → `(Message, InputStream)` and
-//! `OutputStream` → `worker::Response`. Mirrors the native axum adapter
-//! in `wafer-block-http-listener` and the browser adapter in `solobase-web`.
+//! Thin platform glue: the protocol mapping (method→action table, request
+//! meta layout, response-meta classification, terminal-event mapping) lives
+//! in `wafer_block::http_codec` — the same implementation the native axum
+//! listener and the browser adapter use. Only worker-type I/O lives here.
 
-use solobase_core::blocks::helpers::urlencoding_decode;
-use wafer_run::{
-    ErrorCode, InputStream, Message, MetaEntry, OutputStream, TerminalNotResponse, WaferError,
-    META_REQ_ACTION, META_REQ_CLIENT_IP, META_REQ_CONTENT_TYPE, META_REQ_QUERY_PREFIX,
-    META_REQ_RESOURCE, META_RESP_CONTENT_TYPE, META_RESP_COOKIE_PREFIX, META_RESP_HEADER_PREFIX,
-    META_RESP_STATUS,
-};
+use wafer_block::http_codec::{self, META_HTTP_PATH};
+use wafer_run::{InputStream, Message, OutputStream};
 use worker::{Request, Response, Result};
 
 // ---------------------------------------------------------------------------
@@ -53,54 +49,10 @@ pub async fn worker_request_to_message(req: &Request) -> Result<(Message, InputS
         .or_else(|| req.headers().get("x-forwarded-for").ok().flatten())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let mut msg = Message::new(format!("{}:{}", method, path));
-
-    // HTTP-specific meta
-    msg.set_meta("http.method", method.clone());
-    msg.set_meta("http.path", raw_path);
-    msg.set_meta("http.raw_query", query.clone());
-    msg.set_meta("http.remote_addr", remote_addr.clone());
-
-    let content_type = req
-        .headers()
-        .get("content-type")
-        .ok()
-        .flatten()
-        .unwrap_or_default();
-    msg.set_meta("http.content_type", content_type.clone());
-
-    let host = req.headers().get("host").ok().flatten().unwrap_or_default();
-    msg.set_meta("http.host", host);
-
-    // Normalized request meta (using the rewritten path)
-    let action = match method.as_str() {
-        "GET" | "HEAD" => "retrieve",
-        "POST" => "create",
-        "PUT" | "PATCH" => "update",
-        "DELETE" => "delete",
-        _ => "execute",
-    };
-    msg.set_meta(META_REQ_ACTION, action);
-    msg.set_meta(META_REQ_RESOURCE, path);
-    msg.set_meta(META_REQ_CLIENT_IP, remote_addr);
-    msg.set_meta(META_REQ_CONTENT_TYPE, content_type);
-
-    // Copy headers to meta
-    for (name, value) in req.headers() {
-        msg.set_meta(format!("http.header.{}", name), value);
-    }
-
-    // Parse query params
-    if !query.is_empty() {
-        for pair in query.split('&') {
-            let mut parts = pair.splitn(2, '=');
-            if let (Some(key), Some(val)) = (parts.next(), parts.next()) {
-                let decoded = urlencoding_decode(val);
-                msg.set_meta(format!("http.query.{}", key), decoded.clone());
-                msg.set_meta(format!("{}{}", META_REQ_QUERY_PREFIX, key), decoded);
-            }
-        }
-    }
+    let mut msg = http_codec::build_http_message(&method, &path, &query, &remote_addr, req.headers());
+    // The message kind and normalized `req.resource` use the /api-stripped
+    // path; `http.path` keeps the path as received on the wire.
+    msg.set_meta(META_HTTP_PATH, raw_path);
 
     Ok((msg, InputStream::from_bytes(body)))
 }
@@ -111,172 +63,16 @@ pub async fn worker_request_to_message(req: &Request) -> Result<(Message, InputS
 
 /// Convert a WAFER `OutputStream` into a Cloudflare Worker `Response`.
 ///
-/// Buffers the full stream, mirroring the axum + web_sys adapters. Handles
-/// all four `TerminalNotResponse` branches.
+/// Buffers the full stream through the canonical
+/// `http_codec::collect_http_response` terminal mapping, then applies the
+/// transport-neutral parts to the worker types.
 pub async fn output_to_response(output: OutputStream) -> Result<Response> {
-    match output.collect_buffered().await {
-        Ok(buf) => {
-            let status = get_status(&buf.meta, 200);
-
-            let resp = Response::from_bytes(buf.body)?;
-            let mut resp = resp.with_status(status);
-            let headers = resp.headers_mut();
-
-            // Apply response headers from meta
-            apply_meta_headers(headers, &buf.meta)?;
-
-            // Default Content-Type: application/json if unset
-            let has_ct = meta_contains_ct(&buf.meta);
-            if !has_ct {
-                headers.set("Content-Type", "application/json")?;
-            }
-
-            Ok(resp)
-        }
-
-        Err(TerminalNotResponse::Error(err)) => {
-            let err_meta = err.meta.clone();
-            let status = get_error_status(Some(&err), &err_meta);
-
-            let body = serde_json::json!({
-                "error": format!("{:?}", err.code),
-                "message": err.message,
-            })
-            .to_string();
-
-            let resp = Response::ok(body)?;
-            let mut resp = resp.with_status(status);
-            let headers = resp.headers_mut();
-            apply_meta_headers(headers, &err_meta)?;
-            headers.set("Content-Type", "application/json")?;
-
-            Ok(resp)
-        }
-
-        Err(TerminalNotResponse::Drop) => {
-            let resp = Response::empty()?;
-            Ok(resp.with_status(204))
-        }
-
-        Err(TerminalNotResponse::Continue(msg)) => {
-            // At the top-level HTTP boundary, Continue is treated as an empty 200
-            // with the trailing message meta forwarded as headers.
-            let resp = Response::empty()?;
-            let mut resp = resp.with_status(200);
-            let headers = resp.headers_mut();
-            apply_meta_headers(headers, &msg.meta)?;
-            headers.set("Content-Type", "application/json")?;
-            Ok(resp)
-        }
-
-        Err(TerminalNotResponse::Malformed) => {
-            let resp = Response::ok("{\"error\":\"stream ended without terminal event\"}")?;
-            let mut resp = resp.with_status(500);
-            resp.headers_mut().set("Content-Type", "application/json")?;
-            Ok(resp)
-        }
-
-        Err(TerminalNotResponse::Halt(buf)) => {
-            // Halt is a successful short-circuit terminal — body+meta ARE
-            // the response. Same wire shape as the Ok arm.
-            let status = get_status(&buf.meta, 200);
-
-            let resp = Response::from_bytes(buf.body)?;
-            let mut resp = resp.with_status(status);
-            let headers = resp.headers_mut();
-
-            apply_meta_headers(headers, &buf.meta)?;
-
-            let has_ct = meta_contains_ct(&buf.meta);
-            if !has_ct {
-                headers.set("Content-Type", "application/json")?;
-            }
-
-            Ok(resp)
-        }
+    let parts = http_codec::collect_http_response(output).await;
+    let headers = worker::Headers::new();
+    for (name, value) in &parts.headers {
+        headers.append(name, value)?;
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn meta_get(meta: &[MetaEntry], key: &str) -> Option<String> {
-    meta.iter().find(|e| e.key == key).map(|e| e.value.clone())
-}
-
-fn meta_contains_ct(meta: &[MetaEntry]) -> bool {
-    meta.iter()
-        .any(|e| e.key == META_RESP_CONTENT_TYPE || e.key == "Content-Type")
-}
-
-fn get_status(meta: &[MetaEntry], default: u16) -> u16 {
-    meta_get(meta, META_RESP_STATUS)
-        .or_else(|| meta_get(meta, "http.status"))
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
-}
-
-fn get_error_status(error: Option<&WaferError>, meta: &[MetaEntry]) -> u16 {
-    let from_meta = get_status(meta, 0);
-    if from_meta > 0 {
-        return from_meta;
-    }
-    if let Some(err) = error {
-        return error_code_to_http_status(&err.code);
-    }
-    500
-}
-
-fn error_code_to_http_status(code: &ErrorCode) -> u16 {
-    match code {
-        ErrorCode::Ok => 200,
-        ErrorCode::Cancelled => 499,
-        ErrorCode::InvalidArgument => 400,
-        ErrorCode::DeadlineExceeded => 504,
-        ErrorCode::NotFound => 404,
-        ErrorCode::AlreadyExists => 409,
-        ErrorCode::PermissionDenied => 403,
-        ErrorCode::ResourceExhausted => 429,
-        ErrorCode::FailedPrecondition => 412,
-        ErrorCode::Aborted => 409,
-        ErrorCode::OutOfRange => 400,
-        ErrorCode::Unimplemented => 501,
-        ErrorCode::Internal => 500,
-        ErrorCode::Unavailable => 503,
-        ErrorCode::DataLoss => 500,
-        ErrorCode::Unauthenticated => 401,
-        _ => 500,
-    }
-}
-
-/// Apply response headers from meta to the Worker response.
-///
-/// Recognizes:
-/// - `resp.cookie.*` / `resp.set_cookie.*` / `http.resp.set-cookie.*` → Set-Cookie
-/// - `resp.header.*` / `http.resp.header.*` → custom response header
-/// - `resp.content_type` / `Content-Type` → Content-Type
-fn apply_meta_headers(headers: &mut worker::Headers, meta: &[MetaEntry]) -> Result<()> {
-    for entry in meta {
-        let k = entry.key.as_str();
-        let v = &entry.value;
-        // Status is handled separately; skip.
-        if k == META_RESP_STATUS || k == "http.status" {
-            continue;
-        }
-        if k.starts_with(META_RESP_COOKIE_PREFIX)
-            || k.starts_with("resp.set_cookie.")
-            || k.starts_with("http.resp.set-cookie.")
-        {
-            headers.append("Set-Cookie", v)?;
-        } else if let Some(name) = k
-            .strip_prefix(META_RESP_HEADER_PREFIX)
-            .or_else(|| k.strip_prefix("http.resp.header."))
-        {
-            headers.set(name, v)?;
-        } else if k == META_RESP_CONTENT_TYPE || k == "Content-Type" {
-            headers.set("Content-Type", v)?;
-        }
-    }
-    Ok(())
+    Ok(Response::from_bytes(parts.body)?
+        .with_status(parts.status)
+        .with_headers(headers))
 }

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -222,12 +222,9 @@ fn replay_buffered(body: Vec<u8>, meta: Vec<MetaEntry>) -> OutputStream {
 
 /// Pull `Meta` events off the front of an `OutputStream`, stopping at the
 /// first non-`Meta` event. Returns the accumulated meta and the next event
-/// (if any). Lets an HTTP boundary peek the response's headers before
-/// deciding whether to stream the body or buffer it (the browser adapter
-/// reuses this for its streaming-vs-buffered split).
-pub async fn drain_leading_meta(
-    stream: &mut OutputStream,
-) -> (Vec<MetaEntry>, Option<StreamEvent>) {
+/// (if any). Lets the pipeline peek the response's headers before deciding
+/// whether to stream the body or buffer it.
+async fn drain_leading_meta(stream: &mut OutputStream) -> (Vec<MetaEntry>, Option<StreamEvent>) {
     let mut meta = Vec::new();
     while let Some(ev) = stream.next().await {
         match ev {
@@ -241,7 +238,7 @@ pub async fn drain_leading_meta(
 /// The canonical `resp.content_type` among the leading meta entries, if any.
 /// Legacy aliases (a literal `Content-Type` meta key) are not honored — the
 /// canonical-keys-only policy is pinned by `wafer_block::http_codec`.
-pub fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
+fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
     http_codec::response_meta_parts(meta).find_map(|part| match part {
         ResponseMetaPart::ContentType(ct) => Some(ct),
         _ => None,
@@ -251,7 +248,7 @@ pub fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
 /// True for content-types that should stream body chunks to the client as
 /// they're produced rather than buffer the entire response. Today: SSE and
 /// generic byte streams (which feature blocks use for downloads / archives).
-pub fn is_streaming_content_type(ct: &str) -> bool {
+fn is_streaming_content_type(ct: &str) -> bool {
     let lower = ct.to_ascii_lowercase();
     lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
 }
@@ -329,7 +326,7 @@ fn rebuild_streaming(
 ///
 /// `next_event` must come from [`drain_leading_meta`] (i.e. it is never
 /// `StreamEvent::Meta`).
-pub async fn collect_buffered_with_prelude(
+async fn collect_buffered_with_prelude(
     rest: OutputStream,
     leading_meta: Vec<MetaEntry>,
     next_event: Option<StreamEvent>,

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -4,8 +4,10 @@
 //! converting their platform-specific HTTP types into a WAFER Message.
 
 use futures::StreamExt;
-use wafer_block::http_codec::{self, ResponseMetaPart};
-use wafer_block::stream::StreamEvent;
+use wafer_block::{
+    http_codec::{self, ResponseMetaPart},
+    stream::StreamEvent,
+};
 use wafer_core::clients::{config as config_client, database as db};
 use wafer_run::{
     context::Context,

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -4,12 +4,14 @@
 //! converting their platform-specific HTTP types into a WAFER Message.
 
 use futures::StreamExt;
+use wafer_block::http_codec::{self, ResponseMetaPart};
 use wafer_block::stream::StreamEvent;
 use wafer_core::clients::{config as config_client, database as db};
 use wafer_run::{
-    context::Context, streams::output::TerminalNotResponse, BlockInfo, ErrorCode, InputStream,
-    Message, MetaEntry, OutputStream, WaferError, META_REQ_RESOURCE, META_RESP_CONTENT_TYPE,
-    META_RESP_STATUS,
+    context::Context,
+    streams::output::{BufferedResponse, OutputSink, TerminalNotResponse},
+    BlockInfo, ErrorCode, InputStream, Message, MetaEntry, OutputStream, WaferError,
+    META_REQ_RESOURCE,
 };
 
 use crate::{
@@ -140,12 +142,7 @@ pub async fn handle_request(
         OutputStream,
     ) = match collect_buffered_with_prelude(stream, leading_meta, next_event).await {
         Ok(buf) => {
-            let code = buf
-                .meta
-                .iter()
-                .find(|m| m.key == META_RESP_STATUS || m.key == "http.status")
-                .and_then(|m| m.value.parse::<i64>().ok())
-                .unwrap_or(200);
+            let code = i64::from(http_codec::resolve_status(&buf.meta, 200));
             (
                 "OK",
                 code,
@@ -172,12 +169,7 @@ pub async fn handle_request(
             }),
         ),
         Err(TerminalNotResponse::Halt(buf)) => {
-            let code = buf
-                .meta
-                .iter()
-                .find(|m| m.key == META_RESP_STATUS || m.key == "http.status")
-                .and_then(|m| m.value.parse::<i64>().ok())
-                .unwrap_or(200);
+            let code = i64::from(http_codec::resolve_status(&buf.meta, 200));
             (
                 "OK",
                 code,
@@ -194,8 +186,11 @@ pub async fn handle_request(
     let duration_ms = i64::try_from(crate::blocks::helpers::now_millis().saturating_sub(start_ms))
         .unwrap_or(i64::MAX);
 
-    // Skip logging static asset requests to reduce noise
-    if !path.starts_with("/static/") && path != "/health" {
+    // Skip logging static asset requests to reduce noise (one request_logs
+    // write per CSS/JS/font/logo fetch otherwise). The prefix is the shared
+    // `routing::STATIC_PREFIX` const so it can't drift from the routing
+    // table and the `ui::assets` URL builders again.
+    if !path.starts_with(routing::STATIC_PREFIX) && path != "/health" {
         let mut data = std::collections::HashMap::new();
         data.insert("method".to_string(), serde_json::json!(method));
         data.insert("path".to_string(), serde_json::json!(path));
@@ -225,9 +220,12 @@ fn replay_buffered(body: Vec<u8>, meta: Vec<MetaEntry>) -> OutputStream {
 
 /// Pull `Meta` events off the front of an `OutputStream`, stopping at the
 /// first non-`Meta` event. Returns the accumulated meta and the next event
-/// (if any). Lets the pipeline peek the response's headers before deciding
-/// whether to stream the body or buffer + log.
-async fn drain_leading_meta(stream: &mut OutputStream) -> (Vec<MetaEntry>, Option<StreamEvent>) {
+/// (if any). Lets an HTTP boundary peek the response's headers before
+/// deciding whether to stream the body or buffer it (the browser adapter
+/// reuses this for its streaming-vs-buffered split).
+pub async fn drain_leading_meta(
+    stream: &mut OutputStream,
+) -> (Vec<MetaEntry>, Option<StreamEvent>) {
     let mut meta = Vec::new();
     while let Some(ev) = stream.next().await {
         match ev {
@@ -238,18 +236,52 @@ async fn drain_leading_meta(stream: &mut OutputStream) -> (Vec<MetaEntry>, Optio
     (meta, None)
 }
 
-fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
-    for entry in meta {
-        if entry.key == META_RESP_CONTENT_TYPE || entry.key == "Content-Type" {
-            return Some(entry.value.as_str());
-        }
-    }
-    None
+/// The canonical `resp.content_type` among the leading meta entries, if any.
+/// Legacy aliases (a literal `Content-Type` meta key) are not honored — the
+/// canonical-keys-only policy is pinned by `wafer_block::http_codec`.
+pub fn leading_content_type(meta: &[MetaEntry]) -> Option<&str> {
+    http_codec::response_meta_parts(meta).find_map(|part| match part {
+        ResponseMetaPart::ContentType(ct) => Some(ct),
+        _ => None,
+    })
 }
 
-fn is_streaming_content_type(ct: &str) -> bool {
+/// True for content-types that should stream body chunks to the client as
+/// they're produced rather than buffer the entire response. Today: SSE and
+/// generic byte streams (which feature blocks use for downloads / archives).
+pub fn is_streaming_content_type(ct: &str) -> bool {
     let lower = ct.to_ascii_lowercase();
     lower.starts_with("text/event-stream") || lower.starts_with("application/octet-stream")
+}
+
+/// Forward one `StreamEvent` into an `OutputSink`. Returns the sink back for
+/// non-terminal events so the caller can keep pumping; terminal events (and
+/// a hung-up consumer) consume it and return `None`.
+async fn forward_event(sink: OutputSink, ev: StreamEvent) -> Option<OutputSink> {
+    match ev {
+        StreamEvent::Chunk(bytes) => sink.send_chunk(bytes).await.ok().map(|()| sink),
+        StreamEvent::Meta(entry) => sink.send_meta(entry).await.ok().map(|()| sink),
+        StreamEvent::Complete { meta } => {
+            let _ = sink.complete(meta).await;
+            None
+        }
+        StreamEvent::Error(err) => {
+            let _ = sink.error(*err).await;
+            None
+        }
+        StreamEvent::Drop => {
+            let _ = sink.drop_request().await;
+            None
+        }
+        StreamEvent::Continue(msg) => {
+            let _ = sink.continue_with(msg).await;
+            None
+        }
+        StreamEvent::Halt { body, meta } => {
+            let _ = sink.halt(body, meta).await;
+            None
+        }
+    }
 }
 
 /// Replay leading meta + the peeked event + remaining stream events into a
@@ -266,123 +298,79 @@ fn rebuild_streaming(
                 return;
             }
         }
+        let Some(next_event) = next_event else {
+            // The stream ended right after its leading meta with no
+            // terminal; close out as an empty Complete.
+            let _ = sink.complete(Vec::new()).await;
+            return;
+        };
+        let Some(mut sink) = forward_event(sink, next_event).await else {
+            return;
+        };
         let mut rest = rest;
-        match next_event {
-            Some(StreamEvent::Chunk(b)) => {
-                if sink.send_chunk(b).await.is_err() {
-                    return;
-                }
-            }
-            Some(StreamEvent::Meta(_)) => {
-                unreachable!("drain_leading_meta consumed all leading Meta")
-            }
-            Some(StreamEvent::Complete { meta }) => {
-                let _ = sink.complete(meta).await;
-                return;
-            }
-            Some(StreamEvent::Error(err)) => {
-                let _ = sink.error(*err).await;
-                return;
-            }
-            Some(StreamEvent::Drop) => {
-                let _ = sink.drop_request().await;
-                return;
-            }
-            Some(StreamEvent::Continue(m)) => {
-                let _ = sink.continue_with(m).await;
-                return;
-            }
-            Some(StreamEvent::Halt { body, meta }) => {
-                let _ = sink.halt(body, meta).await;
-                return;
-            }
-            None => {
-                let _ = sink.complete(vec![]).await;
-                return;
-            }
-        }
-        // Pump the rest of the events.
         while let Some(ev) = rest.next().await {
-            match ev {
-                StreamEvent::Chunk(b) => {
-                    if sink.send_chunk(b).await.is_err() {
-                        return;
-                    }
-                }
-                StreamEvent::Meta(entry) => {
-                    if sink.send_meta(entry).await.is_err() {
-                        return;
-                    }
-                }
-                StreamEvent::Complete { meta } => {
-                    let _ = sink.complete(meta).await;
-                    return;
-                }
-                StreamEvent::Error(err) => {
-                    let _ = sink.error(*err).await;
-                    return;
-                }
-                StreamEvent::Drop => {
-                    let _ = sink.drop_request().await;
-                    return;
-                }
-                StreamEvent::Continue(m) => {
-                    let _ = sink.continue_with(m).await;
-                    return;
-                }
-                StreamEvent::Halt { body, meta } => {
-                    let _ = sink.halt(body, meta).await;
-                    return;
-                }
+            match forward_event(sink, ev).await {
+                Some(s) => sink = s,
+                None => return,
             }
         }
+        // `rest` ended without a terminal; `from_producer` auto-Completes.
     })
 }
 
-/// Drain remaining stream events into a buffer, prepending the leading meta
-/// + the already-peeked next event. Returns the same shape as
-/// `OutputStream::collect_buffered` so the buffered branch in handle_request
-/// can keep working unchanged.
-async fn collect_buffered_with_prelude(
+/// Collect the remaining stream events into a buffer, prepending the leading
+/// meta + the already-peeked next event. Equivalent to running
+/// [`OutputStream::collect_buffered`] over the reassembled stream — including
+/// its contract that a `Halt` terminal **replaces** any previously streamed
+/// chunks/meta (mixing them is a producer bug `collect_buffered` warns
+/// about), so the prelude is discarded on that path.
+///
+/// `next_event` must come from [`drain_leading_meta`] (i.e. it is never
+/// `StreamEvent::Meta`).
+pub async fn collect_buffered_with_prelude(
     rest: OutputStream,
     leading_meta: Vec<MetaEntry>,
     next_event: Option<StreamEvent>,
-) -> Result<wafer_run::streams::output::BufferedResponse, TerminalNotResponse> {
-    use wafer_run::streams::output::BufferedResponse;
-
-    let mut body = Vec::new();
-    let mut meta = leading_meta;
-    let mut rest = rest;
-
-    // Two phases share the same accumulator+terminal logic: process the
-    // already-peeked event, then drain the rest. Capture the "next event to
-    // consider" in a small generator that yields the peek first then pulls
-    // from `rest`.
-    let mut peeked = next_event;
-    loop {
-        let ev = match peeked.take() {
-            Some(e) => Some(e),
-            None => rest.next().await,
-        };
-        match ev {
-            Some(StreamEvent::Chunk(b)) => body.extend(b),
-            Some(StreamEvent::Meta(entry)) => meta.push(entry),
-            Some(StreamEvent::Complete { meta: m }) => {
-                meta.extend(m);
-                return Ok(BufferedResponse { body, meta });
+) -> Result<BufferedResponse, TerminalNotResponse> {
+    match next_event {
+        // Body already started: drain the remainder with the standard
+        // collector and stitch the prelude onto the front of a successful
+        // response. Non-Complete terminals pass through unchanged, exactly
+        // as `collect_buffered` would have produced them.
+        Some(StreamEvent::Chunk(first)) => match rest.collect_buffered().await {
+            Ok(buf) => {
+                let mut body = first;
+                body.extend(buf.body);
+                let mut meta = leading_meta;
+                meta.extend(buf.meta);
+                Ok(BufferedResponse { body, meta })
             }
-            Some(StreamEvent::Error(err)) => return Err(TerminalNotResponse::Error(*err)),
-            Some(StreamEvent::Drop) => return Err(TerminalNotResponse::Drop),
-            Some(StreamEvent::Continue(m)) => return Err(TerminalNotResponse::Continue(m)),
-            Some(StreamEvent::Halt {
-                body: halt_body,
-                meta: halt_meta,
-            }) => {
-                body.extend(halt_body);
-                meta.extend(halt_meta);
-                return Err(TerminalNotResponse::Halt(BufferedResponse { body, meta }));
-            }
-            None => return Err(TerminalNotResponse::Malformed),
+            Err(terminal) => Err(terminal),
+        },
+        Some(StreamEvent::Meta(_)) => unreachable!("drain_leading_meta consumes Meta events"),
+        Some(StreamEvent::Complete { meta }) => {
+            let mut all_meta = leading_meta;
+            all_meta.extend(meta);
+            Ok(BufferedResponse {
+                body: Vec::new(),
+                meta: all_meta,
+            })
         }
+        Some(StreamEvent::Halt { body, meta }) => {
+            // Halt carries a complete response; per the `collect_buffered`
+            // contract any prior streamed events — the prelude included —
+            // are replaced by its payload.
+            if !leading_meta.is_empty() {
+                tracing::warn!(
+                    discarded_meta_entries = leading_meta.len(),
+                    "Halt terminal arrived after leading Meta; discarding prelude (producer must not mix Halt with streamed events)"
+                );
+            }
+            Err(TerminalNotResponse::Halt(BufferedResponse { body, meta }))
+        }
+        Some(StreamEvent::Error(err)) => Err(TerminalNotResponse::Error(*err)),
+        Some(StreamEvent::Drop) => Err(TerminalNotResponse::Drop),
+        Some(StreamEvent::Continue(msg)) => Err(TerminalNotResponse::Continue(msg)),
+        None => Err(TerminalNotResponse::Malformed),
     }
 }

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -8,6 +8,14 @@ use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use crate::{blocks::helpers, features::FeatureConfig};
 
+/// URL prefix for embedded static assets, served by `suppers-ai/system`.
+///
+/// Single source of truth shared by the routing table below, the
+/// `ui::assets` URL builders, and the pipeline's request-log noise filter —
+/// so the prefix can't drift between them (a stale `/static/` literal in the
+/// filter once made every asset request write a `request_logs` row).
+pub const STATIC_PREFIX: &str = "/b/static/";
+
 /// A single route entry.
 ///
 /// `block` is the solobase block name (`{org}/{block}`) used for feature-gating
@@ -93,7 +101,7 @@ pub struct ExtraRoute {
 pub const ROUTES: &[Route] = &[
     // System & static assets
     Route::new("/health", RouteAccess::Public, "suppers-ai/system"),
-    Route::new("/b/static/", RouteAccess::Public, "suppers-ai/system"),
+    Route::new(STATIC_PREFIX, RouteAccess::Public, "suppers-ai/system"),
     // Inspector — runtime debugging UI (admin only). Feature-gated as
     // `suppers-ai/inspector` but dispatches to the `wafer-run/inspector` block.
     Route::proxy(

--- a/crates/solobase-core/src/ui/assets.rs
+++ b/crates/solobase-core/src/ui/assets.rs
@@ -43,7 +43,12 @@ pub fn logo_long_png() -> &'static [u8] {
 /// Square logo URL with content hash, e.g. `/b/static/solobase-logo-a1b2c3d4.png`.
 pub fn logo_icon_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("{STATIC_PREFIX}solobase-logo-{}.png", short_hash(LOGO_ICON_PNG)))
+    URL.get_or_init(|| {
+        format!(
+            "{STATIC_PREFIX}solobase-logo-{}.png",
+            short_hash(LOGO_ICON_PNG)
+        )
+    })
 }
 
 /// Long/wordmark logo URL with content hash, e.g. `/b/static/solobase-logo-long-a1b2c3d4.png`.
@@ -147,7 +152,12 @@ pub fn css_url() -> &'static str {
 /// htmx JS URL with content hash, e.g. `/b/static/htmx-a1b2c3d4.min.js`
 pub fn htmx_js_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("{STATIC_PREFIX}htmx-{}.min.js", short_hash(htmx_js().as_bytes())))
+    URL.get_or_init(|| {
+        format!(
+            "{STATIC_PREFIX}htmx-{}.min.js",
+            short_hash(htmx_js().as_bytes())
+        )
+    })
 }
 
 const LLM_CHAT_JS: &str = include_str!("assets/llm-chat.js");

--- a/crates/solobase-core/src/ui/assets.rs
+++ b/crates/solobase-core/src/ui/assets.rs
@@ -1,9 +1,11 @@
 //! Embedded static assets — CSS and JS.
 //!
 //! Asset URLs include a content hash for cache busting:
-//! `/static/app-{hash}.css` and `/static/htmx-{hash}.min.js`
+//! `/b/static/app-{hash}.css` and `/b/static/htmx-{hash}.min.js`
 
 use std::sync::OnceLock;
+
+use crate::routing::STATIC_PREFIX;
 
 const TOKENS_CSS: &str = include_str!("assets/tokens.css");
 const BASE_CSS: &str = include_str!("assets/base.css");
@@ -41,7 +43,7 @@ pub fn logo_long_png() -> &'static [u8] {
 /// Square logo URL with content hash, e.g. `/b/static/solobase-logo-a1b2c3d4.png`.
 pub fn logo_icon_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("/b/static/solobase-logo-{}.png", short_hash(LOGO_ICON_PNG)))
+    URL.get_or_init(|| format!("{STATIC_PREFIX}solobase-logo-{}.png", short_hash(LOGO_ICON_PNG)))
 }
 
 /// Long/wordmark logo URL with content hash, e.g. `/b/static/solobase-logo-long-a1b2c3d4.png`.
@@ -49,7 +51,7 @@ pub fn logo_long_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
     URL.get_or_init(|| {
         format!(
-            "/b/static/solobase-logo-long-{}.png",
+            "{STATIC_PREFIX}solobase-logo-long-{}.png",
             short_hash(LOGO_LONG_PNG)
         )
     })
@@ -63,7 +65,7 @@ pub fn favicon_ico() -> &'static [u8] {
 /// Favicon URL with content hash, e.g. `/b/static/favicon-a1b2c3d4.ico`.
 pub fn favicon_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("/b/static/favicon-{}.ico", short_hash(FAVICON_ICO)))
+    URL.get_or_init(|| format!("{STATIC_PREFIX}favicon-{}.ico", short_hash(FAVICON_ICO)))
 }
 
 /// Itim latin (basic) woff2 bytes.
@@ -81,7 +83,7 @@ pub fn itim_latin_woff2_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
     URL.get_or_init(|| {
         format!(
-            "/b/static/itim-latin-{}.woff2",
+            "{STATIC_PREFIX}itim-latin-{}.woff2",
             short_hash(ITIM_LATIN_WOFF2)
         )
     })
@@ -92,7 +94,7 @@ pub fn itim_latin_ext_woff2_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
     URL.get_or_init(|| {
         format!(
-            "/b/static/itim-latin-ext-{}.woff2",
+            "{STATIC_PREFIX}itim-latin-ext-{}.woff2",
             short_hash(ITIM_LATIN_EXT_WOFF2)
         )
     })
@@ -136,16 +138,16 @@ fn short_hash(content: &[u8]) -> String {
     hash.iter().take(4).map(|b| format!("{b:02x}")).collect()
 }
 
-/// CSS URL with content hash, e.g. `/static/app-a1b2c3d4.css`
+/// CSS URL with content hash, e.g. `/b/static/app-a1b2c3d4.css`
 pub fn css_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("/b/static/app-{}.css", short_hash(css().as_bytes())))
+    URL.get_or_init(|| format!("{STATIC_PREFIX}app-{}.css", short_hash(css().as_bytes())))
 }
 
-/// htmx JS URL with content hash, e.g. `/static/htmx-a1b2c3d4.min.js`
+/// htmx JS URL with content hash, e.g. `/b/static/htmx-a1b2c3d4.min.js`
 pub fn htmx_js_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| format!("/b/static/htmx-{}.min.js", short_hash(htmx_js().as_bytes())))
+    URL.get_or_init(|| format!("{STATIC_PREFIX}htmx-{}.min.js", short_hash(htmx_js().as_bytes())))
 }
 
 const LLM_CHAT_JS: &str = include_str!("assets/llm-chat.js");
@@ -165,7 +167,7 @@ pub fn llm_chat_js_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
     URL.get_or_init(|| {
         format!(
-            "/b/static/llm-chat-{}.js",
+            "{STATIC_PREFIX}llm-chat-{}.js",
             short_hash(llm_chat_js().as_bytes())
         )
     })
@@ -186,7 +188,7 @@ pub fn files_browser_js_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
     URL.get_or_init(|| {
         format!(
-            "/b/static/files-browser-{}.js",
+            "{STATIC_PREFIX}files-browser-{}.js",
             short_hash(files_browser_js().as_bytes())
         )
     })

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -24,8 +24,8 @@ use solobase_core::{
 };
 use wafer_block::http_codec;
 use wafer_run::{
-    context::Context, streams::output::TerminalNotResponse, ErrorCode, InputStream, Message,
-    OutputStream, META_AUTH_USER_ID, META_REQ_RESOURCE, META_RESP_STATUS,
+    context::Context, streams::output::TerminalNotResponse, InputStream, Message, OutputStream,
+    META_AUTH_USER_ID, META_REQ_RESOURCE, META_RESP_STATUS,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -22,6 +22,7 @@ use solobase_core::{
     features::FeatureConfig,
     routing::{self, ExtraRoute, RouteAccess},
 };
+use wafer_block::http_codec;
 use wafer_run::{
     context::Context, streams::output::TerminalNotResponse, ErrorCode, InputStream, Message,
     OutputStream, META_AUTH_USER_ID, META_REQ_RESOURCE, META_RESP_STATUS,
@@ -114,28 +115,14 @@ fn make_msg_with_admin(path: &str, user_id: &str) -> Message {
     msg
 }
 
-/// Collect the stream and return the "HTTP-ish" status code.
-///
-/// The pipeline treats Error terminals as HTTP responses by mapping the
-/// `ErrorCode` to a status code (mirroring how `pipeline::handle_request`
-/// builds the log entry). For our tests:
-/// - Buffered response with `resp.status=200` → 200
-/// - `ErrorCode::NotFound` → 404
-/// - `ErrorCode::PermissionDenied` → 403
+/// Collect the stream and return the "HTTP-ish" status code via the
+/// canonical `wafer_block::http_codec` status resolution (explicit
+/// `resp.status` override, else the `ErrorCode`-derived status for Error
+/// terminals — NotFound → 404, PermissionDenied → 403, Unauthenticated → 401).
 async fn response_status(stream: OutputStream) -> i64 {
     match stream.collect_buffered().await {
-        Ok(buf) => buf
-            .meta
-            .iter()
-            .find(|m| m.key == META_RESP_STATUS || m.key == "http.status")
-            .and_then(|m| m.value.parse::<i64>().ok())
-            .unwrap_or(200),
-        Err(TerminalNotResponse::Error(err)) => match err.code {
-            ErrorCode::NotFound => 404,
-            ErrorCode::PermissionDenied => 403,
-            ErrorCode::Unauthenticated => 401,
-            _ => 500,
-        },
+        Ok(buf) => i64::from(http_codec::resolve_status(&buf.meta, 200)),
+        Err(TerminalNotResponse::Error(err)) => i64::from(http_codec::resolve_error_status(&err)),
         Err(other) => panic!("unexpected terminal: {other:?}"),
     }
 }


### PR DESCRIPTION
S1-A http-codec-consumers (phase 2, Wave 1). Consumer half of wafer-run #228 (W2-N).

Rewrites the two solobase HTTP↔Message adapters and the pipeline's status fallbacks onto `wafer_block::http_codec`, dropping every legacy-key tolerance. Behavior-neutral for current blocks — PR #228 verified solobase has **no emitters** of the legacy keys, so every dropped tolerance was a dead reader. The canonical drift decisions (Continue→empty 200, `resp.*`-only keys, `100..=999` status gate, Ok≡Halt) are pinned by `http_codec`'s tests; no per-platform variants re-introduced.

## Findings addressed (all verified)
- [x] **[medium/duplication] HTTP-to-Message / OutputStream-to-Response conversion triplicated** — `solobase-cloudflare/src/convert.rs` (282→79 lines) and `solobase-browser/src/convert.rs` (→404 lines) are now thin platform glue over `http_codec::build_http_message` + `collect_http_response` / `response_meta_parts`. The duplicated method→action table, `error_code_to_http_status`, `get_status`/`apply_meta_headers` and all legacy-key fallbacks (`http.status`, `http.resp.header.*`, `http.resp.set-cookie.*`, literal `Content-Type` meta key, stale `resp.cookie.*` doc) are gone.
- [x] **[high/duplication] protocol mapping triplicated — browser side, STREAMING path** — browser keeps its `ReadableStream` architecture but classifies the leading meta via `http_codec::response_meta_parts` and applies status + headers **before the body finishes** (never routes the streaming path through the buffering `collect_http_response`). Buffered path mirrors `collect_http_response` exactly.
- [x] **[medium/simplification] Pipeline duplicates a 7-arm StreamEvent pump twice + reimplements collect_buffered** — the two pumps collapse into one `forward_event(sink, ev)` helper; `collect_buffered_with_prelude` delegates its drain to `OutputStream::collect_buffered` (adopting its pinned Halt-replaces-prelude contract).
- [x] **[medium/dead-code] Stale '/static/' prefix makes the request-log noise filter dead** — single source of truth `routing::STATIC_PREFIX` (`/b/static/`) now used by the routing table, every `ui::assets` URL builder, and the pipeline's request-log skip. Kills one `request_logs` D1 write per asset per page load (the audit's single best quick win).
- [x] pipeline.rs `http.status`/literal-`Content-Type` readers dropped (`resolve_status`, `response_meta_parts`-classified `leading_content_type`).
- [x] `extra_routes_test.rs` status helper onto `resolve_status`/`resolve_error_status`.

## Decisions / cleanups
- **Browser `Continue` terminal**: was a per-platform `500 {"error":"continue not supported"}`; now the canonical empty-body `200` with meta applied (pinned by `http_codec::continue_maps_to_empty_200_with_meta_applied`). Adopting the codec's decision, not re-introducing a variant.
- **Dropped dead `urlencoding_decode` from `solobase-browser/src/helpers.rs`** — its sole caller (convert.rs) now decodes query via `build_http_message`'s `url::form_urlencoded`. Leaving the only-caller-removed fn would emit a new dead-code warning. The larger percent-coding consolidation in `solobase-core/src/blocks/helpers.rs` is **out of scope** (owned by S2-K) and untouched.
- **Reverted 4 speculative `pub` fns** the preserved commit widened "for reuse by the browser adapter" — solobase-browser is a separate crate that can't import them and re-implements its own copy; no cross-module consumers, so back to private.
- **Reverted accidental Cargo.lock git-source churn** — this package adds/removes no deps, so it must not touch Cargo.lock; restored to main's state.

## Proposed wafer-run follow-up (cross-repo, not blocking)
- `OutputStream::with_prelude` (the plan's optional upstream): the prepend-leading-meta-then-peeked-event logic is duplicated in `pipeline::collect_buffered_with_prelude` and `solobase-browser::convert::collect_buffered_with_prelude` (separate crates, can't share consumer-side). A generic `with_prelude` in wafer-run's streams module would let both delegate. Left as a follow-up for the orchestrator to batch — out of S1-A's solobase-only scope.

## Local verification (CI is the final gate)
- `cargo +nightly fmt --all -- --check` — clean
- `bash scripts/grep-guard-html.sh` — OK; `bash scripts/audit-wrap-grants.sh` — OK, no missing WRAP grants
- `cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare --exclude solobase-browser` — clean (native binary + dependents)
- `cargo check -p solobase-browser --target wasm32-unknown-unknown` — clean
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean
- `cargo check -p minimal-browser --target wasm32-unknown-unknown` — clean
- `cargo clippy -p solobase-core` — no new warnings in touched files (only pre-existing)
- `cargo test -p solobase-core --test extra_routes_test` — 7 passed
- `cargo test -p solobase-core --lib` — 726 passed

No block-SQL changes → no `SOLOBASE_RUN_MIGRATIONS=1` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
