### PR TITLE
fix(S1-G): files quota single-source, i64_field TEXT fallback, bucket dedupe + validation

### DIFF
--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -5,10 +5,7 @@ use wafer_run::{context::Context, Message, OutputStream};
 use wafer_sql_utils::{query, Backend};
 
 use crate::{
-    blocks::{
-        admin::REQUEST_LOGS_TABLE as REQUEST_LOGS,
-        helpers::RecordExt,
-    },
+    blocks::{admin::REQUEST_LOGS_TABLE as REQUEST_LOGS, helpers::RecordExt},
     ui::{components, icons},
 };
 

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -5,7 +5,10 @@ use wafer_run::{context::Context, Message, OutputStream};
 use wafer_sql_utils::{query, Backend};
 
 use crate::{
-    blocks::admin::REQUEST_LOGS_TABLE as REQUEST_LOGS,
+    blocks::{
+        admin::REQUEST_LOGS_TABLE as REQUEST_LOGS,
+        helpers::RecordExt,
+    },
     ui::{components, icons},
 };
 
@@ -240,8 +243,8 @@ pub async fn network_inbound_detail(ctx: &dyn Context, msg: &Message) -> OutputS
             }
             tbody {
                 @for record in display_rows {
-                    @let status_code = record.data.get("status_code").and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))).unwrap_or(0);
-                    @let duration = record.data.get("duration_ms").and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))).unwrap_or(0);
+                    @let status_code = record.i64_field("status_code");
+                    @let duration = record.i64_field("duration_ms");
                     @let client_ip = record.data.get("client_ip").and_then(|v| v.as_str()).unwrap_or("");
                     @let user_id = record.data.get("user_id").and_then(|v| v.as_str()).unwrap_or("");
                     @let created = record.data.get("created_at").and_then(|v| v.as_str()).unwrap_or("");

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -69,14 +69,17 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    // Validate bucket/key
+    // Validate bucket/key through the shared storage validators so the share
+    // path enforces exactly the same rules as upload/download (SEC-064: the
+    // old inline copy here omitted the backslash check, letting a share be
+    // created for a key the storage path would reject).
     if body.bucket.is_empty() || body.key.is_empty() {
         return err_bad_request("Bucket and key are required");
     }
-    if body.bucket.contains("..") || body.bucket.contains('/') || body.bucket.contains('\0') {
+    if !super::storage::is_valid_bucket_name(&body.bucket) {
         return err_bad_request("Invalid bucket name");
     }
-    if body.key.contains("..") || body.key.starts_with('/') || body.key.contains('\0') {
+    if !super::storage::is_valid_storage_key(&body.key) {
         return err_bad_request("Invalid object key");
     }
 
@@ -288,5 +291,77 @@ async fn handle_update_quota(ctx: &dyn Context, msg: &Message, input: InputStrea
     {
         Ok(record) => ok_json(&record),
         Err(e) => err_internal("Database error", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wafer_run::InputStream;
+
+    use super::*;
+    use crate::test_support::{auth_msg, output_is_error, TestContext};
+
+    fn share_body(bucket: &str, key: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({ "bucket": bucket, "key": key })).unwrap()
+    }
+
+    /// Regression (SEC-064): the share path used to inline its own bucket/key
+    /// validation that OMITTED the backslash rejection, so a share could be
+    /// created for a key (`a\..\secret`) that the upload/download path
+    /// (`is_valid_storage_key`) rejects. Now it routes through the shared
+    /// validator and rejects the key before any ownership/existence lookup.
+    #[tokio::test]
+    async fn create_share_rejects_backslash_key() {
+        let ctx = TestContext::with_files().await;
+        let msg = auth_msg("create", "/b/cloudstorage/shares", "u1");
+        let out = handle_create_share(
+            &ctx,
+            &msg,
+            InputStream::from_bytes(share_body("photos", "a\\..\\secret")),
+        )
+        .await;
+        assert!(
+            output_is_error(out, "InvalidArgument").await,
+            "backslash key must be rejected (SEC-064)"
+        );
+    }
+
+    /// The share path now enforces the same S3-compatible bucket-name rule as
+    /// the rest of the block (and the client modal), so an uppercase /
+    /// invalid bucket name is rejected up front.
+    #[tokio::test]
+    async fn create_share_rejects_invalid_bucket_name() {
+        let ctx = TestContext::with_files().await;
+        let msg = auth_msg("create", "/b/cloudstorage/shares", "u1");
+        let out = handle_create_share(
+            &ctx,
+            &msg,
+            InputStream::from_bytes(share_body("Bad/Bucket", "file.txt")),
+        )
+        .await;
+        assert!(
+            output_is_error(out, "InvalidArgument").await,
+            "invalid bucket name must be rejected"
+        );
+    }
+
+    /// A valid key/bucket gets past validation and is denied only by the
+    /// ownership check (the user owns no such bucket) — confirming the
+    /// validator change didn't accidentally reject legitimate input.
+    #[tokio::test]
+    async fn create_share_valid_input_reaches_ownership_check() {
+        let ctx = TestContext::with_files().await;
+        let msg = auth_msg("create", "/b/cloudstorage/shares", "u1");
+        let out = handle_create_share(
+            &ctx,
+            &msg,
+            InputStream::from_bytes(share_body("my-bucket", "dir/file.txt")),
+        )
+        .await;
+        // No bucket owned by u1 → PermissionDenied, NOT InvalidArgument.
+        assert!(
+            output_is_error(out, "PermissionDenied").await,
+            "valid input should pass validation and hit the ownership check"
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -120,7 +120,10 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
         "access_count": 0,
     }));
     if let Some(exp) = &expires_at {
-        data.insert("expires_at".to_string(), serde_json::Value::String(exp.clone()));
+        data.insert(
+            "expires_at".to_string(),
+            serde_json::Value::String(exp.clone()),
+        );
     }
     if let Some(max) = body.max_access_count {
         data.insert("max_access_count".to_string(), serde_json::json!(max));

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -299,9 +299,16 @@ mod tests {
 
     /// Regression (SEC-064): the share path used to inline its own bucket/key
     /// validation that OMITTED the backslash rejection, so a share could be
-    /// created for a key (`a\..\secret`) that the upload/download path
-    /// (`is_valid_storage_key`) rejects. Now it routes through the shared
-    /// validator and rejects the key before any ownership/existence lookup.
+    /// created for a key the upload/download path (`is_valid_storage_key`)
+    /// rejects. Now it routes through the shared validator and rejects the
+    /// key before any ownership/existence lookup.
+    ///
+    /// The key here is a *backslash-only* key with NO `..` segment. This
+    /// pins the actual SEC-064 drift: the old inline check rejected `..` but
+    /// accepted a bare backslash, so a `..`-containing key (e.g. `a\..\secret`)
+    /// would have been rejected by the old code too and would not prove the
+    /// backslash branch. `a\secret` was *accepted* by the old inline check and
+    /// is *rejected* only by the shared validator's `!key.contains('\\')` arm.
     #[tokio::test]
     async fn create_share_rejects_backslash_key() {
         let ctx = TestContext::with_files().await;
@@ -309,7 +316,7 @@ mod tests {
         let out = handle_create_share(
             &ctx,
             &msg,
-            InputStream::from_bytes(share_body("photos", "a\\..\\secret")),
+            InputStream::from_bytes(share_body("photos", "a\\secret")),
         )
         .await;
         assert!(

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -111,27 +111,16 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
         .expires_in_hours
         .map(|h| (now + chrono::Duration::hours(h)).to_rfc3339());
 
-    let mut data = HashMap::new();
-    data.insert(
-        "token".to_string(),
-        serde_json::Value::String(token.clone()),
-    );
-    data.insert("bucket".to_string(), serde_json::Value::String(body.bucket));
-    data.insert("key".to_string(), serde_json::Value::String(body.key));
-    data.insert(
-        "created_by".to_string(),
-        serde_json::Value::String(msg.user_id().to_string()),
-    );
-    data.insert(
-        "created_at".to_string(),
-        serde_json::Value::String(now.to_rfc3339()),
-    );
-    data.insert("access_count".to_string(), serde_json::json!(0));
+    let mut data = helpers::json_map(serde_json::json!({
+        "token": token,
+        "bucket": body.bucket,
+        "key": body.key,
+        "created_by": msg.user_id(),
+        "created_at": now.to_rfc3339(),
+        "access_count": 0,
+    }));
     if let Some(exp) = &expires_at {
-        data.insert(
-            "expires_at".to_string(),
-            serde_json::Value::String(exp.clone()),
-        );
+        data.insert("expires_at".to_string(), serde_json::Value::String(exp.clone()));
     }
     if let Some(max) = body.max_access_count {
         data.insert("max_access_count".to_string(), serde_json::json!(max));

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -90,10 +90,10 @@ impl Block for FilesBlock {
                     .index(&["share_id"]),
                 CollectionSchema::new(QUOTAS_TABLE)
                     .field_unique("user_id", "string")
-                    .field_default("max_storage_bytes", "int64", "1073741824")
-                    .field_default("max_file_size_bytes", "int64", "104857600")
-                    .field_default("max_files_per_bucket", "int", "10000")
-                    .field_default("reset_period_days", "int", "0"),
+                    .field_default("max_storage_bytes", "int64", &models::QuotaConfig::DEFAULT_MAX_STORAGE_BYTES.to_string())
+                    .field_default("max_file_size_bytes", "int64", &models::QuotaConfig::DEFAULT_MAX_FILE_SIZE_BYTES.to_string())
+                    .field_default("max_files_per_bucket", "int", &models::QuotaConfig::DEFAULT_MAX_FILES_PER_BUCKET.to_string())
+                    .field_default("reset_period_days", "int", &models::QuotaConfig::DEFAULT_RESET_PERIOD_DAYS.to_string()),
             ])
             .category(wafer_run::BlockCategory::Feature)
             .description("File storage and management with bucket-based organization. Supports file upload, download, deletion, search, and sharing via public links with expiration and access counting. Includes per-user storage quotas.")
@@ -262,6 +262,55 @@ impl Block for FilesBlock {
 
 #[cfg(not(target_arch = "wasm32"))]
 ::wafer_block::register_static_block!("suppers-ai/files", FilesBlock);
+
+#[cfg(test)]
+mod schema_tests {
+    use wafer_run::Block;
+
+    use super::{models::QuotaConfig, FilesBlock, QUOTAS_TABLE};
+
+    /// The quota defaults advertised through the collection schema must
+    /// match the `QuotaConfig` consts (single in-code source). The
+    /// migration SQL files carry the same values DB-side; if you change
+    /// the consts, change `migrations/001_initial_schema.*.sql` too (and
+    /// remember `SOLOBASE_RUN_MIGRATIONS=1`).
+    #[test]
+    fn quota_schema_defaults_match_quota_config_consts() {
+        let info = FilesBlock::new().info();
+        let quotas = info
+            .collections
+            .iter()
+            .find(|c| c.name == QUOTAS_TABLE)
+            .expect("quotas collection declared");
+
+        let default_of = |field: &str| -> String {
+            quotas
+                .fields
+                .iter()
+                .find(|f| f.name == field)
+                .unwrap_or_else(|| panic!("field {field} declared"))
+                .default_value
+                .clone()
+        };
+
+        assert_eq!(
+            default_of("max_storage_bytes"),
+            QuotaConfig::DEFAULT_MAX_STORAGE_BYTES.to_string()
+        );
+        assert_eq!(
+            default_of("max_file_size_bytes"),
+            QuotaConfig::DEFAULT_MAX_FILE_SIZE_BYTES.to_string()
+        );
+        assert_eq!(
+            default_of("max_files_per_bucket"),
+            QuotaConfig::DEFAULT_MAX_FILES_PER_BUCKET.to_string()
+        );
+        assert_eq!(
+            default_of("reset_period_days"),
+            QuotaConfig::DEFAULT_RESET_PERIOD_DAYS.to_string()
+        );
+    }
+}
 
 #[cfg(test)]
 mod grant_tests {

--- a/crates/solobase-core/src/blocks/files/models.rs
+++ b/crates/solobase-core/src/blocks/files/models.rs
@@ -8,13 +8,31 @@ pub struct QuotaConfig {
     pub reset_period_days: i64,
 }
 
+impl QuotaConfig {
+    /// Default per-user storage cap: 1 GiB.
+    ///
+    /// These consts are the single in-code source of the quota defaults —
+    /// `Default::default()`, the per-field fallbacks in `quota.rs`, and the
+    /// `CollectionSchema` defaults in `mod.rs` all derive from them. The
+    /// migration SQL files carry the same values as DB-side column defaults
+    /// (`migrations/001_initial_schema.*.sql`); a schema test in `mod.rs`
+    /// guards against drift on the in-code side.
+    pub const DEFAULT_MAX_STORAGE_BYTES: i64 = 1_073_741_824;
+    /// Default single-file size cap: 100 MiB.
+    pub const DEFAULT_MAX_FILE_SIZE_BYTES: i64 = 104_857_600;
+    /// Default per-bucket file-count cap.
+    pub const DEFAULT_MAX_FILES_PER_BUCKET: i64 = 10_000;
+    /// Default reset period (0 = never).
+    pub const DEFAULT_RESET_PERIOD_DAYS: i64 = 0;
+}
+
 impl Default for QuotaConfig {
     fn default() -> Self {
         Self {
-            max_storage_bytes: 1_073_741_824, // 1GB
-            max_file_size_bytes: 104_857_600, // 100MB
-            max_files_per_bucket: 10_000,
-            reset_period_days: 0,
+            max_storage_bytes: Self::DEFAULT_MAX_STORAGE_BYTES,
+            max_file_size_bytes: Self::DEFAULT_MAX_FILE_SIZE_BYTES,
+            max_files_per_bucket: Self::DEFAULT_MAX_FILES_PER_BUCKET,
+            reset_period_days: Self::DEFAULT_RESET_PERIOD_DAYS,
         }
     }
 }

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -72,10 +72,12 @@ pub fn render_new_bucket_modal() -> Markup {
                         type="text"
                         name="name"
                         required
-                        minlength="3"
-                        maxlength="63"
-                        // S3-compatible: lowercase letters, digits, hyphens; start/end alnum.
-                        pattern="[a-z0-9]([a-z0-9-]*[a-z0-9])?"
+                        minlength=(super::storage::BUCKET_NAME_MIN_LEN)
+                        maxlength=(super::storage::BUCKET_NAME_MAX_LEN)
+                        // S3-compatible: lowercase letters, digits, hyphens;
+                        // start/end alnum. Single source of truth shared with
+                        // the server-side `is_valid_bucket_name` check.
+                        pattern=(super::storage::BUCKET_NAME_PATTERN)
                         autocomplete="off"
                         spellcheck="false"
                         placeholder="my-bucket";

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -779,63 +779,6 @@ async fn list_shares_for_user(ctx: &dyn Context, user_id: &str) -> Vec<ShareRow>
     }
 }
 
-async fn load_quota_info(ctx: &dyn Context, user_id: &str) -> QuotaInfo {
-    use wafer_block::db::{Filter, FilterOp};
-    use wafer_run::ErrorCode;
-
-    use super::{OBJECTS_TABLE, QUOTAS_TABLE};
-
-    let limit = match db::get_by_field(
-        ctx,
-        QUOTAS_TABLE,
-        "user_id",
-        serde_json::Value::String(user_id.into()),
-    )
-    .await
-    {
-        Ok(r) => r
-            .data
-            .get("max_storage_bytes")
-            .and_then(|v| {
-                v.as_i64()
-                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-            })
-            .unwrap_or(1_073_741_824),
-        Err(e) if e.code == ErrorCode::NotFound => 1_073_741_824,
-        Err(e) => {
-            tracing::warn!(error = %e, "quota lookup failed");
-            1_073_741_824
-        }
-    };
-
-    // used_bytes = SUM(size) over the user's objects. v1 in-process sum.
-    let used_filters = vec![Filter {
-        field: "uploaded_by".into(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String(user_id.into()),
-    }];
-    let used = match db::list_all(ctx, OBJECTS_TABLE, used_filters).await {
-        Ok(recs) => recs
-            .iter()
-            .filter_map(|r| {
-                r.data.get("size").and_then(|v| {
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
-            })
-            .sum(),
-        Err(e) => {
-            tracing::warn!(error = %e, "used-bytes lookup failed");
-            0
-        }
-    };
-
-    QuotaInfo {
-        used_bytes: used,
-        limit_bytes: limit,
-    }
-}
-
 /// GET `/b/cloudstorage/` — share list with quota card.
 pub async fn cloudstorage_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user_id = msg.user_id().to_string();
@@ -844,7 +787,14 @@ pub async fn cloudstorage_page(ctx: &dyn Context, msg: &Message) -> OutputStream
     }
 
     let shares = list_shares_for_user(ctx, &user_id).await;
-    let quota = load_quota_info(ctx, &user_id).await;
+    // Same quota source as upload enforcement (`quota::check_quota`), so
+    // the card can never disagree with what the API enforces.
+    let quota = QuotaInfo {
+        used_bytes: super::quota::get_used_bytes(ctx, &user_id).await,
+        limit_bytes: super::quota::get_user_quota(ctx, &user_id)
+            .await
+            .max_storage_bytes,
+    };
 
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
@@ -1508,6 +1458,36 @@ mod integration_tests {
         assert!(body.contains("photos"));
         assert!(body.contains("a.png"));
         assert!(body.contains(">2<"), "access count cell: {body}");
+    }
+
+    /// Regression: the quota card used to be fed by a page-local
+    /// `load_quota_info` copy of the quota logic. It now reads the same
+    /// `quota::get_user_quota` + `quota::get_used_bytes` the upload
+    /// enforcement uses, so an override row must show up on the page.
+    #[tokio::test]
+    async fn cloudstorage_page_quota_card_reflects_override_and_usage() {
+        let ctx = TestContext::with_files().await;
+
+        let mut quota: HashMap<String, serde_json::Value> = HashMap::new();
+        quota.insert("user_id".into(), json!("admin_1"));
+        quota.insert("max_storage_bytes".into(), json!(2048));
+        db::create(&ctx, QUOTAS_TABLE, quota)
+            .await
+            .expect("seed quota");
+
+        let mut obj: HashMap<String, serde_json::Value> = HashMap::new();
+        obj.insert("bucket".into(), json!("photos"));
+        obj.insert("key".into(), json!("a.png"));
+        obj.insert("size".into(), json!(1024));
+        obj.insert("uploaded_by".into(), json!("admin_1"));
+        db::create(&ctx, OBJECTS_TABLE, obj).await.expect("seed obj");
+
+        let msg = admin_msg("retrieve", "/b/cloudstorage/");
+        let body = output_html(cloudstorage_page(&ctx, &msg).await).await;
+        assert!(
+            body.contains("1024 / 2048 bytes"),
+            "quota card must show summed usage against the override limit: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -1462,7 +1462,9 @@ mod integration_tests {
         obj.insert("key".into(), json!("a.png"));
         obj.insert("size".into(), json!(1024));
         obj.insert("uploaded_by".into(), json!("admin_1"));
-        db::create(&ctx, OBJECTS_TABLE, obj).await.expect("seed obj");
+        db::create(&ctx, OBJECTS_TABLE, obj)
+            .await
+            .expect("seed obj");
 
         let msg = admin_msg("retrieve", "/b/cloudstorage/");
         let body = output_html(cloudstorage_page(&ctx, &msg).await).await;

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -462,32 +462,6 @@ pub fn render_breadcrumbs(bucket: &str, current_prefix: &str) -> Markup {
     }
 }
 
-async fn user_owns_bucket(ctx: &dyn Context, user_id: &str, bucket: &str) -> bool {
-    use wafer_block::db::{Filter, FilterOp};
-
-    use super::BUCKETS_TABLE;
-
-    let filters = vec![
-        Filter {
-            field: "name".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(bucket.into()),
-        },
-        Filter {
-            field: "created_by".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.into()),
-        },
-    ];
-    match db::list_all(ctx, BUCKETS_TABLE, filters).await {
-        Ok(records) => !records.is_empty(),
-        Err(e) => {
-            tracing::warn!(error = %e, bucket = %bucket, "bucket-ownership check failed");
-            false
-        }
-    }
-}
-
 async fn list_objects_in_bucket(ctx: &dyn Context, bucket: &str) -> Vec<ObjectRow> {
     use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 
@@ -568,7 +542,9 @@ pub async fn object_list_page(
     if user_id.is_empty() {
         return crate::ui::not_found_response(msg);
     }
-    if !user_owns_bucket(ctx, &user_id, bucket).await {
+    // SSR portal is strictly owner-scoped (no admin bypass) — see the
+    // `bucket_owned_by` doc comment for the admin-policy split vs the JSON API.
+    if !super::storage::bucket_owned_by(ctx, &user_id, bucket).await {
         return crate::ui::not_found_response(msg);
     }
 
@@ -1394,7 +1370,11 @@ mod integration_tests {
     #[tokio::test]
     async fn object_list_page_404_for_other_users_bucket() {
         // Cross-user isolation: a bucket owned by another user must 404,
-        // not render its contents.
+        // not render its contents. The request is made as an ADMIN, which
+        // pins the documented policy split: the SSR portal routes through the
+        // shared `storage::bucket_owned_by` predicate and deliberately does
+        // NOT grant the admin bypass that the JSON API's
+        // `is_bucket_access_denied` does — so even an admin sees a 404 here.
         let ctx = TestContext::with_files().await;
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("name".into(), json!("secrets"));
@@ -1407,7 +1387,7 @@ mod integration_tests {
         let body = output_html(resp).await;
         assert!(
             body.contains("Not found") || body.contains("404"),
-            "expected 404 for cross-user bucket: {body}"
+            "expected 404 for cross-user bucket (admin, no SSR bypass): {body}"
         );
     }
 

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -5,7 +5,7 @@
 
 use maud::{html, Markup, PreEscaped};
 
-use super::super::helpers::url_path_encode;
+use super::super::helpers::{url_path_encode, RecordExt};
 
 /// Aggregated bucket info as shown in the user-facing table:
 /// name, public flag, created-at ISO string, and live object count.
@@ -181,7 +181,7 @@ pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<Buck
             .into_iter()
             .filter_map(|r| {
                 let bucket = r.data.get("bucket").and_then(|v| v.as_str())?.to_string();
-                let cnt = r.data.get("cnt").and_then(|v| v.as_i64()).unwrap_or(0);
+                let cnt = r.i64_field("cnt");
                 Some((bucket, cnt))
             })
             .collect(),
@@ -518,14 +518,7 @@ async fn list_objects_in_bucket(ctx: &dyn Context, bucket: &str) -> Vec<ObjectRo
                     .and_then(|v| v.as_str())
                     .unwrap_or_default()
                     .to_string(),
-                size: r
-                    .data
-                    .get("size")
-                    .and_then(|v| {
-                        v.as_i64()
-                            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                    })
-                    .unwrap_or(0),
+                size: r.i64_field("size"),
                 modified: r
                     .data
                     .get("uploaded_at")
@@ -776,14 +769,7 @@ async fn list_shares_for_user(ctx: &dyn Context, user_id: &str) -> Vec<ShareRow>
                     .get("expires_at")
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
-                access_count: r
-                    .data
-                    .get("access_count")
-                    .and_then(|v| {
-                        v.as_i64()
-                            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                    })
-                    .unwrap_or(0),
+                access_count: r.i64_field("access_count"),
             })
             .collect(),
         Err(e) => {

--- a/crates/solobase-core/src/blocks/files/quota.rs
+++ b/crates/solobase-core/src/blocks/files/quota.rs
@@ -1,5 +1,5 @@
 use wafer_block::db::{Filter, FilterOp};
-use wafer_core::clients::database as db;
+use wafer_core::clients::database::{self as db, Record};
 use wafer_run::{context::Context, OutputStream};
 
 use super::{models::QuotaConfig, OBJECTS_TABLE};
@@ -8,6 +8,29 @@ use crate::blocks::helpers::{err_bad_request, RecordExt};
 /// Per-user quota override table. Stores explicit byte/file caps that
 /// override the block defaults for individual users.
 pub(crate) const TABLE: &str = "suppers_ai__files__cloud_quotas";
+
+/// Map a quota-override row onto a `QuotaConfig`, falling back to the
+/// block defaults field-by-field. Numeric fields accept both JSON numbers
+/// and TEXT-stored numeric strings (see `RecordExt::opt_i64_field`) so a
+/// TEXT-stored override is honored rather than silently replaced by the
+/// default.
+fn quota_from_record(record: &Record) -> QuotaConfig {
+    let defaults = QuotaConfig::default();
+    QuotaConfig {
+        max_storage_bytes: record
+            .opt_i64_field("max_storage_bytes")
+            .unwrap_or(defaults.max_storage_bytes),
+        max_file_size_bytes: record
+            .opt_i64_field("max_file_size_bytes")
+            .unwrap_or(defaults.max_file_size_bytes),
+        max_files_per_bucket: record
+            .opt_i64_field("max_files_per_bucket")
+            .unwrap_or(defaults.max_files_per_bucket),
+        reset_period_days: record
+            .opt_i64_field("reset_period_days")
+            .unwrap_or(defaults.reset_period_days),
+    }
+}
 
 pub async fn get_user_quota(ctx: &dyn Context, user_id: &str) -> QuotaConfig {
     // Check for user-specific override
@@ -19,43 +42,41 @@ pub async fn get_user_quota(ctx: &dyn Context, user_id: &str) -> QuotaConfig {
     )
     .await
     {
-        Ok(record) => QuotaConfig {
-            max_storage_bytes: record
-                .data
-                .get("max_storage_bytes")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(1_073_741_824),
-            max_file_size_bytes: record
-                .data
-                .get("max_file_size_bytes")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(104_857_600),
-            max_files_per_bucket: record
-                .data
-                .get("max_files_per_bucket")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(10_000),
-            reset_period_days: record.i64_field("reset_period_days"),
-        },
+        Ok(record) => quota_from_record(&record),
         Err(_) => QuotaConfig::default(),
     }
 }
 
-pub async fn get_user_usage(ctx: &dyn Context, user_id: &str) -> serde_json::Value {
-    let filters = vec![Filter {
+/// Filter matching all objects uploaded by `user_id` (the rows that count
+/// toward that user's quota, including in-flight `pending` reservations).
+fn owned_objects_filter(user_id: &str) -> Vec<Filter> {
+    vec![Filter {
         field: "uploaded_by".to_string(),
         operator: FilterOp::Equal,
         value: serde_json::Value::String(user_id.to_string()),
-    }];
+    }]
+}
 
-    let total_bytes = db::sum(ctx, OBJECTS_TABLE, "size", &filters)
+/// Total bytes used by `user_id`, computed as `SUM(size)` over the user's
+/// object rows via the `db::sum` aggregate (no row materialization).
+pub async fn get_used_bytes(ctx: &dyn Context, user_id: &str) -> i64 {
+    db::sum(ctx, OBJECTS_TABLE, "size", &owned_objects_filter(user_id))
         .await
-        .unwrap_or(0.0) as i64;
-    let file_count = db::count(ctx, OBJECTS_TABLE, &filters).await.unwrap_or(0);
+        .unwrap_or(0.0) as i64
+}
 
+/// Number of object rows owned by `user_id`.
+pub async fn get_file_count(ctx: &dyn Context, user_id: &str) -> i64 {
+    db::count(ctx, OBJECTS_TABLE, &owned_objects_filter(user_id))
+        .await
+        .unwrap_or(0)
+}
+
+/// Usage summary as exposed by the `/b/cloudstorage/quota` JSON endpoint.
+pub async fn get_user_usage(ctx: &dyn Context, user_id: &str) -> serde_json::Value {
     serde_json::json!({
-        "total_bytes": total_bytes,
-        "file_count": file_count
+        "total_bytes": get_used_bytes(ctx, user_id).await,
+        "file_count": get_file_count(ctx, user_id).await,
     })
 }
 
@@ -65,12 +86,6 @@ pub async fn check_quota(
     file_size: i64,
 ) -> Result<(), OutputStream> {
     let quota = get_user_quota(ctx, user_id).await;
-    let usage = get_user_usage(ctx, user_id).await;
-
-    let current_bytes = usage
-        .get("total_bytes")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
 
     if file_size > quota.max_file_size_bytes {
         return Err(err_bad_request(&format!(
@@ -79,15 +94,14 @@ pub async fn check_quota(
         )));
     }
 
+    let current_bytes = get_used_bytes(ctx, user_id).await;
     if current_bytes + file_size > quota.max_storage_bytes {
         return Err(err_bad_request("Storage quota exceeded"));
     }
 
-    let file_count = usage
-        .get("file_count")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-    if quota.max_files_per_bucket > 0 && file_count >= quota.max_files_per_bucket {
+    if quota.max_files_per_bucket > 0
+        && get_file_count(ctx, user_id).await >= quota.max_files_per_bucket
+    {
         return Err(err_bad_request(&format!(
             "File count limit reached (max {})",
             quota.max_files_per_bucket
@@ -128,5 +142,142 @@ pub async fn sweep_stale_pending(ctx: &dyn Context, user_id: &str, older_than_se
     ];
     if let Err(e) = db::delete_by_filters(ctx, OBJECTS_TABLE, filters).await {
         tracing::warn!(error = %e, user_id = %user_id, "failed to sweep stale pending uploads");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::test_support::TestContext;
+
+    fn record_with(data: &[(&str, serde_json::Value)]) -> Record {
+        Record {
+            id: "1".to_string(),
+            data: data
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        }
+    }
+
+    /// Regression: the SQLite service returns TEXT-stored columns as JSON
+    /// strings. `get_user_quota` used to read overrides with a bare
+    /// `as_i64()`, so a TEXT-stored `max_storage_bytes` override silently
+    /// fell back to the 1 GiB default and enforcement ignored the
+    /// admin-configured cap.
+    #[test]
+    fn quota_from_record_honors_text_stored_overrides() {
+        let record = record_with(&[
+            ("max_storage_bytes", json!("2048")),
+            ("max_file_size_bytes", json!("1024")),
+            ("max_files_per_bucket", json!("5")),
+            ("reset_period_days", json!("7")),
+        ]);
+        let quota = quota_from_record(&record);
+        assert_eq!(
+            quota.max_storage_bytes, 2048,
+            "TEXT-stored override must be enforced, not replaced by the default"
+        );
+        assert_eq!(quota.max_file_size_bytes, 1024);
+        assert_eq!(quota.max_files_per_bucket, 5);
+        assert_eq!(quota.reset_period_days, 7);
+    }
+
+    #[test]
+    fn quota_from_record_accepts_number_typed_overrides() {
+        let record = record_with(&[
+            ("max_storage_bytes", json!(4096)),
+            ("max_file_size_bytes", json!(2048)),
+        ]);
+        let quota = quota_from_record(&record);
+        assert_eq!(quota.max_storage_bytes, 4096);
+        assert_eq!(quota.max_file_size_bytes, 2048);
+    }
+
+    #[test]
+    fn quota_from_record_defaults_missing_and_junk_fields() {
+        let record = record_with(&[("max_storage_bytes", json!("not-a-number"))]);
+        let quota = quota_from_record(&record);
+        assert_eq!(
+            quota.max_storage_bytes,
+            QuotaConfig::DEFAULT_MAX_STORAGE_BYTES
+        );
+        assert_eq!(
+            quota.max_file_size_bytes,
+            QuotaConfig::DEFAULT_MAX_FILE_SIZE_BYTES
+        );
+        assert_eq!(
+            quota.max_files_per_bucket,
+            QuotaConfig::DEFAULT_MAX_FILES_PER_BUCKET
+        );
+        assert_eq!(quota.reset_period_days, QuotaConfig::DEFAULT_RESET_PERIOD_DAYS);
+    }
+
+    #[tokio::test]
+    async fn get_user_quota_returns_defaults_without_override_row() {
+        let ctx = TestContext::with_files().await;
+        let quota = get_user_quota(&ctx, "nobody").await;
+        assert_eq!(
+            quota.max_storage_bytes,
+            QuotaConfig::DEFAULT_MAX_STORAGE_BYTES
+        );
+    }
+
+    #[tokio::test]
+    async fn get_user_quota_applies_override_row() {
+        let ctx = TestContext::with_files().await;
+        let mut row: HashMap<String, serde_json::Value> = HashMap::new();
+        row.insert("user_id".into(), json!("u1"));
+        row.insert("max_storage_bytes".into(), json!(2048));
+        db::create(&ctx, TABLE, row).await.expect("seed quota");
+
+        let quota = get_user_quota(&ctx, "u1").await;
+        assert_eq!(quota.max_storage_bytes, 2048);
+        // Fields without an explicit override keep the defaults. (The
+        // migration declares DB-side column defaults, so a full row insert
+        // materializes them; either way the value matches the const.)
+        assert_eq!(
+            quota.max_file_size_bytes,
+            QuotaConfig::DEFAULT_MAX_FILE_SIZE_BYTES
+        );
+    }
+
+    #[tokio::test]
+    async fn get_used_bytes_sums_object_sizes_per_user() {
+        let ctx = TestContext::with_files().await;
+        for (key, size, owner) in [("a", 1024, "u1"), ("b", 1024, "u1"), ("c", 4096, "u2")] {
+            let mut row: HashMap<String, serde_json::Value> = HashMap::new();
+            row.insert("bucket".into(), json!("photos"));
+            row.insert("key".into(), json!(key));
+            row.insert("size".into(), json!(size));
+            row.insert("uploaded_by".into(), json!(owner));
+            db::create(&ctx, OBJECTS_TABLE, row).await.expect("seed");
+        }
+
+        assert_eq!(get_used_bytes(&ctx, "u1").await, 2048);
+        assert_eq!(get_used_bytes(&ctx, "u2").await, 4096);
+        assert_eq!(get_used_bytes(&ctx, "u3").await, 0);
+        assert_eq!(get_file_count(&ctx, "u1").await, 2);
+    }
+
+    /// End-to-end: an override row caps enforcement, so a file that fits
+    /// the default 1 GiB quota but not the override is rejected.
+    #[tokio::test]
+    async fn check_quota_enforces_override_storage_cap() {
+        let ctx = TestContext::with_files().await;
+        let mut row: HashMap<String, serde_json::Value> = HashMap::new();
+        row.insert("user_id".into(), json!("u1"));
+        row.insert("max_storage_bytes".into(), json!(2048));
+        db::create(&ctx, TABLE, row).await.expect("seed quota");
+
+        assert!(check_quota(&ctx, "u1", 1024).await.is_ok());
+        assert!(
+            check_quota(&ctx, "u1", 4096).await.is_err(),
+            "file above the override cap must be rejected"
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/files/quota.rs
+++ b/crates/solobase-core/src/blocks/files/quota.rs
@@ -214,7 +214,10 @@ mod tests {
             quota.max_files_per_bucket,
             QuotaConfig::DEFAULT_MAX_FILES_PER_BUCKET
         );
-        assert_eq!(quota.reset_period_days, QuotaConfig::DEFAULT_RESET_PERIOD_DAYS);
+        assert_eq!(
+            quota.reset_period_days,
+            QuotaConfig::DEFAULT_RESET_PERIOD_DAYS
+        );
     }
 
     #[tokio::test]

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -6,7 +6,7 @@ use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 use crate::blocks::{
     helpers::{
         err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
-        ResponseBuilder,
+        RecordExt, ResponseBuilder,
     },
     rate_limit::{check_rate_limit, RateLimit, RateLimitOutcome, UserRateLimiter},
 };
@@ -116,11 +116,7 @@ pub async fn handle_direct_access(
     // accesses with `max_access_count = 1` both pass the check and double-
     // serve the file. With the cap inside the WHERE clause, at most one
     // updater wins per row and rowcount 0 ⇒ cap reached.
-    let max = share
-        .data
-        .get("max_access_count")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let max = share.i64_field("max_access_count");
     match increment_access_count_atomic(ctx, &share.id, max).await {
         Ok(true) => {}
         Ok(false) => return err_forbidden("Share link access limit reached"),

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use wafer_core::clients::{crypto, database as db, storage as store};
 use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
@@ -6,7 +6,7 @@ use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 use crate::blocks::{
     helpers::{
         err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
-        RecordExt, ResponseBuilder,
+        json_map, now_rfc3339, RecordExt, ResponseBuilder,
     },
     rate_limit::{check_rate_limit, RateLimit, RateLimitOutcome, UserRateLimiter},
 };
@@ -22,19 +22,11 @@ pub async fn generate_share_token(
     bucket: &str,
     key: &str,
 ) -> Result<String, OutputStream> {
-    let mut claims = HashMap::new();
-    claims.insert(
-        "bucket".to_string(),
-        serde_json::Value::String(bucket.to_string()),
-    );
-    claims.insert(
-        "key".to_string(),
-        serde_json::Value::String(key.to_string()),
-    );
-    claims.insert(
-        "type".to_string(),
-        serde_json::Value::String("share".to_string()),
-    );
+    let claims = json_map(serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "type": "share",
+    }));
 
     // SEC-055: share JWT lifetime — 30 days. The previous 1-year default
     // gave any leaked share URL effectively unbounded validity. Users who
@@ -141,23 +133,12 @@ pub async fn handle_direct_access(
     }
 
     // Log access
-    let mut log_data = HashMap::new();
-    log_data.insert(
-        "share_id".to_string(),
-        serde_json::Value::String(share.id.clone()),
-    );
-    log_data.insert(
-        "accessed_at".to_string(),
-        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-    );
-    log_data.insert(
-        "ip_address".to_string(),
-        serde_json::Value::String(msg.remote_addr().to_string()),
-    );
-    log_data.insert(
-        "user_agent".to_string(),
-        serde_json::Value::String(msg.header("User-Agent").to_string()),
-    );
+    let log_data = json_map(serde_json::json!({
+        "share_id": share.id,
+        "accessed_at": now_rfc3339(),
+        "ip_address": msg.remote_addr(),
+        "user_agent": msg.header("User-Agent"),
+    }));
     if let Err(e) = db::create(ctx, ACCESS_LOGS_TABLE, log_data).await {
         tracing::warn!("Failed to log share access: {e}");
     }

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -76,19 +76,19 @@ fn extract_object_key(path: &str) -> &str {
     }
 }
 
-/// Check if the current user owns the given bucket (or is admin).
-/// Returns true if access is denied.
-pub(super) async fn is_bucket_access_denied(
-    ctx: &dyn Context,
-    msg: &Message,
-    bucket: &str,
-) -> bool {
-    let is_admin = helpers::is_admin(msg);
-    if is_admin {
-        return false;
-    }
-
-    let user_id = msg.user_id();
+/// True when `user_id` owns a bucket named `bucket` (i.e. a matching row
+/// exists in [`BUCKETS_TABLE`]). DB errors are logged and treated as "not
+/// owned" (fail closed).
+///
+/// This is the single ownership predicate for the files block. Callers
+/// decide the admin policy on top of it:
+/// - JSON API handlers go through [`is_bucket_access_denied`], which grants
+///   admins access to every bucket.
+/// - The SSR user portal (`pages_user::object_list_page`) deliberately does
+///   NOT bypass for admins — the portal is strictly owner-scoped so an
+///   admin browsing `/b/storage/` sees only their own buckets; cross-user
+///   inspection happens via the admin pages instead.
+pub(super) async fn bucket_owned_by(ctx: &dyn Context, user_id: &str, bucket: &str) -> bool {
     let filters = vec![
         Filter {
             field: "name".to_string(),
@@ -102,9 +102,26 @@ pub(super) async fn is_bucket_access_denied(
         },
     ];
     match db::list_all(ctx, BUCKETS_TABLE, filters).await {
-        Ok(records) if !records.is_empty() => false,
-        _ => true, // denied
+        Ok(records) => !records.is_empty(),
+        Err(e) => {
+            tracing::warn!(error = %e, bucket = %bucket, "bucket-ownership check failed");
+            false
+        }
     }
+}
+
+/// Check if the current user owns the given bucket (or is admin).
+/// Returns true if access is denied. See [`bucket_owned_by`] for the
+/// admin-bypass policy split between the JSON API and the SSR portal.
+pub(super) async fn is_bucket_access_denied(
+    ctx: &dyn Context,
+    msg: &Message,
+    bucket: &str,
+) -> bool {
+    if helpers::is_admin(msg) {
+        return false;
+    }
+    !bucket_owned_by(ctx, msg.user_id(), bucket).await
 }
 
 /// Validate a storage key for path traversal attacks.

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -162,7 +162,7 @@ pub(super) const BUCKET_NAME_PATTERN: &str = "[a-z0-9]([a-z0-9-]*[a-z0-9])?";
 /// `pub(super)` so the share path uses the identical rule.
 pub(super) fn is_valid_bucket_name(name: &str) -> bool {
     let len = name.len();
-    if len < BUCKET_NAME_MIN_LEN || len > BUCKET_NAME_MAX_LEN {
+    if !(BUCKET_NAME_MIN_LEN..=BUCKET_NAME_MAX_LEN).contains(&len) {
         return false;
     }
     let bytes = name.as_bytes();

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{database as db, storage as store};
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -131,7 +131,11 @@ pub(super) async fn is_bucket_access_denied(
 /// paths (or any backend that ever normalises `\` to `/`) would otherwise
 /// allow `..\..\etc\passwd`-style traversal that the `..` check alone would
 /// not catch when the segment separator is `\` instead of `/`.
-fn is_valid_storage_key(key: &str) -> bool {
+///
+/// `pub(super)` so the share-creation path (`cloud.rs::handle_create_share`)
+/// enforces exactly the same rule rather than re-inlining a copy that drifts
+/// (the SEC-064 backslash check was the missing piece there).
+pub(super) fn is_valid_storage_key(key: &str) -> bool {
     !key.is_empty()
         && !key.contains("..")
         && !key.starts_with('/')
@@ -139,9 +143,38 @@ fn is_valid_storage_key(key: &str) -> bool {
         && !key.contains('\\')
 }
 
-/// Validate a bucket name. Must be non-empty, no path traversal, no slashes.
-fn is_valid_bucket_name(name: &str) -> bool {
-    !name.is_empty() && !name.contains("..") && !name.contains('/') && !name.contains('\0')
+/// Minimum / maximum bucket-name length (S3-compatible).
+pub(super) const BUCKET_NAME_MIN_LEN: usize = 3;
+pub(super) const BUCKET_NAME_MAX_LEN: usize = 63;
+
+/// HTML5 `pattern=` attribute source for the bucket-name input — the single
+/// source of truth shared with the server-side [`is_valid_bucket_name`] check
+/// so the client modal and the API enforce identically. S3-compatible:
+/// lowercase letters, digits, and hyphens; must start and end with a letter
+/// or digit. (Length is enforced separately via `minlength`/`maxlength` on the
+/// input and the length check in [`is_valid_bucket_name`].)
+pub(super) const BUCKET_NAME_PATTERN: &str = "[a-z0-9]([a-z0-9-]*[a-z0-9])?";
+
+/// Validate a bucket name against the S3-compatible rule the client modal
+/// advertises ([`BUCKET_NAME_PATTERN`] + length bounds): 3–63 chars,
+/// lowercase letters / digits / hyphens, must start and end with a letter or
+/// digit. This rejects path traversal (`..`, `/`, `\`), NUL, uppercase, and
+/// leading/trailing hyphens by construction.
+///
+/// `pub(super)` so the share path uses the identical rule.
+pub(super) fn is_valid_bucket_name(name: &str) -> bool {
+    let len = name.len();
+    if len < BUCKET_NAME_MIN_LEN || len > BUCKET_NAME_MAX_LEN {
+        return false;
+    }
+    let bytes = name.as_bytes();
+    let is_alnum = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    // First and last char must be a lowercase letter or digit.
+    if !is_alnum(bytes[0]) || !is_alnum(bytes[len - 1]) {
+        return false;
+    }
+    // Interior chars: lowercase letter, digit, or hyphen.
+    bytes.iter().all(|&b| is_alnum(b) || b == b'-')
 }
 
 /// Collect an `InputStream` into `Vec<u8>` with a hard size cap. Errors out
@@ -652,10 +685,12 @@ mod tests {
 
     #[test]
     fn test_is_valid_bucket_name() {
-        // Valid bucket names
+        // Valid bucket names (S3-compatible: 3-63 chars, lowercase/digits/
+        // hyphens, start+end alnum).
         assert!(is_valid_bucket_name("my-bucket"));
         assert!(is_valid_bucket_name("bucket123"));
         assert!(is_valid_bucket_name("uploads"));
+        assert!(is_valid_bucket_name("a1b"));
 
         // Invalid bucket names
         assert!(!is_valid_bucket_name(""));
@@ -663,6 +698,35 @@ mod tests {
         assert!(!is_valid_bucket_name("bucket/subdir"));
         assert!(!is_valid_bucket_name("bucket\0name"));
         assert!(!is_valid_bucket_name(".."));
+        // Too short / too long.
+        assert!(!is_valid_bucket_name("ab"));
+        assert!(!is_valid_bucket_name(&"a".repeat(64)));
+        // Uppercase rejected (S3 rule + matches the modal pattern).
+        assert!(!is_valid_bucket_name("MyBucket"));
+        // Leading / trailing hyphen rejected (start+end must be alnum).
+        assert!(!is_valid_bucket_name("-bucket"));
+        assert!(!is_valid_bucket_name("bucket-"));
+        // Backslash rejected (SEC-064; not in the allowed alphabet).
+        assert!(!is_valid_bucket_name("bucket\\name"));
+    }
+
+    /// The server-side validator enforces the same alphabet the HTML
+    /// `pattern=` attribute ([`BUCKET_NAME_PATTERN`]) advertises, so the client
+    /// modal and the API agree on what a valid bucket name is (modulo length,
+    /// which the input enforces separately via minlength/maxlength). This pins
+    /// the cases the pattern accepts/rejects against the validator.
+    #[test]
+    fn bucket_name_validator_matches_advertised_pattern() {
+        // Sanity-check the constant is the S3 alphabet we documented.
+        assert_eq!(BUCKET_NAME_PATTERN, "[a-z0-9]([a-z0-9-]*[a-z0-9])?");
+        // Pattern-accepted names (length-valid) the validator must accept.
+        for name in ["my-bucket", "bucket123", "a1b", "abc"] {
+            assert!(is_valid_bucket_name(name), "validator should accept {name}");
+        }
+        // Pattern-rejected names the validator must reject.
+        for name in ["MyBucket", "-bucket", "bucket-", "bucket/sub", "bucket\\x"] {
+            assert!(!is_valid_bucket_name(name), "validator should reject {name}");
+        }
     }
 }
 

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -381,23 +381,12 @@ async fn handle_get_object(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Track view in DB
-    let mut data = HashMap::new();
-    data.insert(
-        "bucket".to_string(),
-        serde_json::Value::String(bucket.to_string()),
-    );
-    data.insert(
-        "key".to_string(),
-        serde_json::Value::String(key.to_string()),
-    );
-    data.insert(
-        "user_id".to_string(),
-        serde_json::Value::String(msg.user_id().to_string()),
-    );
-    data.insert(
-        "viewed_at".to_string(),
-        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-    );
+    let data = helpers::json_map(serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "user_id": msg.user_id(),
+        "viewed_at": helpers::now_rfc3339(),
+    }));
     if let Err(e) = db::create(ctx, super::VIEWS_TABLE, data).await {
         tracing::warn!("Failed to track storage object view: {e}");
     }
@@ -471,29 +460,15 @@ async fn handle_upload_object(
 
     // Insert a pending record BEFORE uploading so concurrent quota checks see it.
     // This closes the TOCTOU race between check_quota and the actual upload.
-    let mut pending_data = HashMap::new();
-    pending_data.insert(
-        "bucket".to_string(),
-        serde_json::Value::String(bucket.to_string()),
-    );
-    pending_data.insert("key".to_string(), serde_json::Value::String(key.clone()));
-    pending_data.insert("size".to_string(), serde_json::json!(body_bytes.len()));
-    pending_data.insert(
-        "content_type".to_string(),
-        serde_json::Value::String(content_type.clone()),
-    );
-    pending_data.insert(
-        "status".to_string(),
-        serde_json::Value::String("pending".to_string()),
-    );
-    pending_data.insert(
-        "uploaded_by".to_string(),
-        serde_json::Value::String(msg.user_id().to_string()),
-    );
-    pending_data.insert(
-        "uploaded_at".to_string(),
-        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-    );
+    let pending_data = helpers::json_map(serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "size": body_bytes.len(),
+        "content_type": content_type,
+        "status": "pending",
+        "uploaded_by": msg.user_id(),
+        "uploaded_at": helpers::now_rfc3339(),
+    }));
 
     let pending_record = match db::create(ctx, OBJECTS_TABLE, pending_data).await {
         Ok(record) => record,
@@ -503,11 +478,7 @@ async fn handle_upload_object(
     match store::put(ctx, bucket, &key, &body_bytes, &content_type).await {
         Ok(()) => {
             // Upload succeeded — mark the pending record as complete.
-            let mut update_data = HashMap::new();
-            update_data.insert(
-                "status".to_string(),
-                serde_json::Value::String("complete".to_string()),
-            );
+            let update_data = helpers::json_map(serde_json::json!({ "status": "complete" }));
             if let Err(e) = db::update(ctx, OBJECTS_TABLE, &pending_record.id, update_data).await {
                 tracing::warn!("Failed to mark upload as complete: {e}");
             }

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -699,7 +699,10 @@ mod tests {
         }
         // Pattern-rejected names the validator must reject.
         for name in ["MyBucket", "-bucket", "bucket-", "bucket/sub", "bucket\\x"] {
-            assert!(!is_valid_bucket_name(name), "validator should reject {name}");
+            assert!(
+                !is_valid_bucket_name(name),
+                "validator should reject {name}"
+            );
         }
     }
 }
@@ -718,7 +721,9 @@ mod integration_tests {
             "created_by": owner,
             "created_at": helpers::now_rfc3339(),
         }));
-        db::create(ctx, BUCKETS_TABLE, data).await.expect("seed bucket");
+        db::create(ctx, BUCKETS_TABLE, data)
+            .await
+            .expect("seed bucket");
     }
 
     fn bucket_names(v: &serde_json::Value) -> Vec<String> {

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -220,30 +220,30 @@ fn escape_like(input: &str) -> String {
 }
 
 async fn handle_list_buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    // Only show buckets owned by the current user (or all for admin)
+    // [`BUCKETS_TABLE`] is the single source of truth for bucket existence /
+    // ownership / visibility. Both the admin and user branches read it (the
+    // admin sees every bucket, the user only their own) — storage folders are
+    // a blob namespace, not a directory we enumerate here, so the admin list
+    // no longer diverges from `store::list_folders`.
     let user_id = msg.user_id();
-    let is_admin = helpers::is_admin(msg);
-    if is_admin {
-        match store::list_folders(ctx).await {
-            Ok(folders) => ok_json(&serde_json::json!({"buckets": folders})),
-            Err(e) => err_internal("Storage error", e),
-        }
+    let filters = if helpers::is_admin(msg) {
+        Vec::new()
     } else {
-        let filters = vec![Filter {
+        vec![Filter {
             field: "created_by".to_string(),
             operator: FilterOp::Equal,
             value: serde_json::Value::String(user_id.to_string()),
-        }];
-        match db::list_all(ctx, BUCKETS_TABLE, filters).await {
-            Ok(records) => {
-                let names: Vec<&str> = records
-                    .iter()
-                    .filter_map(|r| r.data.get("name").and_then(|v| v.as_str()))
-                    .collect();
-                ok_json(&serde_json::json!({"buckets": names}))
-            }
-            Err(e) => err_internal("Database error", e),
+        }]
+    };
+    match db::list_all(ctx, BUCKETS_TABLE, filters).await {
+        Ok(records) => {
+            let names: Vec<&str> = records
+                .iter()
+                .filter_map(|r| r.data.get("name").and_then(|v| v.as_str()))
+                .collect();
+            ok_json(&serde_json::json!({"buckets": names}))
         }
+        Err(e) => err_internal("Database error", e),
     }
 }
 
@@ -271,30 +271,33 @@ async fn handle_create_bucket(
         return err_bad_request("Invalid bucket name");
     }
 
-    match store::create_folder(ctx, &body.name, body.public).await {
-        Ok(()) => {
-            // Track in DB
-            let mut data = HashMap::new();
-            data.insert(
-                "name".to_string(),
-                serde_json::Value::String(body.name.clone()),
-            );
-            data.insert("public".to_string(), serde_json::Value::Bool(body.public));
-            data.insert(
-                "created_by".to_string(),
-                serde_json::Value::String(msg.user_id().to_string()),
-            );
-            data.insert(
-                "created_at".to_string(),
-                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-            );
-            if let Err(e) = db::create(ctx, BUCKETS_TABLE, data).await {
-                tracing::warn!("Failed to track bucket creation in database: {e}");
-            }
-            ok_json(&serde_json::json!({"name": body.name, "created": true}))
-        }
-        Err(e) => err_internal("Failed to create bucket", e),
+    // Create the blob-namespace folder first, then record the metadata row.
+    if let Err(e) = store::create_folder(ctx, &body.name, body.public).await {
+        return err_internal("Failed to create bucket", e);
     }
+
+    // [`BUCKETS_TABLE`] is the source of truth for bucket existence, so the
+    // metadata insert must succeed for the bucket to count as created. If it
+    // fails, compensate by deleting the just-created folder rather than
+    // warn-and-continue (which would leave an orphan folder invisible to every
+    // listing path, which now all read the table).
+    let data = helpers::json_map(serde_json::json!({
+        "name": body.name,
+        "public": body.public,
+        "created_by": msg.user_id(),
+        "created_at": helpers::now_rfc3339(),
+    }));
+    if let Err(e) = db::create(ctx, BUCKETS_TABLE, data).await {
+        if let Err(cleanup) = store::delete_folder(ctx, &body.name).await {
+            tracing::error!(
+                bucket = %body.name,
+                error = %cleanup,
+                "failed to roll back orphan storage folder after bucket metadata insert failed",
+            );
+        }
+        return err_internal("Failed to create bucket", e);
+    }
+    ok_json(&serde_json::json!({"name": body.name, "created": true}))
 }
 
 async fn handle_delete_bucket(ctx: &dyn Context, msg: &Message) -> OutputStream {
@@ -730,6 +733,77 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod integration_tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::test_support::{admin_msg, auth_msg, output_json, TestContext};
+
+    async fn seed_bucket(ctx: &TestContext, name: &str, owner: &str) {
+        let data = helpers::json_map(json!({
+            "name": name,
+            "public": false,
+            "created_by": owner,
+            "created_at": helpers::now_rfc3339(),
+        }));
+        db::create(ctx, BUCKETS_TABLE, data).await.expect("seed bucket");
+    }
+
+    fn bucket_names(v: &serde_json::Value) -> Vec<String> {
+        v.get("buckets")
+            .and_then(|b| b.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Single source of truth: the admin bucket listing now reads
+    /// [`BUCKETS_TABLE`] (every bucket) instead of `store::list_folders`, so it
+    /// can no longer diverge from the per-user listing that already read the
+    /// table. An admin sees all buckets regardless of owner.
+    #[tokio::test]
+    async fn admin_list_buckets_reads_metadata_table_for_all_owners() {
+        let ctx = TestContext::with_files().await;
+        seed_bucket(&ctx, "alice-bucket", "alice").await;
+        seed_bucket(&ctx, "bob-bucket", "bob").await;
+
+        let out = handle_list_buckets(&ctx, &admin_msg("retrieve", "/storage/buckets")).await;
+        let mut names = bucket_names(&output_json(out).await);
+        names.sort();
+        assert_eq!(names, vec!["alice-bucket", "bob-bucket"]);
+    }
+
+    /// A non-admin user sees only the buckets they own (same table, filtered).
+    #[tokio::test]
+    async fn user_list_buckets_is_owner_scoped() {
+        let ctx = TestContext::with_files().await;
+        seed_bucket(&ctx, "alice-bucket", "alice").await;
+        seed_bucket(&ctx, "bob-bucket", "bob").await;
+
+        let out =
+            handle_list_buckets(&ctx, &auth_msg("retrieve", "/storage/buckets", "alice")).await;
+        let names = bucket_names(&output_json(out).await);
+        assert_eq!(names, vec!["alice-bucket"]);
+    }
+
+    /// `handle_stats` counts buckets from [`BUCKETS_TABLE`] (the same source the
+    /// admin SSR overview uses), not by enumerating storage folders.
+    #[tokio::test]
+    async fn stats_counts_buckets_from_metadata_table() {
+        let ctx = TestContext::with_files().await;
+        seed_bucket(&ctx, "one", "alice").await;
+        seed_bucket(&ctx, "two", "bob").await;
+
+        let out = handle_stats(&ctx, &admin_msg("retrieve", "/admin/storage/stats")).await;
+        let body = output_json(out).await;
+        assert_eq!(body.get("bucket_count").and_then(|v| v.as_i64()), Some(2));
+    }
+}
+
 async fn handle_stats(ctx: &dyn Context, _msg: &Message) -> OutputStream {
     let complete_filter = &[Filter {
         field: "status".to_string(),
@@ -742,7 +816,9 @@ async fn handle_stats(ctx: &dyn Context, _msg: &Message) -> OutputStream {
     let total_size = db::sum(ctx, OBJECTS_TABLE, "size", complete_filter)
         .await
         .unwrap_or(0.0);
-    let bucket_count = store::list_folders(ctx).await.map(|f| f.len()).unwrap_or(0);
+    // Count buckets from the metadata table (single source of truth), the same
+    // way the admin SSR overview does, rather than enumerating storage folders.
+    let bucket_count = db::count(ctx, BUCKETS_TABLE, &[]).await.unwrap_or(0);
 
     ok_json(&serde_json::json!({
         "total_objects": total_objects,

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -26,10 +26,38 @@ pub fn json_map(val: serde_json::Value) -> HashMap<String, serde_json::Value> {
     }
 }
 
+/// Coerce a JSON value to `i64`, accepting both numbers and numeric strings.
+///
+/// The SQLite service stores auto-created (lazily added) columns as TEXT, so
+/// integer values can round-trip as JSON strings (e.g. `"384"`). Try the
+/// number first for backends/columns that round-trip faithfully, then fall
+/// back to parsing the string.
+pub fn json_as_i64(v: &serde_json::Value) -> Option<i64> {
+    v.as_i64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// Coerce a JSON value to `u64`, accepting both numbers and numeric strings.
+/// Same TEXT-column rationale as [`json_as_i64`].
+pub fn json_as_u64(v: &serde_json::Value) -> Option<u64> {
+    v.as_u64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+}
+
 /// Extension trait for convenient field access on database Records.
+///
+/// The numeric accessors accept both JSON numbers and numeric strings
+/// (see [`json_as_i64`]) so TEXT-stored values never silently collapse
+/// to the zero default.
 pub trait RecordExt {
     fn str_field(&self, key: &str) -> &str;
+    /// Field as `i64`, defaulting to `0` when missing/non-numeric.
     fn i64_field(&self, key: &str) -> i64;
+    /// Field as `Option<i64>` — use when the caller needs a non-zero
+    /// default or must distinguish "absent" from "0".
+    fn opt_i64_field(&self, key: &str) -> Option<i64>;
+    /// Field as `u64`, defaulting to `0` when missing/non-numeric/negative.
+    fn u64_field(&self, key: &str) -> u64;
     fn bool_field(&self, key: &str) -> bool;
 }
 
@@ -39,7 +67,15 @@ impl RecordExt for Record {
     }
 
     fn i64_field(&self, key: &str) -> i64 {
-        self.data.get(key).and_then(|v| v.as_i64()).unwrap_or(0)
+        self.opt_i64_field(key).unwrap_or(0)
+    }
+
+    fn opt_i64_field(&self, key: &str) -> Option<i64> {
+        self.data.get(key).and_then(json_as_i64)
+    }
+
+    fn u64_field(&self, key: &str) -> u64 {
+        self.data.get(key).and_then(json_as_u64).unwrap_or(0)
     }
 
     fn bool_field(&self, key: &str) -> bool {
@@ -585,6 +621,83 @@ mod tests {
         assert_eq!(record.i64_field("count"), 42);
         assert_eq!(record.i64_field("missing"), 0);
         assert_eq!(record.i64_field("name"), 0);
+    }
+
+    /// Regression: SQLite stores auto-created columns as TEXT, so integer
+    /// values round-trip as JSON strings. `i64_field` used to silently
+    /// return 0 for them (the silent-zero bug class — e.g. quota
+    /// enforcement ignoring TEXT-stored per-user overrides).
+    #[test]
+    fn test_record_ext_i64_field_parses_text_stored_numbers() {
+        let mut data = HashMap::new();
+        data.insert("count".to_string(), serde_json::json!("42"));
+        data.insert("negative".to_string(), serde_json::json!("-7"));
+        data.insert("not_a_number".to_string(), serde_json::json!("abc"));
+        let record = Record {
+            id: "1".to_string(),
+            data,
+        };
+
+        assert_eq!(
+            record.i64_field("count"),
+            42,
+            "TEXT-stored \"42\" must parse, not silently default to 0"
+        );
+        assert_eq!(record.i64_field("negative"), -7);
+        assert_eq!(record.i64_field("not_a_number"), 0);
+    }
+
+    #[test]
+    fn test_record_ext_opt_i64_field() {
+        let mut data = HashMap::new();
+        data.insert("num".to_string(), serde_json::json!(7));
+        data.insert("text_num".to_string(), serde_json::json!("9"));
+        data.insert("junk".to_string(), serde_json::json!("x"));
+        let record = Record {
+            id: "1".to_string(),
+            data,
+        };
+
+        assert_eq!(record.opt_i64_field("num"), Some(7));
+        assert_eq!(record.opt_i64_field("text_num"), Some(9));
+        assert_eq!(record.opt_i64_field("junk"), None);
+        assert_eq!(
+            record.opt_i64_field("missing"),
+            None,
+            "absent field must be distinguishable from 0"
+        );
+    }
+
+    #[test]
+    fn test_record_ext_u64_field() {
+        let mut data = HashMap::new();
+        data.insert("dims".to_string(), serde_json::json!(384));
+        data.insert("text_dims".to_string(), serde_json::json!("384"));
+        data.insert("negative".to_string(), serde_json::json!(-2));
+        data.insert("text_negative".to_string(), serde_json::json!("-2"));
+        let record = Record {
+            id: "1".to_string(),
+            data,
+        };
+
+        assert_eq!(record.u64_field("dims"), 384);
+        assert_eq!(record.u64_field("text_dims"), 384);
+        assert_eq!(record.u64_field("negative"), 0);
+        assert_eq!(record.u64_field("text_negative"), 0);
+        assert_eq!(record.u64_field("missing"), 0);
+    }
+
+    #[test]
+    fn test_json_as_i64_and_u64() {
+        assert_eq!(json_as_i64(&serde_json::json!(5)), Some(5));
+        assert_eq!(json_as_i64(&serde_json::json!("5")), Some(5));
+        assert_eq!(json_as_i64(&serde_json::json!("-5")), Some(-5));
+        assert_eq!(json_as_i64(&serde_json::json!("nope")), None);
+        assert_eq!(json_as_i64(&serde_json::json!(null)), None);
+        assert_eq!(json_as_u64(&serde_json::json!(5)), Some(5));
+        assert_eq!(json_as_u64(&serde_json::json!("5")), Some(5));
+        assert_eq!(json_as_u64(&serde_json::json!("-5")), None);
+        assert_eq!(json_as_u64(&serde_json::json!(-5)), None);
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -13,8 +13,7 @@ use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream}
 use super::service;
 use crate::{
     blocks::helpers::{
-        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
-        ResponseBuilder,
+        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, ResponseBuilder,
     },
     ui::{
         components, icons, nav_groups,

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -13,7 +13,8 @@ use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream}
 use super::service;
 use crate::{
     blocks::helpers::{
-        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, ResponseBuilder,
+        self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
+        ResponseBuilder,
     },
     ui::{
         components, icons, nav_groups,

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -125,11 +125,10 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(String::from),
-        dimensions: parsed.get("dimensions").and_then(|v| {
-            v.as_u64()
-                .map(|n| n as u32)
-                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        }),
+        dimensions: parsed
+            .get("dimensions")
+            .and_then(crate::blocks::helpers::json_as_u64)
+            .and_then(|n| u32::try_from(n).ok()),
         metric: parsed
             .get("metric")
             .and_then(|v| v.as_str())

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -10,6 +10,8 @@ use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, WaferError};
 use wafer_sql_utils::{introspect, Backend};
 
+use crate::blocks::helpers::RecordExt;
+
 /// Per-row data fed to the vector index list table renderer.
 ///
 /// Lives in the service layer alongside the loader (`list_index_rows`) so
@@ -111,25 +113,9 @@ async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> 
         .to_string();
     // The SQLite service stores all auto-created columns as TEXT, so the
     // numeric registry values arrive as JSON strings (e.g. `"384"`)
-    // rather than numbers. Try a number first for backends that round-trip
-    // them faithfully, then fall back to parsing the string.
-    let dimensions = rec
-        .data
-        .get("dimensions")
-        .and_then(|v| {
-            v.as_u64()
-                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        })
-        .unwrap_or(0) as u32;
-    let keyword_search = rec
-        .data
-        .get("keyword_search")
-        .and_then(|v| {
-            v.as_i64()
-                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        })
-        .map(|n| n != 0)
-        .unwrap_or(false);
+    // rather than numbers. The RecordExt accessors handle both shapes.
+    let dimensions = rec.u64_field("dimensions") as u32;
+    let keyword_search = rec.bool_field("keyword_search");
 
     // Vectors live in `{prefixed}_meta` (see `pages.rs::ingest`/`reindex`),
     // not in the registry's `prefixed_name` table. Counting that meta


### PR DESCRIPTION
S1-G (files-quota-buckets), Wave 1 of the solobase quality-fix program. Resumed + completed the preserved branch work.

## Findings addressed (all 6 from plan section S1-G)
- [x] **RecordExt::i64_field lacks the SQLite TEXT fallback, forcing 12 hand-rolled coercion copies and silent zero-defaults** — added numeric-string fallback to `i64_field` via `json_as_i64`/`json_as_u64` free fns; added `opt_i64_field` (non-zero defaults) and `u64_field`; swept all 12 hand-rolled closures (4x files/pages_user, 2x admin/pages/network, vector/service `dimensions`+`keyword_search`->`bool_field`, vector/pages `dimensions`->`json_as_u64`, 3x legalpages version, files/share `max_access_count`). Regression test `test_record_ext_i64_field_parses_text_stored_numbers` demonstrates the silent-zero bug is gone.
- [x] **Quota lookup + usage computation triplicated; 1GB default in 6 places** — deleted `load_quota_info`; page routes through `quota::get_user_quota` + new `quota::get_used_bytes` (db::sum). 1GiB/100MiB/10k defaults hoisted into `QuotaConfig::DEFAULT_*` consts (single in-code source); `CollectionSchema` defaults derive from them with a schema-drift guard test. Regression tests `quota_from_record_honors_text_stored_overrides` + `check_quota_enforces_override_storage_cap` prove TEXT-stored per-user overrides are now enforced (was the real bug).
- [x] **Bucket-ownership check duplicated between pages_user.rs and storage.rs** — `user_owns_bucket` deleted; single `storage::bucket_owned_by` predicate; admin-policy split (JSON API admin-bypass via `is_bucket_access_denied`; SSR portal owner-scoped) documented in one place; SSR no-bypass regression test (`object_list_page_404_for_other_users_bucket`, made as admin).
- [x] **Bucket/key validation rules forked 4 ways; SEC-064 backslash check missing from the cloud.rs copy** — `is_valid_bucket_name`/`is_valid_storage_key` made `pub(super)`; cloud.rs share path now calls them (picks up the backslash check). `is_valid_bucket_name` tightened to the S3 rule the modal advertises; `BUCKET_NAME_PATTERN`/`MIN`/`MAX_LEN` consts are the single source shared with the maud `pattern=`/`minlength`/`maxlength`. Regression tests `create_share_rejects_backslash_key` (SEC-064), `create_share_rejects_invalid_bucket_name`, `create_share_valid_input_reaches_ownership_check`.
- [x] **Bucket existence has two unreconciled sources of truth: storage folders vs BUCKETS_TABLE** — BUCKETS_TABLE is the single source of truth: admin list + stats now read it (not `store::list_folders`); create-bucket compensates by deleting the folder on metadata-insert failure instead of warn-and-continue. Tests: admin-all-owners list, owner-scoped user list, stats count.
- [x] **files block hand-builds HashMap rows instead of json_map** — swept the 7 production sites (storage view/pending/complete, share claims/log, cloud share row); removed now-unused HashMap import.

## Decisions made
- helpers fix exceeded "lines 44-46 only": the root-cause fix needed `json_as_i64`/`json_as_u64` + `opt_i64_field` (for the legalpages/quota non-zero defaults) + `u64_field` (vector dimensions) — exactly the "u64/f64 variant if needed" the Suggestion anticipated. Kept argon/password logic untouched.
- `create_bucket` folder/compensation path: verified by build + read only — `TestContext` does not register a storage service block, so the `store::create_folder` round-trip can't be unit-tested without new harness scaffolding (out of scope). The listing/stats table-reads are tested.
- `network.rs` i64 sweep sites are the request-log table (status_code/duration_ms), disjoint from the rules surface S1-C deletes — no rebase conflict expected.

## Local verification (CI is the final gate)
- `cargo +nightly fmt --all -- --check` — clean
- `bash scripts/grep-guard-html.sh` + `bash scripts/audit-wrap-grants.sh` — both OK (no missing WRAP grants)
- `cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare` — clean (no dependent breaks)
- `cargo test -p solobase-core --lib` — 746 passed, 0 failed (incl. all new regression tests); files integration tests 70 passed
- `cargo clippy -p solobase-core` — no new warnings in touched files (fixed the one unused-import I introduced)
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` — clean (files block compiles on wasm32)
- Pre-existing unrelated: `tests/lockfile_e2e.rs` fails locally needing the `wasm`/`wasmi` feature (WASM block loading) — not in this diff, not a files-block test.

## No migration impact
No block-SQL/migration files changed — no `SOLOBASE_RUN_MIGRATIONS=1` deploy requirement. The QuotaConfig consts mirror the existing DB-side column defaults (unchanged).
