### PR TITLE
fix(S1-D): admin-ops-dedupe — shared admin/ops.rs domain module

### DIFF
--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -6,6 +6,117 @@ use crate::blocks::helpers::{
     err_bad_request, err_forbidden, err_internal, err_not_found, ok_json,
 };
 
+/// Lightweight per-table summary: name + row count. Shared by the JSON
+/// `GET /admin/database/tables` handler and the SSR database page's
+/// left-pane list so both run the same introspection routine.
+pub(in crate::blocks::admin) struct TableSummary {
+    pub name: String,
+    pub row_count: i64,
+}
+
+/// A single column's introspected metadata. Shared by the JSON
+/// `GET /admin/database/tables/{name}/columns` handler and the SSR
+/// schema panel.
+pub(in crate::blocks::admin) struct ColumnInfo {
+    pub name: String,
+    pub ty: String,
+    pub notnull: bool,
+    pub pk: bool,
+    /// The column's default expression, if any (SQLite `dflt_value`).
+    pub default_value: Option<String>,
+}
+
+/// Run the backend table count for one table name, returning 0 on any
+/// failure (an invalid identifier is treated like a failed count query).
+///
+/// The name always originates from the backend's own table listing, so a
+/// build error here means an identifier the backend can't quote.
+async fn table_row_count(ctx: &dyn Context, name: &str) -> i64 {
+    match introspect::build_table_row_count(name, Backend::Sqlite) {
+        Ok(count_sql) => db::query_raw(ctx, &count_sql, &[])
+            .await
+            .ok()
+            .and_then(|r| {
+                r.first()
+                    .and_then(|r| r.data.get("cnt").and_then(|v| v.as_i64()))
+            })
+            .unwrap_or(0),
+        Err(_) => 0,
+    }
+}
+
+/// List every table with its row count, sorted by name.
+///
+/// Single source of truth for the table-browser introspection shared by the
+/// JSON API and the SSR page. The per-table COUNT is issued sequentially —
+/// concurrent counts on a single backend connection (the SQLite case) can
+/// deadlock, and the row is read-once-per-page, so the dedupe (not the
+/// fan-out) is the win here.
+pub(in crate::blocks::admin) async fn introspect_table_summaries(
+    ctx: &dyn Context,
+) -> Vec<TableSummary> {
+    let sql = introspect::build_list_tables(Backend::Sqlite);
+    let records = db::query_raw(ctx, &sql, &[]).await.unwrap_or_default();
+    let mut out = Vec::with_capacity(records.len());
+    for r in &records {
+        let name = r
+            .data
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let row_count = table_row_count(ctx, &name).await;
+        out.push(TableSummary { name, row_count });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Introspect one table's columns plus its row count. `table` is untrusted
+/// (URL path / selected name); an invalid identifier yields an empty column
+/// list and a 0 count rather than an error, matching both surfaces' prior
+/// behavior.
+pub(in crate::blocks::admin) async fn introspect_columns(
+    ctx: &dyn Context,
+    table: &str,
+) -> (Vec<ColumnInfo>, i64) {
+    let columns = match introspect::build_table_info(table, Backend::Sqlite) {
+        Ok((info_sql, info_args)) => db::query_raw(ctx, &info_sql, &info_args)
+            .await
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    };
+    let cols = columns
+        .iter()
+        .map(|c| ColumnInfo {
+            name: c
+                .data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            ty: c
+                .data
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            notnull: c.data.get("notnull").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
+            pk: c.data.get("pk").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
+            default_value: c
+                .data
+                .get("dflt_value")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        })
+        .collect();
+    let row_count = table_row_count(ctx, table).await;
+    (cols, row_count)
+}
+
 pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let action = msg.action();
     let path = msg.path();
@@ -43,39 +154,16 @@ async fn handle_info(ctx: &dyn Context) -> OutputStream {
 }
 
 async fn handle_tables(ctx: &dyn Context) -> OutputStream {
-    let sql = introspect::build_list_tables(Backend::Sqlite);
-    let tables = match db::query_raw(ctx, &sql, &[]).await {
-        Ok(t) => t,
-        Err(e) => return err_internal("Database error", e),
-    };
-
-    let mut table_info = Vec::new();
-    for table in &tables {
-        let name = table
-            .data
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        // The name comes from the backend's own table listing; a build error
-        // (invalid identifier) is treated like a failed count query: 0 rows.
-        let count = match introspect::build_table_row_count(name, Backend::Sqlite) {
-            Ok(count_sql) => db::query_raw(ctx, &count_sql, &[])
-                .await
-                .ok()
-                .and_then(|r| {
-                    r.first()
-                        .and_then(|r| r.data.get("cnt").and_then(|v| v.as_i64()))
-                })
-                .unwrap_or(0),
-            Err(_) => 0,
-        };
-
-        table_info.push(serde_json::json!({
-            "name": name,
-            "row_count": count
-        }));
-    }
-
+    let table_info: Vec<serde_json::Value> = introspect_table_summaries(ctx)
+        .await
+        .into_iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "row_count": t.row_count,
+            })
+        })
+        .collect();
     ok_json(&serde_json::json!(table_info))
 }
 
@@ -93,24 +181,20 @@ async fn handle_columns(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     // The table name is user input from the URL path; an invalid identifier
     // is a bad request, not a server error.
-    let (info_sql, info_args) = match introspect::build_table_info(table_name, Backend::Sqlite) {
-        Ok(v) => v,
-        Err(_) => return err_bad_request("Invalid table name"),
-    };
-    let columns = match db::query_raw(ctx, &info_sql, &info_args).await {
-        Ok(c) => c,
-        Err(e) => return err_internal("Database error", e),
-    };
+    if introspect::build_table_info(table_name, Backend::Sqlite).is_err() {
+        return err_bad_request("Invalid table name");
+    }
 
+    let (columns, _row_count) = introspect_columns(ctx, table_name).await;
     let col_info: Vec<serde_json::Value> = columns
         .iter()
         .map(|c| {
             serde_json::json!({
-                "name": c.data.get("name").and_then(|v| v.as_str()).unwrap_or(""),
-                "type": c.data.get("type").and_then(|v| v.as_str()).unwrap_or(""),
-                "notnull": c.data.get("notnull").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
-                "pk": c.data.get("pk").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
-                "default_value": c.data.get("dflt_value")
+                "name": c.name,
+                "type": c.ty,
+                "notnull": c.notnull,
+                "pk": c.pk,
+                "default_value": c.default_value,
             })
         })
         .collect();

--- a/crates/solobase-core/src/blocks/admin/iam.rs
+++ b/crates/solobase-core/src/blocks/admin/iam.rs
@@ -25,7 +25,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
     match (action, path) {
         // Roles
         ("retrieve", "/admin/iam/roles") => handle_list_roles(ctx).await,
-        ("create", "/admin/iam/roles") => handle_create_role(ctx, input).await,
+        ("create", "/admin/iam/roles") => handle_create_role(ctx, msg, input).await,
         ("update", _) if path.starts_with("/admin/iam/roles/") => {
             handle_update_role(ctx, msg, input).await
         }
@@ -63,7 +63,7 @@ async fn handle_list_roles(ctx: &dyn Context) -> OutputStream {
     }
 }
 
-async fn handle_create_role(ctx: &dyn Context, input: InputStream) -> OutputStream {
+async fn handle_create_role(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     #[derive(serde::Deserialize)]
     struct Req {
         name: String,
@@ -75,16 +75,18 @@ async fn handle_create_role(ctx: &dyn Context, input: InputStream) -> OutputStre
         Ok(b) => b,
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
-    let mut data = json_map(serde_json::json!({
-        "name": body.name,
-        "description": body.description.unwrap_or_default(),
-        "permissions": body.permissions.unwrap_or_default(),
-        "is_system": false
-    }));
-    helpers::stamp_created(&mut data);
-    match db::create(ctx, ROLES_TABLE, data).await {
+    // Validation, audit-log write, and the create live in the shared ops layer.
+    match super::ops::create_role(
+        ctx,
+        msg,
+        &body.name,
+        body.description.as_deref(),
+        body.permissions,
+    )
+    .await
+    {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal("Database error", e),
+        Err(out) => out,
     }
 }
 
@@ -138,21 +140,11 @@ async fn handle_update_role(ctx: &dyn Context, msg: &Message, input: InputStream
 async fn handle_delete_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let path = msg.path();
     let id = path.strip_prefix("/admin/iam/roles/").unwrap_or("");
-    if id.is_empty() {
-        return err_bad_request("Missing role ID");
-    }
-
-    // Check if system role
-    if let Ok(role) = db::get(ctx, ROLES_TABLE, id).await {
-        if role.bool_field("is_system") {
-            return err_forbidden("Cannot delete system role");
-        }
-    }
-
-    match db::delete(ctx, ROLES_TABLE, id).await {
+    // System-role guard, delete, and audit-log write live in the shared ops
+    // layer (the JSON path previously logged nothing).
+    match super::ops::delete_role(ctx, msg, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("Role not found"),
-        Err(e) => err_internal("Database error", e),
+        Err(out) => out,
     }
 }
 

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -3,6 +3,7 @@ mod database;
 mod iam;
 mod logs;
 pub mod migrations;
+mod ops;
 mod pages;
 mod route;
 mod settings;

--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -26,12 +26,10 @@ use wafer_block::db::{Filter, FilterOp};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 
-use super::logs::audit_log;
-use super::settings::VARIABLES_TABLE;
-use super::{ROLES_TABLE, USER_ROLES_TABLE};
-use crate::blocks::auth::USERS_TABLE;
-use crate::blocks::helpers::{
-    self, err_bad_request, err_forbidden, err_internal, err_not_found, RecordExt,
+use super::{logs::audit_log, settings::VARIABLES_TABLE, ROLES_TABLE, USER_ROLES_TABLE};
+use crate::blocks::{
+    auth::USERS_TABLE,
+    helpers::{self, err_bad_request, err_forbidden, err_internal, err_not_found, RecordExt},
 };
 
 /// Masked placeholder shown in place of a sensitive value.
@@ -189,7 +187,11 @@ pub(super) async fn set_user_disabled(
         Err(e) => return Err(err_internal("Database error", e)),
     };
 
-    let action = if disabled { "user.disable" } else { "user.enable" };
+    let action = if disabled {
+        "user.disable"
+    } else {
+        "user.enable"
+    };
     audit_log(
         ctx,
         &admin_id,
@@ -510,5 +512,166 @@ mod tests {
         assert!(validate_url_value("https://192.168.1.1").is_err());
         assert!(validate_url_value("https://127.0.0.1").is_err());
         assert!(validate_url_value("https://example.com\r\nHost: evil").is_err());
+    }
+
+    // --- End-to-end regression tests for the security drifts this module
+    // closes. They run the ops functions against the real DatabaseBlock (via
+    // TestContext) so they exercise the same statements both surfaces now share.
+
+    use crate::test_support::{admin_msg, TestContext};
+
+    /// Assert an ops call succeeded. `OutputStream` (the `Err` arm) isn't
+    /// `Debug`, so `.expect()` can't be used directly.
+    #[track_caller]
+    fn expect_ok<T>(res: Result<T, OutputStream>) -> T {
+        match res {
+            Ok(v) => v,
+            Err(_) => panic!("expected ops call to succeed, got an error OutputStream"),
+        }
+    }
+
+    /// Set up a context with the admin schema (variables, roles, audit_logs).
+    async fn admin_ctx() -> TestContext {
+        let ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+        ctx
+    }
+
+    /// Count audit-log rows whose `action` matches.
+    async fn audit_count(ctx: &dyn Context, action: &str) -> usize {
+        let filters = vec![Filter {
+            field: "action".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(action.to_string()),
+        }];
+        db::list_all(ctx, super::super::logs::AUDIT_LOGS_TABLE, filters)
+            .await
+            .map(|r| r.len())
+            .unwrap_or(0)
+    }
+
+    /// SEC drift: the JSON variable path wrote zero audit rows. Both surfaces
+    /// now go through `create_variable` / `update_variable`, which always log.
+    #[tokio::test]
+    async fn variable_create_and_update_write_audit_rows() {
+        let ctx = admin_ctx().await;
+        let msg = admin_msg("create", "/admin/settings");
+
+        expect_ok(create_variable(&ctx, &msg, "SITE_NAME", "Acme", None, None, false).await);
+        assert_eq!(audit_count(&ctx, "variable.create").await, 1);
+
+        expect_ok(
+            update_variable(
+                &ctx,
+                &msg,
+                "SITE_NAME",
+                VariableUpdate {
+                    value: Some("Acme Two"),
+                    description: None,
+                },
+            )
+            .await,
+        );
+        assert_eq!(audit_count(&ctx, "variable.update").await, 1);
+    }
+
+    /// SEC drift: the SSR variable path ran no URL/SSRF validation. Both
+    /// surfaces now share the `_URL` check in create/update.
+    #[tokio::test]
+    async fn variable_url_keys_are_ssrf_validated_on_both_paths() {
+        let ctx = admin_ctx().await;
+        let msg = admin_msg("create", "/admin/settings");
+
+        // A private-IP URL is rejected on create.
+        assert!(create_variable(
+            &ctx,
+            &msg,
+            "WEBHOOK_URL",
+            "https://10.0.0.1/x",
+            None,
+            None,
+            false
+        )
+        .await
+        .is_err());
+        // ...and on update.
+        assert!(update_variable(
+            &ctx,
+            &msg,
+            "WEBHOOK_URL",
+            VariableUpdate {
+                value: Some("https://192.168.1.1"),
+                description: None,
+            },
+        )
+        .await
+        .is_err());
+        // A public HTTPS URL is accepted.
+        assert!(create_variable(
+            &ctx,
+            &msg,
+            "WEBHOOK_URL",
+            "https://example.com/hook",
+            None,
+            None,
+            false
+        )
+        .await
+        .is_ok());
+    }
+
+    /// A sensitive (`_SECRET` / `_KEY`) value can't be cleared to empty on
+    /// either surface (would break auth).
+    #[tokio::test]
+    async fn sensitive_key_cannot_be_cleared() {
+        let ctx = admin_ctx().await;
+        let msg = admin_msg("update", "/admin/settings");
+        assert!(update_variable(
+            &ctx,
+            &msg,
+            "JWT_SECRET",
+            VariableUpdate {
+                value: Some(""),
+                description: None,
+            },
+        )
+        .await
+        .is_err());
+    }
+
+    /// Self-disable and self-delete guards hold; a successful user mutation
+    /// writes an audit row.
+    #[tokio::test]
+    async fn user_self_mutation_guards_and_audit() {
+        let ctx = admin_ctx().await;
+        // The user mutations touch the auth `users` table.
+        crate::blocks::auth::migrations::apply(&ctx)
+            .await
+            .expect("apply auth migrations");
+        // admin_msg's user is "admin_1".
+        let msg = admin_msg("update", "/admin/users/admin_1");
+
+        // Disabling yourself is rejected (and writes no audit row).
+        assert!(set_user_disabled(&ctx, &msg, "admin_1", true)
+            .await
+            .is_err());
+        // Deleting yourself is rejected.
+        assert!(delete_user(&ctx, &msg, "admin_1").await.is_err());
+        assert_eq!(audit_count(&ctx, "user.disable").await, 0);
+
+        // Seed another user, then disable them — succeeds and logs.
+        let mut data = HashMap::new();
+        data.insert("id".to_string(), serde_json::json!("u2"));
+        data.insert("email".to_string(), serde_json::json!("u2@example.com"));
+        data.insert("display_name".to_string(), serde_json::json!("User Two"));
+        helpers::stamp_created(&mut data);
+        db::create(&ctx, USERS_TABLE, data)
+            .await
+            .expect("seed user");
+
+        expect_ok(set_user_disabled(&ctx, &msg, "u2", true).await);
+        assert_eq!(audit_count(&ctx, "user.disable").await, 1);
     }
 }

--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -1,0 +1,514 @@
+//! Shared admin-mutation domain layer.
+//!
+//! Both admin surfaces — the JSON API (`users.rs` / `iam.rs` / `settings.rs`)
+//! and the SSR htmx pages (`pages/users.rs` / `pages/variables.rs`) — drive the
+//! same handful of privileged operations: disable / enable / delete a user,
+//! create / delete a role, create / update a config variable. Historically each
+//! surface hand-copied the business rules, and the copies drifted on exactly the
+//! things that matter most:
+//!
+//! * the JSON path issued **zero audit-log rows** for any of these mutations;
+//! * the SSR variable create/update path skipped **URL/SSRF validation**;
+//! * the SSR variable read path masked secrets on the `sensitive` flag only,
+//!   ignoring the SEC-060 `_SECRET` / `_KEY` suffix rule.
+//!
+//! This module is the single owner of those rules so the surfaces can't diverge
+//! again. Every function here performs the guard checks, the validation, the
+//! audit-log write, and the database mutation; the callers keep only their
+//! response shape (a JSON record vs. an htmx fragment + toast). Guard/validation
+//! failures are returned as a ready-to-emit [`OutputStream`] error via the
+//! shared `helpers::err_*` constructors, so both surfaces report failures
+//! identically.
+
+use std::collections::HashMap;
+
+use wafer_block::db::{Filter, FilterOp};
+use wafer_core::clients::database as db;
+use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
+
+use super::logs::audit_log;
+use super::settings::VARIABLES_TABLE;
+use super::{ROLES_TABLE, USER_ROLES_TABLE};
+use crate::blocks::auth::USERS_TABLE;
+use crate::blocks::helpers::{
+    self, err_bad_request, err_forbidden, err_internal, err_not_found, RecordExt,
+};
+
+/// Masked placeholder shown in place of a sensitive value.
+pub(super) const MASKED_VALUE: &str = "********";
+
+/// SEC-060: a config value is sensitive when the row's `sensitive` flag is set
+/// **or** the key follows the `_SECRET` / `_KEY` suffix convention. Both
+/// surfaces (JSON `handle_list*` and the SSR variable tables) must agree on
+/// this — masking on the flag alone leaked a `*_SECRET` value whenever an admin
+/// forgot to flip the flag. This is the single source of truth for that rule.
+pub(super) fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
+    sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
+}
+
+/// Validate a URL-type config value against SSRF attacks.
+///
+/// Empty values are allowed (clears the setting). Relative paths starting with
+/// a single `/` are allowed. Otherwise the value must be HTTPS (or
+/// `http://localhost` for local development), must not contain newlines (header
+/// injection), and must not resolve to a private/internal/loopback IP.
+///
+/// Used by every variable create/update path — JSON **and** SSR — so a value an
+/// admin can't set through the API can't be smuggled in through the page form.
+pub(super) fn validate_url_value(value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    // Allow relative paths.
+    if value.starts_with('/') && !value.starts_with("//") {
+        return Ok(());
+    }
+    // Block newlines (header injection).
+    if value.contains('\n') || value.contains('\r') {
+        return Err("URL must not contain newlines".to_string());
+    }
+    // Must be https:// or http://localhost for dev.
+    let is_localhost = value.starts_with("http://localhost");
+    if !value.starts_with("https://") && !is_localhost {
+        return Err("URL must use HTTPS (or http://localhost for development)".to_string());
+    }
+    // Extract hostname and check for private/internal IPs.
+    let host = value
+        .split("://")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .and_then(|authority| {
+            // Handle [IPv6]:port
+            if authority.starts_with('[') {
+                authority.strip_prefix('[')?.split(']').next()
+            } else {
+                authority.split(':').next()
+            }
+        })
+        .unwrap_or("");
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        match ip {
+            std::net::IpAddr::V4(v4) => {
+                let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
+                    || v4.is_loopback()                // 127.x
+                    || v4.is_link_local()              // 169.254.x
+                    || v4.octets()[0] == 0; // 0.0.0.0/8
+                if is_blocked && !is_localhost {
+                    return Err("URL must not point to private/internal IP addresses".to_string());
+                }
+            }
+            std::net::IpAddr::V6(v6) => {
+                if v6.is_loopback() {
+                    return Err("URL must not point to loopback address".to_string());
+                }
+                // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
+                if let Some(v4) = v6.to_ipv4_mapped() {
+                    if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
+                        return Err(
+                            "URL must not point to private/internal IP addresses".to_string()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Bulk-fetch the roles assigned to each of `user_ids` in a single `In`-filter
+/// query, bucketed back into a `user_id -> [role]` map.
+///
+/// Replaces the per-user `list_all(USER_ROLES_TABLE, …)` loop that both the
+/// JSON `users::handle_list` / `get_user` paths and the SSR
+/// `pages/users.rs::user_row_fragment` re-implemented. The single-row lookup is
+/// the `user_ids = [one]` case, so this is the only roles-fetch helper.
+///
+/// On query failure every requested user maps to an empty role list (the prior
+/// per-surface code swallowed the error the same way).
+pub(super) async fn fetch_roles(
+    ctx: &dyn Context,
+    user_ids: &[&str],
+) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    if user_ids.is_empty() {
+        return out;
+    }
+    let values: Vec<serde_json::Value> = user_ids
+        .iter()
+        .map(|id| serde_json::Value::String((*id).to_string()))
+        .collect();
+    let filters = vec![Filter {
+        field: "user_id".to_string(),
+        operator: FilterOp::In,
+        value: serde_json::Value::Array(values),
+    }];
+    if let Ok(rows) = db::list_all(ctx, USER_ROLES_TABLE, filters).await {
+        for rec in &rows {
+            let uid = rec.str_field("user_id").to_string();
+            let role = rec.str_field("role").to_string();
+            if !uid.is_empty() && !role.is_empty() {
+                out.entry(uid).or_default().push(role);
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// User mutations
+// ---------------------------------------------------------------------------
+
+/// Set the `disabled` flag on a user (true = disable, false = enable), writing
+/// an audit-log row. The self-disable guard only applies when disabling.
+///
+/// Returns the updated [`db::Record`] (password hash stripped) on success.
+pub(super) async fn set_user_disabled(
+    ctx: &dyn Context,
+    msg: &Message,
+    user_id: &str,
+    disabled: bool,
+) -> Result<db::Record, OutputStream> {
+    let admin_id = msg.user_id().to_string();
+    // Prevent admins from disabling themselves (lockout). Enabling yourself is
+    // harmless, so the guard is disable-only.
+    if disabled && admin_id == user_id {
+        return Err(err_bad_request("Cannot disable your own account"));
+    }
+
+    let mut data = HashMap::new();
+    data.insert("disabled".to_string(), serde_json::json!(disabled));
+    helpers::stamp_updated(&mut data);
+
+    let record = match db::update(ctx, USERS_TABLE, user_id, data).await {
+        Ok(mut record) => {
+            record.data.remove("password_hash");
+            record
+        }
+        Err(e) if e.code == ErrorCode::NotFound => return Err(err_not_found("User not found")),
+        Err(e) => return Err(err_internal("Database error", e)),
+    };
+
+    let action = if disabled { "user.disable" } else { "user.enable" };
+    audit_log(
+        ctx,
+        &admin_id,
+        action,
+        &format!("users/{user_id}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(record)
+}
+
+/// Soft-delete a user, writing an audit-log row. Rejects self-deletion.
+pub(super) async fn delete_user(
+    ctx: &dyn Context,
+    msg: &Message,
+    user_id: &str,
+) -> Result<(), OutputStream> {
+    let admin_id = msg.user_id().to_string();
+    if admin_id == user_id {
+        return Err(err_bad_request("Cannot delete your own account"));
+    }
+
+    match db::soft_delete(ctx, USERS_TABLE, user_id).await {
+        Ok(_) => {}
+        Err(e) if e.code == ErrorCode::NotFound => return Err(err_not_found("User not found")),
+        Err(e) => return Err(err_internal("Database error", e)),
+    }
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "user.delete",
+        &format!("users/{user_id}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(())
+}
+
+/// Apply the whitelisted user-profile fields (`name`, `disabled`,
+/// `avatar_url`) from `body`, writing an audit-log row. Enforces the
+/// self-disable guard, mirroring [`set_user_disabled`].
+///
+/// Returns the updated record (password hash stripped).
+pub(super) async fn update_user_fields(
+    ctx: &dyn Context,
+    msg: &Message,
+    user_id: &str,
+    body: &HashMap<String, serde_json::Value>,
+) -> Result<db::Record, OutputStream> {
+    let admin_id = msg.user_id().to_string();
+    if admin_id == user_id {
+        if let Some(disabled) = body.get("disabled") {
+            if disabled == &serde_json::Value::Bool(true) || disabled == &serde_json::json!(1) {
+                return Err(err_bad_request("Cannot disable your own account"));
+            }
+        }
+    }
+
+    let mut data = HashMap::new();
+    for key in &["name", "disabled", "avatar_url"] {
+        if let Some(val) = body.get(*key) {
+            data.insert(key.to_string(), val.clone());
+        }
+    }
+    helpers::stamp_updated(&mut data);
+
+    let record = match db::update(ctx, USERS_TABLE, user_id, data).await {
+        Ok(mut record) => {
+            record.data.remove("password_hash");
+            record
+        }
+        Err(e) if e.code == ErrorCode::NotFound => return Err(err_not_found("User not found")),
+        Err(e) => return Err(err_internal("Database error", e)),
+    };
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "user.update",
+        &format!("users/{user_id}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(record)
+}
+
+// ---------------------------------------------------------------------------
+// Role mutations
+// ---------------------------------------------------------------------------
+
+/// Create a role with the given name and optional description, writing an
+/// audit-log row. `description` / `permissions` default to empty.
+pub(super) async fn create_role(
+    ctx: &dyn Context,
+    msg: &Message,
+    name: &str,
+    description: Option<&str>,
+    permissions: Option<Vec<String>>,
+) -> Result<db::Record, OutputStream> {
+    if name.is_empty() {
+        return Err(err_bad_request("Role name is required"));
+    }
+    let admin_id = msg.user_id().to_string();
+
+    let mut data = helpers::json_map(serde_json::json!({
+        "name": name,
+        "description": description.unwrap_or_default(),
+        "permissions": permissions.unwrap_or_default(),
+        "is_system": false,
+    }));
+    helpers::stamp_created(&mut data);
+
+    let record = match db::create(ctx, ROLES_TABLE, data).await {
+        Ok(record) => record,
+        Err(e) => return Err(err_internal("Database error", e)),
+    };
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "role.create",
+        &format!("roles/{name}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(record)
+}
+
+/// Delete a role, writing an audit-log row. Rejects deletion of system roles
+/// (the `is_system` flag), which would break auth.
+pub(super) async fn delete_role(
+    ctx: &dyn Context,
+    msg: &Message,
+    role_id: &str,
+) -> Result<(), OutputStream> {
+    if role_id.is_empty() {
+        return Err(err_bad_request("Missing role ID"));
+    }
+    let admin_id = msg.user_id().to_string();
+
+    // Protect system roles. A missing row falls through to db::delete, which
+    // returns NotFound below.
+    if let Ok(role) = db::get(ctx, ROLES_TABLE, role_id).await {
+        if role.bool_field("is_system") {
+            return Err(err_forbidden("Cannot delete system role"));
+        }
+    }
+
+    match db::delete(ctx, ROLES_TABLE, role_id).await {
+        Ok(()) => {}
+        Err(e) if e.code == ErrorCode::NotFound => return Err(err_not_found("Role not found")),
+        Err(e) => return Err(err_internal("Database error", e)),
+    }
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "role.delete",
+        &format!("roles/{role_id}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Variable mutations
+// ---------------------------------------------------------------------------
+
+/// Create a config variable, writing an audit-log row. Validates `_URL` keys
+/// against [`validate_url_value`] (SSRF). `key` must be non-empty.
+pub(super) async fn create_variable(
+    ctx: &dyn Context,
+    msg: &Message,
+    key: &str,
+    value: &str,
+    name: Option<&str>,
+    description: Option<&str>,
+    sensitive: bool,
+) -> Result<db::Record, OutputStream> {
+    if key.is_empty() {
+        return Err(err_bad_request("Key is required"));
+    }
+    let admin_id = msg.user_id().to_string();
+
+    // Validate URL-type keys (SSRF) on both surfaces.
+    if key.ends_with("_URL") {
+        if let Err(e) = validate_url_value(value) {
+            return Err(err_bad_request(&format!("Invalid value for {key}: {e}")));
+        }
+    }
+
+    let mut data = helpers::json_map(serde_json::json!({
+        "key": key,
+        "value": value,
+        "name": name.filter(|n| !n.is_empty()).unwrap_or(key),
+        "description": description.unwrap_or_default(),
+        "sensitive": if sensitive { 1 } else { 0 },
+        "updated_by": msg.user_id(),
+    }));
+    helpers::stamp_created(&mut data);
+
+    let record = match db::create(ctx, VARIABLES_TABLE, data).await {
+        Ok(record) => record,
+        Err(e) => return Err(err_internal("Database error", e)),
+    };
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "variable.create",
+        &format!("variables/{key}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(record)
+}
+
+/// Fields a variable update may change. `None` leaves the existing column
+/// untouched.
+#[derive(Default)]
+pub(super) struct VariableUpdate<'a> {
+    pub value: Option<&'a str>,
+    pub description: Option<&'a str>,
+}
+
+/// Update a config variable identified by `key` (upsert on the `key` column),
+/// writing an audit-log row. Enforces the sensitive-empty guard (a `_SECRET` /
+/// `_KEY` value can't be cleared) and the `_URL` SSRF validation on both
+/// surfaces.
+///
+/// Returns the upserted record.
+pub(super) async fn update_variable(
+    ctx: &dyn Context,
+    msg: &Message,
+    key: &str,
+    update: VariableUpdate<'_>,
+) -> Result<db::Record, OutputStream> {
+    if key.is_empty() {
+        return Err(err_bad_request("Missing setting key"));
+    }
+    let admin_id = msg.user_id().to_string();
+
+    if let Some(value) = update.value {
+        // Prevent clearing a secret/key (would break auth).
+        if (key.ends_with("_SECRET") || key.ends_with("_KEY")) && value.is_empty() {
+            return Err(err_bad_request(&format!(
+                "Cannot set {key} to an empty value"
+            )));
+        }
+        // Validate URL-type keys (SSRF) on both surfaces.
+        if key.ends_with("_URL") {
+            if let Err(e) = validate_url_value(value) {
+                return Err(err_bad_request(&format!("Invalid value for {key}: {e}")));
+            }
+        }
+    }
+
+    let mut data = HashMap::new();
+    if let Some(value) = update.value {
+        data.insert("value".to_string(), serde_json::json!(value));
+    }
+    if let Some(description) = update.description {
+        data.insert("description".to_string(), serde_json::json!(description));
+    }
+    data.insert("updated_by".to_string(), serde_json::json!(msg.user_id()));
+    helpers::stamp_updated(&mut data);
+
+    let record = match db::upsert(
+        ctx,
+        VARIABLES_TABLE,
+        "key",
+        serde_json::Value::String(key.to_string()),
+        data,
+    )
+    .await
+    {
+        Ok(record) => record,
+        Err(e) => return Err(err_internal("Database error", e)),
+    };
+
+    audit_log(
+        ctx,
+        &admin_id,
+        "variable.update",
+        &format!("variables/{key}"),
+        msg.remote_addr(),
+    )
+    .await;
+    Ok(record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_sensitive_key_honors_flag_and_suffix() {
+        // Flag set → sensitive regardless of name.
+        assert!(is_sensitive_key("PLAIN", 1));
+        // SEC-060: suffix makes it sensitive even when the flag is clear.
+        assert!(is_sensitive_key("STRIPE_SECRET", 0));
+        assert!(is_sensitive_key("JWT_KEY", 0));
+        // Neither flag nor suffix → not sensitive.
+        assert!(!is_sensitive_key("SITE_NAME", 0));
+    }
+
+    #[test]
+    fn validate_url_value_blocks_ssrf_and_allows_safe() {
+        assert!(validate_url_value("").is_ok());
+        assert!(validate_url_value("/relative/path").is_ok());
+        assert!(validate_url_value("https://example.com/ok").is_ok());
+        assert!(validate_url_value("http://localhost:8080").is_ok());
+        // SSRF vectors.
+        assert!(validate_url_value("http://example.com").is_err()); // not https
+        assert!(validate_url_value("https://10.0.0.1/admin").is_err());
+        assert!(validate_url_value("https://192.168.1.1").is_err());
+        assert!(validate_url_value("https://127.0.0.1").is_err());
+        assert!(validate_url_value("https://example.com\r\nHost: evil").is_err());
+    }
+}

--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -452,6 +452,11 @@ pub(super) async fn update_variable(
     }
 
     let mut data = HashMap::new();
+    // `key` is `NOT NULL` and supplies the row's identity on the upsert-create
+    // branch (PUT to a not-yet-present key). On the update branch it resolves
+    // to a no-op (sets `key` to its current value), so it's safe to always
+    // include — and required for the create branch to satisfy the constraint.
+    data.insert("key".to_string(), serde_json::json!(key));
     if let Some(value) = update.value {
         data.insert("value".to_string(), serde_json::json!(value));
     }
@@ -575,6 +580,80 @@ mod tests {
             .await,
         );
         assert_eq!(audit_count(&ctx, "variable.update").await, 1);
+    }
+
+    /// `update_variable` upserts: a PUT to a not-yet-present key must create a
+    /// row whose `NOT NULL` `key` column is persisted (the JSON `handle_set`
+    /// create-via-PUT contract from main). Regression for the upsert-create
+    /// branch omitting `key` and tripping the constraint.
+    #[tokio::test]
+    async fn update_variable_creates_row_for_new_key() {
+        let ctx = admin_ctx().await;
+        let msg = admin_msg("update", "/admin/settings");
+
+        // The key does not exist yet → upsert takes the create branch.
+        let record = expect_ok(
+            update_variable(
+                &ctx,
+                &msg,
+                "NEW_SITE_TAGLINE",
+                VariableUpdate {
+                    value: Some("Hello"),
+                    description: Some("a fresh key"),
+                },
+            )
+            .await,
+        );
+        assert_eq!(
+            record.data.get("key").and_then(|v| v.as_str()),
+            Some("NEW_SITE_TAGLINE"),
+            "the created row must persist its key column"
+        );
+
+        // The row is now findable by `key` (proves the NOT NULL row landed).
+        let found = db::get_by_field(
+            &ctx,
+            VARIABLES_TABLE,
+            "key",
+            serde_json::Value::String("NEW_SITE_TAGLINE".to_string()),
+        )
+        .await
+        .expect("the upserted variable is findable by key");
+        assert_eq!(
+            found.data.get("value").and_then(|v| v.as_str()),
+            Some("Hello")
+        );
+
+        // A second update on the same key takes the update branch (no
+        // duplicate row, key unchanged).
+        expect_ok(
+            update_variable(
+                &ctx,
+                &msg,
+                "NEW_SITE_TAGLINE",
+                VariableUpdate {
+                    value: Some("Goodbye"),
+                    description: None,
+                },
+            )
+            .await,
+        );
+        let rows = db::list_all(
+            &ctx,
+            VARIABLES_TABLE,
+            vec![Filter {
+                field: "key".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String("NEW_SITE_TAGLINE".to_string()),
+            }],
+        )
+        .await
+        .expect("list variables by key");
+        assert_eq!(rows.len(), 1, "update must not create a second row");
+        assert_eq!(
+            rows[0].data.get("value").and_then(|v| v.as_str()),
+            Some("Goodbye")
+        );
     }
 
     /// SEC drift: the SSR variable path ran no URL/SSRF validation. Both

--- a/crates/solobase-core/src/blocks/admin/pages/database.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/database.rs
@@ -12,12 +12,13 @@
 use maud::{html, Markup};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
-use wafer_sql_utils::{introspect, Backend};
 
 use super::{admin_page, crumb};
 use crate::{
     blocks::{
-        admin::database::validate_readonly_query,
+        admin::database::{
+            introspect_columns, introspect_table_summaries, validate_readonly_query, TableSummary,
+        },
         helpers::{now_millis, parse_form_body, url_path_encode as pct_encode},
     },
     ui::{
@@ -48,45 +49,6 @@ impl Tab {
             Tab::Sql => "sql",
         }
     }
-}
-
-/// Lightweight summary for the left-pane list.
-struct TableSummary {
-    name: String,
-    row_count: i64,
-}
-
-async fn load_tables(ctx: &dyn Context) -> Vec<TableSummary> {
-    let sql = introspect::build_list_tables(Backend::Sqlite);
-    let records = db::query_raw(ctx, &sql, &[]).await.unwrap_or_default();
-    let mut out = Vec::with_capacity(records.len());
-    for r in &records {
-        let name = r
-            .data
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if name.is_empty() {
-            continue;
-        }
-        // The name comes from the backend's own table listing; a build error
-        // (invalid identifier) is treated like a failed count query: 0 rows.
-        let row_count = match introspect::build_table_row_count(&name, Backend::Sqlite) {
-            Ok(count_sql) => db::query_raw(ctx, &count_sql, &[])
-                .await
-                .ok()
-                .and_then(|r| {
-                    r.first()
-                        .and_then(|r| r.data.get("cnt").and_then(|v| v.as_i64()))
-                })
-                .unwrap_or(0),
-            Err(_) => 0,
-        };
-        out.push(TableSummary { name, row_count });
-    }
-    out.sort_by(|a, b| a.name.cmp(&b.name));
-    out
 }
 
 fn backend_badge(table_count: usize) -> Markup {
@@ -247,24 +209,9 @@ async fn schema_panel(ctx: &dyn Context, table: Option<&str>) -> Markup {
     };
 
     // The selected name is user input; an invalid identifier renders the same
-    // empty state as a table the backend can't introspect.
-    let columns = match introspect::build_table_info(name, Backend::Sqlite) {
-        Ok((info_sql, info_args)) => db::query_raw(ctx, &info_sql, &info_args)
-            .await
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
-    };
-    let row_count = match introspect::build_table_row_count(name, Backend::Sqlite) {
-        Ok(count_sql) => db::query_raw(ctx, &count_sql, &[])
-            .await
-            .ok()
-            .and_then(|r| {
-                r.first()
-                    .and_then(|r| r.data.get("cnt").and_then(|v| v.as_i64()))
-            })
-            .unwrap_or(0),
-        Err(_) => 0,
-    };
+    // empty state as a table the backend can't introspect. Columns + row count
+    // come from the shared introspection routine used by the JSON API too.
+    let (columns, row_count) = introspect_columns(ctx, name).await;
 
     html! {
         div .db-panel {
@@ -288,17 +235,12 @@ async fn schema_panel(ctx: &dyn Context, table: Option<&str>) -> Markup {
                         }
                         tbody {
                             @for c in &columns {
-                                @let col = c.data.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                                @let ty = c.data.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                                @let notnull = c.data.get("notnull").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-                                @let pk = c.data.get("pk").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-                                @let dflt = c.data.get("dflt_value").and_then(|v| v.as_str()).unwrap_or("");
                                 tr {
-                                    td .font-medium { (col) }
-                                    td .text-muted { (ty) }
-                                    td { @if notnull { "✓" } @else { "" } }
-                                    td { @if pk { "✓" } @else { "" } }
-                                    td .text-muted .text-sm { (dflt) }
+                                    td .font-medium { (c.name) }
+                                    td .text-muted { (c.ty) }
+                                    td { @if c.notnull { "✓" } @else { "" } }
+                                    td { @if c.pk { "✓" } @else { "" } }
+                                    td .text-muted .text-sm { (c.default_value.as_deref().unwrap_or("")) }
                                 }
                             }
                         }
@@ -423,7 +365,7 @@ pub async fn database_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
 
-    let tables = load_tables(ctx).await;
+    let tables = introspect_table_summaries(ctx).await;
     let selected = msg.query("table");
     let tab = Tab::from_query(msg.query("tab"));
 

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -6,12 +6,9 @@ use wafer_run::{context::Context, InputStream, Message, OutputStream};
 use super::{admin_page, crumb};
 use crate::{
     blocks::{
-        admin::{ROLES_TABLE, USER_ROLES_TABLE},
+        admin::{ops, ROLES_TABLE},
         auth::{API_KEYS_TABLE as API_KEYS, USERS_TABLE as USERS},
-        helpers::{
-            self, err_bad_request, err_forbidden, err_internal, parse_form_body, RecordExt,
-            ResponseBuilder,
-        },
+        helpers::{parse_form_body, RecordExt, ResponseBuilder},
     },
     ui::{
         self,
@@ -184,30 +181,9 @@ async fn users_tab(ctx: &dyn Context, msg: &Message, current_user_id: &str) -> M
 /// Render the users table body. Async because it enriches each user with roles.
 async fn users_table(records: &[db::Record], ctx: &dyn Context, current_user_id: &str) -> Markup {
     // Bulk-fetch all roles for the visible users in a single query (was N+1:
-    // one `list_all` per row). The `InOp` filter takes a JSON array of
-    // user_ids; we bucket the rows by user_id back into a map.
-    let user_ids: Vec<serde_json::Value> = records
-        .iter()
-        .map(|r| serde_json::Value::String(r.id.clone()))
-        .collect();
-    let mut user_roles: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
-    if !user_ids.is_empty() {
-        let role_filters = vec![Filter {
-            field: "user_id".into(),
-            operator: FilterOp::In,
-            value: serde_json::Value::Array(user_ids),
-        }];
-        if let Ok(rows) = db::list_all(ctx, USER_ROLES_TABLE, role_filters).await {
-            for rec in rows {
-                let uid = rec.str_field("user_id").to_string();
-                let role = rec.str_field("role").to_string();
-                if !uid.is_empty() && !role.is_empty() {
-                    user_roles.entry(uid).or_default().push(role);
-                }
-            }
-        }
-    }
+    // one `list_all` per row), via the shared `ops::fetch_roles` helper.
+    let user_ids: Vec<&str> = records.iter().map(|r| r.id.as_str()).collect();
+    let user_roles = ops::fetch_roles(ctx, &user_ids).await;
 
     html! {
         div .table-container {
@@ -309,88 +285,42 @@ async fn user_row_fragment(ctx: &dyn Context, user_id: &str) -> Markup {
         Err(_) => return html! {},
     };
 
-    let role_filters = vec![Filter {
-        field: "user_id".into(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String(user_id.to_string()),
-    }];
-    let roles: Vec<String> = match db::list_all(ctx, USER_ROLES_TABLE, role_filters).await {
-        Ok(records) => records
-            .iter()
-            .map(|rec| rec.str_field("role").to_string())
-            .filter(|s| !s.is_empty())
-            .collect(),
-        Err(_) => Vec::new(),
-    };
+    // Single-user lookup via the shared roles helper (the `[one]` case).
+    let roles = ops::fetch_roles(ctx, &[user_id])
+        .await
+        .remove(user_id)
+        .unwrap_or_default();
 
     single_user_row(&record, &roles, "")
 }
 
 /// POST /b/admin/users/{id}/disable
 pub async fn handle_user_disable(ctx: &dyn Context, msg: &Message, user_id: &str) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    if admin_id == user_id {
-        return err_bad_request("Cannot disable your own account");
+    // Self-disable guard, update, and audit-log write live in the shared ops
+    // layer (single source of truth shared with the JSON surface).
+    if let Err(out) = ops::set_user_disabled(ctx, msg, user_id, true).await {
+        return out;
     }
-    let ip = msg.remote_addr().to_string();
-    let mut data = std::collections::HashMap::new();
-    data.insert("disabled".to_string(), serde_json::json!(true));
-    helpers::stamp_updated(&mut data);
-    if let Err(e) = db::update(ctx, USERS, user_id, data).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "user.disable",
-        &format!("users/{user_id}"),
-        &ip,
-    )
-    .await;
     let row = user_row_fragment(ctx, user_id).await;
     ui::html_response_with_toast(row, "User disabled", "success")
 }
 
 /// POST /b/admin/users/{id}/enable
 pub async fn handle_user_enable(ctx: &dyn Context, msg: &Message, user_id: &str) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
-    let mut data = std::collections::HashMap::new();
-    data.insert("disabled".to_string(), serde_json::json!(false));
-    helpers::stamp_updated(&mut data);
-    if let Err(e) = db::update(ctx, USERS, user_id, data).await {
-        return err_internal("Failed", e.message);
+    if let Err(out) = ops::set_user_disabled(ctx, msg, user_id, false).await {
+        return out;
     }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "user.enable",
-        &format!("users/{user_id}"),
-        &ip,
-    )
-    .await;
     let row = user_row_fragment(ctx, user_id).await;
     ui::html_response_with_toast(row, "User enabled", "success")
 }
 
 /// DELETE /b/admin/users/{id}
 pub async fn handle_user_delete(ctx: &dyn Context, msg: &Message, user_id: &str) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    if admin_id == user_id {
-        return err_bad_request("Cannot delete your own account");
+    // Self-delete guard, soft-delete, and audit-log write live in the shared
+    // ops layer.
+    if let Err(out) = ops::delete_user(ctx, msg, user_id).await {
+        return out;
     }
-    let ip = msg.remote_addr().to_string();
-    if let Err(e) = db::soft_delete(ctx, USERS, user_id).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "user.delete",
-        &format!("users/{user_id}"),
-        &ip,
-    )
-    .await;
     ui::html_response_with_toast(html! {}, "User deleted", "success")
 }
 
@@ -400,32 +330,17 @@ pub async fn handle_create_role(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
     let bytes = input.collect_to_bytes().await;
     let body = parse_form_body(&bytes);
 
-    let name = body
-        .get("name")
-        .map(|s| s.as_str())
-        .unwrap_or("")
-        .to_string();
-    if name.is_empty() {
-        return err_bad_request("Role name is required");
-    }
+    let name = body.get("name").map(|s| s.as_str()).unwrap_or("");
+    let description = body.get("description").map(|s| s.as_str());
 
-    let mut data = std::collections::HashMap::new();
-    data.insert("name".to_string(), serde_json::json!(name));
-    if let Some(desc) = body.get("description") {
-        data.insert("description".to_string(), serde_json::json!(desc));
+    // Name-required guard, create, and audit-log write live in the shared ops
+    // layer (single source of truth shared with the JSON surface).
+    if let Err(out) = ops::create_role(ctx, msg, name, description, None).await {
+        return out;
     }
-    helpers::stamp_created(&mut data);
-
-    if let Err(e) = db::create(ctx, ROLES_TABLE, data).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(ctx, &admin_id, "role.create", &format!("roles/{name}"), &ip)
-        .await;
 
     // Return the updated roles tab + close modal + toast
     let content = roles_tab(ctx).await;
@@ -439,27 +354,11 @@ pub async fn handle_create_role(
 }
 
 pub async fn handle_delete_role(ctx: &dyn Context, msg: &Message, role_id: &str) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
-    // Check if system role
-    if let Ok(record) = db::get(ctx, ROLES_TABLE, role_id).await {
-        if record.bool_field("is_system") {
-            return err_forbidden("Cannot delete system role");
-        }
+    // System-role guard, delete, and audit-log write live in the shared ops
+    // layer.
+    if let Err(out) = ops::delete_role(ctx, msg, role_id).await {
+        return out;
     }
-
-    if let Err(e) = db::delete(ctx, ROLES_TABLE, role_id).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "role.delete",
-        &format!("roles/{role_id}"),
-        &ip,
-    )
-    .await;
-
     let content = roles_tab(ctx).await;
     ui::html_response_with_toast(content, "Role deleted", "success")
 }

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -4,8 +4,8 @@ use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use crate::{
     blocks::{
-        admin::VARIABLES_TABLE as VARIABLES,
-        helpers::{self, err_bad_request, err_internal, err_not_found, parse_form_body, RecordExt},
+        admin::{ops, VARIABLES_TABLE as VARIABLES},
+        helpers::{err_not_found, parse_form_body, RecordExt},
     },
     ui::{self, components, icons},
 };
@@ -450,46 +450,20 @@ pub async fn handle_create_variable(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
     let bytes = input.collect_to_bytes().await;
     let body = parse_form_body(&bytes);
 
-    let key = body
-        .get("key")
-        .map(|s| s.as_str())
-        .unwrap_or("")
-        .to_string();
-    if key.is_empty() {
-        return err_bad_request("Key is required");
-    }
+    let key = body.get("key").map(|s| s.as_str()).unwrap_or("");
+    let value = body.get("value").map(|s| s.as_str()).unwrap_or("");
+    let description = body.get("description").map(|s| s.as_str());
+    let sensitive = body.get("sensitive").map(|s| s.as_str()).unwrap_or("0") == "1";
 
-    let mut data = std::collections::HashMap::new();
-    data.insert("key".to_string(), serde_json::json!(key));
-    if let Some(v) = body.get("value") {
-        data.insert("value".to_string(), serde_json::json!(v));
+    // Key-required guard, URL/SSRF validation (the SSR path previously had
+    // none), audit-log write, and the create live in the shared ops layer.
+    if let Err(out) = ops::create_variable(ctx, msg, key, value, None, description, sensitive).await
+    {
+        return out;
     }
-    if let Some(v) = body.get("description") {
-        data.insert("description".to_string(), serde_json::json!(v));
-    }
-    let sensitive = body.get("sensitive").map(|s| s.as_str()).unwrap_or("0");
-    data.insert(
-        "sensitive".to_string(),
-        serde_json::json!(if sensitive == "1" { 1 } else { 0 }),
-    );
-    helpers::stamp_created(&mut data);
-
-    if let Err(e) = db::create(ctx, VARIABLES, data).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "variable.create",
-        &format!("variables/{key}"),
-        &ip,
-    )
-    .await;
 
     // Re-render the variables page (htmx will swap #content)
     variables_page(ctx, &msg).await
@@ -581,52 +555,18 @@ pub async fn handle_update_variable(
     input: InputStream,
     var_key: &str,
 ) -> OutputStream {
-    let admin_id = msg.user_id().to_string();
-    let ip = msg.remote_addr().to_string();
     let bytes = input.collect_to_bytes().await;
     let body = parse_form_body(&bytes);
 
-    // Prevent setting sensitive keys (secrets/keys) to empty (would break auth)
-    if var_key.ends_with("_SECRET") || var_key.ends_with("_KEY") {
-        let new_value = body.get("value").map(|s| s.as_str()).unwrap_or("");
-        if new_value.is_empty() {
-            return err_bad_request(&format!("Cannot set {} to an empty value", var_key));
-        }
-    }
-
-    // Find existing record by key
-    let record = match db::get_by_field(
-        ctx,
-        VARIABLES,
-        "key",
-        serde_json::Value::String(var_key.to_string()),
-    )
-    .await
-    {
-        Ok(r) => r,
-        Err(_) => return err_not_found("Variable not found"),
+    // Sensitive-empty guard, URL/SSRF validation (the SSR path previously had
+    // none), audit-log write, and the upsert live in the shared ops layer.
+    let update = ops::VariableUpdate {
+        value: body.get("value").map(|s| s.as_str()),
+        description: body.get("description").map(|s| s.as_str()),
     };
-
-    let mut data = std::collections::HashMap::new();
-    if let Some(v) = body.get("value") {
-        data.insert("value".to_string(), serde_json::json!(v));
+    if let Err(out) = ops::update_variable(ctx, msg, var_key, update).await {
+        return out;
     }
-    if let Some(v) = body.get("description") {
-        data.insert("description".to_string(), serde_json::json!(v));
-    }
-    helpers::stamp_updated(&mut data);
-
-    if let Err(e) = db::update(ctx, VARIABLES, &record.id, data).await {
-        return err_internal("Failed", e.message);
-    }
-    super::super::logs::audit_log(
-        ctx,
-        &admin_id,
-        "variable.update",
-        &format!("variables/{var_key}"),
-        &ip,
-    )
-    .await;
 
     variables_page(ctx, &msg).await
 }

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -92,6 +92,152 @@ async fn variables_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     super::settings::settings_page(ctx, msg, "variables").await
 }
 
+/// How a variable's value cell should render. SEC-060: the masking decision
+/// is made once, by `ops::is_sensitive_key`, so every table agrees on it.
+enum ValueState {
+    /// Sensitive value present — show the mask.
+    Masked,
+    /// Non-sensitive value present — show it verbatim.
+    Plain(String),
+    /// No value stored (block-config tables distinguish this from empty).
+    NotSet,
+}
+
+impl ValueState {
+    /// Resolve the value cell from a key + raw value + sensitive flag, applying
+    /// the SEC-060 suffix rule via `ops::is_sensitive_key`. `track_unset`
+    /// controls whether an empty value renders as `(not set)` (block-config
+    /// tables) or as an empty `code` cell (flat DB-record tables).
+    fn resolve(key: &str, value: &str, sensitive_flag: i64, track_unset: bool) -> Self {
+        let sensitive = ops::is_sensitive_key(key, sensitive_flag);
+        if track_unset && value.is_empty() {
+            ValueState::NotSet
+        } else if sensitive {
+            ValueState::Masked
+        } else {
+            ValueState::Plain(value.to_string())
+        }
+    }
+}
+
+/// The data needed to render one variable table row. Built per-section, then
+/// handed to [`var_row`] so the masking/edit-button/warning markup lives in
+/// one place.
+struct VarRow<'a> {
+    key: &'a str,
+    /// Friendly name shown under the key (block-config tables only).
+    name: Option<&'a str>,
+    value: ValueState,
+    /// Declared default / auto-generate state (block-config tables only).
+    default: Option<&'a str>,
+    auto_generate: bool,
+    description: &'a str,
+    warning: &'a str,
+    /// Whether to render the "Default" column cell (block-config tables).
+    show_default: bool,
+}
+
+/// Render one variable table row: key (+ optional name), value cell (masked
+/// per SEC-060), optional default column, description (+ optional warning),
+/// and the edit button. Shared by all four variable tables so the masking
+/// policy and edit affordance can't drift between them.
+fn var_row(row: &VarRow) -> Markup {
+    html! {
+        tr {
+            td .font-medium style="font-size:13px" {
+                code { (row.key) }
+                @if let Some(name) = row.name {
+                    @if !name.is_empty() {
+                        br;
+                        span .text-muted style="font-size:12px" { (name) }
+                    }
+                }
+            }
+            td style="font-size:13px" {
+                @match &row.value {
+                    ValueState::Masked => code { "********" },
+                    ValueState::Plain(v) => code { (v) },
+                    ValueState::NotSet => span .text-muted { "(not set)" },
+                }
+            }
+            @if row.show_default {
+                td style="font-size:12px" {
+                    @match row.default {
+                        Some(d) if !d.is_empty() => code .text-muted { (d) },
+                        _ => @if row.auto_generate {
+                            span .badge .badge-info style="font-size:11px" { "auto-generated" }
+                        },
+                    }
+                }
+            }
+            td style="font-size:12px" {
+                (row.description)
+                @if !row.warning.is_empty() {
+                    div style="color:#92400e;font-size:11px;margin-top:2px" {
+                        "Warning: " (row.warning)
+                    }
+                }
+            }
+            td {
+                button .btn .btn-sm .btn-ghost
+                    hx-get={"/b/admin/variables/" (row.key) "/edit"}
+                    hx-target="#edit-var-modal"
+                    hx-swap="innerHTML"
+                    title="Edit"
+                { (icons::edit()) }
+            }
+        }
+    }
+}
+
+/// Build and render one row for a declared [`ConfigVar`] (the shared + per-block
+/// tables): pulls the stored value + sensitive flag from `var_map`, falling
+/// back to the var's declared sensitivity when no DB row exists, and shows the
+/// declared default / auto-generate badge.
+fn config_var_row(
+    var: &wafer_run::ConfigVar,
+    var_map: &std::collections::HashMap<String, (String, i64)>,
+) -> Markup {
+    let (db_value, sensitive_flag) = var_map
+        .get(&var.key)
+        .map(|(v, s)| (v.as_str(), *s))
+        .unwrap_or(("", var.is_sensitive() as i64));
+    var_row(&VarRow {
+        key: &var.key,
+        name: Some(&var.name),
+        value: ValueState::resolve(&var.key, db_value, sensitive_flag, true),
+        default: Some(&var.default),
+        auto_generate: var.auto_generate,
+        description: &var.description,
+        warning: &var.warning,
+        show_default: true,
+    })
+}
+
+/// Render a titled card wrapping a variable table. `show_default` adds the
+/// "Default" column header to match [`var_row`]'s default cell.
+fn var_table(header: Markup, show_default: bool, body: Markup) -> Markup {
+    html! {
+        div .card .mt-4 {
+            (header)
+            div .card-body {
+                table .table {
+                    thead {
+                        tr {
+                            th { "Key" }
+                            th { "Value" }
+                            @if show_default { th { "Default" } }
+                            th { "Description" }
+                            th style="width:50px" {}
+                        }
+                    }
+                    tbody { (body) }
+                }
+            }
+        }
+    }
+}
+
 /// "All Variables" tab -- flat table of all config variables from the DB.
 async fn config_all_tab(ctx: &dyn Context) -> Markup {
     let settings = db::list_all(ctx, VARIABLES, vec![]).await;
@@ -115,11 +261,13 @@ async fn config_all_tab(ctx: &dyn Context) -> Markup {
                                 @let value = record.str_field("value");
                                 @let description = record.str_field("description");
                                 @let warning = record.str_field("warning");
-                                @let sensitive = record.i64_field("sensitive") != 0;
+                                // SEC-060: mask via the shared rule, not the
+                                // `sensitive` flag alone.
+                                @let masked = ops::is_sensitive_key(key, record.i64_field("sensitive"));
                                 tr #{"var-row-" (key)} {
                                     td .font-medium { (key) }
                                     td .text-sm {
-                                        @if sensitive {
+                                        @if masked {
                                             code { "********" }
                                         } @else {
                                             code { (value) }
@@ -166,13 +314,15 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
         .await
         .unwrap_or_default();
 
-    // Build a map of key -> (value, sensitive)
-    let var_map: std::collections::HashMap<String, (String, bool)> = all_vars
+    // Build a map of key -> (value, sensitive-flag). The flag is kept as the
+    // raw `i64` so the SEC-060 suffix rule can be applied via
+    // `ops::is_sensitive_key` at render time.
+    let var_map: std::collections::HashMap<String, (String, i64)> = all_vars
         .iter()
         .map(|r| {
             let key = r.str_field("key").to_string();
             let value = r.str_field("value").to_string();
-            let sensitive = r.i64_field("sensitive") != 0;
+            let sensitive = r.i64_field("sensitive");
             (key, (value, sensitive))
         })
         .collect();
@@ -212,103 +362,52 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
     html! {
         // Shared variables section
         @if !shared_vars.is_empty() {
-            div .card .mt-4 {
-                div .card-header {
-                    h3 .card-title {
-                        span .badge .badge-warning .mr-2 { "shared" }
-                        " Shared Platform Config"
-                    }
-                    p .text-muted style="font-size:12px" {
-                        "Any block can read. Only admin can write."
-                    }
-                }
-                div .card-body {
-                    table .table {
-                        thead {
-                            tr {
-                                th { "Key" }
-                                th { "Value" }
-                                th { "Default" }
-                                th { "Description" }
-                                th style="width:50px" {}
-                            }
+            (var_table(
+                html! {
+                    div .card-header {
+                        h3 .card-title {
+                            span .badge .badge-warning .mr-2 { "shared" }
+                            " Shared Platform Config"
                         }
-                        tbody {
-                            @for var in &shared_vars {
-                                @let (db_value, sensitive) = var_map.get(&var.key)
-                                    .map(|(v, s)| (v.as_str(), *s))
-                                    .unwrap_or(("", var.is_sensitive()));
-                                @let has_value = !db_value.is_empty();
-                                tr {
-                                    td .font-medium style="font-size:13px" {
-                                        code { (var.key) }
-                                        @if !var.name.is_empty() {
-                                            br;
-                                            span .text-muted style="font-size:12px" { (var.name) }
-                                        }
-                                    }
-                                    td style="font-size:13px" {
-                                        @if sensitive {
-                                            @if has_value {
-                                                code { "********" }
-                                            } @else {
-                                                span .text-muted { "(not set)" }
-                                            }
-                                        } @else {
-                                            @if has_value {
-                                                code { (db_value) }
-                                            } @else {
-                                                span .text-muted { "(not set)" }
-                                            }
-                                        }
-                                    }
-                                    td style="font-size:12px" {
-                                        @if !var.default.is_empty() {
-                                            code .text-muted { (var.default) }
-                                        } @else if var.auto_generate {
-                                            span .badge .badge-info style="font-size:11px" { "auto-generated" }
-                                        }
-                                    }
-                                    td style="font-size:12px" { (var.description) }
-                                    td {
-                                        button .btn .btn-sm .btn-ghost
-                                            hx-get={"/b/admin/variables/" (var.key) "/edit"}
-                                            hx-target="#edit-var-modal"
-                                            hx-swap="innerHTML"
-                                            title="Edit"
-                                        { (icons::edit()) }
-                                    }
-                                }
-                            }
+                        p .text-muted style="font-size:12px" {
+                            "Any block can read. Only admin can write."
                         }
                     }
-                }
-            }
+                },
+                true,
+                html! {
+                    @for var in &shared_vars {
+                        (config_var_row(var, &var_map))
+                    }
+                },
+            ))
         }
 
         // Per-block sections
         @for block in &blocks_with_config {
-            div .card .mt-4 {
-                div .card-header {
-                    h3 .card-title {
-                        span .badge .badge-info .mr-2 { (block.name) }
-                        " Configuration"
-                    }
-                    // Show WRAP access info for this block's config. The
-                    // grants are looked up by exact resource pattern via the
-                    // `grants_by_resource` map built above — used to be a
-                    // cubic `blocks × grants × config_keys` loop per render.
-                    p .text-muted style="font-size:12px" {
-                        "Owner: " code { (block.name) }
-                        " \u{2014} Admin can read/write all. "
-                        @for ck in &block.config_keys {
-                            @for resource in [ck.key.clone(), format!("{}*", ck.key)] {
-                                @if let Some(matches) = grants_by_resource.get(&resource) {
-                                    @for (grantee, write) in matches {
-                                        @if *grantee != block.name {
-                                            span .badge .badge-secondary .mr-1 style="font-size:11px" {
-                                                (grantee) ": "
-                                                @if *write { "read+write" } @else { "read" }
+            (var_table(
+                html! {
+                    div .card-header {
+                        h3 .card-title {
+                            span .badge .badge-info .mr-2 { (block.name) }
+                            " Configuration"
+                        }
+                        // Show WRAP access info for this block's config. The
+                        // grants are looked up by exact resource pattern via the
+                        // `grants_by_resource` map built above — used to be a
+                        // cubic `blocks × grants × config_keys` loop per render.
+                        p .text-muted style="font-size:12px" {
+                            "Owner: " code { (block.name) }
+                            " \u{2014} Admin can read/write all. "
+                            @for ck in &block.config_keys {
+                                @for resource in [ck.key.clone(), format!("{}*", ck.key)] {
+                                    @if let Some(matches) = grants_by_resource.get(&resource) {
+                                        @for (grantee, write) in matches {
+                                            @if *grantee != block.name {
+                                                span .badge .badge-secondary .mr-1 style="font-size:11px" {
+                                                    (grantee) ": "
+                                                    @if *write { "read+write" } @else { "read" }
+                                                }
                                             }
                                         }
                                     }
@@ -316,76 +415,14 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
                             }
                         }
                     }
-                }
-                div .card-body {
-                    table .table {
-                        thead {
-                            tr {
-                                th { "Key" }
-                                th { "Value" }
-                                th { "Default" }
-                                th { "Description" }
-                                th style="width:50px" {}
-                            }
-                        }
-                        tbody {
-                            @for var in &block.config_keys {
-                                @let (db_value, sensitive) = var_map.get(&var.key)
-                                    .map(|(v, s)| (v.as_str(), *s))
-                                    .unwrap_or(("", var.is_sensitive()));
-                                @let has_value = !db_value.is_empty();
-                                tr {
-                                    td .font-medium style="font-size:13px" {
-                                        code { (var.key) }
-                                        @if !var.name.is_empty() {
-                                            br;
-                                            span .text-muted style="font-size:12px" { (var.name) }
-                                        }
-                                    }
-                                    td style="font-size:13px" {
-                                        @if sensitive {
-                                            @if has_value {
-                                                code { "********" }
-                                            } @else {
-                                                span .text-muted { "(not set)" }
-                                            }
-                                        } @else {
-                                            @if has_value {
-                                                code { (db_value) }
-                                            } @else {
-                                                span .text-muted { "(not set)" }
-                                            }
-                                        }
-                                    }
-                                    td style="font-size:12px" {
-                                        @if !var.default.is_empty() {
-                                            code .text-muted { (var.default) }
-                                        } @else if var.auto_generate {
-                                            span .badge .badge-info style="font-size:11px" { "auto-generated" }
-                                        }
-                                    }
-                                    td style="font-size:12px" {
-                                        (var.description)
-                                        @if !var.warning.is_empty() {
-                                            div style="color:#92400e;font-size:11px;margin-top:2px" {
-                                                "Warning: " (var.warning)
-                                            }
-                                        }
-                                    }
-                                    td {
-                                        button .btn .btn-sm .btn-ghost
-                                            hx-get={"/b/admin/variables/" (var.key) "/edit"}
-                                            hx-target="#edit-var-modal"
-                                            hx-swap="innerHTML"
-                                            title="Edit"
-                                        { (icons::edit()) }
-                                    }
-                                }
-                            }
-                        }
+                },
+                true,
+                html! {
+                    @for var in &block.config_keys {
+                        (config_var_row(var, &var_map))
                     }
-                }
-            }
+                },
+            ))
         }
 
         // Unowned variables section -- keys in DB not declared by any block or shared
@@ -393,53 +430,43 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
             .filter(|r| !known_keys.contains(r.str_field("key")))
             .collect();
         @if !unowned_vars.is_empty() {
-            div .card .mt-4 {
-                div .card-header {
-                    h3 .card-title {
-                        span .badge .badge-secondary .mr-2 { "unowned" }
-                        " Unowned Variables"
-                    }
-                    p .text-muted style="font-size:12px" {
-                        "Variables in the database not declared by any block. These may be legacy or manually created."
-                    }
-                }
-                div .card-body {
-                    table .table {
-                        thead {
-                            tr {
-                                th { "Key" }
-                                th { "Value" }
-                                th { "Description" }
-                                th style="width:50px" {}
-                            }
+            (var_table(
+                html! {
+                    div .card-header {
+                        h3 .card-title {
+                            span .badge .badge-secondary .mr-2 { "unowned" }
+                            " Unowned Variables"
                         }
-                        tbody {
-                            @for record in &unowned_vars {
-                                @let key = record.str_field("key");
-                                @let value = record.str_field("value");
-                                @let description = record.str_field("description");
-                                @let sensitive = record.i64_field("sensitive") != 0;
-                                tr {
-                                    td .font-medium style="font-size:13px" { code { (key) } }
-                                    td style="font-size:13px" {
-                                        @if sensitive { code { "********" } }
-                                        @else { code { (value) } }
-                                    }
-                                    td style="font-size:12px" { (description) }
-                                    td {
-                                        button .btn .btn-sm .btn-ghost
-                                            hx-get={"/b/admin/variables/" (key) "/edit"}
-                                            hx-target="#edit-var-modal"
-                                            hx-swap="innerHTML"
-                                            title="Edit"
-                                        { (icons::edit()) }
-                                    }
-                                }
-                            }
+                        p .text-muted style="font-size:12px" {
+                            "Variables in the database not declared by any block. These may be legacy or manually created."
                         }
                     }
-                }
-            }
+                },
+                false,
+                html! {
+                    @for record in &unowned_vars {
+                        @let key = record.str_field("key");
+                        // SEC-060: mask via the shared rule. `track_unset` is
+                        // false here so an empty value renders as an empty
+                        // `code` cell, matching the prior flat layout.
+                        (var_row(&VarRow {
+                            key,
+                            name: None,
+                            value: ValueState::resolve(
+                                key,
+                                record.str_field("value"),
+                                record.i64_field("sensitive"),
+                                false,
+                            ),
+                            default: None,
+                            auto_generate: false,
+                            description: record.str_field("description"),
+                            warning: "",
+                            show_default: false,
+                        }))
+                    }
+                },
+            ))
         }
     }
 }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -715,4 +715,41 @@ mod tests {
             "is_enabled should return true after set_enabled(true)"
         );
     }
+
+    /// SEC-060 regression: the single-key getter must mask a `*_SECRET` value
+    /// even when its `sensitive` flag is 0 (the prior code masked on the flag
+    /// alone, leaking the secret here).
+    #[tokio::test]
+    async fn handle_get_masks_secret_suffix_without_flag() {
+        use crate::test_support::{admin_msg, output_json};
+
+        let ctx = TestContext::new().await;
+        crate::blocks::admin::migrations::apply(&ctx)
+            .await
+            .expect("apply admin migrations");
+
+        // Insert a *_SECRET row with the sensitive flag explicitly unset.
+        let mut data = json_map(serde_json::json!({
+            "key": "STRIPE_SECRET",
+            "value": "sk_live_supersecret",
+            "name": "Stripe secret",
+            "sensitive": 0,
+        }));
+        helpers::stamp_created(&mut data);
+        db::create(&ctx, VARIABLES_TABLE, data)
+            .await
+            .expect("seed secret var");
+
+        let msg = admin_msg("retrieve", "/admin/settings/STRIPE_SECRET");
+        let out = handle(&ctx, &msg, InputStream::empty()).await;
+        let body = output_json(out).await;
+        // `Record` serializes as `{ id, data: { value, ... } }`.
+        assert_eq!(
+            body.get("data")
+                .and_then(|d| d.get("value"))
+                .and_then(|v| v.as_str()),
+            Some(MASKED_VALUE),
+            "a *_SECRET value must be masked even with the sensitive flag unset"
+        );
+    }
 }

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -5,6 +5,7 @@ use wafer_run::{
     context::Context, ConfigVar, ErrorCode, InputStream, InputType, Message, OutputStream,
 };
 
+use super::ops::{self, MASKED_VALUE};
 use crate::blocks::helpers::{
     self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
 };
@@ -104,19 +105,6 @@ pub const BLOCK_SETTINGS_TABLE: &str = "suppers_ai__admin__block_settings";
 /// reference this table by name.
 pub const VARIABLES_TABLE: &str = "suppers_ai__admin__variables";
 
-const MASKED_VALUE: &str = "********";
-
-/// SEC-060: unified sensitive-key check used by both `handle_list_full` and
-/// `handle_list`. A value is sensitive if the row's `sensitive` flag is 1
-/// OR the key name follows the `_SECRET` / `_KEY` suffix convention. Both
-/// listing endpoints must agree on this — the previous code masked on the
-/// suffix in `list_full` but only on the flag in `list`, so an admin who
-/// forgot to flip the `sensitive` flag on a `*_SECRET` key would have it
-/// leak through the lightweight listing.
-fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
-    sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
-}
-
 pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let action = msg.action();
     let path = msg.path();
@@ -136,72 +124,6 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
     }
 }
 
-/// Validate a URL-type config value against SSRF attacks.
-/// Empty values are allowed (clears the setting).
-/// Relative paths starting with `/` (but not `//`) are allowed.
-/// Otherwise must be HTTPS, or http://localhost for local development.
-/// Private/internal IP ranges are blocked to prevent SSRF.
-fn validate_url_value(value: &str) -> Result<(), String> {
-    if value.is_empty() {
-        return Ok(());
-    }
-    // Allow relative paths
-    if value.starts_with('/') && !value.starts_with("//") {
-        return Ok(());
-    }
-    // Block newlines (header injection)
-    if value.contains('\n') || value.contains('\r') {
-        return Err("URL must not contain newlines".to_string());
-    }
-    // Must be https:// or http://localhost for dev
-    let is_localhost = value.starts_with("http://localhost");
-    if !value.starts_with("https://") && !is_localhost {
-        return Err("URL must use HTTPS (or http://localhost for development)".to_string());
-    }
-    // Extract hostname and check for private/internal IPs
-    let host = value
-        .split("://")
-        .nth(1)
-        .and_then(|rest| rest.split('/').next())
-        .and_then(|authority| {
-            // Handle [IPv6]:port
-            if authority.starts_with('[') {
-                authority.strip_prefix('[')?.split(']').next()
-            } else {
-                authority.split(':').next()
-            }
-        })
-        .unwrap_or("");
-
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        match ip {
-            std::net::IpAddr::V4(v4) => {
-                let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
-                    || v4.is_loopback()                // 127.x
-                    || v4.is_link_local()              // 169.254.x
-                    || v4.octets()[0] == 0; // 0.0.0.0/8
-                if is_blocked && !is_localhost {
-                    return Err("URL must not point to private/internal IP addresses".to_string());
-                }
-            }
-            std::net::IpAddr::V6(v6) => {
-                if v6.is_loopback() {
-                    return Err("URL must not point to loopback address".to_string());
-                }
-                // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
-                if let Some(v4) = v6.to_ipv4_mapped() {
-                    if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
-                        return Err(
-                            "URL must not point to private/internal IP addresses".to_string()
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
     match db::list_all(ctx, VARIABLES_TABLE, vec![]).await {
         Ok(records) => {
@@ -209,7 +131,7 @@ async fn handle_list_full(ctx: &dyn Context) -> OutputStream {
                 .iter()
                 .map(|record| {
                     let key = record.str_field("key").to_string();
-                    let is_sensitive = is_sensitive_key(&key, record.i64_field("sensitive"));
+                    let is_sensitive = ops::is_sensitive_key(&key, record.i64_field("sensitive"));
                     let is_system = key.starts_with("SOLOBASE_SHARED__");
                     // Mask sensitive values even in the "full" listing
                     let value = if is_sensitive {
@@ -242,7 +164,7 @@ async fn handle_list(ctx: &dyn Context) -> OutputStream {
             let mut settings = HashMap::new();
             for record in &records {
                 let key = record.str_field("key");
-                let is_sensitive = is_sensitive_key(key, record.i64_field("sensitive"));
+                let is_sensitive = ops::is_sensitive_key(key, record.i64_field("sensitive"));
                 let value = if is_sensitive {
                     serde_json::Value::String(MASKED_VALUE.to_string())
                 } else {
@@ -281,7 +203,10 @@ async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await
     {
         Ok(mut record) => {
-            let is_sensitive = record.i64_field("sensitive") == 1;
+            // SEC-060: mask on the row flag OR the `_SECRET` / `_KEY` suffix —
+            // the single-key getter previously masked on the flag alone, so a
+            // `*_SECRET` key with the flag unset leaked its value here.
+            let is_sensitive = ops::is_sensitive_key(key, record.i64_field("sensitive"));
             if is_sensitive {
                 record.data.insert(
                     "value".to_string(),
@@ -312,40 +237,29 @@ async fn handle_set(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    // Prevent setting sensitive keys (secrets/keys) to empty (would break auth)
-    if key.ends_with("_SECRET") || key.ends_with("_KEY") {
-        let val_str = body.value.as_str().unwrap_or("");
-        if val_str.is_empty() {
-            return err_bad_request(&format!("Cannot set {} to an empty value", key));
-        }
-    }
+    // The `value` column is TEXT; a string value is stored verbatim, anything
+    // else as its JSON form (the prior validation already read it via
+    // `as_str().unwrap_or("")`, so non-string values were treated as empty).
+    let value = match &body.value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
 
-    // Validate URL-type keys
-    if key.ends_with("_URL") {
-        let val_str = body.value.as_str().unwrap_or("");
-        if let Err(e) = validate_url_value(val_str) {
-            return err_bad_request(&format!("Invalid value for {}: {}", key, e));
-        }
-    }
-
-    let mut data = json_map(serde_json::json!({
-        "key": key,
-        "value": body.value,
-        "updated_by": msg.user_id()
-    }));
-    helpers::stamp_updated(&mut data);
-
-    match db::upsert(
+    // Guards (sensitive-empty + URL/SSRF), audit-log write, and upsert live in
+    // the shared ops layer so the SSR variable surface can't diverge.
+    match ops::update_variable(
         ctx,
-        VARIABLES_TABLE,
-        "key",
-        serde_json::Value::String(key.to_string()),
-        data,
+        msg,
+        key,
+        ops::VariableUpdate {
+            value: Some(&value),
+            description: None,
+        },
     )
     .await
     {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal("Database error", e),
+        Err(out) => out,
     }
 }
 
@@ -363,30 +277,21 @@ async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
         Ok(b) => b,
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
-    if body.key.is_empty() {
-        return err_bad_request("key is required");
-    }
-
-    // Validate URL-type keys
-    if body.key.ends_with("_URL") {
-        let val_str = body.value.as_deref().unwrap_or("");
-        if let Err(e) = validate_url_value(val_str) {
-            return err_bad_request(&format!("Invalid value for {}: {}", body.key, e));
-        }
-    }
-
-    let data = json_map(serde_json::json!({
-        "key": body.key,
-        "value": body.value.unwrap_or_default(),
-        "name": body.name.unwrap_or_else(|| body.key.clone()),
-        "description": body.description.unwrap_or_default(),
-        "sensitive": if body.sensitive.unwrap_or(false) { 1 } else { 0 },
-        "updated_by": msg.user_id(),
-        "created_at": helpers::now_rfc3339()
-    }));
-    match db::create(ctx, VARIABLES_TABLE, data).await {
+    // Key-empty guard, URL/SSRF validation, audit-log write, and the create
+    // live in the shared ops layer so the SSR variable surface can't diverge.
+    match ops::create_variable(
+        ctx,
+        msg,
+        &body.key,
+        body.value.as_deref().unwrap_or(""),
+        body.name.as_deref(),
+        body.description.as_deref(),
+        body.sensitive.unwrap_or(false),
+    )
+    .await
+    {
         Ok(record) => ok_json(&record),
-        Err(e) => err_internal("Database error", e),
+        Err(out) => out,
     }
 }
 

--- a/crates/solobase-core/src/blocks/admin/users.rs
+++ b/crates/solobase-core/src/blocks/admin/users.rs
@@ -4,10 +4,10 @@ use wafer_block::db::{Filter, FilterOp, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
-use super::USER_ROLES_TABLE;
+use super::ops;
 use crate::blocks::{
     auth::USERS_TABLE as COLLECTION,
-    helpers::{self, err_bad_request, err_internal, err_not_found, ok_json, RecordExt},
+    helpers::{err_bad_request, err_internal, err_not_found, ok_json},
 };
 
 pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
@@ -57,23 +57,13 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
     .await
     {
         Ok(mut result) => {
-            // Strip password hashes and enrich with roles
+            // Strip password hashes and bulk-enrich with roles via a single
+            // `In`-filter query (was N+1: one `list_all` per row).
+            let user_ids: Vec<&str> = result.records.iter().map(|r| r.id.as_str()).collect();
+            let roles_by_user = ops::fetch_roles(ctx, &user_ids).await;
             for record in &mut result.records {
                 record.data.remove("password_hash");
-                let role_filters = vec![Filter {
-                    field: "user_id".to_string(),
-                    operator: FilterOp::Equal,
-                    value: serde_json::Value::String(record.id.clone()),
-                }];
-                let roles: Vec<String> =
-                    match db::list_all(ctx, USER_ROLES_TABLE, role_filters).await {
-                        Ok(records) => records
-                            .iter()
-                            .map(|rec| rec.str_field("role").to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect(),
-                        Err(_) => Vec::new(),
-                    };
+                let roles = roles_by_user.get(&record.id).cloned().unwrap_or_default();
                 record
                     .data
                     .insert("roles".to_string(), serde_json::json!(roles));
@@ -102,20 +92,11 @@ async fn get_user(ctx: &dyn Context, id: &str) -> OutputStream {
     match db::get(ctx, COLLECTION, id).await {
         Ok(mut record) => {
             record.data.remove("password_hash");
-            // Get roles
-            let role_filters = vec![Filter {
-                field: "user_id".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(id.to_string()),
-            }];
-            let roles: Vec<String> = match db::list_all(ctx, USER_ROLES_TABLE, role_filters).await {
-                Ok(records) => records
-                    .iter()
-                    .map(|rec| rec.str_field("role").to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect(),
-                Err(_) => Vec::new(),
-            };
+            // Get roles via the shared single-query helper.
+            let roles = ops::fetch_roles(ctx, &[id])
+                .await
+                .remove(id)
+                .unwrap_or_default();
             let mut resp = match serde_json::to_value(&record) {
                 Ok(v) => v,
                 Err(e) => return err_internal("Failed to serialize user record", e),
@@ -142,37 +123,17 @@ async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
         return err_bad_request("Missing user ID");
     }
 
-    // Prevent admin from disabling themselves
-    let current_user_id = msg.user_id();
     let raw = input.collect_to_bytes().await;
     let body: HashMap<String, serde_json::Value> = match serde_json::from_slice(&raw) {
         Ok(b) => b,
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
-    if id == current_user_id {
-        if let Some(disabled) = body.get("disabled") {
-            if disabled == &serde_json::Value::Bool(true) || disabled == &serde_json::json!(1) {
-                return err_bad_request("Cannot disable your own account");
-            }
-        }
-    }
 
-    // Only allow safe fields
-    let mut data = HashMap::new();
-    for key in &["name", "disabled", "avatar_url"] {
-        if let Some(val) = body.get(*key) {
-            data.insert(key.to_string(), val.clone());
-        }
-    }
-    helpers::stamp_updated(&mut data);
-
-    match db::update(ctx, COLLECTION, id, data).await {
-        Ok(mut record) => {
-            record.data.remove("password_hash");
-            ok_json(&record)
-        }
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("User not found"),
-        Err(e) => err_internal("Database error", e),
+    // The self-disable guard, safe-field whitelist, and audit-log write all
+    // live in the shared ops layer so the SSR surface can't diverge.
+    match ops::update_user_fields(ctx, msg, id, &body).await {
+        Ok(record) => ok_json(&record),
+        Err(out) => out,
     }
 }
 
@@ -195,15 +156,10 @@ async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
         return err_bad_request("Missing user ID");
     }
 
-    // Prevent admin from deleting themselves
-    if id == msg.user_id() {
-        return err_bad_request("Cannot delete your own account");
-    }
-
-    // Soft delete
-    match db::soft_delete(ctx, COLLECTION, id).await {
-        Ok(_) => ok_json(&serde_json::json!({"deleted": true})),
-        Err(e) if e.code == ErrorCode::NotFound => err_not_found("User not found"),
-        Err(e) => err_internal("Database error", e),
+    // Self-delete guard, soft-delete, and audit-log write live in the shared
+    // ops layer (the JSON path previously logged nothing).
+    match ops::delete_user(ctx, msg, id).await {
+        Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
+        Err(out) => out,
     }
 }


### PR DESCRIPTION
WIP — S1-D admin-ops-dedupe (wave 1). Resuming preserved WIP commit e653e9b.

Extracts a shared \`admin/ops.rs\` domain module owning the privileged admin mutations + read-side dedupes, converging the JSON and SSR surfaces onto one implementation. Security drifts closed by construction converge on the SAFER side: JSON path gains audit logging; SSR variable path gains URL/SSRF validation; SEC-060 \`_SECRET\`/\`_KEY\` suffix masking applied uniformly (incl. JSON \`handle_get\`).

## Findings checklist (S1-D plan section)
- [ ] [high/architecture] Parallel JSON/SSR admin mutations with divergent security/validation/audit — extract \`admin/ops.rs\` (6 mutations + guards + validate_url_value + is_sensitive_key + audit_log)
- [ ] [medium/duplication] Variables page renders the same variable-row table 4x — var_row/var_table helpers
- [ ] [medium/duplication] DB introspection duplicated SSR page vs JSON API, both N+1 COUNT — shared introspect_table_summaries/introspect_columns, concurrent counts
- [ ] [low/duplication] User-roles enrichment copied 3x; JSON users N+1 — fetch_roles(ctx, user_ids) single In-query

## Progress
- ops.rs domain module created (514 lines); JSON \`iam.rs\`/\`users.rs\` wired (preserved WIP). Remaining: JSON settings.rs, SSR pages/users.rs + pages/variables.rs wiring; var_row/var_table; introspection dedupe; verification.

## Verification
Pending — local CI-mirror suite to run before marking ready.