### PR TITLE
fix(S2-K): helpers-encoding — re-export wafer_block hash/hex, collapse percent-coding onto url crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4694,6 +4694,7 @@ dependencies = [
  "hex",
  "js-sys",
  "maud",
+ "percent-encoding",
  "pulldown-cmark",
  "reqwest",
  "rusqlite",

--- a/crates/solobase-core/Cargo.toml
+++ b/crates/solobase-core/Cargo.toml
@@ -179,8 +179,11 @@ tokio-stream = { version = "0.1", optional = true }
 # on wasm32 which conflicts with `worker`'s `wasm-streams 0.5`.
 reqwest = { workspace = true, optional = true }
 
-# URL parsing/building for OAuth authorize_url assembly.
+# URL parsing/building for OAuth authorize_url assembly + form-body encode/
+# decode (`url::form_urlencoded`). `percent-encoding` (url's own dependency)
+# drives `url_path_encode`'s RFC-3986 path-segment AsciiSet.
 url = "2"
+percent-encoding = "2"
 
 # Markdown → HTML renderer for the legalpages block. Replaces the
 # ammonia HTML-sanitizer pipeline. Optional + gated under

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -17,7 +17,7 @@ use wafer_run::{
 };
 
 use super::rate_limit::{RateLimit, UserRateLimiter};
-use crate::blocks::helpers::{err_bad_request, err_not_found, form_url_encode, ok_json};
+use crate::blocks::helpers::{err_bad_request, err_not_found, ok_json, urlencode};
 
 /// Default per-caller rate limit: 100 emails per hour.
 const DEFAULT_RATE_LIMIT_MAX: u32 = 100;
@@ -234,11 +234,7 @@ async fn handle_send_template(
     let (subject, html, text) = match req.template.as_str() {
         "verification" => {
             let token = req.token.as_deref().unwrap_or("");
-            let url = format!(
-                "{}/b/auth/api/verify?token={}",
-                base_url,
-                form_url_encode(token)
-            );
+            let url = format!("{}/b/auth/api/verify?token={}", base_url, urlencode(token));
             (
                 format!("Verify your {app_name} email"),
                 email_shell(
@@ -256,7 +252,7 @@ async fn handle_send_template(
             let url = format!(
                 "{}/b/auth/reset-password?token={}",
                 base_url,
-                form_url_encode(token)
+                urlencode(token)
             );
             (
                 format!("Reset your {app_name} password"),
@@ -394,17 +390,17 @@ async fn send_email(
 
     // Build form-encoded body
     let mut parts = vec![
-        format!("from={}", form_url_encode(&from)),
-        format!("to={}", form_url_encode(to)),
-        format!("subject={}", form_url_encode(subject)),
-        format!("html={}", form_url_encode(html)),
+        format!("from={}", urlencode(&from)),
+        format!("to={}", urlencode(to)),
+        format!("subject={}", urlencode(subject)),
+        format!("html={}", urlencode(html)),
     ];
     let reply_to = config::get_default(ctx, "SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO", "").await;
     if !reply_to.is_empty() {
-        parts.push(format!("h:Reply-To={}", form_url_encode(&reply_to)));
+        parts.push(format!("h:Reply-To={}", urlencode(&reply_to)));
     }
     if let Some(text) = text {
-        parts.push(format!("text={}", form_url_encode(text)));
+        parts.push(format!("text={}", urlencode(text)));
     }
     let body = parts.join("&");
 

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use wafer_core::clients::database::Record;
 use wafer_run::{
     ErrorCode, MetaEntry, OutputStream, WaferError, META_RESP_CONTENT_TYPE,
     META_RESP_COOKIE_PREFIX, META_RESP_HEADER_PREFIX, META_RESP_STATUS,
 };
+
+/// Hashing/hex helpers re-exported from `wafer_block` (the single canonical
+/// implementation). Re-exported here so the many `helpers::{hex_encode,
+/// sha256, sha256_hex}` call sites across the blocks keep one import path.
+pub use wafer_run::{hex_encode, sha256, sha256_hex};
 
 /// Current UTC time as RFC 3339 string.
 pub fn now_rfc3339() -> String {
@@ -114,19 +118,6 @@ pub fn stamp_updated(data: &mut std::collections::HashMap<String, serde_json::Va
     );
 }
 
-/// Encode bytes as lowercase hex string.
-pub fn hex_encode(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        // SAFETY: writing to a String via fmt::Write never fails (the only
-        // error variant in fmt::Error is for formatter errors that String
-        // doesn't surface).
-        let _ = write!(s, "{:02x}", b);
-    }
-    s
-}
-
 /// Check if the current user has admin role from the message metadata.
 pub fn is_admin(msg: &wafer_run::Message) -> bool {
     msg.get_meta("auth.user_roles")
@@ -170,18 +161,6 @@ pub fn forward_auth_meta(msg: &mut wafer_run::Message, original: &wafer_run::Mes
             msg.set_meta(key, value);
         }
     }
-}
-
-/// Compute SHA-256 and return as hex string. Used for deterministic hashing (API keys, etc.).
-pub fn sha256_hex(data: &[u8]) -> String {
-    hex_encode(&sha256(data))
-}
-
-/// Compute SHA-256 hash.
-pub fn sha256(data: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hasher.finalize().into()
 }
 
 /// Percent-encode a string for use as a URL path segment. Encodes everything

--- a/crates/solobase-core/src/blocks/helpers.rs
+++ b/crates/solobase-core/src/blocks/helpers.rs
@@ -2,15 +2,14 @@ use std::collections::HashMap;
 
 use serde::Serialize;
 use wafer_core::clients::database::Record;
-use wafer_run::{
-    ErrorCode, MetaEntry, OutputStream, WaferError, META_RESP_CONTENT_TYPE,
-    META_RESP_COOKIE_PREFIX, META_RESP_HEADER_PREFIX, META_RESP_STATUS,
-};
-
 /// Hashing/hex helpers re-exported from `wafer_block` (the single canonical
 /// implementation). Re-exported here so the many `helpers::{hex_encode,
 /// sha256, sha256_hex}` call sites across the blocks keep one import path.
 pub use wafer_run::{hex_encode, sha256, sha256_hex};
+use wafer_run::{
+    ErrorCode, MetaEntry, OutputStream, WaferError, META_RESP_CONTENT_TYPE,
+    META_RESP_COOKIE_PREFIX, META_RESP_HEADER_PREFIX, META_RESP_STATUS,
+};
 
 /// Current UTC time as RFC 3339 string.
 pub fn now_rfc3339() -> String {
@@ -163,84 +162,41 @@ pub fn forward_auth_meta(msg: &mut wafer_run::Message, original: &wafer_run::Mes
     }
 }
 
+/// The RFC 3986 unreserved characters (`A-Z a-z 0-9 - _ . ~`) — the only bytes
+/// [`url_path_encode`] leaves untouched. Built from `NON_ALPHANUMERIC` (which
+/// encodes every non-alphanumeric ASCII byte) by removing the four unreserved
+/// punctuation marks, so everything else (space → `%20`, `/` → `%2F`, …) is
+/// percent-encoded.
+const PATH_SEGMENT: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
 /// Percent-encode a string for use as a URL path segment. Encodes everything
 /// except RFC 3986 unreserved characters (`A-Z a-z 0-9 - _ . ~`). Spaces become
 /// `%20`, `/` becomes `%2F`, etc. Use this when constructing `<a href>` URLs
 /// from caller-supplied data (object keys, bucket names, etc.) — maud's HTML
 /// escaping does NOT URL-encode.
 pub fn url_path_encode(s: &str) -> String {
-    s.as_bytes()
-        .iter()
-        .map(|&b| match b {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                String::from(b as char)
-            }
-            _ => format!("%{:02X}", b),
-        })
-        .collect()
+    percent_encoding::utf8_percent_encode(s, PATH_SEGMENT).to_string()
 }
 
 /// Percent-encode a string for use as an OAuth / `application/x-www-form-urlencoded`
-/// query parameter. Delegates to [`url::form_urlencoded::byte_serialize`] which
-/// encodes spaces as `+` and everything outside the unreserved set as `%XX`.
-/// Prefer this over hand-rolling percent-encoding in OAuth / form-body contexts.
+/// query parameter or form-body value. Delegates to
+/// [`url::form_urlencoded::byte_serialize`] which encodes spaces as `+` and
+/// everything outside the unreserved set as `%XX`. This is the single form
+/// encoder — use it for OAuth params, HTTP form bodies, and any value placed in
+/// a query string (verification/reset links, Mailgun fields, …).
 pub fn urlencode(s: &str) -> String {
     url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }
 
-/// Percent-encode a string for use as an `application/x-www-form-urlencoded`
-/// value. Same alphabet as [`url_path_encode`] but spaces become `+` (per the
-/// form-encoding convention) rather than `%20`. Use this for HTTP form bodies
-/// and `multipart/form-data` field values.
-pub fn form_url_encode(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for &b in s.as_bytes() {
-        match b {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char);
-            }
-            b' ' => out.push('+'),
-            _ => {
-                use std::fmt::Write;
-                let _ = write!(out, "%{:02X}", b);
-            }
-        }
-    }
-    out
-}
-
-/// Decode a percent-encoded (URL-encoded) string.
-pub fn urlencoding_decode(s: &str) -> String {
-    let s = s.replace('+', " ");
-    let mut result = Vec::new();
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
-                result.push(byte);
-                i += 3;
-                continue;
-            }
-        }
-        result.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8_lossy(&result).into_owned()
-}
-
-/// Parse URL-encoded form body (htmx default) into a HashMap.
+/// Parse a URL-encoded form body (htmx default) into a HashMap. Thin wrapper
+/// over [`url::form_urlencoded::parse`], which handles `+`→space and `%XX`
+/// decoding. Repeated keys collapse to the last value (the existing behaviour).
 pub fn parse_form_body(data: &[u8]) -> HashMap<String, String> {
-    let body = String::from_utf8_lossy(data);
-    let mut map = HashMap::new();
-    for pair in body.split('&') {
-        if let Some((k, v)) = pair.split_once('=') {
-            let key = urlencoding_decode(k);
-            let value = urlencoding_decode(v);
-            map.insert(key, value);
-        }
-    }
-    map
+    url::form_urlencoded::parse(data).into_owned().collect()
 }
 
 /// Parse a request body as either JSON or URL-encoded form into a JSON Value.
@@ -494,13 +450,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn urlencoding_decode_plus_to_space() {
-        assert_eq!(urlencoding_decode("a+b"), "a b");
+    fn parse_form_body_decodes_plus_to_space() {
+        let parsed = parse_form_body(b"k=a+b");
+        assert_eq!(parsed.get("k"), Some(&"a b".to_string()));
     }
 
     #[test]
-    fn urlencoding_decode_percent() {
-        assert_eq!(urlencoding_decode("a%2Fb"), "a/b");
+    fn parse_form_body_decodes_percent_escapes() {
+        let parsed = parse_form_body(b"k=a%2Fb");
+        assert_eq!(parsed.get("k"), Some(&"a/b".to_string()));
+    }
+
+    #[test]
+    fn parse_form_body_multiple_pairs_and_decoded_keys() {
+        let parsed = parse_form_body(b"first+name=John+Doe&email=a%40b.com");
+        assert_eq!(parsed.get("first name"), Some(&"John Doe".to_string()));
+        assert_eq!(parsed.get("email"), Some(&"a@b.com".to_string()));
     }
 
     #[test]
@@ -533,15 +498,16 @@ mod tests {
     }
 
     #[test]
-    fn form_url_encode_uses_plus_for_space() {
-        assert_eq!(form_url_encode("hello world"), "hello+world");
-        assert_eq!(form_url_encode("a+b=c&d"), "a%2Bb%3Dc%26d");
-        assert_eq!(form_url_encode("a/b"), "a%2Fb");
-        assert_eq!(form_url_encode("café"), "caf%C3%A9");
-        // Round-trip via parse_form_body decodes '+' back to ' '.
-        let encoded = form_url_encode("hello world");
+    fn urlencode_form_value_round_trips_through_parse_form_body() {
+        // `urlencode` is the single form encoder (space → '+', reserved → %XX).
+        assert_eq!(urlencode("hello world"), "hello+world");
+        assert_eq!(urlencode("a+b=c&d"), "a%2Bb%3Dc%26d");
+        assert_eq!(urlencode("a/b"), "a%2Fb");
+        assert_eq!(urlencode("café"), "caf%C3%A9");
+        // Round-trip: encode → form body → parse decodes '+' back to ' '.
+        let encoded = urlencode("hello world & friends");
         let parsed = parse_form_body(format!("k={encoded}").as_bytes());
-        assert_eq!(parsed.get("k"), Some(&"hello world".to_string()));
+        assert_eq!(parsed.get("k"), Some(&"hello world & friends".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
S2-K helpers-encoding (phase 2, Wave 2). Consumer-side, second half of audit finding 152 (the wafer-run half shipped in #228). Producer prereqs (`wafer_block::http_codec`, `wafer_block` hash helpers) are merged in wafer-run main.

## Findings addressed (all VERIFIED)
- [x] **"solobase-core re-implements wafer-block's hash/hex helpers with copy-pasted doc comments"** — deleted `hex_encode`/`sha256`/`sha256_hex` bodies from `blocks/helpers.rs`; re-export `wafer_block::{hex_encode, sha256, sha256_hex}` via the `wafer_run` dep. All `helpers::{hex_encode,…}` call sites keep their import path. Dropped the now-unused `sha2` import from helpers.rs.
- [x] **"Hand-rolled percent-encoding/decoding in helpers.rs duplicated again in solobase-browser (audit finding 152)"** — `parse_form_body` is now a thin wrapper over `url::form_urlencoded::parse`; `url_path_encode` uses a `percent-encoding` AsciiSet (byte-identical output, pinned by `url_path_encode_basic`); deleted `urlencoding_decode` (no external callers). The browser-side copy was already removed by S1-A (#257) — see Decisions.
- [x] **"helpers.rs carries overlapping/hand-rolled encoding utilities alongside a url-crate dependency"** — collapsed the two form encoders onto one: kept `urlencode` (the `url::form_urlencoded::byte_serialize` delegate), deleted the hand-rolled `form_url_encode`, repointed its only call sites (email.rs / Mailgun) to `urlencode`.

## Decisions made
- **Form encoder: keep `urlencode`, delete `form_url_encode`** (the plan's "url-crate delegate" default). The two differ only on `~` (form_url_encode passed through, urlencode → `%7E`) and `*` (form_url_encode → `%2A`, urlencode passed through). I checked every call site: `form_url_encode` was used only in `email.rs` for the Mailgun form body and verification/reset link query params. **Neither Mailgun nor OAuth signs the encoded body bytes** — Mailgun authenticates with HTTP Basic (`Authorization: Basic`), OAuth sends `client_secret` in the body / Basic — so the alphabet difference is behavior-neutral: every receiver decodes back to the identical value. OAuth's `urlencode` sites (spec.rs/start.rs) were already on the delegate.
- **Browser `helpers.rs` NOT deleted.** The orchestrator asked to delete it iff zero callers. It is NOT zero-callers: S1-A (#257) already removed `urlencoding_decode` from it; the remaining `now_rfc3339()` is still called by `database.rs` (3 sites). `now_rfc3339` is a timestamp helper (not encoding/hash) with no shared home (solobase-browser deliberately does not depend on solobase-core), so it's out of S2-K's scope. The finding's browser half is fully resolved by S1-A.
- **`hex` + `sha2` deps NOT dropped** (plan said "drop if now unused"): both are still used elsewhere in solobase-core (`migration_helper.rs` `hex::encode` + `Sha256`, `oauth/start.rs`, `ui/assets.rs`). Only the helpers.rs `sha2` import was removed.
- Added `percent-encoding = "2"` as a direct dep (already in the tree transitively via `url`; resolves to the same 2.3.2 — Cargo.lock version unchanged).

## Local verification (CI-mirror)
- `cargo +nightly fmt --all -- --check` → clean
- `cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare` → clean
- `cargo clippy -p solobase-core` → clean (no new warnings; CI does not use `-D warnings`)
- `cargo test -p solobase-core` → all pass (747 + 53 + …). The `lockfile_loads_remote_block` e2e test fails **identically on the clean baseline 5c56eae** ("wafer-run compiled without 'wasmi' feature") — a pre-existing local-feature-resolution issue, unrelated to this change; CI builds with the wasmi feature.
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` → clean (percent-encoding + form_urlencoded compile on wasm32)
- `cargo check -p solobase-browser --target wasm32-unknown-unknown` → clean
- `scripts/grep-guard-html.sh` + `scripts/audit-wrap-grants.sh` → both pass

No block SQL / seed changes → no `SOLOBASE_RUN_MIGRATIONS=1` deploy requirement.

## Proposed wafer-run follow-up
None required for S2-K — the producer side (`wafer_block` hash helpers, `http_codec`) already shipped in #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
