### PR TITLE
fix(S2-O): thread db_backend through query-builder call sites + wire native db/storage dispatch

### DIFF
--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -32,7 +32,7 @@ pub(in crate::blocks::admin) struct ColumnInfo {
 /// The name always originates from the backend's own table listing, so a
 /// build error here means an identifier the backend can't quote.
 async fn table_row_count(ctx: &dyn Context, name: &str) -> i64 {
-    match introspect::build_table_row_count(name, Backend::Sqlite) {
+    match introspect::build_table_row_count(name, crate::db_backend(ctx).await) {
         Ok(count_sql) => db::query_raw(ctx, &count_sql, &[])
             .await
             .ok()
@@ -55,7 +55,7 @@ async fn table_row_count(ctx: &dyn Context, name: &str) -> i64 {
 pub(in crate::blocks::admin) async fn introspect_table_summaries(
     ctx: &dyn Context,
 ) -> Vec<TableSummary> {
-    let sql = introspect::build_list_tables(Backend::Sqlite);
+    let sql = introspect::build_list_tables(crate::db_backend(ctx).await);
     let records = db::query_raw(ctx, &sql, &[]).await.unwrap_or_default();
     let mut out = Vec::with_capacity(records.len());
     for r in &records {
@@ -83,7 +83,7 @@ pub(in crate::blocks::admin) async fn introspect_columns(
     ctx: &dyn Context,
     table: &str,
 ) -> (Vec<ColumnInfo>, i64) {
-    let columns = match introspect::build_table_info(table, Backend::Sqlite) {
+    let columns = match introspect::build_table_info(table, crate::db_backend(ctx).await) {
         Ok((info_sql, info_args)) => db::query_raw(ctx, &info_sql, &info_args)
             .await
             .unwrap_or_default(),
@@ -135,7 +135,8 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
 }
 
 async fn handle_info(ctx: &dyn Context) -> OutputStream {
-    let sql = introspect::build_list_tables(Backend::Sqlite);
+    let backend = crate::db_backend(ctx).await;
+    let sql = introspect::build_list_tables(backend);
     let tables = match db::query_raw(ctx, &sql, &[]).await {
         Ok(t) => t,
         Err(e) => return err_internal("Database error", e),
@@ -147,10 +148,19 @@ async fn handle_info(ctx: &dyn Context) -> OutputStream {
         .collect();
 
     ok_json(&serde_json::json!({
-        "type": "sqlite",
+        "type": backend_name(backend),
         "tables": table_names,
         "table_count": table_names.len()
     }))
+}
+
+/// Lowercase dialect name for the JSON `type` field, matching the
+/// `SOLOBASE_SHARED__DATABASE__BACKEND` config var values.
+fn backend_name(backend: Backend) -> &'static str {
+    match backend {
+        Backend::Sqlite => "sqlite",
+        Backend::Postgres => "postgres",
+    }
 }
 
 async fn handle_tables(ctx: &dyn Context) -> OutputStream {
@@ -181,7 +191,7 @@ async fn handle_columns(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     // The table name is user input from the URL path; an invalid identifier
     // is a bad request, not a server error.
-    if introspect::build_table_info(table_name, Backend::Sqlite).is_err() {
+    if introspect::build_table_info(table_name, crate::db_backend(ctx).await).is_err() {
         return err_bad_request("Invalid table name");
     }
 

--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -4,7 +4,7 @@ use maud::html;
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
-use wafer_sql_utils::{aggregate, query, Backend};
+use wafer_sql_utils::{aggregate, query};
 
 use super::{admin_page, crumb};
 use crate::{
@@ -74,6 +74,7 @@ async fn daily_counts_30d(
 ) -> Vec<(String, i64)> {
     use chrono::Duration;
 
+    let backend = crate::db_backend(ctx).await;
     let today = chrono::Utc::now().date_naive();
     let start = today - Duration::days(29);
     let start_iso = format!("{start}T00:00:00");
@@ -85,7 +86,7 @@ async fn daily_counts_30d(
     }];
     filters.extend(extra_filters);
 
-    let rows = match aggregate::build_daily_count(table, "created_at", &filters, Backend::Sqlite) {
+    let rows = match aggregate::build_daily_count(table, "created_at", &filters, backend) {
         Ok(stmt) => db::query(ctx, &stmt).await.unwrap_or_default(),
         // `date_field` is the constant "created_at", so a build error is
         // unreachable here; fall back to an empty series defensively.
@@ -113,6 +114,12 @@ async fn daily_counts_30d(
 pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let config = SiteConfig::load(ctx).await;
     let user = UserInfo::from_message(msg);
+
+    // Resolve the dialect up front: the per-tile statements (and the `!Send`
+    // `sea_query::Cond` below) are built and held live across the
+    // `futures::join!` await, so the `db_backend` await must happen before
+    // any of them is constructed or the page future becomes `!Send`.
+    let backend = crate::db_backend(ctx).await;
 
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
     let today_start = format!("{today}T00:00:00");
@@ -144,7 +151,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 value: serde_json::json!(&today_start),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     let new_users_fut = db::query(ctx, &stmt_nu);
 
@@ -155,7 +162,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
             operator: FilterOp::GreaterEqual,
             value: serde_json::json!(&today_start),
         }],
-        Backend::Sqlite,
+        backend,
     );
     let requests_fut = db::query(ctx, &stmt_rq);
 
@@ -173,7 +180,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 value: serde_json::json!(&today_start),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     let errors_fut = db::query(ctx, &stmt_er);
 
@@ -185,7 +192,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
             operator: FilterOp::GreaterEqual,
             value: serde_json::json!(&today_start),
         }],
-        Backend::Sqlite,
+        backend,
     );
     let avg_ms_fut = db::query(ctx, &stmt_av);
 
@@ -206,7 +213,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
             ..Default::default()
         },
         None,
-        Backend::Sqlite,
+        backend,
     );
     let recent_users_fut = db::query(ctx, &stmt_ru);
 
@@ -225,7 +232,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
             ..Default::default()
         },
         Some(or_cond),
-        Backend::Sqlite,
+        backend,
     );
     let recent_errors_fut = db::query(ctx, &stmt_re);
 

--- a/crates/solobase-core/src/blocks/admin/pages/database.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/database.rs
@@ -51,10 +51,14 @@ impl Tab {
     }
 }
 
-fn backend_badge(table_count: usize) -> Markup {
+fn backend_badge(backend: wafer_sql_utils::Backend, table_count: usize) -> Markup {
+    let label = match backend {
+        wafer_sql_utils::Backend::Sqlite => "SQLite",
+        wafer_sql_utils::Backend::Postgres => "PostgreSQL",
+    };
     html! {
         span .badge .badge-info .text-xs title="Database backend" {
-            "SQLite · " (table_count) " tables"
+            (label) " · " (table_count) " tables"
         }
     }
 }
@@ -366,6 +370,7 @@ pub async fn database_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let user = UserInfo::from_message(msg);
 
     let tables = introspect_table_summaries(ctx).await;
+    let backend = crate::db_backend(ctx).await;
     let selected = msg.query("table");
     let tab = Tab::from_query(msg.query("tab"));
 
@@ -392,7 +397,7 @@ pub async fn database_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         user.as_ref(),
         Topbar {
             crumbs: crumb("Database"),
-            primary_action: Some(backend_badge(tables.len())),
+            primary_action: Some(backend_badge(backend, tables.len())),
             subtitle: Some("Browse tables, view schema, run read-only SQL"),
             show_palette: true,
         },

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -2,7 +2,7 @@ use maud::{html, Markup};
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
-use wafer_sql_utils::{query, Backend};
+use wafer_sql_utils::query;
 
 use crate::{
     blocks::{admin::REQUEST_LOGS_TABLE as REQUEST_LOGS, helpers::RecordExt},
@@ -43,6 +43,8 @@ async fn network_inbound_tab(ctx: &dyn Context, msg: &Message) -> Markup {
     };
 
     let search = msg.query("search").to_string();
+    // Resolve the dialect before building the `!Send` `GroupedQueryConfig`.
+    let backend = crate::db_backend(ctx).await;
 
     let filters = if search.is_empty() {
         vec![]
@@ -94,7 +96,7 @@ async fn network_inbound_tab(ctx: &dyn Context, msg: &Message) -> Markup {
             }],
             limit: Some(50),
         },
-        Backend::Sqlite,
+        backend,
     );
     let summary = db::query(ctx, &stmt).await.unwrap_or_default();
 
@@ -184,6 +186,7 @@ pub async fn network_inbound_detail(ctx: &dyn Context, msg: &Message) -> OutputS
     let path = msg.query("path").to_string();
     let offset: i64 = msg.query("offset").parse().unwrap_or(0);
     let limit: i64 = 20;
+    let backend = crate::db_backend(ctx).await;
 
     let stmt = query::build_select_columns(
         REQUEST_LOGS,
@@ -216,7 +219,7 @@ pub async fn network_inbound_detail(ctx: &dyn Context, msg: &Message) -> OutputS
             ..Default::default()
         },
         None,
-        Backend::Sqlite,
+        backend,
     );
     let rows = db::query(ctx, &stmt).await.unwrap_or_default();
 

--- a/crates/solobase-core/src/blocks/admin/pages/storage.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/storage.rs
@@ -2,7 +2,7 @@ use maud::{html, Markup};
 use wafer_block::db::{ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
-use wafer_sql_utils::{query, Backend};
+use wafer_sql_utils::query;
 
 use super::{admin_page, crumb};
 use crate::{
@@ -69,6 +69,7 @@ pub async fn storage_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn storage_logs_tab(ctx: &dyn Context, _msg: &Message) -> Markup {
+    let backend = crate::db_backend(ctx).await;
     let stmt = query::build_select_columns(
         STORAGE_ACCESS_LOGS,
         &["source_block", "operation", "path", "status", "created_at"],
@@ -81,7 +82,7 @@ async fn storage_logs_tab(ctx: &dyn Context, _msg: &Message) -> Markup {
             ..Default::default()
         },
         None,
-        Backend::Sqlite,
+        backend,
     );
     let logs = db::query(ctx, &stmt).await.unwrap_or_default();
 

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -108,8 +108,10 @@ async fn users_tab(ctx: &dyn Context, msg: &Message, current_user_id: &str) -> M
         // `build_select_with_condition` rather than the flat-filters
         // `db::paginated_list` typed client.
         use sea_query::{Cond, Expr};
-        use wafer_sql_utils::{ident::DynCol, query, Backend};
+        use wafer_sql_utils::{ident::DynCol, query};
 
+        // Resolve the dialect before building the `!Send` `Cond`.
+        let backend = crate::db_backend(ctx).await;
         let like = format!("%{search}%");
         let offset = ((page - 1) * page_size) as i64;
         let or_group = Cond::any()
@@ -133,7 +135,7 @@ async fn users_tab(ctx: &dyn Context, msg: &Message, current_user_id: &str) -> M
                 ..Default::default()
             },
             Some(or_group),
-            Backend::Sqlite,
+            backend,
         );
         let records = db::query(ctx, &stmt).await;
         // Wrap in RecordList format. total_count is the in-page count here;

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -17,7 +17,7 @@ pub mod block_settings {
     use wafer_block::db::{Filter, FilterOp, ListOptions};
     use wafer_core::clients::database as db;
     use wafer_run::context::Context;
-    use wafer_sql_utils::{query, Backend};
+    use wafer_sql_utils::query;
 
     use super::BLOCK_SETTINGS_TABLE as TABLE;
 
@@ -26,6 +26,7 @@ pub mod block_settings {
     /// Reads the `enabled` column from [`BLOCK_SETTINGS_TABLE`]. Defaults to
     /// `true` when no row exists (all blocks are enabled by default).
     pub async fn is_enabled(ctx: &dyn Context, block_name: &str) -> bool {
+        let backend = crate::db_backend(ctx).await;
         let stmt = query::build_select_columns(
             TABLE,
             &["enabled"],
@@ -38,7 +39,7 @@ pub mod block_settings {
                 ..Default::default()
             },
             None,
-            Backend::Sqlite,
+            backend,
         );
         db::query(ctx, &stmt)
             .await

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -120,9 +120,8 @@ pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<Buck
     use std::collections::HashMap;
 
     use wafer_block::db::{Filter, FilterOp, SortField};
-    use wafer_sql_utils::{
-        aggregate::{build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig},
-        Backend,
+    use wafer_sql_utils::aggregate::{
+        build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig,
     };
 
     use super::{BUCKETS_TABLE, OBJECTS_TABLE};
@@ -148,6 +147,9 @@ pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<Buck
             Vec::new()
         }
     };
+
+    // Resolve the dialect before constructing the `!Send` `GroupedQueryConfig`.
+    let backend = crate::db_backend(ctx).await;
 
     // Build a list of bucket names this user owns; restrict the GROUP BY
     // to those buckets so the count matches the previous per-bucket
@@ -177,7 +179,7 @@ pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<Buck
         order_by: vec![],
         limit: None,
     };
-    let stmt = build_grouped_query(counts_cfg, Backend::Sqlite);
+    let stmt = build_grouped_query(counts_cfg, backend);
     let counts_by_bucket: HashMap<String, i64> = match db::query(ctx, &stmt).await {
         Ok(rows) => rows
             .into_iter()

--- a/crates/solobase-core/src/blocks/products/repo/purchases.rs
+++ b/crates/solobase-core/src/blocks/products/repo/purchases.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database::{self as db, Record, RecordList};
 use wafer_run::{context::Context, WaferError};
-use wafer_sql_utils::Backend;
 
 /// Purchase header table — one row per checkout / order.
 pub(crate) const PURCHASES_TABLE: &str = "suppers_ai__products__purchases";
@@ -88,6 +87,7 @@ pub(crate) async fn complete_atomic(
     payment_intent: &str,
 ) -> Result<i64, WaferError> {
     let now = chrono::Utc::now().to_rfc3339();
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         PURCHASES_TABLE,
         &[
@@ -111,7 +111,7 @@ pub(crate) async fn complete_atomic(
                 value: serde_json::json!(["checkout_started", "pending"]),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -122,6 +122,7 @@ pub(crate) async fn claim_for_checkout(
     ctx: &dyn Context,
     purchase_id: &str,
 ) -> Result<i64, WaferError> {
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         PURCHASES_TABLE,
         &[
@@ -143,7 +144,7 @@ pub(crate) async fn claim_for_checkout(
                 value: serde_json::json!("pending"),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -154,6 +155,7 @@ pub(crate) async fn revert_checkout_claim(
     ctx: &dyn Context,
     purchase_id: &str,
 ) -> Result<i64, WaferError> {
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         PURCHASES_TABLE,
         &[
@@ -175,7 +177,7 @@ pub(crate) async fn revert_checkout_claim(
                 value: serde_json::json!("checkout_started"),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -189,6 +191,7 @@ pub(crate) async fn refund_atomic(
     reason: &str,
 ) -> Result<i64, WaferError> {
     let now = chrono::Utc::now().to_rfc3339();
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         PURCHASES_TABLE,
         &[
@@ -210,7 +213,7 @@ pub(crate) async fn refund_atomic(
                 value: serde_json::json!("completed"),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -260,12 +263,13 @@ pub(crate) async fn line_item_product_ids(
         limit: 1,
         ..Default::default()
     };
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_select_columns(
         LINE_ITEMS_TABLE,
         &["product_id"],
         &opts,
         None,
-        Backend::Sqlite,
+        backend,
     );
     db::query(ctx, &stmt).await
 }
@@ -310,12 +314,13 @@ pub(crate) async fn completed_purchase_ids(
         ],
         ..Default::default()
     };
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_select_columns(
         PURCHASES_TABLE,
         &["id"],
         &opts,
         None,
-        Backend::Sqlite,
+        backend,
     );
     db::query(ctx, &stmt).await
 }
@@ -345,12 +350,13 @@ pub(crate) async fn line_item_exists_for_product(
         limit: 1,
         ..Default::default()
     };
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_select_columns(
         LINE_ITEMS_TABLE,
         &["id"],
         &opts,
         None,
-        Backend::Sqlite,
+        backend,
     );
     matches!(db::query(ctx, &stmt).await, Ok(rows) if !rows.is_empty())
 }

--- a/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
+++ b/crates/solobase-core/src/blocks/products/repo/subscriptions.rs
@@ -3,9 +3,8 @@
 use wafer_block::db::{Filter, FilterOp, ListOptions};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, WaferError};
-use wafer_sql_utils::{
-    aggregate::{build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig},
-    Backend,
+use wafer_sql_utils::aggregate::{
+    build_grouped_query, AggFunc, AggregateColumn, GroupedQueryConfig,
 };
 
 /// Platform-billing subscription table — one row per user.
@@ -24,6 +23,7 @@ pub(crate) async fn upsert_platform(
 ) -> Result<i64, WaferError> {
     let now = chrono::Utc::now().to_rfc3339();
     let sub_id = format!("sub_{user_id}");
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::upsert::build_upsert(
         SUBSCRIPTIONS_TABLE,
         &[
@@ -50,7 +50,7 @@ pub(crate) async fn upsert_platform(
             "status",
             "updated_at",
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -71,6 +71,7 @@ pub(crate) async fn update_status_plan(
     if let Some(plan) = plan {
         data.push(("plan".to_string(), serde_json::json!(plan)));
     }
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         SUBSCRIPTIONS_TABLE,
         &data,
@@ -79,7 +80,7 @@ pub(crate) async fn update_status_plan(
             operator: FilterOp::Equal,
             value: serde_json::json!(stripe_subscription_id),
         }],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -93,6 +94,7 @@ pub(crate) async fn mark_past_due(
     let now = chrono::Utc::now();
     let grace_end = (now + chrono::Duration::days(7)).to_rfc3339();
     let now = now.to_rfc3339();
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         SUBSCRIPTIONS_TABLE,
         &[
@@ -108,7 +110,7 @@ pub(crate) async fn mark_past_due(
             operator: FilterOp::Equal,
             value: serde_json::json!(stripe_subscription_id),
         }],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -120,6 +122,7 @@ pub(crate) async fn cancel_and_reset_addons(
     stripe_subscription_id: &str,
 ) -> Result<i64, WaferError> {
     let now = chrono::Utc::now().to_rfc3339();
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         SUBSCRIPTIONS_TABLE,
         &[
@@ -135,7 +138,7 @@ pub(crate) async fn cancel_and_reset_addons(
             operator: FilterOp::Equal,
             value: serde_json::json!(stripe_subscription_id),
         }],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -152,6 +155,7 @@ pub(crate) async fn set_addon_totals(
     d1_bytes: i64,
 ) -> Result<i64, WaferError> {
     let now = chrono::Utc::now().to_rfc3339();
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_update_where(
         SUBSCRIPTIONS_TABLE,
         &[
@@ -173,7 +177,7 @@ pub(crate) async fn set_addon_totals(
                 value: serde_json::json!("active"),
             },
         ],
-        Backend::Sqlite,
+        backend,
     );
     db::execute(ctx, &stmt).await
 }
@@ -193,12 +197,13 @@ pub(crate) async fn find_user_by_stripe_sub(
         limit: 1,
         ..Default::default()
     };
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_select_columns(
         SUBSCRIPTIONS_TABLE,
         &["user_id"],
         &opts,
         None,
-        Backend::Sqlite,
+        backend,
     );
     let rows = db::query(ctx, &stmt).await.ok()?;
     rows.first()?
@@ -231,12 +236,13 @@ pub(crate) async fn active_plan_exists(ctx: &dyn Context, user_id: &str, plan: &
         limit: 1,
         ..Default::default()
     };
+    let backend = crate::db_backend(ctx).await;
     let stmt = wafer_sql_utils::query::build_select_columns(
         SUBSCRIPTIONS_TABLE,
         &["id"],
         &opts,
         None,
-        Backend::Sqlite,
+        backend,
     );
     matches!(db::query(ctx, &stmt).await, Ok(rows) if !rows.is_empty())
 }
@@ -248,6 +254,10 @@ pub(crate) async fn subscription_for_user(
     ctx: &dyn Context,
     user_id: &str,
 ) -> Option<serde_json::Value> {
+    // Resolve the dialect before constructing the `!Send` `GroupedQueryConfig`
+    // so this future stays `Send` (the config holds `Rc<dyn Iden>` and must
+    // not be live across the `db_backend` await).
+    let backend = crate::db_backend(ctx).await;
     let coalesced = |alias: &str, field: &str| AggregateColumn {
         func: AggFunc::Coalesce(serde_json::json!(0)),
         field: Some(field.into()),
@@ -281,7 +291,7 @@ pub(crate) async fn subscription_for_user(
         order_by: vec![],
         limit: Some(1),
     };
-    let stmt = build_grouped_query(cfg, Backend::Sqlite);
+    let stmt = build_grouped_query(cfg, backend);
     match db::query(ctx, &stmt).await {
         Ok(records) if !records.is_empty() => serde_json::to_value(&records[0].data).ok(),
         _ => None,

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -46,7 +46,7 @@ use wafer_core::{
     interfaces::vector::{get_model, DEFAULT_MODEL},
 };
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream, WaferError};
-use wafer_sql_utils::{introspect, query, upsert, Backend};
+use wafer_sql_utils::{introspect, query, upsert};
 
 use super::{
     ingestion::{self, DEFAULT_CHUNK_TOKENS, DEFAULT_OVERLAP_RATIO},
@@ -188,6 +188,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
     // The registry table itself is owned by the block's
     // `migrations/001_vector_schema.*.sql` script (run at block Init via
     // `apply_if_blessed`), so no inline CREATE TABLE is required here.
+    let backend = crate::db_backend(ctx).await;
     let stmt = upsert::build_upsert(
         REGISTRY_TABLE,
         &[
@@ -201,7 +202,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
         ],
         &["prefixed_name"],
         &["model", "dimensions", "keyword_search"],
-        Backend::Sqlite,
+        backend,
     );
     if let Err(e) = db::execute(ctx, &stmt).await {
         return err_internal("registry write failed", e);
@@ -255,7 +256,8 @@ async fn discover_indexes(ctx: &dyn Context) -> Result<Vec<String>, WaferError> 
     // The builder pattern is `prefix%`; we want `prefix%_meta`. Filter the
     // suffix in Rust after the prefix scan rather than adding a new builder
     // overload — cheap because the table count is tiny (one row per index).
-    let (sql, args) = introspect::build_list_tables_like(TABLE_PREFIX, Backend::Sqlite);
+    let (sql, args) =
+        introspect::build_list_tables_like(TABLE_PREFIX, crate::db_backend(ctx).await);
     let rows = db::query_raw(ctx, &sql, &args).await?;
 
     let mut indexes: Vec<String> = Vec::with_capacity(rows.len());
@@ -292,6 +294,7 @@ async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
             // (pre-registry deployment) is not a failure, so we only surface
             // errors that aren't about the table itself. The row-level
             // `OR REPLACE` in create_index makes this robustly idempotent.
+            let backend = crate::db_backend(ctx).await;
             let stmt = query::build_delete_where(
                 REGISTRY_TABLE,
                 &[Filter {
@@ -299,7 +302,7 @@ async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
                     operator: FilterOp::Equal,
                     value: serde_json::json!(prefixed),
                 }],
-                Backend::Sqlite,
+                backend,
             );
             let _ = db::execute(ctx, &stmt).await;
             ok_json(&serde_json::json!({ "ok": true }))
@@ -555,6 +558,7 @@ async fn load_index_metadata(
 ) -> Result<(String, bool), WaferError> {
     // First try the registry. An error here (e.g. the table doesn't exist)
     // is treated as "no row", not fatal — we fall through to the scan.
+    let backend = crate::db_backend(ctx).await;
     let stmt = query::build_select_columns(
         REGISTRY_TABLE,
         &["model", "keyword_search"],
@@ -568,7 +572,7 @@ async fn load_index_metadata(
             ..Default::default()
         },
         None,
-        Backend::Sqlite,
+        backend,
     );
     let rows = db::query(ctx, &stmt).await;
 

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -8,7 +8,7 @@
 use wafer_block::db::SortField;
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, WaferError};
-use wafer_sql_utils::{introspect, Backend};
+use wafer_sql_utils::introspect;
 
 use crate::blocks::helpers::RecordExt;
 
@@ -202,7 +202,7 @@ pub async fn introspect_columns(
     ctx: &dyn Context,
     table: &str,
 ) -> Result<Vec<(String, String)>, WaferError> {
-    let (sql, args) = introspect::build_table_info(table, Backend::Sqlite)
+    let (sql, args) = introspect::build_table_info(table, crate::db_backend(ctx).await)
         .map_err(|e| WaferError::new(ErrorCode::InvalidArgument, e.to_string()))?;
     let rows = db::query_raw(ctx, &sql, &args).await?;
     Ok(rows

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -25,5 +25,6 @@ pub mod ui;
 pub mod test_support;
 
 pub use features::FeatureConfig;
+pub use migration_helper::db_backend;
 pub use pipeline::handle_request;
 pub use routing::{ExtraRoute, RouteAccess};

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -18,6 +18,7 @@
 use sha2::{Digest, Sha256};
 use wafer_core::clients::{config, database as db};
 use wafer_run::context::Context;
+use wafer_sql_utils::Backend;
 
 use crate::features::{BlockSettings, MigrationState, BLOCK_SETTINGS_CONFIG_KEY};
 // NOTE: `BlockSettings::state_for` parses only the requested block's entry
@@ -27,6 +28,41 @@ use crate::features::{BlockSettings, MigrationState, BLOCK_SETTINGS_CONFIG_KEY};
 /// Env-var name set by `solobase --run-migrations` (native) or
 /// `deploy-cloudflare.sh deploy --run-migrations` (CF).
 pub const RUN_MIGRATIONS_KEY: &str = "SOLOBASE_RUN_MIGRATIONS";
+
+/// Shared config var that selects the SQL dialect. `"postgres"`
+/// (case-insensitive) picks the PostgreSQL dialect; anything else (including
+/// the unset default) picks SQLite. Read by both the migration dispatcher
+/// ([`apply_migrations`]) and the runtime query-builder helper
+/// ([`db_backend`]) so a deployment's migrations and its live queries always
+/// render against the same dialect.
+pub const DATABASE_BACKEND_KEY: &str = "SOLOBASE_SHARED__DATABASE__BACKEND";
+
+/// Resolve the active SQL [`Backend`] from the config snapshot.
+///
+/// Reads [`DATABASE_BACKEND_KEY`] (the same var [`apply_migrations`] uses to
+/// pick which `.sql` dialect files to run) and maps `"postgres"`
+/// (case-insensitive) to [`Backend::Postgres`], everything else to
+/// [`Backend::Sqlite`].
+///
+/// This is the single runtime source of truth for the query-builder dialect:
+/// every `wafer_sql_utils::{query,aggregate,introspect,upsert}` call site in
+/// a block passes the result of this helper rather than a hardcoded
+/// `Backend::Sqlite`, so a postgres deployment renders postgres-dialect SQL
+/// at runtime, matching the migrations it applied at boot.
+///
+/// Cheap to call per request: the value comes from the in-memory config
+/// snapshot via `config::get_default` (no DB hop), so call sites read it
+/// inline rather than threading a cached `Backend` through every signature.
+pub async fn db_backend(ctx: &dyn Context) -> Backend {
+    let backend = config::get_default(ctx, DATABASE_BACKEND_KEY, "sqlite")
+        .await
+        .to_ascii_lowercase();
+    if backend == "postgres" {
+        Backend::Postgres
+    } else {
+        Backend::Sqlite
+    }
+}
 
 /// Full table name for the block_settings collection. Hardcoded here to
 /// avoid a circular dep on `crate::blocks::admin`.
@@ -62,13 +98,9 @@ pub async fn apply_migrations(
     sqlite_files: &[&str],
     postgres_files: &[&str],
 ) -> Result<(), String> {
-    let backend = config::get_default(ctx, "SOLOBASE_SHARED__DATABASE__BACKEND", "sqlite")
-        .await
-        .to_ascii_lowercase();
-    let files = if backend == "postgres" {
-        postgres_files
-    } else {
-        sqlite_files
+    let files = match db_backend(ctx).await {
+        Backend::Postgres => postgres_files,
+        Backend::Sqlite => sqlite_files,
     };
     let sql = files.join("\n");
     apply_if_blessed(ctx, block_name, &sql).await

--- a/crates/solobase-native/src/database.rs
+++ b/crates/solobase-native/src/database.rs
@@ -1,13 +1,69 @@
 //! Database platform-service factories for native targets.
 //!
+//! - `make_database_service(db_type, db_path, db_url)` — dispatches on the
+//!   `SOLOBASE_DB_TYPE` value (`sqlite` | `postgres`).
 //! - `make_sqlite_database_service(path)` — wraps `wafer-block-sqlite`
 //!   `SQLiteDatabaseService`.
 //! - `make_postgres_database_service(url)` — feature-gated on `postgres`.
 
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use wafer_core::interfaces::database::service::DatabaseService;
+
+/// Construct the database service selected by `SOLOBASE_DB_TYPE`.
+///
+/// - `"sqlite"` (the default) opens a SQLite database at `db_path`.
+/// - `"postgres"` connects to `db_url` (`SOLOBASE_DB_URL`). Requires the
+///   `postgres` cargo feature; without it (or with no `db_url`) this is a
+///   hard boot error rather than a silent fallback to SQLite.
+/// - any other value is a hard error.
+///
+/// Centralises the `db_type` → factory dispatch so the boot path can't log
+/// `db = postgres` while silently running SQLite.
+///
+/// # Errors
+///
+/// Returns an error when the type is unknown, when `postgres` is requested
+/// but the feature is off / `db_url` is missing, or when the underlying
+/// factory fails.
+pub async fn make_database_service(
+    db_type: &str,
+    db_path: &str,
+    db_url: Option<&str>,
+) -> Result<Arc<dyn DatabaseService>> {
+    match db_type {
+        "sqlite" => make_sqlite_database_service(db_path),
+        "postgres" => make_postgres_database_service_dispatch(db_url).await,
+        other => Err(anyhow!(
+            "unsupported SOLOBASE_DB_TYPE `{other}` (expected `sqlite` or `postgres`)"
+        )),
+    }
+}
+
+/// Postgres branch of [`make_database_service`], split out so the
+/// feature-gate + missing-url error live in one place.
+#[cfg(feature = "postgres")]
+async fn make_postgres_database_service_dispatch(
+    db_url: Option<&str>,
+) -> Result<Arc<dyn DatabaseService>> {
+    let url = db_url
+        .ok_or_else(|| anyhow!("SOLOBASE_DB_TYPE=postgres requires SOLOBASE_DB_URL to be set"))?;
+    make_postgres_database_service(url).await
+}
+
+/// Feature-off branch: postgres was requested but the binary wasn't built
+/// with the `postgres` feature. Fail loudly instead of running SQLite.
+#[cfg(not(feature = "postgres"))]
+async fn make_postgres_database_service_dispatch(
+    _db_url: Option<&str>,
+) -> Result<Arc<dyn DatabaseService>> {
+    Err(anyhow!(
+        "SOLOBASE_DB_TYPE=postgres but this binary was built without the \
+         `postgres` feature; rebuild with `--features solobase-native/postgres` \
+         (or set SOLOBASE_DB_TYPE=sqlite)"
+    ))
+}
 
 /// Open a SQLite database at `path` and wrap it in `Arc<dyn DatabaseService>`.
 ///

--- a/crates/solobase-native/src/lib.rs
+++ b/crates/solobase-native/src/lib.rs
@@ -21,13 +21,13 @@ pub mod storage;
 pub use crypto::make_jwt_crypto_service;
 #[cfg(feature = "postgres")]
 pub use database::make_postgres_database_service;
-pub use database::make_sqlite_database_service;
+pub use database::{make_database_service, make_sqlite_database_service};
 pub use env::{collect_app_env_vars, load_dotenv, InfraConfig};
 pub use hooks::register_observability_hooks;
 pub use log_init::init_tracing;
 pub use logger::make_tracing_logger;
 pub use network::make_fetch_network_service;
 pub use serve::{register_http_listener, serve_until_shutdown};
-pub use storage::make_local_storage_service;
+pub use storage::{make_local_storage_service, make_storage_service};
 #[cfg(feature = "s3")]
 pub use storage::{make_s3_storage_service, S3Config};

--- a/crates/solobase-native/src/storage.rs
+++ b/crates/solobase-native/src/storage.rs
@@ -2,8 +2,66 @@
 
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use wafer_core::interfaces::storage::service::StorageService;
+
+/// Construct the storage service selected by `SOLOBASE_STORAGE_TYPE`.
+///
+/// - `"local"` (the default) roots a local-filesystem store at
+///   `storage_root` (`SOLOBASE_STORAGE_ROOT`).
+/// - `"s3"` builds an S3-compatible store from the `SOLOBASE_S3_*` env vars
+///   (`BUCKET` required; `PREFIX`/`ENDPOINT`/`REGION` optional). Requires the
+///   `s3` cargo feature; without it this is a hard boot error rather than a
+///   silent fallback to local disk.
+/// - any other value is a hard error.
+///
+/// Centralises the `storage_type` → factory dispatch so the boot path can't
+/// log `storage = s3` while silently writing to local disk.
+///
+/// # Errors
+///
+/// Returns an error when the type is unknown, when `s3` is requested but the
+/// feature is off / `SOLOBASE_S3_BUCKET` is missing, or when the underlying
+/// factory fails.
+pub async fn make_storage_service(
+    storage_type: &str,
+    storage_root: &str,
+) -> Result<Arc<dyn StorageService>> {
+    match storage_type {
+        "local" => make_local_storage_service(storage_root),
+        "s3" => make_s3_storage_service_dispatch().await,
+        other => Err(anyhow!(
+            "unsupported SOLOBASE_STORAGE_TYPE `{other}` (expected `local` or `s3`)"
+        )),
+    }
+}
+
+/// S3 branch of [`make_storage_service`], split out so the feature-gate +
+/// env-var sourcing live in one place. Reads `SOLOBASE_S3_BUCKET` (required),
+/// `SOLOBASE_S3_PREFIX`, `SOLOBASE_S3_ENDPOINT`, and `SOLOBASE_S3_REGION`.
+#[cfg(feature = "s3")]
+async fn make_s3_storage_service_dispatch() -> Result<Arc<dyn StorageService>> {
+    let bucket = std::env::var("SOLOBASE_S3_BUCKET")
+        .map_err(|_| anyhow!("SOLOBASE_STORAGE_TYPE=s3 requires SOLOBASE_S3_BUCKET to be set"))?;
+    let config = S3Config {
+        bucket,
+        prefix: std::env::var("SOLOBASE_S3_PREFIX").unwrap_or_default(),
+        endpoint: std::env::var("SOLOBASE_S3_ENDPOINT").ok(),
+        region: std::env::var("SOLOBASE_S3_REGION").ok(),
+    };
+    make_s3_storage_service(config).await
+}
+
+/// Feature-off branch: s3 was requested but the binary wasn't built with the
+/// `s3` feature. Fail loudly instead of writing to local disk.
+#[cfg(not(feature = "s3"))]
+async fn make_s3_storage_service_dispatch() -> Result<Arc<dyn StorageService>> {
+    Err(anyhow!(
+        "SOLOBASE_STORAGE_TYPE=s3 but this binary was built without the `s3` \
+         feature; rebuild with `--features solobase-native/s3` (or set \
+         SOLOBASE_STORAGE_TYPE=local)"
+    ))
+}
 
 /// Initialise a local-filesystem storage service rooted at `root`.
 ///

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -111,13 +111,25 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
         );
     }
 
+    // Dispatch on the infra config: `SOLOBASE_DB_TYPE` (sqlite|postgres) and
+    // `SOLOBASE_STORAGE_TYPE` (local|s3) select the platform service. An
+    // unsupported value, or a type whose cargo feature is off, is a hard boot
+    // error — the boot path no longer logs `db = postgres` / `storage = s3`
+    // while silently running SQLite / local disk.
+    let database = solobase_native::make_database_service(
+        &infra.db_type,
+        &infra.db_path,
+        infra.db_url.as_deref(),
+    )
+    .await
+    .context("construct database service")?;
+    let storage = solobase_native::make_storage_service(&infra.storage_type, &infra.storage_root)
+        .await
+        .context("construct storage service")?;
+
     let (mut wafer, storage_block) = SolobaseBuilder::new()
-        .database(solobase_native::make_sqlite_database_service(
-            &infra.db_path,
-        )?)
-        .storage(solobase_native::make_local_storage_service(
-            &infra.storage_root,
-        )?)
+        .database(database)
+        .storage(storage)
         .config(Arc::new(config_service))
         .config_source(Arc::new(wafer_run::StaticConfigSource::new(vars.clone())))
         .crypto(solobase_native::make_jwt_crypto_service(jwt_secret)?)


### PR DESCRIPTION
WIP — S2-O db-backend-selection (phase 2, Wave 2). Decision 2 = THREAD the backend.

Threads the SQL dialect that `migration_helper` already detects through every runtime query-builder call site (replacing hardcoded `Backend::Sqlite`), and wires the native db/storage factory dispatch so `SOLOBASE_DB_TYPE=postgres` / `SOLOBASE_STORAGE_TYPE=s3` actually select the right service instead of silently running SQLite/local.

NOTE: there is no postgres CI job. This is type-level threading only — it does NOT claim postgres runtime correctness, it just stops the half-claim where migrations dispatch on the backend but live queries hardcoded SQLite.

## Findings checklist
- [ ] (1) add `solobase_core::db_backend(ctx) -> Backend` helper (config read of `SOLOBASE_SHARED__DATABASE__BACKEND`), refactor `apply_migrations` onto it
- [ ] [medium] Backend::Sqlite hardcoded at admin query-builder call sites + `pages/database.rs backend_badge` hardcode
- [ ] [medium] Backend::Sqlite hardcoded at 15 products repo call sites (purchases.rs, subscriptions.rs)
- [ ] [low] `files/pages_user.rs` bucket-count `build_grouped_query` hardcode
- [ ] vector block Backend::Sqlite sites (pages.rs, service.rs) + rate_limit.rs
- [ ] [medium/dead-code] wire native dispatch in `cli/server.rs` on `InfraConfig db_type/storage_type` (error when feature off); postgres/s3 factories feature-gated

## Verification
Pending — see final body.

## Coordination
- Shares `migration_helper.rs` with S2-N and admin/products/files files with S2-M/S2-N — staying strictly in backend-selection scope (only `Backend::Sqlite` → `db_backend(ctx)` swaps + the helper + the native dispatch block).
- `cli/server.rs` factory-dispatch block only; S3-R owns the rest of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)