### PR TITLE
fix(S1-F): auth credential-flow dedupe (issue_tokens_and_cookie) + 2 OAuth security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,6 +5808,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5831,6 +5832,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5842,6 +5844,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5862,6 +5865,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5871,6 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5884,6 +5889,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5897,6 +5903,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5908,6 +5915,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5918,6 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5934,6 +5943,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5954,6 +5964,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5963,6 +5974,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5974,6 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5989,6 +6002,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5998,6 +6012,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6018,6 +6033,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6029,6 +6045,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6050,6 +6067,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6059,6 +6077,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6088,6 +6107,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6097,6 +6117,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5832,7 +5831,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5844,7 +5842,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5865,7 +5862,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5875,7 +5871,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5889,7 +5884,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5903,7 +5897,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5915,7 +5908,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5926,7 +5918,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5943,7 +5934,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5964,7 +5954,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5974,7 +5963,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5986,7 +5974,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6002,7 +5989,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6012,7 +5998,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6033,7 +6018,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6045,7 +6029,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6067,7 +6050,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6077,7 +6059,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6107,7 +6088,6 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -6117,7 +6097,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/auth/config.rs
+++ b/crates/solobase-core/src/blocks/auth/config.rs
@@ -262,8 +262,9 @@ mod tests {
 
     #[test]
     fn auth_config_vars_declares_password_min_length() {
-        let keys: Vec<String> = auth_config_vars().iter().map(|v| v.key.clone()).collect();
-        assert!(keys.contains(&PASSWORD_MIN_LENGTH_KEY.to_string()));
+        let vars = auth_config_vars();
+        let keys: Vec<&str> = vars.iter().map(|v| v.key.as_str()).collect();
+        assert!(keys.contains(&PASSWORD_MIN_LENGTH_KEY));
     }
 
     #[test]
@@ -271,10 +272,13 @@ mod tests {
         // SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED was a dead duplicate of the
         // shared SOLOBASE_SHARED__ALLOW_SIGNUP toggle (opposite default, no
         // reader) and has been removed. The admin UI must not advertise it.
-        let keys: Vec<String> = auth_config_vars().iter().map(|v| v.key.clone()).collect();
-        assert!(!keys
-            .iter()
-            .any(|k| k == "SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED"));
+        let vars = auth_config_vars();
+        assert!(
+            !vars
+                .iter()
+                .any(|v| v.key == "SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED"),
+            "dead SIGNUP_ENABLED var must not be advertised"
+        );
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/auth/config.rs
+++ b/crates/solobase-core/src/blocks/auth/config.rs
@@ -34,11 +34,6 @@ pub const BOOTSTRAP_ADMIN_PASSWORD_KEY: &str = "SOLOBASE_SHARED__AUTH__BOOTSTRAP
 /// the holder redeems it to create the first admin.
 pub const BOOTSTRAP_ADMIN_TOKEN_KEY: &str = "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_TOKEN";
 
-/// `SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED` — gates the signup page and
-/// POST /auth/signup handler. When false the signup link is suppressed on
-/// the login page and the endpoints return 404.
-pub const SIGNUP_ENABLED_KEY: &str = "SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED";
-
 /// `SOLOBASE_SHARED__AUTH__PASSWORD_MIN_LENGTH` — minimum password length
 /// enforced at signup. Existing accounts are not re-validated.
 pub const PASSWORD_MIN_LENGTH_KEY: &str = "SOLOBASE_SHARED__AUTH__PASSWORD_MIN_LENGTH";
@@ -51,10 +46,6 @@ pub const ACCESS_TOKEN_LIFETIME_SECS_KEY: &str = "SUPPERS_AI__AUTH__ACCESS_TOKEN
 
 /// Default session lifetime when the config var is unset.
 pub const SESSION_LIFETIME_DAYS_DEFAULT: u32 = 30;
-
-/// Default value for [`SIGNUP_ENABLED_KEY`]. Signup is off by default —
-/// self-hosters must flip this explicitly.
-pub const SIGNUP_ENABLED_DEFAULT: bool = false;
 
 /// Default value for [`PASSWORD_MIN_LENGTH_KEY`].
 pub const PASSWORD_MIN_LENGTH_DEFAULT: u32 = 8;
@@ -100,13 +91,6 @@ pub fn auth_config_vars() -> Vec<ConfigVar> {
         .input_type(InputType::Password)
         .optional(),
         ConfigVar::new(
-            SIGNUP_ENABLED_KEY,
-            "If true, GET /auth/signup and POST /auth/signup are enabled and a 'create account' link appears on the login page.",
-            "false",
-        )
-        .name("Signup Enabled")
-        .input_type(InputType::Toggle),
-        ConfigVar::new(
             PASSWORD_MIN_LENGTH_KEY,
             "Minimum password length enforced at signup. Existing accounts are not re-validated.",
             &PASSWORD_MIN_LENGTH_DEFAULT.to_string(),
@@ -132,8 +116,6 @@ pub struct AuthConfig {
     pub bootstrap_admin_email: Option<String>,
     pub bootstrap_admin_password: Option<String>,
     pub bootstrap_admin_token: Option<String>,
-    pub signup_enabled: bool,
-    pub password_min_length: u32,
 }
 
 impl AuthConfig {
@@ -146,21 +128,11 @@ impl AuthConfig {
             .get(SESSION_LIFETIME_DAYS_KEY)
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(SESSION_LIFETIME_DAYS_DEFAULT);
-        let signup_enabled = env
-            .get(SIGNUP_ENABLED_KEY)
-            .map(|s| matches!(s.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
-            .unwrap_or(SIGNUP_ENABLED_DEFAULT);
-        let password_min_length = env
-            .get(PASSWORD_MIN_LENGTH_KEY)
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(PASSWORD_MIN_LENGTH_DEFAULT);
         Self {
             session_lifetime_days,
             bootstrap_admin_email: non_empty(env.get(BOOTSTRAP_ADMIN_EMAIL_KEY)),
             bootstrap_admin_password: non_empty(env.get(BOOTSTRAP_ADMIN_PASSWORD_KEY)),
             bootstrap_admin_token: non_empty(env.get(BOOTSTRAP_ADMIN_TOKEN_KEY)),
-            signup_enabled,
-            password_min_length,
         }
     }
 
@@ -176,8 +148,6 @@ impl AuthConfig {
             BOOTSTRAP_ADMIN_EMAIL_KEY,
             BOOTSTRAP_ADMIN_PASSWORD_KEY,
             BOOTSTRAP_ADMIN_TOKEN_KEY,
-            SIGNUP_ENABLED_KEY,
-            PASSWORD_MIN_LENGTH_KEY,
         ] {
             let val = config_client::get_default(ctx, key, "").await;
             if !val.is_empty() {
@@ -291,21 +261,20 @@ mod tests {
     }
 
     #[test]
-    fn auth_config_vars_declares_signup_enabled_and_password_min_length() {
+    fn auth_config_vars_declares_password_min_length() {
         let keys: Vec<String> = auth_config_vars().iter().map(|v| v.key.clone()).collect();
-        assert!(keys.contains(&SIGNUP_ENABLED_KEY.to_string()));
         assert!(keys.contains(&PASSWORD_MIN_LENGTH_KEY.to_string()));
     }
 
     #[test]
-    fn signup_enabled_var_defaults_to_false_as_toggle() {
-        let var = auth_config_vars()
-            .into_iter()
-            .find(|v| v.key == SIGNUP_ENABLED_KEY)
-            .expect("signup_enabled declared");
-        assert_eq!(var.default, "false");
-        assert_eq!(var.input_type, InputType::Toggle);
-        assert!(!var.is_sensitive());
+    fn auth_config_vars_does_not_declare_dead_signup_enabled_key() {
+        // SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED was a dead duplicate of the
+        // shared SOLOBASE_SHARED__ALLOW_SIGNUP toggle (opposite default, no
+        // reader) and has been removed. The admin UI must not advertise it.
+        let keys: Vec<String> = auth_config_vars().iter().map(|v| v.key.clone()).collect();
+        assert!(!keys
+            .iter()
+            .any(|k| k == "SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED"));
     }
 
     #[test]
@@ -315,31 +284,5 @@ mod tests {
             .find(|v| v.key == PASSWORD_MIN_LENGTH_KEY)
             .expect("password_min_length declared");
         assert_eq!(var.default, "8");
-    }
-
-    #[test]
-    fn signup_enabled_parses_bool_from_map() {
-        let cfg = AuthConfig::from_env_for_test(&[(SIGNUP_ENABLED_KEY, "true")]);
-        assert!(cfg.signup_enabled);
-        let cfg = AuthConfig::from_env_for_test(&[(SIGNUP_ENABLED_KEY, "false")]);
-        assert!(!cfg.signup_enabled);
-    }
-
-    #[test]
-    fn signup_enabled_defaults_false_when_unset() {
-        let cfg = AuthConfig::from_env_for_test(&[]);
-        assert!(!cfg.signup_enabled);
-    }
-
-    #[test]
-    fn password_min_length_parses_int_from_map() {
-        let cfg = AuthConfig::from_env_for_test(&[(PASSWORD_MIN_LENGTH_KEY, "12")]);
-        assert_eq!(cfg.password_min_length, 12);
-    }
-
-    #[test]
-    fn password_min_length_defaults_to_eight_when_unset() {
-        let cfg = AuthConfig::from_env_for_test(&[]);
-        assert_eq!(cfg.password_min_length, 8);
     }
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -177,6 +177,53 @@ pub(crate) mod helpers {
         roles
     }
 
+    /// Whether new-account registration is allowed
+    /// (`SOLOBASE_SHARED__ALLOW_SIGNUP`, default on). The single signup toggle
+    /// across the JSON signup endpoint and the OAuth callback's
+    /// brand-new-user branch — `SOLOBASE_SHARED__AUTH__SIGNUP_ENABLED` was a
+    /// dead duplicate with the opposite default and has been removed.
+    pub(crate) async fn signup_allowed(ctx: &dyn wafer_run::context::Context) -> bool {
+        let raw = config_client::get_default(ctx, "SOLOBASE_SHARED__ALLOW_SIGNUP", "true").await;
+        raw == "true" || raw == "1"
+    }
+
+    /// Whether `email`'s domain is permitted to register.
+    ///
+    /// When `SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS` is unset (the default)
+    /// every domain is allowed. When set to a comma-separated allow-list, only
+    /// matching domains pass. `email` is expected pre-lowercased; the domain is
+    /// the substring after the last `@` (empty for a malformed address, which
+    /// then fails a non-empty allow-list).
+    pub(crate) async fn email_domain_allowed(
+        ctx: &dyn wafer_run::context::Context,
+        email: &str,
+    ) -> bool {
+        let allowed =
+            config_client::get_default(ctx, "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS", "").await;
+        if allowed.is_empty() {
+            return true;
+        }
+        let domain = email.rsplit_once('@').map(|(_, d)| d).unwrap_or("");
+        allowed.split(',').any(|d| d.trim() == domain)
+    }
+
+    /// The role a newly registered user should receive: `"admin"` when `email`
+    /// matches the configured `SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL`,
+    /// otherwise `"user"`. Shared by the JSON signup and OAuth-callback create
+    /// paths so the bootstrap-admin rule can't drift between them.
+    pub(crate) async fn initial_role_for(
+        ctx: &dyn wafer_run::context::Context,
+        email: &str,
+    ) -> &'static str {
+        use super::config::BOOTSTRAP_ADMIN_EMAIL_KEY;
+        let admin_email = config_client::get_default(ctx, BOOTSTRAP_ADMIN_EMAIL_KEY, "").await;
+        if !admin_email.is_empty() && email.eq_ignore_ascii_case(&admin_email) {
+            "admin"
+        } else {
+            "user"
+        }
+    }
+
     /// Resolve the configured access-token lifetime (SEC-042). Reads
     /// `SUPPERS_AI__AUTH__ACCESS_TOKEN_LIFETIME_SECS`; falls back to the
     /// declared default (30 min) if unset or unparseable.
@@ -359,6 +406,20 @@ pub(crate) mod helpers {
         )
     }
 
+    /// Resolve the configured minimum signup password length
+    /// (`SOLOBASE_SHARED__AUTH__PASSWORD_MIN_LENGTH`). Falls back to the
+    /// declared default (8) if unset or unparseable. Read by the signup
+    /// handler so the admin-visible config var is actually enforced instead of
+    /// a hardcoded literal.
+    pub(crate) async fn password_min_length(ctx: &dyn wafer_run::context::Context) -> usize {
+        use super::config::{PASSWORD_MIN_LENGTH_DEFAULT, PASSWORD_MIN_LENGTH_KEY};
+        let raw = config_client::get_default(ctx, PASSWORD_MIN_LENGTH_KEY, "").await;
+        raw.parse::<usize>()
+            .ok()
+            .filter(|n| *n > 0)
+            .unwrap_or(PASSWORD_MIN_LENGTH_DEFAULT as usize)
+    }
+
     /// Resolve the configured session-row lifetime in days
     /// (`SOLOBASE_SHARED__AUTH__SESSION_LIFETIME_DAYS`). Falls back to the
     /// declared default if unset or unparseable. The session row is the
@@ -374,13 +435,13 @@ pub(crate) mod helpers {
     }
 
     /// Outcome of [`issue_tokens_and_cookie`]: the freshly minted token pair,
-    /// its rotation family, the access-token lifetime (seconds) and the
-    /// ready-to-set `auth_token` cookie. Callers add only their response shape
-    /// (JSON body vs. 302 redirect).
+    /// the access-token lifetime (seconds) and the ready-to-set `auth_token`
+    /// cookie. Callers add only their response shape (JSON body vs. 302
+    /// redirect). The rotation family is persisted internally (on the refresh
+    /// row); no caller needs it back, so it is intentionally not surfaced here.
     pub(crate) struct IssuedLogin {
         pub access_token: String,
         pub refresh_token: String,
-        pub family: String,
         pub access_lifetime: u64,
         pub cookie: String,
     }
@@ -415,10 +476,10 @@ pub(crate) mod helpers {
         use super::repo::sessions;
         use super::service::hash_token;
 
-        let (access_token, refresh_token, family) =
+        let (access_token, refresh_token, issued_family) =
             generate_tokens(ctx, user_id, email, roles, auth_method, family).await?;
 
-        store_refresh_token(ctx, user_id, &refresh_token, &family, generation).await;
+        store_refresh_token(ctx, user_id, &refresh_token, &issued_family, generation).await;
 
         let lifetime_days = session_lifetime_days(ctx).await;
         if let Err(e) =
@@ -437,7 +498,6 @@ pub(crate) mod helpers {
         Ok(IssuedLogin {
             access_token,
             refresh_token,
-            family,
             access_lifetime,
             cookie,
         })

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -473,8 +473,7 @@ pub(crate) mod helpers {
         family: Option<&str>,
         generation: i64,
     ) -> std::result::Result<IssuedLogin, wafer_run::OutputStream> {
-        use super::repo::sessions;
-        use super::service::hash_token;
+        use super::{repo::sessions, service::hash_token};
 
         let (access_token, refresh_token, issued_family) =
             generate_tokens(ctx, user_id, email, roles, auth_method, family).await?;

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -197,6 +197,13 @@ pub(crate) mod helpers {
     /// refresh tokens so it survives refresh, letting downstream gates (like
     /// the wafer registry's publish endpoint) require a stronger method.
     ///
+    /// `family` selects the refresh-token rotation family for the SEC-039
+    /// reuse-detection ladder: pass `None` to mint a brand-new family (initial
+    /// login / signup / OAuth / bootstrap), or `Some(existing)` to re-issue
+    /// within an established family on refresh rotation so the new refresh
+    /// JWT's `family` claim agrees with the DB row that anchors reuse
+    /// detection.
+    ///
     /// Access tokens carry a random `jti` so logout can blocklist the
     /// in-flight JWT (SEC-042) without affecting other live sessions for
     /// the same user.
@@ -206,10 +213,14 @@ pub(crate) mod helpers {
         email: &str,
         roles: &[String],
         auth_method: &str,
+        family: Option<&str>,
     ) -> std::result::Result<(String, String, String), wafer_run::OutputStream> {
-        let family = match crypto::random_bytes(ctx, 16).await {
-            Ok(bytes) => hex_encode(&bytes),
-            Err(e) => return Err(wafer_run::OutputStream::error(e)),
+        let family = match family {
+            Some(f) => f.to_string(),
+            None => match crypto::random_bytes(ctx, 16).await {
+                Ok(bytes) => hex_encode(&bytes),
+                Err(e) => return Err(wafer_run::OutputStream::error(e)),
+            },
         };
         // SEC-042: per-token random id so logout can revoke a single JWT
         // without touching other live sessions for the same user.
@@ -346,6 +357,90 @@ pub(crate) mod helpers {
             max_age,
             if secure { "; Secure" } else { "" }
         )
+    }
+
+    /// Resolve the configured session-row lifetime in days
+    /// (`SOLOBASE_SHARED__AUTH__SESSION_LIFETIME_DAYS`). Falls back to the
+    /// declared default if unset or unparseable. The session row is the
+    /// userportal device-list signal; its expiry is independent of the JWT
+    /// access-token lifetime (which is gated by [`access_token_lifetime_secs`]).
+    pub(crate) async fn session_lifetime_days(ctx: &dyn wafer_run::context::Context) -> u32 {
+        use super::config::{SESSION_LIFETIME_DAYS_DEFAULT, SESSION_LIFETIME_DAYS_KEY};
+        let raw = config_client::get_default(ctx, SESSION_LIFETIME_DAYS_KEY, "").await;
+        raw.parse::<u32>()
+            .ok()
+            .filter(|n| *n > 0)
+            .unwrap_or(SESSION_LIFETIME_DAYS_DEFAULT)
+    }
+
+    /// Outcome of [`issue_tokens_and_cookie`]: the freshly minted token pair,
+    /// its rotation family, the access-token lifetime (seconds) and the
+    /// ready-to-set `auth_token` cookie. Callers add only their response shape
+    /// (JSON body vs. 302 redirect).
+    pub(crate) struct IssuedLogin {
+        pub access_token: String,
+        pub refresh_token: String,
+        pub family: String,
+        pub access_lifetime: u64,
+        pub cookie: String,
+    }
+
+    /// Shared token-issuance tail for every login flow (password login, signup,
+    /// bootstrap redemption, OAuth callback, and refresh rotation).
+    ///
+    /// Mints the access + refresh JWTs, persists the refresh-token row, writes
+    /// the userportal session row, and builds the `auth_token` cookie — the
+    /// exact sequence that was previously copy-pasted across all five handlers
+    /// (and which the OAuth copy had drifted from, silently omitting the
+    /// session row). Centralising it guarantees every authentication path is
+    /// visible on the userportal device list.
+    ///
+    /// `family` follows [`generate_tokens`]: `None` mints a brand-new rotation
+    /// family (initial authentication), `Some(existing)` re-issues within an
+    /// established family (refresh rotation). `generation` is the refresh-row
+    /// generation to persist (`0` for a new family, `prev + 1` on rotation).
+    ///
+    /// The session-row write failing does not abort issuance — it is a UX
+    /// signal, not a security gate (auth is entirely JWT-based today) — but it
+    /// is logged.
+    pub(crate) async fn issue_tokens_and_cookie(
+        ctx: &dyn wafer_run::context::Context,
+        user_id: &str,
+        email: &str,
+        roles: &[String],
+        auth_method: &str,
+        family: Option<&str>,
+        generation: i64,
+    ) -> std::result::Result<IssuedLogin, wafer_run::OutputStream> {
+        use super::repo::sessions;
+        use super::service::hash_token;
+
+        let (access_token, refresh_token, family) =
+            generate_tokens(ctx, user_id, email, roles, auth_method, family).await?;
+
+        store_refresh_token(ctx, user_id, &refresh_token, &family, generation).await;
+
+        let lifetime_days = session_lifetime_days(ctx).await;
+        if let Err(e) =
+            sessions::create_for_user(ctx, user_id, hash_token(&access_token), lifetime_days).await
+        {
+            tracing::warn!(
+                user_id = %user_id,
+                auth_method = %auth_method,
+                "failed to persist session row for login: {e}"
+            );
+        }
+
+        let access_lifetime = access_token_lifetime_secs(ctx).await;
+        let cookie = build_auth_cookie(&access_token, access_lifetime, ctx).await;
+
+        Ok(IssuedLogin {
+            access_token,
+            refresh_token,
+            family,
+            access_lifetime,
+            cookie,
+        })
     }
 }
 

--- a/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
@@ -16,8 +16,8 @@ use wafer_run::{context::Context, InputStream, OutputStream};
 use crate::blocks::{
     auth::{
         bootstrap,
-        helpers::{build_auth_cookie, generate_tokens, store_refresh_token},
-        repo::{bootstrap_tokens, sessions, users},
+        helpers::issue_tokens_and_cookie,
+        repo::{bootstrap_tokens, users},
         service::hash_token,
     },
     helpers::{
@@ -82,29 +82,20 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         Err(e) => return err_internal("users::find_by_email after bootstrap", e),
     };
 
-    // 5. Mint a session — same pattern as auth_ui::api::login::handle.
+    // 5. Mint a session — same shared token-issuance tail as login/signup.
     let roles = vec!["admin".to_string()];
-    let (access_token, refresh_token, family) =
-        match generate_tokens(ctx, &user.id, &email, &roles, "password").await {
-            Ok(t) => t,
+    let issued =
+        match issue_tokens_and_cookie(ctx, &user.id, &email, &roles, "password", None, 0).await {
+            Ok(i) => i,
             Err(r) => return r,
         };
-    store_refresh_token(ctx, &user.id, &refresh_token, &family, 0).await;
-    if let Err(e) = sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await {
-        tracing::warn!(
-            user_id = %user.id,
-            "failed to persist session row for bootstrap redemption: {e}"
-        );
-    }
 
     // 6. Set the auth cookie + redirect to the dashboard. The form is a
     //    plain HTML POST (no JS), so a 302 with Set-Cookie is the right
     //    completion signal.
-    let access_lifetime = crate::blocks::auth::helpers::access_token_lifetime_secs(ctx).await;
-    let cookie = build_auth_cookie(&access_token, access_lifetime, ctx).await;
     ResponseBuilder::new()
         .status(302)
-        .set_cookie(&cookie)
+        .set_cookie(&issued.cookie)
         .set_header("Location", "/b/auth/dashboard")
         .empty()
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/forgot_password.rs
@@ -1,7 +1,7 @@
 //! POST /b/auth/api/forgot-password — relocated from auth/login.rs in Task 5.
 
 use wafer_core::clients::{crypto, database as db};
-use wafer_run::{context::Context, InputStream, Message, OutputStream};
+use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::USERS_TABLE,
@@ -56,31 +56,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     }
 
     // Send the raw token in the email; the hash lives only in the DB.
-    send_reset_email(ctx, &email_lower, &reset_token).await;
+    super::send_template_email(ctx, "password_reset", &email_lower, &reset_token).await;
 
     ok_json(&serde_json::json!({"message": safe_msg}))
-}
-
-/// Send password reset email via the suppers-ai/email block.
-async fn send_reset_email(ctx: &dyn Context, email: &str, token: &str) {
-    let req = serde_json::json!({
-        "template": "password_reset",
-        "to": email,
-        "token": token,
-    });
-    let email_msg = Message {
-        kind: "email.send_template".to_string(),
-        meta: Vec::new(),
-    };
-    let body_bytes = serde_json::to_vec(&req).unwrap_or_default();
-    let out = ctx
-        .call_block(
-            "suppers-ai/email",
-            email_msg,
-            InputStream::from_bytes(body_bytes),
-        )
-        .await;
-    if let Err(e) = out.collect_buffered().await {
-        tracing::warn!("Failed to send password_reset email to {}: {:?}", email, e);
-    }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/login.rs
@@ -5,9 +5,8 @@ use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{build_auth_cookie, ensure_admin_role, generate_tokens, store_refresh_token},
-        repo::{local_credentials, sessions, users},
-        service::hash_token,
+        helpers::{ensure_admin_role, issue_tokens_and_cookie},
+        repo::{local_credentials, users},
         DUMMY_HASH, USERS_TABLE,
     },
     errors::{error_response, ErrorCode},
@@ -81,26 +80,14 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Get roles, granting admin role idempotently when ADMIN_EMAIL matches
     let roles = ensure_admin_role(ctx, &user.id, &email_lower).await;
 
-    // Generate tokens
-    let (access_token, refresh_token, family) =
-        match generate_tokens(ctx, &user.id, &email_lower, &roles, "password").await {
-            Ok(t) => t,
+    // Mint tokens, persist the refresh + session rows, build the cookie.
+    let issued =
+        match issue_tokens_and_cookie(ctx, &user.id, &email_lower, &roles, "password", None, 0)
+            .await
+        {
+            Ok(i) => i,
             Err(r) => return r,
         };
-
-    // Store refresh token
-    store_refresh_token(ctx, &user.id, &refresh_token, &family, 0).await;
-
-    // Persist a session row so the userportal `/b/userportal/sessions`
-    // page can show this login. Failure must not block login — the
-    // session row is a UX signal, not a security gate (auth is still
-    // entirely JWT-based today).
-    if let Err(e) = sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await {
-        tracing::warn!(
-            user_id = %user.id,
-            "failed to persist session row for JWT login: {e}"
-        );
-    }
 
     // Update last login
     let upd = json_map(serde_json::json!({"last_login_at": crate::blocks::helpers::now_rfc3339()}));
@@ -108,16 +95,13 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         tracing::warn!("Failed to update last login time: {e}");
     }
 
-    let access_lifetime = crate::blocks::auth::helpers::access_token_lifetime_secs(ctx).await;
-    let cookie = build_auth_cookie(&access_token, access_lifetime, ctx).await;
-
     ResponseBuilder::new()
-        .set_cookie(&cookie)
+        .set_cookie(&issued.cookie)
         .json(&serde_json::json!({
-            "access_token": access_token,
-            "refresh_token": refresh_token,
+            "access_token": issued.access_token,
+            "refresh_token": issued.refresh_token,
             "token_type": "Bearer",
-            "expires_in": access_lifetime,
+            "expires_in": issued.access_lifetime,
             "user": {
                 "id": user.id,
                 "email": email_lower,

--- a/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
@@ -1,6 +1,8 @@
 //! JSON API handlers for the auth-ui block. One handler per leaf module;
 //! routed from `auth_ui::AuthUiBlock::handle`.
 
+use wafer_run::{context::Context, InputStream, Message};
+
 pub mod api_keys;
 pub mod bootstrap;
 pub mod change_password;
@@ -13,3 +15,41 @@ pub mod reset_password;
 pub mod signup;
 pub mod sync_user;
 pub mod verify;
+
+/// Send a transactional email through the `suppers-ai/email` block.
+///
+/// Shared by the signup, email-verify and forgot-password handlers — every
+/// caller builds the same `email.send_template` envelope `{template, to,
+/// token}` and only the template name differs. A send failure is logged and
+/// swallowed: email delivery is best-effort, and a 5xx from the email block
+/// must not turn a successful signup / reset request into an error.
+pub(crate) async fn send_template_email(
+    ctx: &dyn Context,
+    template: &str,
+    to: &str,
+    token: &str,
+) {
+    let req = serde_json::json!({
+        "template": template,
+        "to": to,
+        "token": token,
+    });
+    let email_msg = Message {
+        kind: "email.send_template".to_string(),
+        meta: Vec::new(),
+    };
+    let body_bytes = serde_json::to_vec(&req).unwrap_or_default();
+    let out = ctx
+        .call_block(
+            "suppers-ai/email",
+            email_msg,
+            InputStream::from_bytes(body_bytes),
+        )
+        .await;
+    if let Err(e) = out.collect_buffered().await {
+        tracing::warn!(
+            template = %template,
+            "Failed to send {template} email to {to}: {e:?}"
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
@@ -23,12 +23,7 @@ pub mod verify;
 /// token}` and only the template name differs. A send failure is logged and
 /// swallowed: email delivery is best-effort, and a 5xx from the email block
 /// must not turn a successful signup / reset request into an error.
-pub(crate) async fn send_template_email(
-    ctx: &dyn Context,
-    template: &str,
-    to: &str,
-    token: &str,
-) {
+pub(crate) async fn send_template_email(ctx: &dyn Context, template: &str, to: &str, token: &str) {
     let req = serde_json::json!({
         "template": template,
         "to": to,

--- a/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
@@ -16,12 +16,8 @@ use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{
-            build_auth_cookie, ensure_admin_role, expected_issuer, generate_tokens,
-            store_refresh_token,
-        },
-        repo::{sessions, tokens, users},
-        service::hash_token,
+        helpers::{ensure_admin_role, expected_issuer, issue_tokens_and_cookie},
+        repo::{tokens, users},
     },
     errors::{error_response, ErrorCode},
     helpers::{err_bad_request, ResponseBuilder},
@@ -137,109 +133,41 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         .unwrap_or("password")
         .to_string();
 
-    // Mint the new access JWT via the shared helper. We discard its refresh
-    // JWT because `generate_tokens` allocates a fresh family for it — we
-    // need the new refresh JWT to carry the *preserved* family so reuse
-    // detection survives across rotation (SEC-039).
-    let (access_token, _discarded_refresh, _discarded_new_family) =
-        match generate_tokens(ctx, &user_id, &email, &roles, &prior_auth_method).await {
-            Ok(t) => t,
-            Err(r) => return r,
-        };
-    let refresh_token =
-        match resign_refresh_with_family(ctx, &user_id, &prior_auth_method, &row.family).await {
-            Ok(t) => t,
-            Err(r) => return r,
-        };
-
-    // Atomic-ish rotation: mark old row revoked, insert new row under the
-    // same family with generation+1. If the second step fails after the
-    // first succeeds the user simply gets logged out — a recoverable UX
-    // outcome — but we never leave two live rows in a family.
+    // Atomic-ish rotation: mark the old row revoked *before* minting the
+    // replacement, so we never leave two live rows in a family. If issuance
+    // then fails the user simply gets logged out — a recoverable UX outcome.
     if let Err(e) = tokens::revoke_by_id(ctx, &row.id).await {
         tracing::warn!("refresh: failed to revoke prior token row: {e}");
         return error_response(ErrorCode::InvalidToken, "Could not rotate refresh token");
     }
-    store_refresh_token(
+
+    // Re-issue within the *preserved* family (SEC-039): passing
+    // `Some(&row.family)` makes `generate_tokens` carry the existing family on
+    // the new refresh JWT so its `family` claim agrees with the DB row that
+    // anchors reuse detection. `generation = row.generation + 1` advances the
+    // rotation counter. This is the same shared issuance tail every other
+    // login flow uses, so the userportal session row is written here too.
+    let issued = match issue_tokens_and_cookie(
         ctx,
         &user_id,
-        &refresh_token,
-        &row.family,
+        &email,
+        &roles,
+        &prior_auth_method,
+        Some(&row.family),
         row.generation + 1,
     )
-    .await;
-
-    if let Err(e) = sessions::create_for_user(ctx, &user_id, hash_token(&access_token), 1).await {
-        tracing::warn!(
-            user_id = %user_id,
-            "failed to persist session row for JWT refresh: {e}"
-        );
-    }
-
-    let access_lifetime = crate::blocks::auth::helpers::access_token_lifetime_secs(ctx).await;
-    let cookie = build_auth_cookie(&access_token, access_lifetime, ctx).await;
+    .await
+    {
+        Ok(i) => i,
+        Err(r) => return r,
+    };
 
     ResponseBuilder::new()
-        .set_cookie(&cookie)
+        .set_cookie(&issued.cookie)
         .json(&serde_json::json!({
-            "access_token": access_token,
-            "refresh_token": refresh_token,
+            "access_token": issued.access_token,
+            "refresh_token": issued.refresh_token,
             "token_type": "Bearer",
-            "expires_in": access_lifetime
+            "expires_in": issued.access_lifetime
         }))
-}
-
-/// Mint a refresh JWT with a caller-chosen `family` claim.
-///
-/// `generate_tokens` always allocates a fresh family. On rotation we need to
-/// preserve the prior family so the JWT's `family` claim agrees with the DB
-/// row, which is the anchor for SEC-039 reuse detection. Rather than reshape
-/// the shared helper (it has four other callers — login, signup, OAuth
-/// callback, bootstrap — that legitimately want a new family), we re-sign
-/// with the desired family here.
-async fn resign_refresh_with_family(
-    ctx: &dyn Context,
-    user_id: &str,
-    auth_method: &str,
-    family: &str,
-) -> std::result::Result<String, OutputStream> {
-    use std::{collections::HashMap, time::Duration};
-
-    use crate::blocks::auth::REFRESH_TOKEN_TTL_SECS;
-
-    // [SEC-038] Stamp `iss` so the next refresh's `iss` check (lines 72-76)
-    // still succeeds. Without it, the rotated refresh JWT has no issuer and
-    // every subsequent refresh attempt fails forever.
-    let issuer = expected_issuer(ctx).await;
-
-    let mut refresh_claims = HashMap::new();
-    refresh_claims.insert(
-        "user_id".to_string(),
-        serde_json::Value::String(user_id.to_string()),
-    );
-    refresh_claims.insert(
-        "sub".to_string(),
-        serde_json::Value::String(user_id.to_string()),
-    );
-    refresh_claims.insert(
-        "type".to_string(),
-        serde_json::Value::String("refresh".to_string()),
-    );
-    refresh_claims.insert(
-        "family".to_string(),
-        serde_json::Value::String(family.to_string()),
-    );
-    refresh_claims.insert(
-        "auth_method".to_string(),
-        serde_json::Value::String(auth_method.to_string()),
-    );
-    refresh_claims.insert("iss".to_string(), serde_json::Value::String(issuer));
-
-    crypto::sign(
-        ctx,
-        &refresh_claims,
-        Duration::from_secs(REFRESH_TOKEN_TTL_SECS),
-    )
-    .await
-    .map_err(OutputStream::error)
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -5,7 +5,10 @@ use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::issue_tokens_and_cookie,
+        helpers::{
+            email_domain_allowed, initial_role_for, issue_tokens_and_cookie, password_min_length,
+            signup_allowed,
+        },
         repo::{local_credentials, users},
         USERS_TABLE,
     },
@@ -26,8 +29,7 @@ async fn user_exists(ctx: &dyn Context, email_lower: &str) -> Result<bool, Strin
 
 pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Enforce ALLOW_SIGNUP on the API (not just the page)
-    let allow_signup = config::get_default(ctx, "SOLOBASE_SHARED__ALLOW_SIGNUP", "true").await;
-    if allow_signup != "true" && allow_signup != "1" {
+    if !signup_allowed(ctx).await {
         return error_response(ErrorCode::Forbidden, "Signups are currently disabled");
     }
 
@@ -50,23 +52,18 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     }
 
     // Check allowed email domains (if configured)
-    let allowed_domains =
-        config::get_default(ctx, "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS", "").await;
-    if !allowed_domains.is_empty() {
-        let email_domain = parts[1];
-        let allowed = allowed_domains.split(',').any(|d| d.trim() == email_domain);
-        if !allowed {
-            return error_response(
-                ErrorCode::InvalidEmail,
-                "Signups from this email domain are not allowed",
-            );
-        }
+    if !email_domain_allowed(ctx, &email_lower).await {
+        return error_response(
+            ErrorCode::InvalidEmail,
+            "Signups from this email domain are not allowed",
+        );
     }
 
-    if body.password.len() < 8 {
+    let min_len = password_min_length(ctx).await;
+    if body.password.len() < min_len {
         return error_response(
             ErrorCode::PasswordTooShort,
-            "Password must be at least 8 characters",
+            &format!("Password must be at least {min_len} characters"),
         );
     }
     if body.password.len() > 1024 {
@@ -158,17 +155,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
 
     // Determine the role: admin if the email matches the configured bootstrap
     // admin email (re-uses the same key as bootstrap for consistency).
-    let admin_email = config::get_default(
-        ctx,
-        crate::blocks::auth::config::BOOTSTRAP_ADMIN_EMAIL_KEY,
-        "",
-    )
-    .await;
-    let role = if !admin_email.is_empty() && email_lower.eq_ignore_ascii_case(&admin_email) {
-        "admin"
-    } else {
-        "user"
-    };
+    let role = initial_role_for(ctx, &email_lower).await;
 
     // Insert via typed repo — no password_hash on the users row.
     let user = match users::insert(

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -1,7 +1,7 @@
 //! POST /b/auth/api/signup — relocated from auth/login.rs in Task 5.
 
 use wafer_core::clients::{config, crypto, database as db};
-use wafer_run::{context::Context, InputStream, Message, OutputStream};
+use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::blocks::{
     auth::{
@@ -201,7 +201,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
 
     // Send verification email if required
     if require_verification {
-        send_verification_email(ctx, &email_lower, &verification_token).await;
+        super::send_template_email(ctx, "verification", &email_lower, &verification_token).await;
         // Do NOT issue tokens before email is verified
         return ResponseBuilder::new().status(201).json(&serde_json::json!({
             "email_verified": false,
@@ -280,28 +280,4 @@ const COMMON_PASSWORDS: &[&str] = &[
 
 fn is_common_password(pw: &str) -> bool {
     COMMON_PASSWORDS.iter().any(|p| p.eq_ignore_ascii_case(pw))
-}
-
-/// Send verification email via the suppers-ai/email block.
-async fn send_verification_email(ctx: &dyn Context, email: &str, token: &str) {
-    let req = serde_json::json!({
-        "template": "verification",
-        "to": email,
-        "token": token,
-    });
-    let email_msg = Message {
-        kind: "email.send_template".to_string(),
-        meta: Vec::new(),
-    };
-    let body_bytes = serde_json::to_vec(&req).unwrap_or_default();
-    let out = ctx
-        .call_block(
-            "suppers-ai/email",
-            email_msg,
-            InputStream::from_bytes(body_bytes),
-        )
-        .await;
-    if let Err(e) = out.collect_buffered().await {
-        tracing::warn!("Failed to send verification email to {}: {:?}", email, e);
-    }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -226,33 +226,24 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         }));
     }
 
-    // Generate tokens (only when email verification is NOT required)
-    let (access_token, refresh_token, family) =
-        match generate_tokens(ctx, &user.id, &email_lower, &roles, "password").await {
-            Ok(t) => t,
+    // Mint tokens, persist the refresh + session rows, build the cookie
+    // (only when email verification is NOT required).
+    let issued =
+        match issue_tokens_and_cookie(ctx, &user.id, &email_lower, &roles, "password", None, 0)
+            .await
+        {
+            Ok(i) => i,
             Err(r) => return r,
         };
 
-    store_refresh_token(ctx, &user.id, &refresh_token, &family, 0).await;
-
-    if let Err(e) = sessions::create_for_user(ctx, &user.id, hash_token(&access_token), 1).await {
-        tracing::warn!(
-            user_id = %user.id,
-            "failed to persist session row for JWT signup: {e}"
-        );
-    }
-
-    let access_lifetime = crate::blocks::auth::helpers::access_token_lifetime_secs(ctx).await;
-    let cookie = build_auth_cookie(&access_token, access_lifetime, ctx).await;
-
     ResponseBuilder::new()
         .status(201)
-        .set_cookie(&cookie)
+        .set_cookie(&issued.cookie)
         .json(&serde_json::json!({
-            "access_token": access_token,
-            "refresh_token": refresh_token,
+            "access_token": issued.access_token,
+            "refresh_token": issued.refresh_token,
             "token_type": "Bearer",
-            "expires_in": access_lifetime,
+            "expires_in": issued.access_lifetime,
             "email_verified": true,
             "user": {
                 "id": user.id,

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -5,9 +5,8 @@ use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{build_auth_cookie, generate_tokens, store_refresh_token},
-        repo::{local_credentials, sessions, users},
-        service::hash_token,
+        helpers::issue_tokens_and_cookie,
+        repo::{local_credentials, users},
         USERS_TABLE,
     },
     errors::{error_response, ErrorCode},

--- a/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
@@ -159,7 +159,7 @@ pub async fn handle_resend(ctx: &dyn Context, input: InputStream) -> OutputStrea
         return err_internal("Failed to update token", e);
     }
 
-    send_verification_email(ctx, &email_lower, &new_token).await;
+    super::send_template_email(ctx, "verification", &email_lower, &new_token).await;
 
     ok_json(&serde_json::json!({"message": safe_msg}))
 }
@@ -203,26 +203,3 @@ fn html_respond(title: &str, message: &str, success: bool, logo_url: &str) -> Ou
     ui::html_response(markup)
 }
 
-/// Send verification email via the suppers-ai/email block.
-async fn send_verification_email(ctx: &dyn Context, email: &str, token: &str) {
-    let req = serde_json::json!({
-        "template": "verification",
-        "to": email,
-        "token": token,
-    });
-    let email_msg = Message {
-        kind: "email.send_template".to_string(),
-        meta: Vec::new(),
-    };
-    let body_bytes = serde_json::to_vec(&req).unwrap_or_default();
-    let out = ctx
-        .call_block(
-            "suppers-ai/email",
-            email_msg,
-            InputStream::from_bytes(body_bytes),
-        )
-        .await;
-    if let Err(e) = out.collect_buffered().await {
-        tracing::warn!("Failed to send verification email to {}: {:?}", email, e);
-    }
-}

--- a/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/verify.rs
@@ -202,4 +202,3 @@ fn html_respond(title: &str, message: &str, success: bool, logo_url: &str) -> Ou
     );
     ui::html_response(markup)
 }
-

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -213,13 +213,18 @@ async fn exchange_code(
     headers.insert("Accept".to_string(), "application/json".to_string());
 
     let token_body_bytes = token_body_str.into_bytes();
-    let token_resp =
-        match network::do_request(ctx, "POST", spec.token_url, &headers, Some(&token_body_bytes))
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => return Err(err_internal("Token exchange failed", e)),
-        };
+    let token_resp = match network::do_request(
+        ctx,
+        "POST",
+        spec.token_url,
+        &headers,
+        Some(&token_body_bytes),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return Err(err_internal("Token exchange failed", e)),
+    };
 
     let token_data: serde_json::Value = match serde_json::from_slice(&token_resp.body) {
         Ok(d) => d,
@@ -668,8 +673,9 @@ mod security_regression_tests {
             )
             .expect("test secret is long enough"),
         );
-        let crypto_block: Arc<dyn Block> =
-            Arc::new(wafer_core::service_blocks::crypto::CryptoBlock::new(crypto_svc));
+        let crypto_block: Arc<dyn Block> = Arc::new(
+            wafer_core::service_blocks::crypto::CryptoBlock::new(crypto_svc),
+        );
         ctx.register_block("wafer-run/crypto", crypto_block);
 
         // Mock network block under the production block id.

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -78,281 +78,44 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         return err_internal_no_cause("OAuth provider not fully configured");
     }
 
-    // Exchange code for token (URL-encode all values, include PKCE verifier)
-    let token_url = spec.token_url;
-    let token_body_str = spec.build_token_body(
+    // Phase 1: exchange the authorization code for a provider access token.
+    let oauth_token = match exchange_code(
+        ctx,
+        spec,
         code,
         &client_id,
         &client_secret,
         &redirect_uri,
         &code_verifier,
-    );
-
-    let mut headers = HashMap::new();
-    headers.insert(
-        "Content-Type".to_string(),
-        "application/x-www-form-urlencoded".to_string(),
-    );
-    headers.insert("Accept".to_string(), "application/json".to_string());
-
-    let token_body_bytes = token_body_str.into_bytes();
-    let token_resp = match network::do_request(
-        ctx,
-        "POST",
-        token_url,
-        &headers,
-        Some(&token_body_bytes),
     )
     .await
     {
-        Ok(r) => r,
-        Err(e) => return err_internal("Token exchange failed", e),
+        Ok(t) => t,
+        Err(r) => return r,
     };
 
-    let token_data: serde_json::Value = match serde_json::from_slice(&token_resp.body) {
-        Ok(d) => d,
-        Err(_) => return err_internal_no_cause("Failed to parse token response"),
+    // Phase 2: fetch the user's profile (with GitHub's /user/emails fallback).
+    let info = match fetch_user_info(ctx, spec, &oauth_token).await {
+        Ok(i) => i,
+        Err(r) => return r,
     };
 
-    let access_token_oauth = token_data
-        .get("access_token")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    if access_token_oauth.is_empty() {
-        return err_internal_no_cause("No access token in OAuth response");
-    }
-
-    // Get user info
-    let userinfo_url = spec.userinfo_url;
-    let auth_header = spec.userinfo_auth_header(access_token_oauth);
-
-    let mut info_headers = HashMap::new();
-    info_headers.insert("Authorization".to_string(), auth_header);
-    info_headers.insert("Accept".to_string(), "application/json".to_string());
-    // GitHub's REST API rejects requests without a User-Agent header
-    // (returns 403 + an HTML error body). Other providers accept it.
-    info_headers.insert(
-        "User-Agent".to_string(),
-        concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
-    );
-
-    let info_resp = match network::do_request(ctx, "GET", userinfo_url, &info_headers, None).await {
-        Ok(r) => r,
-        Err(e) => return err_internal("User info request failed", e),
+    // Phase 3: resolve the local user (link / email-merge / create), enforcing
+    // the disabled-account and signup gates, and upsert the provider link.
+    let user_id = match resolve_user(ctx, &provider, &oauth_token, &info).await {
+        Ok(id) => id,
+        Err(r) => return r,
     };
 
-    let user_info: serde_json::Value = match serde_json::from_slice(&info_resp.body) {
-        Ok(d) => d,
-        Err(e) => {
-            // Log the SHA-256 hash of the body instead of the body itself —
-            // a parse failure is rare and the raw body typically contains
-            // the upstream email / provider IDs that we don't want to drop
-            // into the error log surface.
-            let body_hash = crate::blocks::helpers::sha256_hex(&info_resp.body);
-            return err_internal(
-                "Failed to parse OAuth user info",
-                format!(
-                    "status={} parse={} body_len={} body_sha256={}",
-                    info_resp.status_code,
-                    e,
-                    info_resp.body.len(),
-                    body_hash
-                ),
-            );
-        }
-    };
-
-    let mut email = user_info
-        .get("email")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_lowercase();
-    let name = user_info
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let avatar = user_info
-        .get("picture")
-        .or_else(|| user_info.get("avatar_url"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-
-    // GitHub's /user endpoint returns a null `email` for users who have
-    // their primary email set to private. The authoritative list lives at
-    // /user/emails — which is only returned when the `user:email` scope
-    // was granted. Pick the first primary verified address. Only providers
-    // with an `emails_url` (GitHub) carry this fallback.
-    if let (true, Some(emails_url)) = (email.is_empty(), spec.emails_url) {
-        let mut emails_headers = HashMap::new();
-        emails_headers.insert(
-            "Authorization".to_string(),
-            spec.userinfo_auth_header(access_token_oauth),
-        );
-        emails_headers.insert("Accept".to_string(), "application/json".to_string());
-        emails_headers.insert(
-            "User-Agent".to_string(),
-            concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
-        );
-        if let Ok(emails_resp) =
-            network::do_request(ctx, "GET", emails_url, &emails_headers, None).await
-        {
-            if let Ok(arr) = serde_json::from_slice::<serde_json::Value>(&emails_resp.body) {
-                if let Some(entries) = arr.as_array() {
-                    // Prefer primary+verified; fall back to any verified.
-                    let pick = entries
-                        .iter()
-                        .find(|e| {
-                            e.get("primary").and_then(|v| v.as_bool()).unwrap_or(false)
-                                && e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
-                        })
-                        .or_else(|| {
-                            entries.iter().find(|e| {
-                                e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
-                            })
-                        });
-                    if let Some(e) = pick {
-                        if let Some(s) = e.get("email").and_then(|v| v.as_str()) {
-                            email = s.to_lowercase();
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if email.is_empty() {
-        return err_internal_no_cause("No email returned by OAuth provider");
-    }
-
-    // Extract the stable provider-side user identifier.
-    // GitHub returns `id` as a JSON number; Google returns `sub` (string);
-    // Microsoft returns `id` (string). Coerce to string in all cases.
-    let provider_ref = {
-        // Try `sub` first (Google OIDC), then `id` (GitHub, Microsoft).
-        let raw = user_info.get("sub").or_else(|| user_info.get("id"));
-        match raw {
-            Some(serde_json::Value::String(s)) => s.clone(),
-            Some(serde_json::Value::Number(n)) => n.to_string(),
-            _ => String::new(),
-        }
-    };
-    if provider_ref.is_empty() {
-        return err_internal_no_cause("OAuth provider did not return a stable user id");
-    }
-
-    // Stable per-provider handle (GitHub `login`, others fall back to email local-part).
-    let provider_login = user_info
-        .get("login")
-        .and_then(|v| v.as_str())
-        .unwrap_or_else(|| email.split('@').next().unwrap_or(""))
-        .to_string();
-
-    // --- Step 1: look up existing link by (provider, provider_ref) ---
-    let existing_link =
-        match provider_links::find_by_provider_ref(ctx, &provider, &provider_ref).await {
-            Ok(l) => l,
-            Err(e) => return err_internal("provider_links lookup failed", e),
-        };
-
-    // --- Step 2 / 3: resolve user_id ---
-    let user_id: String = if let Some(link) = existing_link {
-        // Known provider link — reuse the bound user.
-        link.user_id
-    } else {
-        // No link yet. Try email-based account merging.
-        match users::find_by_email(ctx, &email).await {
-            Ok(Some(existing_user)) => {
-                // Check if the existing user account is disabled. The
-                // authoritative flag is `UserRow.disabled`; the previous
-                // `role == "disabled"` check tested a value nothing ever
-                // writes, so disabled accounts could still authenticate via
-                // OAuth.
-                if existing_user.disabled {
-                    return err_forbidden("Account is disabled");
-                }
-                // Reuse this account; the upsert below will create the new link.
-                existing_user.id
-            }
-            Ok(None) => {
-                // Brand-new user — enforce signup gates. Shared with the JSON
-                // signup handler so the ALLOW_SIGNUP / ALLOWED_EMAIL_DOMAINS /
-                // bootstrap-admin rules can't drift between the two flows.
-                if !signup_allowed(ctx).await {
-                    return err_forbidden("Signups are currently disabled");
-                }
-
-                if !email_domain_allowed(ctx, &email).await {
-                    return err_forbidden("Signups from this email domain are not allowed");
-                }
-
-                // Determine role: admin if email matches bootstrap email.
-                let role = initial_role_for(ctx, &email).await;
-
-                let display_name = if name.is_empty() {
-                    email.clone()
-                } else {
-                    name.clone()
-                };
-                let new_user = users::NewUser {
-                    email: email.clone(),
-                    display_name,
-                    avatar_url: if avatar.is_empty() {
-                        None
-                    } else {
-                        Some(avatar.clone())
-                    },
-                    role: role.to_string(),
-                };
-                match users::insert(ctx, new_user).await {
-                    Ok(u) => {
-                        // Assign role row in USER_ROLES_TABLE for legacy readers.
-                        let role_data = json_map(serde_json::json!({
-                            "user_id": u.id,
-                            "role": role,
-                            "assigned_at": crate::blocks::helpers::now_rfc3339()
-                        }));
-                        if let Err(e) =
-                            db::create(ctx, crate::blocks::admin::USER_ROLES_TABLE, role_data).await
-                        {
-                            tracing::warn!("Failed to assign default role on OAuth signup: {e}");
-                        }
-                        u.id
-                    }
-                    Err(e) => return err_internal("Failed to create user", e),
-                }
-            }
-            Err(e) => return err_internal("User lookup failed", e),
-        }
-    };
-
-    // --- Step 4: upsert the provider_links row ---
-    if let Err(e) = provider_links::upsert(
-        ctx,
-        provider_links::NewLink {
-            provider: &provider,
-            provider_ref: &provider_ref,
-            user_id: &user_id,
-            provider_login: &provider_login,
-            access_token: access_token_oauth,
-        },
-    )
-    .await
-    {
-        // Log but don't fail — the user is authenticated; link persistence
-        // is best-effort metadata. A failed upsert means re-login will
-        // fall back to email-based merging on next attempt.
-        tracing::warn!("Failed to upsert provider_links: {e}");
-    }
-
-    // Step 5: update last_login_at on the users row (best-effort).
+    // Update last_login_at on the users row (best-effort).
     let upd = json_map(serde_json::json!({
         "last_login_at": crate::blocks::helpers::now_rfc3339()
     }));
     if let Err(e) = db::update(ctx, USERS_TABLE, &user_id, upd).await {
         tracing::warn!("Failed to update last_login_at: {e}");
     }
+
+    let email = info.email;
 
     let roles = ensure_admin_role(ctx, &user_id, &email).await;
 
@@ -407,6 +170,323 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         .set_cookie(&issued.cookie)
         .set_header("Location", &redirect_url)
         .json(&serde_json::json!({"redirect": redirect_url}))
+}
+
+/// The profile fields the callback needs from a provider's userinfo response,
+/// already normalised (email lowercased, missing strings empty).
+struct OAuthUserInfo {
+    /// Lowercased verified email (after the GitHub `/user/emails` fallback).
+    email: String,
+    /// Display name, empty if the provider omitted it.
+    name: String,
+    /// Avatar URL, empty if the provider omitted it.
+    avatar: String,
+    /// Stable provider-side user id (`sub` for Google, `id` for GitHub /
+    /// Microsoft), coerced to a string.
+    provider_ref: String,
+    /// Per-provider login handle (GitHub `login`, else the email local-part).
+    provider_login: String,
+}
+
+/// Phase 1 — exchange the authorization `code` for a provider access token.
+///
+/// POSTs the token-exchange body (PKCE verifier included where the provider
+/// uses it) and returns the `access_token` string. Any transport / parse
+/// failure or a missing token is mapped to a ready-to-return [`OutputStream`].
+async fn exchange_code(
+    ctx: &dyn Context,
+    spec: &super::spec::OAuthProviderSpec,
+    code: &str,
+    client_id: &str,
+    client_secret: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+) -> Result<String, OutputStream> {
+    let token_body_str =
+        spec.build_token_body(code, client_id, client_secret, redirect_uri, code_verifier);
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Content-Type".to_string(),
+        "application/x-www-form-urlencoded".to_string(),
+    );
+    headers.insert("Accept".to_string(), "application/json".to_string());
+
+    let token_body_bytes = token_body_str.into_bytes();
+    let token_resp =
+        match network::do_request(ctx, "POST", spec.token_url, &headers, Some(&token_body_bytes))
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Err(err_internal("Token exchange failed", e)),
+        };
+
+    let token_data: serde_json::Value = match serde_json::from_slice(&token_resp.body) {
+        Ok(d) => d,
+        Err(_) => return Err(err_internal_no_cause("Failed to parse token response")),
+    };
+
+    let access_token_oauth = token_data
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if access_token_oauth.is_empty() {
+        return Err(err_internal_no_cause("No access token in OAuth response"));
+    }
+    Ok(access_token_oauth.to_string())
+}
+
+/// Phase 2 — fetch and normalise the user's profile.
+///
+/// Calls the provider userinfo endpoint, then (for providers with an
+/// `emails_url`, i.e. GitHub) falls back to `/user/emails` for a verified
+/// primary address when the userinfo payload omits one. Returns the normalised
+/// [`OAuthUserInfo`]; a missing email or stable id is an error.
+async fn fetch_user_info(
+    ctx: &dyn Context,
+    spec: &super::spec::OAuthProviderSpec,
+    oauth_token: &str,
+) -> Result<OAuthUserInfo, OutputStream> {
+    // Shared header set for every provider API call. GitHub's REST API rejects
+    // requests without a User-Agent header (returns 403 + an HTML error body);
+    // other providers accept it.
+    let api_headers = || {
+        let mut h = HashMap::new();
+        h.insert(
+            "Authorization".to_string(),
+            spec.userinfo_auth_header(oauth_token),
+        );
+        h.insert("Accept".to_string(), "application/json".to_string());
+        h.insert(
+            "User-Agent".to_string(),
+            concat!("solobase-auth/", env!("CARGO_PKG_VERSION")).to_string(),
+        );
+        h
+    };
+
+    let info_resp =
+        match network::do_request(ctx, "GET", spec.userinfo_url, &api_headers(), None).await {
+            Ok(r) => r,
+            Err(e) => return Err(err_internal("User info request failed", e)),
+        };
+
+    let user_info: serde_json::Value = match serde_json::from_slice(&info_resp.body) {
+        Ok(d) => d,
+        Err(e) => {
+            // Log the SHA-256 hash of the body instead of the body itself —
+            // a parse failure is rare and the raw body typically contains
+            // the upstream email / provider IDs that we don't want to drop
+            // into the error log surface.
+            let body_hash = crate::blocks::helpers::sha256_hex(&info_resp.body);
+            return Err(err_internal(
+                "Failed to parse OAuth user info",
+                format!(
+                    "status={} parse={} body_len={} body_sha256={}",
+                    info_resp.status_code,
+                    e,
+                    info_resp.body.len(),
+                    body_hash
+                ),
+            ));
+        }
+    };
+
+    let mut email = user_info
+        .get("email")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let name = user_info
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let avatar = user_info
+        .get("picture")
+        .or_else(|| user_info.get("avatar_url"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // GitHub's /user endpoint returns a null `email` for users who have
+    // their primary email set to private. The authoritative list lives at
+    // /user/emails — which is only returned when the `user:email` scope
+    // was granted. Pick the first primary verified address. Only providers
+    // with an `emails_url` (GitHub) carry this fallback.
+    if let (true, Some(emails_url)) = (email.is_empty(), spec.emails_url) {
+        if let Ok(emails_resp) =
+            network::do_request(ctx, "GET", emails_url, &api_headers(), None).await
+        {
+            if let Ok(arr) = serde_json::from_slice::<serde_json::Value>(&emails_resp.body) {
+                if let Some(entries) = arr.as_array() {
+                    // Prefer primary+verified; fall back to any verified.
+                    let pick = entries
+                        .iter()
+                        .find(|e| {
+                            e.get("primary").and_then(|v| v.as_bool()).unwrap_or(false)
+                                && e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
+                        })
+                        .or_else(|| {
+                            entries.iter().find(|e| {
+                                e.get("verified").and_then(|v| v.as_bool()).unwrap_or(false)
+                            })
+                        });
+                    if let Some(e) = pick {
+                        if let Some(s) = e.get("email").and_then(|v| v.as_str()) {
+                            email = s.to_lowercase();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if email.is_empty() {
+        return Err(err_internal_no_cause("No email returned by OAuth provider"));
+    }
+
+    // Extract the stable provider-side user identifier.
+    // GitHub returns `id` as a JSON number; Google returns `sub` (string);
+    // Microsoft returns `id` (string). Coerce to string in all cases.
+    let provider_ref = match user_info.get("sub").or_else(|| user_info.get("id")) {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        _ => String::new(),
+    };
+    if provider_ref.is_empty() {
+        return Err(err_internal_no_cause(
+            "OAuth provider did not return a stable user id",
+        ));
+    }
+
+    // Stable per-provider handle (GitHub `login`, others fall back to email local-part).
+    let provider_login = user_info
+        .get("login")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| email.split('@').next().unwrap_or(""))
+        .to_string();
+
+    Ok(OAuthUserInfo {
+        email,
+        name,
+        avatar,
+        provider_ref,
+        provider_login,
+    })
+}
+
+/// Phase 3 — resolve the local user id for this OAuth identity.
+///
+/// Tries, in order: an existing `(provider, provider_ref)` link; an
+/// email-matched local account (rejected if disabled); otherwise creates a new
+/// user (subject to the shared signup gates). Then upserts the provider link.
+/// Returns the resolved local user id.
+async fn resolve_user(
+    ctx: &dyn Context,
+    provider: &str,
+    oauth_token: &str,
+    info: &OAuthUserInfo,
+) -> Result<String, OutputStream> {
+    // --- Step 1: look up existing link by (provider, provider_ref) ---
+    let existing_link =
+        match provider_links::find_by_provider_ref(ctx, provider, &info.provider_ref).await {
+            Ok(l) => l,
+            Err(e) => return Err(err_internal("provider_links lookup failed", e)),
+        };
+
+    // --- Step 2 / 3: resolve user_id ---
+    let user_id: String = if let Some(link) = existing_link {
+        // Known provider link — reuse the bound user.
+        link.user_id
+    } else {
+        // No link yet. Try email-based account merging.
+        match users::find_by_email(ctx, &info.email).await {
+            Ok(Some(existing_user)) => {
+                // Check if the existing user account is disabled. The
+                // authoritative flag is `UserRow.disabled`; the previous
+                // `role == "disabled"` check tested a value nothing ever
+                // writes, so disabled accounts could still authenticate via
+                // OAuth.
+                if existing_user.disabled {
+                    return Err(err_forbidden("Account is disabled"));
+                }
+                // Reuse this account; the upsert below will create the new link.
+                existing_user.id
+            }
+            Ok(None) => {
+                // Brand-new user — enforce signup gates. Shared with the JSON
+                // signup handler so the ALLOW_SIGNUP / ALLOWED_EMAIL_DOMAINS /
+                // bootstrap-admin rules can't drift between the two flows.
+                if !signup_allowed(ctx).await {
+                    return Err(err_forbidden("Signups are currently disabled"));
+                }
+
+                if !email_domain_allowed(ctx, &info.email).await {
+                    return Err(err_forbidden(
+                        "Signups from this email domain are not allowed",
+                    ));
+                }
+
+                // Determine role: admin if email matches bootstrap email.
+                let role = initial_role_for(ctx, &info.email).await;
+
+                let display_name = if info.name.is_empty() {
+                    info.email.clone()
+                } else {
+                    info.name.clone()
+                };
+                let new_user = users::NewUser {
+                    email: info.email.clone(),
+                    display_name,
+                    avatar_url: if info.avatar.is_empty() {
+                        None
+                    } else {
+                        Some(info.avatar.clone())
+                    },
+                    role: role.to_string(),
+                };
+                match users::insert(ctx, new_user).await {
+                    Ok(u) => {
+                        // Assign role row in USER_ROLES_TABLE for legacy readers.
+                        let role_data = json_map(serde_json::json!({
+                            "user_id": u.id,
+                            "role": role,
+                            "assigned_at": crate::blocks::helpers::now_rfc3339()
+                        }));
+                        if let Err(e) =
+                            db::create(ctx, crate::blocks::admin::USER_ROLES_TABLE, role_data).await
+                        {
+                            tracing::warn!("Failed to assign default role on OAuth signup: {e}");
+                        }
+                        u.id
+                    }
+                    Err(e) => return Err(err_internal("Failed to create user", e)),
+                }
+            }
+            Err(e) => return Err(err_internal("User lookup failed", e)),
+        }
+    };
+
+    // --- Step 4: upsert the provider_links row ---
+    if let Err(e) = provider_links::upsert(
+        ctx,
+        provider_links::NewLink {
+            provider,
+            provider_ref: &info.provider_ref,
+            user_id: &user_id,
+            provider_login: &info.provider_login,
+            access_token: oauth_token,
+        },
+    )
+    .await
+    {
+        // Log but don't fail — the user is authenticated; link persistence
+        // is best-effort metadata. A failed upsert means re-login will
+        // fall back to email-based merging on next attempt.
+        tracing::warn!("Failed to upsert provider_links: {e}");
+    }
+
+    Ok(user_id)
 }
 
 /// [SEC-036] Validates `SOLOBASE_SHARED__FRONTEND_URL` before it is used as

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -8,7 +8,7 @@ use wafer_run::{context::Context, Message, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{build_auth_cookie, ensure_admin_role, generate_tokens, store_refresh_token},
+        helpers::{ensure_admin_role, issue_tokens_and_cookie},
         repo::{oauth_pkce, provider_links, users},
         USERS_TABLE,
     },
@@ -261,8 +261,12 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         // No link yet. Try email-based account merging.
         match users::find_by_email(ctx, &email).await {
             Ok(Some(existing_user)) => {
-                // Check if the existing user account is disabled.
-                if existing_user.role == "disabled" {
+                // Check if the existing user account is disabled. The
+                // authoritative flag is `UserRow.disabled`; the previous
+                // `role == "disabled"` check tested a value nothing ever
+                // writes, so disabled accounts could still authenticate via
+                // OAuth.
+                if existing_user.disabled {
                     return err_forbidden("Account is disabled");
                 }
                 // Reuse this account; the upsert below will create the new link.
@@ -361,19 +365,26 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     let roles = ensure_admin_role(ctx, &user_id, &email).await;
-    let (jwt_token, refresh_token, family) = match generate_tokens(
+
+    // Mint tokens, persist the refresh + session rows, build the cookie via
+    // the shared issuance tail. Previously this flow hand-rolled token minting
+    // and *omitted* the session row, so OAuth logins were invisible on the
+    // userportal device list; routing through `issue_tokens_and_cookie` fixes
+    // that by construction.
+    let issued = match issue_tokens_and_cookie(
         ctx,
         &user_id,
         &email,
         &roles,
         &format!("oauth.{}", provider),
+        None,
+        0,
     )
     .await
     {
-        Ok(t) => t,
+        Ok(i) => i,
         Err(r) => return r,
     };
-    store_refresh_token(ctx, &user_id, &refresh_token, &family, 0).await;
 
     // Redirect to frontend — token is set via HttpOnly cookie only (not URL)
     let frontend_url = config::get_default(
@@ -401,12 +412,9 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
     let redirect_url = format!("{}{}", frontend_url.trim_end_matches('/'), post_login);
 
-    let access_lifetime = crate::blocks::auth::helpers::access_token_lifetime_secs(ctx).await;
-    let cookie = build_auth_cookie(&jwt_token, access_lifetime, ctx).await;
-
     ResponseBuilder::new()
         .status(302)
-        .set_cookie(&cookie)
+        .set_cookie(&issued.cookie)
         .set_header("Location", &redirect_url)
         .json(&serde_json::json!({"redirect": redirect_url}))
 }

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -594,3 +594,220 @@ mod tests {
         assert!(!is_safe_frontend_url("https://example.com\n"));
     }
 }
+
+/// End-to-end regression tests for the OAuth callback's two historical
+/// security drifts (audit Top-10 #4):
+///
+/// 1. OAuth logins never created a session row, so they were invisible on the
+///    userportal device list. [`oauth_login_creates_session_row`] proves the
+///    row now exists after a successful Google callback.
+/// 2. Disabled accounts could still authenticate via OAuth because the
+///    callback checked `role == "disabled"` (a value nothing ever writes)
+///    instead of the real `UserRow.disabled` flag.
+///    [`disabled_user_cannot_oauth_in`] proves a disabled account is rejected
+///    and no session is minted.
+///
+/// Both drive the real [`handle`] end-to-end through a mock `wafer-run/network`
+/// block that returns canned Google token + userinfo responses, so a future
+/// refactor that re-breaks either path fails here.
+#[cfg(test)]
+mod security_regression_tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use async_trait::async_trait;
+    use wafer_core::interfaces::network::service::{
+        NetworkError, NetworkService, Request, Response,
+    };
+    use wafer_run::{Block, Message};
+
+    use super::handle;
+    use crate::{
+        blocks::auth::repo::{oauth_pkce, sessions, users},
+        test_support::TestContext,
+    };
+
+    /// Mock network block: maps Google's token + userinfo URLs to canned JSON.
+    /// The userinfo email is fixed so tests can pre-seed a matching user.
+    struct MockGoogleNetwork {
+        userinfo_email: String,
+    }
+
+    #[async_trait]
+    impl NetworkService for MockGoogleNetwork {
+        async fn do_request(&self, req: &Request) -> Result<Response, NetworkError> {
+            let body = if req.url.contains("oauth2.googleapis.com/token") {
+                serde_json::json!({ "access_token": "mock-google-access-token" })
+            } else if req.url.contains("googleapis.com/oauth2/v2/userinfo") {
+                serde_json::json!({
+                    "sub": "google-user-123",
+                    "email": self.userinfo_email,
+                    "name": "Mock Google User",
+                })
+            } else {
+                return Err(NetworkError::Other(format!("unexpected URL: {}", req.url)));
+            };
+            Ok(Response {
+                status_code: 200,
+                headers: HashMap::new(),
+                body: serde_json::to_vec(&body).unwrap(),
+            })
+        }
+    }
+
+    /// Build a ctx with auth migrations, a crypto block (token minting), a mock
+    /// Google network block, OAuth enabled, and a seeded PKCE state row so the
+    /// callback's single-use state redemption succeeds.
+    async fn ctx_for_oauth(userinfo_email: &str) -> TestContext {
+        let mut ctx = TestContext::with_auth().await;
+
+        // Crypto block — issue_tokens_and_cookie signs JWTs and pulls random
+        // bytes for the rotation family / jti.
+        let crypto_svc = Arc::new(
+            wafer_block_crypto::service::Argon2JwtCryptoService::new(
+                "test-jwt-secret-padded-to-min-32-bytes-aaaa".to_string(),
+            )
+            .expect("test secret is long enough"),
+        );
+        let crypto_block: Arc<dyn Block> =
+            Arc::new(wafer_core::service_blocks::crypto::CryptoBlock::new(crypto_svc));
+        ctx.register_block("wafer-run/crypto", crypto_block);
+
+        // Mock network block under the production block id.
+        let net: Arc<dyn Block> = Arc::new(crate::blocks::network::SolobaseNetworkBlock::new(
+            Arc::new(MockGoogleNetwork {
+                userinfo_email: userinfo_email.to_string(),
+            }),
+        ));
+        ctx.register_block("wafer-run/network", net);
+
+        // Config block — the handler reads OAuth flags / client credentials via
+        // `config::get_default`, which dispatches to the `wafer-run/config`
+        // block (NOT the TestContext config_get snapshot). Register one backed
+        // by an override map seeded with what the callback needs before it will
+        // attempt the code exchange.
+        use wafer_core::{
+            interfaces::config::service::ConfigService,
+            service_blocks::config::{ConfigBlock, EnvConfigService},
+        };
+        let cfg_svc = EnvConfigService::new();
+        cfg_svc.set("SOLOBASE_SHARED__ENABLE_OAUTH", "true");
+        cfg_svc.set("SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_ID", "client-id");
+        cfg_svc.set(
+            "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_SECRET",
+            "client-secret",
+        );
+        let cfg_block: Arc<dyn Block> = Arc::new(ConfigBlock::new(Arc::new(cfg_svc)));
+        ctx.register_block("wafer-run/config", cfg_block);
+
+        // Seed a single-use PKCE state row keyed by the `state` query param.
+        let expires = (chrono::Utc::now() + chrono::Duration::minutes(10))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        oauth_pkce::insert(
+            &ctx,
+            oauth_pkce::NewPkceState {
+                state_id: "state-xyz",
+                provider: "google",
+                code_verifier: "verifier-abc",
+                redirect_uri: "https://app.example.com/b/auth/oauth/callback",
+                expires_at: &expires,
+            },
+        )
+        .await
+        .expect("seed pkce state");
+
+        ctx
+    }
+
+    /// Build the callback request message carrying `code` + `state` query
+    /// params (read via `msg.query(...)` → `req.query.*` meta).
+    fn callback_msg() -> Message {
+        let mut msg = Message::new("auth.oauth.callback");
+        msg.set_meta("req.query.code", "auth-code-123");
+        msg.set_meta("req.query.state", "state-xyz");
+        msg
+    }
+
+    #[tokio::test]
+    async fn oauth_login_creates_session_row() {
+        // No pre-existing user: the callback creates one, then must persist a
+        // session row (the drift that made OAuth logins invisible on the
+        // userportal device list).
+        let email = "newoauth@example.com";
+        let ctx = ctx_for_oauth(email).await;
+
+        let out = handle(&ctx, &callback_msg()).await;
+        let status = crate::test_support::output_status(out).await;
+        assert_eq!(status, 302, "successful OAuth callback should 302-redirect");
+
+        let user = users::find_by_email(&ctx, email)
+            .await
+            .expect("user lookup ok")
+            .expect("OAuth callback created the user");
+
+        let session_rows = sessions::list_for_user(&ctx, &user.id)
+            .await
+            .expect("list sessions ok");
+        assert_eq!(
+            session_rows.len(),
+            1,
+            "OAuth login must persist exactly one session row (regression: it persisted none)"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_user_cannot_oauth_in() {
+        // Seed a DISABLED user with the email the provider will return.
+        let email = "disabled@example.com";
+        let ctx = ctx_for_oauth(email).await;
+
+        let user = users::insert(
+            &ctx,
+            users::NewUser {
+                email: email.to_string(),
+                display_name: "Disabled User".to_string(),
+                avatar_url: None,
+                role: "user".to_string(),
+            },
+        )
+        .await
+        .expect("seed user");
+        // Flip the real `disabled` flag (the value the fixed check reads).
+        let mut upd = crate::blocks::helpers::json_map(serde_json::json!({ "disabled": true }));
+        crate::blocks::helpers::stamp_updated(&mut upd);
+        wafer_core::clients::database::update(
+            &ctx,
+            crate::blocks::auth::USERS_TABLE,
+            &user.id,
+            upd,
+        )
+        .await
+        .expect("disable user");
+        // Sanity: the typed row now reports disabled.
+        assert!(
+            users::find_by_id(&ctx, &user.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .disabled,
+            "fixture user must be disabled"
+        );
+
+        // The callback rejects with a PermissionDenied error stream (mapped to
+        // HTTP 403 at the boundary). Before the fix this returned a 302 login.
+        let out = handle(&ctx, &callback_msg()).await;
+        assert!(
+            crate::test_support::output_is_error(out, "PermissionDenied").await,
+            "disabled account must be rejected at the OAuth callback (regression: it logged in)"
+        );
+
+        // And no session row was minted for the disabled user.
+        let session_rows = sessions::list_for_user(&ctx, &user.id)
+            .await
+            .expect("list sessions ok");
+        assert!(
+            session_rows.is_empty(),
+            "no session may be created for a disabled OAuth login"
+        );
+    }
+}

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -8,7 +8,10 @@ use wafer_run::{context::Context, Message, OutputStream};
 
 use crate::blocks::{
     auth::{
-        helpers::{ensure_admin_role, issue_tokens_and_cookie},
+        helpers::{
+            email_domain_allowed, ensure_admin_role, initial_role_for, issue_tokens_and_cookie,
+            signup_allowed,
+        },
         repo::{oauth_pkce, provider_links, users},
         USERS_TABLE,
     },
@@ -273,32 +276,19 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 existing_user.id
             }
             Ok(None) => {
-                // Brand-new user — enforce signup gates.
-                let allow_signup =
-                    config::get_default(ctx, "SOLOBASE_SHARED__ALLOW_SIGNUP", "true").await;
-                if allow_signup != "true" && allow_signup != "1" {
+                // Brand-new user — enforce signup gates. Shared with the JSON
+                // signup handler so the ALLOW_SIGNUP / ALLOWED_EMAIL_DOMAINS /
+                // bootstrap-admin rules can't drift between the two flows.
+                if !signup_allowed(ctx).await {
                     return err_forbidden("Signups are currently disabled");
                 }
 
-                let allowed_domains =
-                    config::get_default(ctx, "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS", "").await;
-                if !allowed_domains.is_empty() {
-                    let email_domain = email.split_once('@').map(|x| x.1).unwrap_or("");
-                    let allowed = allowed_domains.split(',').any(|d| d.trim() == email_domain);
-                    if !allowed {
-                        return err_forbidden("Signups from this email domain are not allowed");
-                    }
+                if !email_domain_allowed(ctx, &email).await {
+                    return err_forbidden("Signups from this email domain are not allowed");
                 }
 
                 // Determine role: admin if email matches bootstrap email.
-                let admin_email =
-                    config::get_default(ctx, "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL", "")
-                        .await;
-                let role = if !admin_email.is_empty() && email.eq_ignore_ascii_case(&admin_email) {
-                    "admin"
-                } else {
-                    "user"
-                };
+                let role = initial_role_for(ctx, &email).await;
 
                 let display_name = if name.is_empty() {
                     email.clone()


### PR DESCRIPTION
WIP — see checklist below. S1-F (auth-flows), wave 1 of the solobase quality-fix program (phase 2).

Audit Top-10 #4: the credential-flow dedupe that fixes two user-visible security bugs **by construction**.

## Findings checklist
- [x] **Token-issuance tail copy-pasted across 5 handlers (OAuth drift)** — extracted `issue_tokens_and_cookie`; all 5 handlers (login/signup/refresh/bootstrap/oauth-callback) ported. OAuth gains the session row it was missing.
- [ ] **Signup gating + admin-email role logic duplicated, drifted on 'disabled'** — `signup_allowed`/`email_domain_allowed`/`initial_role_for` helpers; standardize disabled check on `UserRow.disabled` (OAuth disabled-check fix DONE; gating-helper extraction remaining).
- [x] **resign_refresh_with_family re-implements generate_tokens** — `generate_tokens` now takes `family: Option<&str>`; `resign_refresh_with_family` deleted.
- [ ] **Email-send helper triplicated** — extract `send_template_email`.
- [ ] **oauth/callback.rs::handle is a 390-line single function** — split into `exchange_code`/`fetch_user_info`/`resolve_user` phases.
- [ ] **Declared config vars are dead; two competing signup toggles** — delete `SIGNUP_ENABLED_KEY`, wire or drop `PASSWORD_MIN_LENGTH_KEY`/`SESSION_LIFETIME_DAYS_KEY`.
- [ ] **Regression tests** for both fixed security drifts (OAuth session row exists; disabled user cannot OAuth in).

## Security fixes (live bugs)
1. OAuth logins never created a session row → invisible on userportal device list. Fixed via shared issuance tail.
2. Disabled accounts could OAuth in: callback checked `role == "disabled"` (a value nothing writes); the real flag is `UserRow.disabled`. Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)