### PR TITLE
fix(S1-H): llm-small-dedupe + key_var resolution

### DIFF
--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -98,6 +98,44 @@ pub fn is_admin(msg: &wafer_run::Message) -> bool {
         .any(|r| r.trim() == "admin")
 }
 
+/// Build a `Message` for an inter-block `ctx.call_block` dispatch, forwarding
+/// the caller's auth identity from the originating request.
+///
+/// Sets the routing metas the receiving block's dispatcher keys off
+/// (`req.action`, `req.resource`, `http.method`, `http.path`) and forwards
+/// `auth.user_id` / `auth.user_email` / `auth.user_roles` when present, so the
+/// callee sees the same caller identity it would on a direct HTTP request.
+/// Empty auth fields are skipped rather than forwarded as empty strings.
+///
+/// All three identity fields forward on every call; a previous hand-rolled
+/// copy dropped `auth.user_email` on read paths, an unexplained asymmetry that
+/// this single source removes.
+pub fn block_request(
+    action: &str,
+    method: &str,
+    resource: &str,
+    original: &wafer_run::Message,
+) -> wafer_run::Message {
+    let mut msg = wafer_run::Message::new(format!("{action}:{resource}"));
+    msg.set_meta("req.action", action);
+    msg.set_meta("req.resource", resource);
+    msg.set_meta("http.method", method);
+    msg.set_meta("http.path", resource);
+    forward_auth_meta(&mut msg, original);
+    msg
+}
+
+/// Forward the caller's auth identity (`auth.user_id` / `auth.user_email` /
+/// `auth.user_roles`) from `original` onto `msg`, skipping empty fields.
+pub fn forward_auth_meta(msg: &mut wafer_run::Message, original: &wafer_run::Message) {
+    for key in ["auth.user_id", "auth.user_email", "auth.user_roles"] {
+        let value = original.get_meta(key);
+        if !value.is_empty() {
+            msg.set_meta(key, value);
+        }
+    }
+}
+
 /// Compute SHA-256 and return as hex string. Used for deterministic hashing (API keys, etc.).
 pub fn sha256_hex(data: &[u8]) -> String {
     hex_encode(&sha256(data))
@@ -715,5 +753,44 @@ mod tests {
             !msg.contains("Thread setting"),
             "context label leaked into client message: {msg:?}"
         );
+    }
+
+    #[test]
+    fn block_request_sets_routing_metas_and_kind() {
+        let original = wafer_run::Message::new("retrieve:/x");
+        let msg = block_request("create", "POST", "/b/messages/api/x", &original);
+        assert_eq!(msg.get_meta("req.action"), "create");
+        assert_eq!(msg.get_meta("req.resource"), "/b/messages/api/x");
+        assert_eq!(msg.get_meta("http.method"), "POST");
+        assert_eq!(msg.get_meta("http.path"), "/b/messages/api/x");
+    }
+
+    #[test]
+    fn block_request_forwards_all_three_auth_fields() {
+        // Both read and write paths must forward the full caller identity —
+        // the previous hand-rolled list path dropped `auth.user_email`.
+        let mut original = wafer_run::Message::new("get:/x");
+        original.set_meta("auth.user_id", "u-1");
+        original.set_meta("auth.user_email", "u@example.com");
+        original.set_meta("auth.user_roles", "user,beta");
+
+        let msg = block_request("retrieve", "GET", "/b/messages/api/x", &original);
+        assert_eq!(msg.get_meta("auth.user_id"), "u-1");
+        assert_eq!(msg.get_meta("auth.user_email"), "u@example.com");
+        assert_eq!(msg.get_meta("auth.user_roles"), "user,beta");
+    }
+
+    #[test]
+    fn forward_auth_meta_skips_empty_fields() {
+        let mut original = wafer_run::Message::new("get:/x");
+        original.set_meta("auth.user_id", "u-1");
+        // email + roles unset on the original.
+
+        let mut msg = wafer_run::Message::new("get:/y");
+        forward_auth_meta(&mut msg, &original);
+        assert_eq!(msg.get_meta("auth.user_id"), "u-1");
+        // Absent fields are not materialized as empty strings.
+        assert_eq!(msg.get_meta("auth.user_email"), "");
+        assert_eq!(msg.get_meta("auth.user_roles"), "");
     }
 }

--- a/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/legacy_providers.rs
@@ -30,7 +30,7 @@ use super::super::{
         config::{ProviderConfig, ProviderProtocol},
         ProviderLlmService,
     },
-    schema::{config_to_row, TABLE as PROVIDERS_TABLE},
+    schema::{config_to_row, parse_enabled_field, parse_models_field, TABLE as PROVIDERS_TABLE},
 };
 
 /// The legacy providers collection. Owned by the provider-llm block (still
@@ -80,25 +80,10 @@ pub(in crate::blocks::llm) fn map_legacy_row(
         .unwrap_or("https://api.openai.com/v1")
         .to_string();
 
-    let models = match data.get("models") {
-        Some(serde_json::Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect(),
-        // Legacy stored `models` as a JSON string in a `text` column.
-        Some(serde_json::Value::String(s)) if !s.is_empty() => {
-            serde_json::from_str::<Vec<String>>(s).unwrap_or_default()
-        }
-        _ => Vec::new(),
-    };
-
-    let enabled = match data.get("enabled") {
-        Some(serde_json::Value::Bool(b)) => *b,
-        Some(serde_json::Value::Number(n)) => n.as_i64().unwrap_or(0) != 0,
-        Some(serde_json::Value::String(s)) => matches!(s.as_str(), "1" | "true"),
-        None => true,
-        _ => true,
-    };
+    // Legacy stored `models` as a JSON string in a `text` column — the
+    // shared schema helper handles both that and the canonical array shape.
+    let models = parse_models_field(data.get("models"));
+    let enabled = parse_enabled_field(data.get("enabled"));
 
     Some(ProviderConfig {
         name,
@@ -171,8 +156,14 @@ pub(in crate::blocks::llm) async fn migrate_legacy_providers(
     drop_legacy_table(ctx).await;
 
     // Step 4: refresh the in-memory ProviderLlmService from the new table so
-    // chat routes pick up the migrated providers without a restart.
-    reload_service(ctx, provider_svc).await;
+    // chat routes pick up the migrated providers without a restart. Shares
+    // the routes-module reload — the single place where rows become live
+    // configs (including `key_var` → `api_key` resolution). Non-fatal: the
+    // rows are migrated either way and the Init-time reload that follows
+    // this migration retries.
+    if let Err(e) = super::super::routes::reload_provider_service(ctx, provider_svc).await {
+        tracing::warn!("post-migration provider reload failed: {e}");
+    }
 
     Ok(())
 }
@@ -224,30 +215,6 @@ async fn drop_legacy_table(ctx: &dyn Context) {
     if let Err(e) = db::exec_raw(ctx, &stmt, &[]).await {
         tracing::warn!("failed to drop legacy table {LEGACY_TABLE}: {e}");
     }
-}
-
-/// Reload enabled providers from the new table and push into the service.
-/// Mirrors `routes::reload_provider_service` but is intentionally duplicated
-/// here to keep the migration self-contained (no cross-module coupling).
-async fn reload_service(ctx: &dyn Context, provider_svc: &ProviderLlmService) {
-    let records = match db::list_all(ctx, PROVIDERS_TABLE, vec![]).await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!("post-migration reload list failed: {e}");
-            return;
-        }
-    };
-    let mut configs = Vec::with_capacity(records.len());
-    for rec in &records {
-        match super::super::schema::row_to_config(rec) {
-            Ok(cfg) if cfg.enabled => configs.push(cfg),
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!("post-migration: skipping malformed row {}: {e}", rec.id);
-            }
-        }
-    }
-    provider_svc.configure(configs);
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -556,7 +556,7 @@ impl Block for LlmBlock {
             // startup so chat dispatch finds them without waiting for an
             // admin CRUD write. Non-fatal if it fails — admins can trigger
             // a reload via any provider write.
-            if let Err(e) = routes::reload_provider_service(self, ctx).await {
+            if let Err(e) = routes::reload_provider_service(ctx, &self.provider_svc).await {
                 tracing::warn!("initial provider reload failed: {e}");
             }
         }

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -9,13 +9,13 @@ use std::sync::Arc;
 
 use wafer_core::clients::{config, database as db};
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, ErrorCode, InputStream,
-    InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, InputStream, InstanceMode,
+    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
 };
 
 use self::providers::ProviderLlmService;
 use crate::blocks::helpers::{
-    self, err_bad_request, err_internal, err_internal_no_cause, err_not_found, json_map, ok_json,
+    self, err_bad_request, err_internal, err_not_found, json_map, ok_json,
 };
 
 /// LLM feature block. Owns the provider admin UI + chat thread persistence.
@@ -39,8 +39,8 @@ impl LlmBlock {
 
 pub(crate) const SETTINGS_TABLE: &str = "suppers_ai__llm__settings";
 
-const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
-const DEFAULT_MODEL_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_MODEL";
+pub(super) const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
+pub(super) const DEFAULT_MODEL_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_MODEL";
 pub(super) const DEFAULT_PROVIDER: &str = "suppers-ai/provider-llm";
 
 // The previous in-process `default_target()` helper has moved to a
@@ -80,25 +80,8 @@ pub(super) async fn messages_create(
     };
 
     let resource = format!("/b/messages/api/contexts/{context_id}/entries");
-    let mut msg = Message::new(format!("create:{resource}"));
-    msg.set_meta("req.action", "create");
-    msg.set_meta("req.resource", &resource);
-    msg.set_meta("http.method", "POST");
-    msg.set_meta("http.path", &resource);
+    let mut msg = helpers::block_request("create", "POST", &resource, original_msg);
     msg.set_meta("req.content_type", "application/json");
-    // Forward auth from original request
-    let user_id = original_msg.user_id().to_string();
-    if !user_id.is_empty() {
-        msg.set_meta("auth.user_id", &user_id);
-    }
-    let user_email = original_msg.get_meta("auth.user_email").to_string();
-    if !user_email.is_empty() {
-        msg.set_meta("auth.user_email", &user_email);
-    }
-    let user_roles = original_msg.get_meta("auth.user_roles").to_string();
-    if !user_roles.is_empty() {
-        msg.set_meta("auth.user_roles", &user_roles);
-    }
 
     let out = ctx
         .call_block("suppers-ai/messages", msg, InputStream::from_bytes(body))
@@ -116,19 +99,7 @@ pub(super) async fn messages_list(
     context_id: &str,
 ) -> Vec<serde_json::Value> {
     let resource = format!("/b/messages/api/contexts/{context_id}/entries?kind=message");
-    let mut msg = Message::new(format!("retrieve:{resource}"));
-    msg.set_meta("req.action", "retrieve");
-    msg.set_meta("req.resource", &resource);
-    msg.set_meta("http.method", "GET");
-    msg.set_meta("http.path", &resource);
-    let user_id = original_msg.user_id().to_string();
-    if !user_id.is_empty() {
-        msg.set_meta("auth.user_id", &user_id);
-    }
-    let user_roles = original_msg.get_meta("auth.user_roles").to_string();
-    if !user_roles.is_empty() {
-        msg.set_meta("auth.user_roles", &user_roles);
-    }
+    let msg = helpers::block_request("retrieve", "GET", &resource, original_msg);
 
     let out = ctx
         .call_block("suppers-ai/messages", msg, InputStream::empty())
@@ -161,7 +132,7 @@ impl LlmBlock {
 
         let provider_block = thread_setting
             .as_ref()
-            .and_then(|s| s.get("provider_block").and_then(|v| v.as_str()))
+            .and_then(|s| s.data.get("provider_block").and_then(|v| v.as_str()))
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .or_else(|| req_provider.map(|s| s.to_string()))
@@ -172,7 +143,7 @@ impl LlmBlock {
 
         let model = thread_setting
             .as_ref()
-            .and_then(|s| s.get("model").and_then(|v| v.as_str()))
+            .and_then(|s| s.data.get("model").and_then(|v| v.as_str()))
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .or_else(|| req_model.map(|s| s.to_string()))
@@ -197,23 +168,19 @@ impl LlmBlock {
         (final_provider, final_model)
     }
 
-    /// Get per-thread settings record from DB, if any.
-    async fn get_thread_setting(
-        &self,
-        ctx: &dyn Context,
-        thread_id: &str,
-    ) -> Option<std::collections::HashMap<String, serde_json::Value>> {
-        match db::get_by_field(
+    /// Get the per-thread settings record from the DB, if any.
+    ///
+    /// Returns the whole [`db::Record`] (not just its `data`) so callers that
+    /// need the record id for a follow-up update don't have to re-query.
+    async fn get_thread_setting(&self, ctx: &dyn Context, thread_id: &str) -> Option<db::Record> {
+        db::get_by_field(
             ctx,
             SETTINGS_TABLE,
             "thread_id",
             serde_json::Value::String(thread_id.to_string()),
         )
         .await
-        {
-            Ok(record) => Some(record.data),
-            Err(_) => None,
-        }
+        .ok()
     }
 
     // --- Config ---
@@ -271,24 +238,10 @@ impl LlmBlock {
         if let Some(thread_id) = body.thread_id {
             let existing = self.get_thread_setting(ctx, &thread_id).await;
 
-            if let Some(mut data) = existing {
-                // Update existing record — find record ID
-                let record = match db::get_by_field(
-                    ctx,
-                    SETTINGS_TABLE,
-                    "thread_id",
-                    serde_json::Value::String(thread_id.clone()),
-                )
-                .await
-                {
-                    Ok(r) => r,
-                    Err(e) if e.code == ErrorCode::NotFound => {
-                        return err_internal_no_cause(
-                            "Thread setting vanished between read and update",
-                        )
-                    }
-                    Err(e) => return err_internal("Database error", e),
-                };
+            if let Some(record) = existing {
+                // Update the existing record in place — the single fetch above
+                // already gave us both the id and the current data.
+                let mut data = record.data;
                 if let Some(pb) = body.provider_block {
                     data.insert("provider_block".to_string(), serde_json::json!(pb));
                 }

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -10,7 +10,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, Message, OutputStream};
 
-use super::SETTINGS_TABLE;
+use super::{DEFAULT_MODEL_VAR, DEFAULT_PROVIDER, DEFAULT_PROVIDER_VAR, SETTINGS_TABLE};
 use crate::{
     blocks::helpers::RecordExt,
     // Read messages-owned rows by table name. Constants live in a sibling
@@ -24,10 +24,6 @@ use crate::{
         SiteConfig, UserInfo,
     },
 };
-
-const DEFAULT_PROVIDER_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_PROVIDER";
-const DEFAULT_MODEL_VAR: &str = "SUPPERS_AI__LLM__DEFAULT_MODEL";
-const DEFAULT_PROVIDER: &str = "suppers-ai/provider-llm";
 
 // ---------------------------------------------------------------------------
 // Unified chat page (handles `/b/llm/` and `/b/llm/threads/{id}`)

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -161,7 +161,7 @@ pub async fn page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         .filter(|s| !s.is_empty());
     let display_title = thread_title.as_deref().unwrap_or("Chat");
 
-    let models = load_models(ctx, msg).await;
+    let models = load_models(ctx).await;
     let default_model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
 
     let llm_chat_js_url = crate::ui::assets::llm_chat_js_url();
@@ -554,8 +554,7 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 ///
 /// Returns an empty vec on any failure — the picker falls back to the
 /// "Default (remote)" option and the user can still send a request.
-async fn load_models(ctx: &dyn Context, original_msg: &Message) -> Vec<serde_json::Value> {
-    let _ = original_msg;
+async fn load_models(ctx: &dyn Context) -> Vec<serde_json::Value> {
     // The picker keys off `model_id` / `display_name` / `backend_id`. A
     // dispatch failure is treated as "no models" so the picker still renders —
     // the user can fall back to the default remote option.

--- a/crates/solobase-core/src/blocks/llm/providers/config.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/config.rs
@@ -64,8 +64,11 @@ pub struct ProviderConfig {
     pub api_key: Option<String>,
 
     /// Optional config-var reference, e.g. `"SUPPERS_AI__LLM__OPENAI_KEY_PROD"`.
-    /// When set, the runtime resolves the value from configuration at request
-    /// time — takes precedence over `api_key` when both are set.
+    /// When set, the feature block resolves the value from the config client
+    /// into `api_key` whenever providers are (re)loaded into the in-memory
+    /// service — at `Init` and on every provider CRUD write (see
+    /// `routes::reload_provider_service`). Takes precedence over an inline
+    /// `api_key` when both are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_var: Option<String>,
 

--- a/crates/solobase-core/src/blocks/llm/providers/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/mod.rs
@@ -194,13 +194,13 @@ impl ProviderLlmService {
         Ok(models)
     }
 
-    fn provider_snapshot(&self, backend_id: &str) -> Option<ProviderSnapshot> {
+    /// Clone of a single provider's config, keyed by backend_id. The
+    /// `api_key` it carries was resolved from `key_var` by the feature
+    /// block's reload (see `routes::reload_provider_service`) before
+    /// `configure()` — this service never touches the config store itself.
+    fn provider_config(&self, backend_id: &str) -> Option<ProviderConfig> {
         let inner = recover_lock!(self.inner.read(), "provider svc read");
-        let p = inner.providers.get(backend_id)?;
-        Some(ProviderSnapshot {
-            config: p.clone(),
-            resolved_key: resolve_key(p),
-        })
+        inner.providers.get(backend_id).cloned()
     }
 }
 
@@ -210,27 +210,6 @@ impl Default for ProviderLlmService {
     }
 }
 
-struct ProviderSnapshot {
-    config: ProviderConfig,
-    resolved_key: Option<String>,
-}
-
-/// Resolve the effective API key for a provider. `key_var` takes precedence
-/// when set — the runtime reads the referenced config var at request time.
-/// Falls back to `api_key`. Returns `None` if neither is present; callers
-/// decide whether that's an error per protocol.
-///
-/// NOTE: config-var resolution is currently a no-op placeholder. The feature
-/// block resolves `key_var` to a value before calling `configure()` and
-/// stashes the result into `api_key`. This function encodes that precedence
-/// rule so other call sites can share it.
-fn resolve_key(cfg: &ProviderConfig) -> Option<String> {
-    // The feature block is responsible for reading `key_var` out of the
-    // config client and writing the resolved value into `api_key`. Here we
-    // just read `api_key`. See `llm/mod.rs` (future) for the resolution.
-    cfg.api_key.clone()
-}
-
 #[async_trait]
 impl LlmService for ProviderLlmService {
     async fn chat_stream(
@@ -238,7 +217,7 @@ impl LlmService for ProviderLlmService {
         req: ChatRequest,
         cancel: CancellationToken,
     ) -> BoxStream<'static, Result<ChatChunk, LlmError>> {
-        let Some(snap) = self.provider_snapshot(&req.backend_id) else {
+        let Some(cfg) = self.provider_config(&req.backend_id) else {
             let id = req.backend_id;
             return Box::pin(futures::stream::once(async move {
                 Err(LlmError::InvalidRequest(format!("unknown backend: {id}")))
@@ -248,27 +227,22 @@ impl LlmService for ProviderLlmService {
 
         // Build the provider-specific request up front so any encode error is
         // surfaced synchronously before we start streaming.
-        let encoded = match snap.config.protocol {
-            ProviderProtocol::OpenAi => {
-                openai::encode_chat_request(&req, &snap.config, snap.resolved_key.as_deref())
+        let api_key = cfg.api_key.as_deref();
+        let encoded = match cfg.protocol {
+            ProviderProtocol::OpenAi => openai::encode_chat_request(&req, &cfg, api_key)
+                .map_err(map_openai_encode_error),
+            ProviderProtocol::Anthropic => anthropic::encode_chat_request(&req, &cfg, api_key)
+                .map_err(map_anthropic_encode_error),
+            ProviderProtocol::OpenAiCompatible => {
+                openai_compatible::encode_chat_request(&req, &cfg, api_key)
                     .map_err(map_openai_encode_error)
             }
-            ProviderProtocol::Anthropic => {
-                anthropic::encode_chat_request(&req, &snap.config, snap.resolved_key.as_deref())
-                    .map_err(map_anthropic_encode_error)
-            }
-            ProviderProtocol::OpenAiCompatible => openai_compatible::encode_chat_request(
-                &req,
-                &snap.config,
-                snap.resolved_key.as_deref(),
-            )
-            .map_err(map_openai_encode_error),
         };
         let (url, headers, body) = match encoded {
             Ok(v) => v,
             Err(e) => return Box::pin(futures::stream::once(async move { Err(e) })),
         };
-        let protocol = snap.config.protocol;
+        let protocol = cfg.protocol;
 
         let (tx, rx) = mpsc::channel::<Result<ChatChunk, LlmError>>(16);
         tokio::spawn(async move {
@@ -306,55 +280,26 @@ impl LlmService for ProviderLlmService {
             }
 
             let mut body_stream = resp.bytes_stream();
-            match protocol {
-                ProviderProtocol::OpenAi | ProviderProtocol::OpenAiCompatible => {
-                    let mut decoder = openai::OpenAiSseDecoder::new();
-                    loop {
-                        tokio::select! {
-                            _ = cancel.cancelled() => {
-                                let _ = tx_err.send(Err(LlmError::Cancelled)).await;
-                                return;
-                            }
-                            next = body_stream.next() => match next {
-                                Some(Ok(bytes)) => {
-                                    let batch = decoder.push(&bytes);
-                                    for chunk in batch.chunks {
-                                        if tx_err.send(Ok(chunk)).await.is_err() { return; }
-                                    }
-                                    if batch.done { return; }
-                                }
-                                Some(Err(e)) => {
-                                    let _ = tx_err.send(Err(LlmError::Network(e.to_string()))).await;
-                                    return;
-                                }
-                                None => return,
-                            }
-                        }
+            let mut decoder = Decoder::for_protocol(protocol);
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        let _ = tx_err.send(Err(LlmError::Cancelled)).await;
+                        return;
                     }
-                }
-                ProviderProtocol::Anthropic => {
-                    let mut decoder = anthropic::AnthropicSseDecoder::new();
-                    loop {
-                        tokio::select! {
-                            _ = cancel.cancelled() => {
-                                let _ = tx_err.send(Err(LlmError::Cancelled)).await;
-                                return;
+                    next = body_stream.next() => match next {
+                        Some(Ok(bytes)) => {
+                            let batch = decoder.push(&bytes);
+                            for chunk in batch.chunks {
+                                if tx_err.send(Ok(chunk)).await.is_err() { return; }
                             }
-                            next = body_stream.next() => match next {
-                                Some(Ok(bytes)) => {
-                                    let batch = decoder.push(&bytes);
-                                    for chunk in batch.chunks {
-                                        if tx_err.send(Ok(chunk)).await.is_err() { return; }
-                                    }
-                                    if batch.done { return; }
-                                }
-                                Some(Err(e)) => {
-                                    let _ = tx_err.send(Err(LlmError::Network(e.to_string()))).await;
-                                    return;
-                                }
-                                None => return,
-                            }
+                            if batch.done { return; }
                         }
+                        Some(Err(e)) => {
+                            let _ = tx_err.send(Err(LlmError::Network(e.to_string()))).await;
+                            return;
+                        }
+                        None => return,
                     }
                 }
             }
@@ -395,6 +340,34 @@ impl LlmService for ProviderLlmService {
     fn claims_backend(&self, backend_id: &str) -> bool {
         let inner = recover_lock!(self.inner.read(), "provider svc read");
         inner.providers.contains_key(backend_id)
+    }
+}
+
+/// Protocol-selected SSE chunk decoder. Both provider decoders share the
+/// same `push(&[u8]) -> DecodeBatch` interface; this enum picks the variant
+/// from the wire protocol once, so `chat_stream` keeps exactly one decode
+/// loop. Adding a fourth protocol is a one-arm change here instead of a
+/// copied ~25-line loop.
+enum Decoder {
+    OpenAi(openai::OpenAiSseDecoder),
+    Anthropic(anthropic::AnthropicSseDecoder),
+}
+
+impl Decoder {
+    fn for_protocol(protocol: ProviderProtocol) -> Self {
+        match protocol {
+            ProviderProtocol::OpenAi | ProviderProtocol::OpenAiCompatible => {
+                Self::OpenAi(openai::OpenAiSseDecoder::new())
+            }
+            ProviderProtocol::Anthropic => Self::Anthropic(anthropic::AnthropicSseDecoder::new()),
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) -> sse::DecodeBatch {
+        match self {
+            Self::OpenAi(d) => d.push(bytes),
+            Self::Anthropic(d) => d.push(bytes),
+        }
     }
 }
 

--- a/crates/solobase-core/src/blocks/llm/providers/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/mod.rs
@@ -229,8 +229,9 @@ impl LlmService for ProviderLlmService {
         // surfaced synchronously before we start streaming.
         let api_key = cfg.api_key.as_deref();
         let encoded = match cfg.protocol {
-            ProviderProtocol::OpenAi => openai::encode_chat_request(&req, &cfg, api_key)
-                .map_err(map_openai_encode_error),
+            ProviderProtocol::OpenAi => {
+                openai::encode_chat_request(&req, &cfg, api_key).map_err(map_openai_encode_error)
+            }
             ProviderProtocol::Anthropic => anthropic::encode_chat_request(&req, &cfg, api_key)
                 .map_err(map_anthropic_encode_error),
             ProviderProtocol::OpenAiCompatible => {

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -120,8 +120,6 @@ fn resolve_backend_id(block: &LlmBlock, provider_block: &str) -> Result<String, 
         .ok_or("no enabled provider configured")
 }
 
-/// Build the `Message` used to dispatch `llm.chat` to `wafer-run/llm`,
-/// forwarding auth metadata from the incoming request.
 /// Common prelude for both chat handlers: parse the body, persist the user
 /// message, load history, resolve provider + model, build the `ChatRequest`,
 /// and call `wafer-run/llm` via the typed client.
@@ -165,7 +163,6 @@ async fn dispatch_chat(
     };
 
     // 5. Build the service request and dispatch via the typed client.
-    let _ = msg; // auth-meta propagation removed — see PR description.
     let chat_req = ChatRequest {
         backend_id,
         model: resolved_model.clone(),
@@ -309,9 +306,25 @@ pub(super) async fn handle_chat_stream(
     // TODO(llm-phase-b-task-14): wire assistant persistence through a
     // dedicated "finalize" call that doesn't require capturing `ctx`.
     let _ = thread_id;
-    let _ = msg;
-    let _ = ctx;
 
+    sse_json_response(stream)
+}
+
+/// Stream a typed frame stream to the client as JSON Server-Sent Events.
+///
+/// Emits the `text/event-stream` content-type as a mid-stream meta event so
+/// the HTTP listener writes the SSE header before the first `data:` frame,
+/// then re-encodes each typed item as a `data: <json>\n\n` frame. A service
+/// or encode error becomes a terminal `event: error\ndata: {}\n\n` frame; a
+/// natural end-of-stream becomes a terminal `data: [DONE]\n\n` frame so
+/// clients can distinguish it from a transport-level disconnect.
+///
+/// Shared by every LLM SSE endpoint (chat-stream, model-load) so the wire
+/// format can't drift between them.
+fn sse_json_response<T>(stream: NativeTypedFrameStream<T>) -> OutputStream
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + Unpin + Send + 'static,
+{
     OutputStream::from_producer(move |sink, _cancel| async move {
         // Send the content-type as a mid-stream meta event so the HTTP
         // listener writes the SSE header before the first `data:` frame.
@@ -324,19 +337,11 @@ pub(super) async fn handle_chat_stream(
 
         let mut stream = stream;
         while let Some(item) = stream.next().await {
-            let Ok(chunk) = item else {
-                // Mid-stream service error: emit an `event: error` frame then
-                // stop. The consumer sees a final SSE event instead of an
-                // abrupt disconnect.
-                let frame = b"event: error\ndata: {}\n\n".to_vec();
-                let _ = sink.send_chunk(frame).await;
-                return;
-            };
-            // Re-encode the typed chunk as JSON for the SSE wire — clients
-            // consume JSON.
-            let Ok(json) = serde_json::to_vec(&chunk) else {
-                let frame = b"event: error\ndata: {}\n\n".to_vec();
-                let _ = sink.send_chunk(frame).await;
+            // A mid-stream service error or a JSON-encode failure both
+            // terminate the stream with a final `event: error` frame, so the
+            // consumer sees a clean SSE event instead of an abrupt disconnect.
+            let Some(json) = item.ok().and_then(|v| serde_json::to_vec(&v).ok()) else {
+                let _ = sink.send_chunk(b"event: error\ndata: {}\n\n".to_vec()).await;
                 return;
             };
             let mut frame = Vec::with_capacity(json.len() + 8);
@@ -701,8 +706,6 @@ fn extract_model_path(msg: &Message) -> (String, String) {
     (backend, model)
 }
 
-/// Build a `Message` to dispatch an LLM-service op, forwarding auth metadata
-/// from the incoming HTTP request.
 /// `GET /b/llm/api/models` — aggregated list across all registered LLM
 /// backends. Authenticated (any logged-in user).
 pub(super) async fn list_models(
@@ -759,39 +762,8 @@ pub(super) async fn load_model(
         Ok(s) => s,
         Err(e) => return err_internal("llm load_model failed", e.message),
     };
-    let _ = msg;
 
-    OutputStream::from_producer(move |sink, _cancel| async move {
-        let _ = sink
-            .send_meta(MetaEntry {
-                key: META_RESP_CONTENT_TYPE.to_string(),
-                value: "text/event-stream".to_string(),
-            })
-            .await;
-
-        let mut stream = stream;
-        while let Some(item) = stream.next().await {
-            let Ok(progress) = item else {
-                let frame = b"event: error\ndata: {}\n\n".to_vec();
-                let _ = sink.send_chunk(frame).await;
-                return;
-            };
-            // Re-encode the typed progress event as JSON for the SSE wire.
-            let Ok(json) = serde_json::to_vec(&progress) else {
-                let frame = b"event: error\ndata: {}\n\n".to_vec();
-                let _ = sink.send_chunk(frame).await;
-                return;
-            };
-            let mut frame = Vec::with_capacity(json.len() + 8);
-            frame.extend_from_slice(b"data: ");
-            frame.extend_from_slice(&json);
-            frame.extend_from_slice(b"\n\n");
-            if sink.send_chunk(frame).await.is_err() {
-                return;
-            }
-        }
-        let _ = sink.send_chunk(b"data: [DONE]\n\n".to_vec()).await;
-    })
+    sse_json_response(stream)
 }
 
 /// `POST /b/llm/api/models/:backend_id/:model_id/unload` — buffered unload.
@@ -812,7 +784,6 @@ pub(super) async fn unload_model(
         backend_id,
         model_id,
     };
-    let _ = msg;
     match llm_client::unload_model(ctx, &req).await {
         Ok(()) => ok_json(&serde_json::json!({ "unloaded": true })),
         Err(e) => err_internal("llm unload_model failed", e.message),

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -341,7 +341,9 @@ where
             // terminate the stream with a final `event: error` frame, so the
             // consumer sees a clean SSE event instead of an abrupt disconnect.
             let Some(json) = item.ok().and_then(|v| serde_json::to_vec(&v).ok()) else {
-                let _ = sink.send_chunk(b"event: error\ndata: {}\n\n".to_vec()).await;
+                let _ = sink
+                    .send_chunk(b"event: error\ndata: {}\n\n".to_vec())
+                    .await;
                 return;
             };
             let mut frame = Vec::with_capacity(json.len() + 8);

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -9,7 +9,7 @@
 
 use futures::StreamExt;
 use wafer_core::clients::{
-    database as db,
+    config, database as db,
     llm::{
         self as llm_client, ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole,
         ChunkDelta, LoadModelRequest, StatusRequest, UnloadModelRequest,
@@ -22,7 +22,10 @@ use wafer_run::{
 
 use super::{
     messages_create, messages_list,
-    providers::config::{ProviderConfig, ProviderProtocol},
+    providers::{
+        config::{ProviderConfig, ProviderProtocol},
+        ProviderLlmService,
+    },
     schema::{config_to_row, row_to_config, TABLE as PROVIDERS_TABLE},
     LlmBlock, DEFAULT_PROVIDER,
 };
@@ -404,12 +407,23 @@ fn provider_to_json(id: &str, cfg: &ProviderConfig) -> serde_json::Value {
 /// Reload all enabled providers from the DB and push the snapshot into the
 /// in-memory `ProviderLlmService`.
 ///
+/// This is the single choke point where stored rows become live
+/// `ProviderConfig`s: rows are decoded via [`row_to_config`] (which never
+/// yields an `api_key`) and each config's `key_var` is resolved into
+/// `api_key` here, via the config client, before `configure()`. Secret
+/// rotation therefore takes effect on the next reload (boot or any provider
+/// CRUD write), not per chat request.
+///
+/// Shared by the provider CRUD handlers, `LlmBlock::lifecycle(Init)`, and
+/// the one-shot legacy-provider migration (which is why it takes the
+/// service handle rather than the whole block).
+///
 /// Errors are returned to the caller; callers translate to 500. We do not
 /// silently swallow — a failure here means the in-memory service is stale
 /// and the admin needs to know.
-pub(super) async fn reload_provider_service(
-    block: &LlmBlock,
+pub(in crate::blocks::llm) async fn reload_provider_service(
     ctx: &dyn Context,
+    provider_svc: &ProviderLlmService,
 ) -> Result<(), String> {
     let records = db::list_all(ctx, PROVIDERS_TABLE, vec![])
         .await
@@ -417,20 +431,46 @@ pub(super) async fn reload_provider_service(
     let mut configs: Vec<ProviderConfig> = Vec::with_capacity(records.len());
     for rec in &records {
         match row_to_config(rec) {
-            Ok(cfg) if cfg.enabled => configs.push(cfg),
+            Ok(mut cfg) if cfg.enabled => {
+                resolve_provider_key(ctx, &mut cfg).await;
+                configs.push(cfg);
+            }
             Ok(_) => {} // disabled — skip
             Err(e) => {
-                // A malformed row should not poison the whole reload. Log via
-                // the returned error if every row fails; otherwise drop just
-                // that one. Tracing isn't available across all targets here,
-                // so we propagate via the eventual Err only when nothing was
-                // decodable.
+                // A malformed row should not poison the whole reload —
+                // drop just that one.
                 tracing::warn!("skipping malformed provider row {}: {e}", rec.id);
             }
         }
     }
-    block.provider_svc.configure(configs);
+    provider_svc.configure(configs);
     Ok(())
+}
+
+/// Resolve a provider's `key_var` into its plaintext `api_key` via the
+/// config client. `key_var` takes precedence over any inline `api_key`;
+/// with no `key_var` the config is left untouched.
+///
+/// Resolution failure (unset var, empty value, denied read) is logged and
+/// leaves `api_key` as-is — the provider then runs unauthenticated, and the
+/// per-protocol encoder decides whether that's an error (`MissingApiKey` →
+/// 401) on the next chat call. Local OpenAI-compatible servers legitimately
+/// run without a key.
+async fn resolve_provider_key(ctx: &dyn Context, cfg: &mut ProviderConfig) {
+    let Some(var) = cfg.key_var.as_deref() else {
+        return;
+    };
+    match config::get(ctx, var).await {
+        Ok(value) if !value.is_empty() => cfg.api_key = Some(value),
+        Ok(_) => tracing::warn!(
+            "provider '{}': key_var `{var}` is set but empty — provider will run unauthenticated",
+            cfg.name
+        ),
+        Err(e) => tracing::warn!(
+            "provider '{}': failed to resolve key_var `{var}`: {e} — provider will run unauthenticated",
+            cfg.name
+        ),
+    }
 }
 
 /// `GET /b/llm/api/providers` — list all rows. Admin-only.
@@ -518,7 +558,7 @@ pub(super) async fn create_provider(
         Err(e) => return err_internal("Database error", e),
     };
 
-    if let Err(e) = reload_provider_service(block, ctx).await {
+    if let Err(e) = reload_provider_service(ctx, &block.provider_svc).await {
         return err_internal("reload_provider_service failed", e);
     }
 
@@ -596,7 +636,7 @@ pub(super) async fn update_provider(
         Err(e) => return err_internal("Database error", e),
     };
 
-    if let Err(e) = reload_provider_service(block, ctx).await {
+    if let Err(e) = reload_provider_service(ctx, &block.provider_svc).await {
         return err_internal("reload_provider_service failed", e);
     }
 
@@ -624,7 +664,7 @@ pub(super) async fn delete_provider(
         Err(e) => return err_internal("Database error", e),
     }
 
-    if let Err(e) = reload_provider_service(block, ctx).await {
+    if let Err(e) = reload_provider_service(ctx, &block.provider_svc).await {
         return err_internal("reload_provider_service failed", e);
     }
 
@@ -813,7 +853,7 @@ pub(super) async fn discover_models(
     // looks up by name, and the service may be empty if the process just
     // started or the row is disabled (and so was excluded from the last
     // configure call).
-    if let Err(e) = reload_provider_service(block, ctx).await {
+    if let Err(e) = reload_provider_service(ctx, &block.provider_svc).await {
         return err_internal("reload_provider_service failed", e);
     }
 
@@ -829,7 +869,7 @@ pub(super) async fn discover_models(
         return err_internal("Database error", e);
     }
 
-    if let Err(e) = reload_provider_service(block, ctx).await {
+    if let Err(e) = reload_provider_service(ctx, &block.provider_svc).await {
         return err_internal("reload_provider_service failed", e);
     }
 
@@ -1359,5 +1399,81 @@ mod tests {
         let msgs = history_to_messages(&history);
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, ChatRole::System);
+    }
+
+    // -----------------------------------------------------------------
+    // reload_provider_service — key_var resolution
+    // -----------------------------------------------------------------
+
+    /// End-to-end reload over a real in-memory DB + config block:
+    /// a row whose `key_var` resolves gets its `api_key` populated, a row
+    /// without `key_var` stays unauthenticated, and an unresolvable
+    /// `key_var` degrades to no key (warn) instead of failing the reload.
+    #[tokio::test]
+    async fn reload_provider_service_resolves_key_var_into_api_key() {
+        use wafer_core::{
+            interfaces::config::service::ConfigService,
+            service_blocks::config::{ConfigBlock, EnvConfigService},
+        };
+
+        use crate::test_support::TestContext;
+
+        let mut ctx = TestContext::with_admin().await;
+        crate::blocks::llm::migrations::apply(&ctx)
+            .await
+            .expect("apply llm migrations");
+
+        let config_svc = Arc::new(EnvConfigService::new());
+        config_svc.set("SUPPERS_AI__LLM__OPENAI_KEY", "sk-resolved");
+        ctx.register_block("wafer-run/config", Arc::new(ConfigBlock::new(config_svc)));
+
+        for cfg in [
+            ProviderConfig::new(
+                "with-key-var",
+                ProviderProtocol::OpenAi,
+                "https://api.openai.com/v1",
+            )
+            .with_key_var("SUPPERS_AI__LLM__OPENAI_KEY"),
+            ProviderConfig::new(
+                "no-key-var",
+                ProviderProtocol::OpenAiCompatible,
+                "http://localhost:11434/v1",
+            ),
+            ProviderConfig::new(
+                "unresolvable-key-var",
+                ProviderProtocol::OpenAi,
+                "https://api.openai.com/v1",
+            )
+            .with_key_var("SUPPERS_AI__LLM__TEST_MISSING_KEY"),
+        ] {
+            let mut data = config_to_row(&cfg);
+            helpers::stamp_created(&mut data);
+            db::create(&ctx, PROVIDERS_TABLE, data)
+                .await
+                .expect("create provider row");
+        }
+
+        let svc = ProviderLlmService::new();
+        reload_provider_service(&ctx, &svc)
+            .await
+            .expect("reload succeeds");
+
+        let by_name = |name: &str| {
+            svc.providers_snapshot()
+                .into_iter()
+                .find(|c| c.name == name)
+                .unwrap_or_else(|| panic!("provider '{name}' missing from snapshot"))
+        };
+        assert_eq!(
+            by_name("with-key-var").api_key.as_deref(),
+            Some("sk-resolved"),
+            "key_var must resolve into api_key at reload"
+        );
+        assert_eq!(by_name("no-key-var").api_key, None);
+        assert_eq!(
+            by_name("unresolvable-key-var").api_key,
+            None,
+            "unresolvable key_var degrades to no key, not a reload failure"
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/llm/schema.rs
+++ b/crates/solobase-core/src/blocks/llm/schema.rs
@@ -5,11 +5,12 @@
 //!
 //! Secrets are NOT stored in this table. Providers reference an entry in
 //! `suppers_ai__admin__variables` via [`ProviderConfig::key_var`]; the
-//! feature block resolves `key_var` → plaintext `api_key` at runtime
-//! before calling `ProviderLlmService::configure`. This matches the
-//! project-wide convention for sensitive config (single storage location,
-//! admin-gated, masked in API responses) and avoids a `*_encrypted` column
-//! name that would not actually be encrypted.
+//! feature block resolves `key_var` → plaintext `api_key` in
+//! `routes::reload_provider_service` (the single point where stored rows
+//! become live configs) before calling `ProviderLlmService::configure`.
+//! This matches the project-wide convention for sensitive config (single
+//! storage location, admin-gated, masked in API responses) and avoids a
+//! `*_encrypted` column name that would not actually be encrypted.
 
 use std::collections::HashMap;
 
@@ -67,8 +68,9 @@ pub fn config_into_row(cfg: ProviderConfig) -> HashMap<String, serde_json::Value
 
 /// Decode a database [`Record`] into a [`ProviderConfig`].
 ///
-/// The returned `api_key` is always `None` — callers resolve it from
-/// `key_var` at call time via the config client.
+/// The returned `api_key` is always `None` — the reload path
+/// (`routes::reload_provider_service`) resolves it from `key_var` via the
+/// config client before handing the config to the in-memory service.
 pub fn row_to_config(record: &Record) -> Result<ProviderConfig, String> {
     let name = record
         .data
@@ -99,25 +101,8 @@ pub fn row_to_config(record: &Record) -> Result<ProviderConfig, String> {
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
-    let models = match record.data.get("models") {
-        Some(serde_json::Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect(),
-        Some(serde_json::Value::String(s)) if !s.is_empty() => {
-            serde_json::from_str::<Vec<String>>(s)
-                .map_err(|e| format!("invalid `models` json: {e}"))?
-        }
-        _ => Vec::new(),
-    };
-
-    let enabled = match record.data.get("enabled") {
-        Some(serde_json::Value::Bool(b)) => *b,
-        Some(serde_json::Value::Number(n)) => n.as_i64().unwrap_or(0) != 0,
-        Some(serde_json::Value::String(s)) => matches!(s.as_str(), "1" | "true"),
-        None => true,
-        _ => true,
-    };
+    let models = parse_models_field(record.data.get("models"));
+    let enabled = parse_enabled_field(record.data.get("enabled"));
 
     Ok(ProviderConfig {
         name,
@@ -128,6 +113,44 @@ pub fn row_to_config(record: &Record) -> Result<ProviderConfig, String> {
         models,
         enabled,
     })
+}
+
+/// Coerce a stored `models` column value into the explicit model list.
+///
+/// Accepts a JSON array of strings (canonical) or a JSON-string-encoded
+/// array (some DB backends serialise json columns as TEXT — the legacy
+/// `provider_llm` table also stored models this way). Anything malformed
+/// degrades to an empty list with a warning rather than poisoning the whole
+/// row: the provider still works and models can be re-discovered via
+/// `/v1/models`.
+pub fn parse_models_field(value: Option<&serde_json::Value>) -> Vec<String> {
+    match value {
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        Some(serde_json::Value::String(s)) if !s.is_empty() => {
+            match serde_json::from_str::<Vec<String>>(s) {
+                Ok(models) => models,
+                Err(e) => {
+                    tracing::warn!("invalid `models` json — treating as empty: {e}");
+                    Vec::new()
+                }
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Coerce a stored `enabled` column value (bool / int / string across DB
+/// backends) into a bool. Missing or unrecognised values default to `true`.
+pub fn parse_enabled_field(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::Bool(b)) => *b,
+        Some(serde_json::Value::Number(n)) => n.as_i64().unwrap_or(0) != 0,
+        Some(serde_json::Value::String(s)) => matches!(s.as_str(), "1" | "true"),
+        _ => true,
+    }
 }
 
 #[cfg(test)]
@@ -276,6 +299,25 @@ mod tests {
         };
         let cfg = row_to_config(&record).expect("decode");
         assert_eq!(cfg.models, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn row_to_config_treats_malformed_models_json_as_empty() {
+        // A malformed models string must not poison the whole row — the
+        // provider still decodes (models can be re-discovered).
+        let record = Record {
+            id: "r1".into(),
+            data: {
+                let mut d = HashMap::new();
+                d.insert("name".into(), serde_json::json!("x"));
+                d.insert("protocol".into(), serde_json::json!("open_ai"));
+                d.insert("endpoint".into(), serde_json::json!("https://x"));
+                d.insert("models".into(), serde_json::json!("this is not json"));
+                d
+            },
+        };
+        let cfg = row_to_config(&record).expect("decode");
+        assert!(cfg.models.is_empty(), "bad JSON should fall back to []");
     }
 
     #[test]


### PR DESCRIPTION
WIP — S1-H package (llm-small-dedupe). Resuming preserved work from a crashed Wave-1 run.

## Findings checklist (plan section S1-H)
- [ ] **#1 [high] key_var resolution dead wiring** — resolve at reload choke point; delete/simplify resolve_key; fix 3 false doc claims (closes 2026-06-05 PR4 key_var)
- [ ] **#2 [med] SSE re-encoding producer duplicated** — extract `sse_json_response<T>`
- [ ] **#3 [med] chat_stream decode loop duplicated per decoder** — `Decoder` enum
- [ ] **#4 [med] get_thread_setting double-fetch** — return `Option<db::Record>`, drop 'vanished' branch
- [ ] **#5 [low] legacy_providers reload + row-coercion dup** — shared reload + parse_models_field/parse_enabled_field
- [ ] **#6 [low] routes.rs refactor residue** — dead `let _=` + dangling doc fragments (keep only tagged PR4 suppression)
- [ ] **#7 [low] default-provider/model constants duplicated** — pub(super) in mod.rs, delete pages.rs copies
- [ ] **#8 [low] messages_create/list Message-build dup** — `block_request`/`forward_auth_meta` helper
- [ ] update `docs/CODE_REVIEW_2026-06-05_HANDOFF.md` (PR4 key_var closed)

Out of scope: LlmBlock trait seam + browser codec (S2-Q); PR4 streaming-persistence half (the `let _ = thread_id` TODO at routes.rs stays, tagged).

Preserved commits being verified/continued:
- `8955a22` key_var resolution + Decoder enum + legacy reload + parse helpers (findings 1, 3, 5)
- `9ec9e10` WIP: sse_json_response + partial residue sweep (findings 2, 6 partial)