### PR TITLE
fix(S2-M): ui-shared-machinery — settings_form + shell_page + data_table

### DIFF
--- a/crates/solobase-core/src/blocks/auth/config.rs
+++ b/crates/solobase-core/src/blocks/auth/config.rs
@@ -44,6 +44,14 @@ pub const PASSWORD_MIN_LENGTH_KEY: &str = "SOLOBASE_SHARED__AUTH__PASSWORD_MIN_L
 /// regular use never hits the natural-expiry path on every request.
 pub const ACCESS_TOKEN_LIFETIME_SECS_KEY: &str = "SUPPERS_AI__AUTH__ACCESS_TOKEN_LIFETIME_SECS";
 
+/// `SUPPERS_AI__AUTH__REQUIRE_VERIFICATION` — when `true`, users must verify
+/// their email before they can log in. Read by login/signup/refresh.
+pub const REQUIRE_VERIFICATION_KEY: &str = "SUPPERS_AI__AUTH__REQUIRE_VERIFICATION";
+
+/// `SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS` — comma-separated allowlist of
+/// signup email domains. Empty (the default) allows any domain.
+pub const ALLOWED_EMAIL_DOMAINS_KEY: &str = "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS";
+
 /// Default session lifetime when the config var is unset.
 pub const SESSION_LIFETIME_DAYS_DEFAULT: u32 = 30;
 
@@ -102,6 +110,33 @@ pub fn auth_config_vars() -> Vec<ConfigVar> {
             &ACCESS_TOKEN_LIFETIME_SECS_DEFAULT.to_string(),
         )
         .name("Access Token Lifetime (seconds)"),
+    ]
+}
+
+/// Block-scoped (`SUPPERS_AI__AUTH__*`) auth-identity config vars that the
+/// auth flows read directly via the config client (verification gate + signup
+/// domain allowlist). Declared here as [`ConfigVar`] metadata so the auth_ui
+/// admin settings page renders them through `ui::settings_form` instead of a
+/// hand-maintained tuple table. They are not contributed to a `BlockInfo`
+/// because there is no standalone `suppers-ai/auth` Block — `auth/` is a
+/// library module consumed by `auth_ui` — but they remain ConfigVar-declared
+/// in one place (no-hardcoded-lists rule).
+pub fn auth_identity_config_vars() -> Vec<ConfigVar> {
+    vec![
+        ConfigVar::new(
+            REQUIRE_VERIFICATION_KEY,
+            "Require users to verify their email before they can log in.",
+            "false",
+        )
+        .name("Require Email Verification")
+        .input_type(InputType::Toggle),
+        ConfigVar::new(
+            ALLOWED_EMAIL_DOMAINS_KEY,
+            "Restrict signup to specific email domains (comma-separated, e.g. \"company.com,org.com\"). Leave empty to allow all.",
+            "",
+        )
+        .name("Allowed Email Domains")
+        .input_type(InputType::Text),
     ]
 }
 

--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -90,6 +90,73 @@ const RATE_LIMIT_ROUTES: &[RouteLimit] = &[
     },
 ];
 
+/// The auth-ui block's own declared config vars (OAuth provider creds). Single
+/// source of truth for both `BlockInfo::config_keys` and the admin settings
+/// page (rendered via `ui::settings_form`, not a parallel tuple table).
+///
+/// OAuth provider creds live under the auth-ui prefix
+/// (`SUPPERS_AI__AUTH_UI__OAUTH_*`) to keep the prefix-equals-block-name
+/// invariant the runtime enforces (see `block_name_to_var_prefix`). The
+/// auth-identity vars JWT_SECRET / REQUIRE_VERIFICATION / ALLOWED_EMAIL_DOMAINS
+/// are `SUPPERS_AI__AUTH__*` and declared in `auth::config` instead.
+pub(crate) fn config_vars() -> Vec<ConfigVar> {
+    vec![
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_ID",
+            "Google OAuth client ID",
+            "",
+        )
+        .name("Google Client ID")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_SECRET",
+            "Google OAuth client secret",
+            "",
+        )
+        .name("Google Client Secret")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_ID",
+            "GitHub OAuth client ID",
+            "",
+        )
+        .name("GitHub Client ID")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_SECRET",
+            "GitHub OAuth client secret",
+            "",
+        )
+        .name("GitHub Client Secret")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_MICROSOFT_CLIENT_ID",
+            "Microsoft OAuth client ID",
+            "",
+        )
+        .name("Microsoft Client ID")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_MICROSOFT_CLIENT_SECRET",
+            "Microsoft OAuth client secret",
+            "",
+        )
+        .name("Microsoft Client Secret")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI",
+            "OAuth callback URL",
+            "",
+        )
+        .name("OAuth Redirect URI")
+        .input_type(InputType::Url)
+        .optional(),
+    ]
+}
+
 pub struct AuthUiBlock {
     limiter: UserRateLimiter,
 }
@@ -166,73 +233,7 @@ impl Block for AuthUiBlock {
             BlockEndpoint::get("/b/auth/bootstrap").summary("Bootstrap token redemption form"),
             BlockEndpoint::post("/b/auth/api/bootstrap").summary("Redeem bootstrap admin token"),
         ])
-        .config_keys({
-            // OAuth provider creds belong with the OAuth UI flows, so they
-            // live on auth-ui under the auth-ui prefix
-            // (`SUPPERS_AI__AUTH_UI__OAUTH_*`). The framework AuthBlock
-            // owns JWT_SECRET / REQUIRE_VERIFICATION / ALLOWED_EMAIL_DOMAINS
-            // / INTERNAL_SECRET — those are auth identity infra used by
-            // AuthServiceImpl, not UI, and currently aren't exposed as
-            // declared config_keys (wafer-run gap; vars still resolve via
-            // env). Renaming from the legacy `SUPPERS_AI__AUTH__OAUTH_*`
-            // keeps the prefix-equals-block-name invariant the runtime
-            // enforces (see `block_name_to_var_prefix` in wafer-run).
-            vec![
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_ID",
-                    "Google OAuth client ID",
-                    "",
-                )
-                .name("Google Client ID")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_SECRET",
-                    "Google OAuth client secret",
-                    "",
-                )
-                .name("Google Client Secret")
-                .input_type(InputType::Password)
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_ID",
-                    "GitHub OAuth client ID",
-                    "",
-                )
-                .name("GitHub Client ID")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_SECRET",
-                    "GitHub OAuth client secret",
-                    "",
-                )
-                .name("GitHub Client Secret")
-                .input_type(InputType::Password)
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_MICROSOFT_CLIENT_ID",
-                    "Microsoft OAuth client ID",
-                    "",
-                )
-                .name("Microsoft Client ID")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_MICROSOFT_CLIENT_SECRET",
-                    "Microsoft OAuth client secret",
-                    "",
-                )
-                .name("Microsoft Client Secret")
-                .input_type(InputType::Password)
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__AUTH_UI__OAUTH_REDIRECT_URI",
-                    "OAuth callback URL",
-                    "",
-                )
-                .name("OAuth Redirect URI")
-                .input_type(InputType::Url)
-                .optional(),
-            ]
-        })
+        .config_keys(config_vars())
         .admin_url("/b/auth/admin/settings")
     }
 

--- a/crates/solobase-core/src/blocks/auth_ui/pages/settings.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/settings.rs
@@ -1,280 +1,81 @@
-//! GET / POST /b/auth/admin/settings — relocated from auth/pages/mod.rs in Task 5.
+//! GET / POST /b/auth/admin/settings — the auth admin settings page, rendered
+//! through the shared `ui::settings_form` (ConfigVar-driven; no tuple table).
 
-use std::collections::HashMap;
-
-use maud::{html, Markup, PreEscaped};
-use wafer_core::clients::config;
+use maud::html;
 use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use crate::{
-    blocks::helpers::{err_bad_request, ok_json},
+    blocks::auth::config as auth_config,
+    config_vars,
     ui::{
-        self, components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
+        self, components, icons,
+        settings_form::{self, SettingsSection},
     },
 };
 
-/// (key, label, help_text, default, is_sensitive, input_type)
-const SETTINGS_KEYS: &[(&str, &str, &str, &str, bool, &str)] = &[
-    (
-        "SOLOBASE_SHARED__ALLOW_SIGNUP",
-        "Allow Signup",
-        "Allow new user registration.",
-        "true",
-        false,
-        "toggle",
-    ),
-    (
-        "SUPPERS_AI__AUTH__REQUIRE_VERIFICATION",
-        "Require Email Verification",
-        "Require users to verify their email before they can log in.",
-        "false",
-        false,
-        "toggle",
-    ),
-    (
-        "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS",
-        "Allowed Email Domains",
-        "Restrict signup to specific email domains (comma-separated, e.g. \"company.com,org.com\"). Leave empty to allow all.",
-        "",
-        false,
-        "text",
-    ),
-    (
-        "SOLOBASE_SHARED__POST_LOGIN_REDIRECT",
-        "Post-Login Redirect",
-        "Where to send users after successful login.",
-        "/b/admin/",
-        false,
-        "text",
-    ),
-    (
-        "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL",
-        "Bootstrap Admin Email",
-        "Email of the admin user created on first startup (bootstrap only).",
-        "",
-        false,
-        "text",
-    ),
-    (
-        "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_PASSWORD",
-        "Bootstrap Admin Password",
-        "Password for the bootstrap admin account (bootstrap only).",
-        "",
-        true,
-        "password",
-    ),
-    (
-        "SOLOBASE_SHARED__ENABLE_OAUTH",
-        "Enable OAuth",
-        "Enable OAuth login providers (Google, GitHub).",
-        "false",
-        false,
-        "toggle",
-    ),
-    (
-        "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_ID",
-        "Google Client ID",
-        "OAuth client ID from Google Cloud Console.",
-        "",
-        false,
-        "text",
-    ),
-    (
-        "SUPPERS_AI__AUTH_UI__OAUTH_GOOGLE_CLIENT_SECRET",
-        "Google Client Secret",
-        "OAuth client secret from Google Cloud Console.",
-        "",
-        true,
-        "password",
-    ),
-    (
-        "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_ID",
-        "GitHub Client ID",
-        "OAuth client ID from GitHub developer settings.",
-        "",
-        false,
-        "text",
-    ),
-    (
-        "SUPPERS_AI__AUTH_UI__OAUTH_GITHUB_CLIENT_SECRET",
-        "GitHub Client Secret",
-        "OAuth client secret from GitHub developer settings.",
-        "",
-        true,
-        "password",
-    ),
-];
+/// The config vars rendered on the auth settings page, grouped into the three
+/// on-page sections. Each var is pulled from its declared [`ConfigVar`] source
+/// — shared vars from `config_vars::shared_var`, the auth-identity vars from
+/// `auth::config::auth_identity_config_vars`, and the OAuth provider creds from
+/// the auth-ui block's own `config_vars()` — so nothing is re-declared here.
+struct Sections {
+    registration: Vec<wafer_run::ConfigVar>,
+    admin: Vec<wafer_run::ConfigVar>,
+    oauth: Vec<wafer_run::ConfigVar>,
+}
+
+fn sections() -> Sections {
+    let identity = auth_config::auth_identity_config_vars();
+    let oauth_creds = super::super::config_vars();
+
+    let mut oauth = vec![config_vars::shared_var("SOLOBASE_SHARED__ENABLE_OAUTH")];
+    oauth.extend(oauth_creds);
+
+    Sections {
+        registration: vec![
+            config_vars::shared_var("SOLOBASE_SHARED__ALLOW_SIGNUP"),
+            config_vars::var_in(&identity, auth_config::REQUIRE_VERIFICATION_KEY),
+            config_vars::var_in(&identity, auth_config::ALLOWED_EMAIL_DOMAINS_KEY),
+            config_vars::shared_var("SOLOBASE_SHARED__POST_LOGIN_REDIRECT"),
+        ],
+        admin: vec![
+            config_vars::shared_var(auth_config::BOOTSTRAP_ADMIN_EMAIL_KEY),
+            config_vars::shared_var(auth_config::BOOTSTRAP_ADMIN_PASSWORD_KEY),
+        ],
+        oauth,
+    }
+}
+
+impl Sections {
+    /// Flatten to a single save allowlist.
+    fn all(&self) -> Vec<wafer_run::ConfigVar> {
+        let mut v = self.registration.clone();
+        v.extend(self.admin.iter().cloned());
+        v.extend(self.oauth.iter().cloned());
+        v
+    }
+}
 
 pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
-    let mut values = Vec::new();
-    for &(key, label, help, default, sensitive, input_type) in SETTINGS_KEYS {
-        let value = config::get_default(ctx, key, default).await;
-        values.push((key, label, help, default, value, sensitive, input_type));
-    }
-
+    let s = sections();
+    let form_sections = [
+        SettingsSection::new("Registration", icons::users(), &s.registration),
+        SettingsSection::new("Admin", icons::shield(), &s.admin),
+        SettingsSection::new("OAuth Providers", icons::globe(), &s.oauth),
+    ];
     let content = html! {
         (components::page_header("Authentication Settings", Some("Configure registration, OAuth providers, and security"), None))
-
-        form #settings-form onsubmit="return submitSettings(event)" {
-            // Registration section
-            h3 style="font-size:1rem;font-weight:600;margin:0 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::users()) " Registration"
-            }
-            @for (key, label, help, default, ref value, _sensitive, input_type) in values.iter().take(4) {
-                (render_setting_field(key, label, help, default, value, input_type))
-            }
-
-            // Admin section
-            h3 style="font-size:1rem;font-weight:600;margin:1.5rem 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::shield()) " Admin"
-            }
-            @for (key, label, help, default, ref value, _sensitive, input_type) in values.iter().skip(4).take(1) {
-                (render_setting_field(key, label, help, default, value, input_type))
-            }
-
-            // OAuth section
-            h3 style="font-size:1rem;font-weight:600;margin:1.5rem 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::globe()) " OAuth Providers"
-            }
-            @for (key, label, help, _default, ref value, sensitive, input_type) in values.iter().skip(5) {
-                @if *sensitive {
-                    (render_sensitive_field(key, label, help, value))
-                } @else {
-                    (render_setting_field(key, label, help, _default, value, input_type))
-                }
-            }
-
-            button .btn .btn-primary type="submit" style="margin-top:1rem" { "Save Settings" }
-        }
-
-        script { (PreEscaped(SETTINGS_JS)) }
+        (settings_form::settings_form(ctx, "/b/auth/admin/settings", &form_sections, html! {}).await)
     };
-
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: "Auth Settings",
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    ui::Page {
-        config: &site_config,
-        title: "Auth Settings",
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: "/b/auth/admin/settings",
-        topbar,
-        body: content,
-    }
-    .response(msg)
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell::simple("Auth Settings", ui::NavKind::Admin, "Auth Settings"),
+        content,
+    )
+    .await
 }
-
-const SETTINGS_JS: &str = r#"
-function submitSettings(e) {
-    e.preventDefault();
-    var form = document.getElementById('settings-form');
-    var data = {};
-    form.querySelectorAll('input[name], select[name], textarea[name]').forEach(function(el) {
-        if (el.type === 'checkbox') {
-            data[el.name] = el.checked ? 'true' : 'false';
-        } else {
-            data[el.name] = el.value;
-        }
-    });
-    var btn = form.querySelector('button[type="submit"]');
-    btn.disabled = true; btn.textContent = 'Saving...';
-    fetch('/b/auth/admin/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
-    })
-    .then(function(r) { return r.json(); })
-    .then(function(d) {
-        document.body.dispatchEvent(new CustomEvent('showToast', {
-            detail: { message: d.message || 'Saved', type: d.error ? 'error' : 'success' }
-        }));
-    })
-    .catch(function(err) {
-        document.body.dispatchEvent(new CustomEvent('showToast', {
-            detail: { message: 'Error: ' + err.message, type: 'error' }
-        }));
-    })
-    .finally(function() { btn.disabled = false; btn.textContent = 'Save Settings'; });
-    return false;
-}
-"#;
 
 pub async fn handle_post(ctx: &dyn Context, input: InputStream) -> OutputStream {
-    let raw = input.collect_to_bytes().await;
-    let body: HashMap<String, String> = match serde_json::from_slice(&raw) {
-        Ok(b) => b,
-        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
-    };
-
-    for &(key, _, _, _, _, _) in SETTINGS_KEYS {
-        if let Some(value) = body.get(key) {
-            let _ = config::set(ctx, key, value).await;
-        }
-    }
-
-    ok_json(&serde_json::json!({"message": "Settings saved"}))
-}
-
-fn render_setting_field(
-    key: &str,
-    label: &str,
-    help: &str,
-    default: &str,
-    value: &str,
-    input_type: &str,
-) -> Markup {
-    html! {
-        div .form-group style="margin-bottom:1.25rem" {
-            @if input_type == "toggle" {
-                label style="display:flex;align-items:center;gap:0.75rem;cursor:pointer" {
-                    input type="checkbox" name=(key)
-                        checked[value == "true"]
-                        style="width:1.25rem;height:1.25rem;accent-color:var(--primary)";
-                    span .form-label style="margin:0" { (label) }
-                }
-            } @else {
-                label .form-label for=(key) { (label) }
-                input .form-input #(key) name=(key)
-                    type="text"
-                    value=(value)
-                    placeholder=(default);
-            }
-            p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-        }
-    }
-}
-
-fn render_sensitive_field(key: &str, label: &str, help: &str, value: &str) -> Markup {
-    let has_value = !value.is_empty();
-    html! {
-        div .form-group style="margin-bottom:1.25rem" {
-            label .form-label for=(key) { (label) }
-            div style="display:flex;align-items:center;gap:0.5rem" {
-                input .form-input #(key) name=(key)
-                    type="password"
-                    value=(value)
-                    placeholder=(if has_value { "******** (set)" } else { "Not configured" })
-                    style="flex:1";
-                button type="button" .btn .btn-ghost .btn-sm
-                    onclick={"var i=document.getElementById('" (key) "');i.type=i.type==='password'?'text':'password'"}
-                {
-                    (icons::eye())
-                }
-            }
-            p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-        }
-    }
+    settings_form::save_settings(ctx, input, &sections().all(), "auth-ui").await
 }

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -8,11 +8,7 @@ use wafer_run::{context::Context, Message, OutputStream};
 use super::{BUCKETS_TABLE, OBJECTS_TABLE, QUOTAS_TABLE, SHARES_TABLE};
 use crate::{
     blocks::helpers::RecordExt,
-    ui::{
-        components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    ui::{self, components, icons, shell::Crumb},
 };
 
 /// Tabs navigation across the storage-admin sub-pages
@@ -38,66 +34,45 @@ pub(crate) fn admin_tabs(active: &str) -> Markup {
     }
 }
 
-fn files_page<'a>(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
+async fn files_page<'a>(
+    ctx: &dyn Context,
+    title: &'a str,
     crumb_label: &'a str,
     subtitle: Option<&'a str>,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    files_page_with_action(
-        title,
-        config,
-        path,
-        user,
-        crumb_label,
-        subtitle,
-        None,
-        content,
-        msg,
-    )
+    files_page_with_action(ctx, title, crumb_label, subtitle, None, content, msg).await
 }
 
-#[allow(clippy::too_many_arguments)]
-fn files_page_with_action<'a>(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
+/// Admin storage shell. Thin wrapper over [`ui::shell_page`] that fixes the
+/// nav to Admin and keeps the storage pages' single-crumb shape; tabs ride in
+/// each caller's `list_page` `filters` slot (matching `/b/admin/users`).
+async fn files_page_with_action<'a>(
+    ctx: &dyn Context,
+    title: &'a str,
     crumb_label: &'a str,
     subtitle: Option<&'a str>,
     primary_action: Option<Markup>,
     content: Markup,
     msg: &Message,
 ) -> OutputStream {
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action,
-        subtitle,
-        show_palette: true,
-    };
-    // Tabs are now embedded into `list_page` by each caller (in the
-    // `filters` slot, matching how the Users page wires its tab strip).
-    // That keeps the storage admin pages' padding consistent with
-    // `/b/admin/users`; previously the tabs sat outside `.page--list`
-    // and lost the page gutter.
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title,
+            nav: ui::NavKind::Admin,
+            crumbs: vec![Crumb {
+                label: crumb_label,
+                href: None,
+            }],
+            subtitle,
+            primary_action,
+        },
+        content,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -145,9 +120,6 @@ pub fn render_admin_overview_quotas_hint(quotas_count: i64) -> Markup {
 pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let stats = load_admin_stats(ctx).await;
 
     // Tabs go in the `filters` slot (their padding gutter matches
@@ -169,15 +141,14 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
 
     files_page(
+        ctx,
         "Storage",
-        &config,
-        "/b/storage/admin/",
-        user.as_ref(),
         "Overview",
         Some("File storage statistics"),
         body,
         msg,
     )
+    .await
 }
 
 async fn load_admin_stats(ctx: &dyn Context) -> AdminStats {
@@ -274,9 +245,6 @@ pub fn render_admin_buckets_table(rows: &[AdminBucketRow]) -> Markup {
 pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let opts = ListOptions {
         sort: vec![SortField {
             field: "created_at".into(),
@@ -335,10 +303,8 @@ pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
 
     files_page_with_action(
+        ctx,
         "Buckets",
-        &config,
-        "/b/storage/admin/buckets",
-        user.as_ref(),
         "Buckets",
         Some("All storage buckets"),
         Some(crate::ui::components::button(
@@ -350,6 +316,7 @@ pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
         body,
         msg,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -412,9 +379,6 @@ pub fn render_admin_shares_table(rows: &[AdminShareRow]) -> Markup {
 pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let opts = ListOptions {
         sort: vec![SortField {
             field: "created_at".into(),
@@ -474,15 +438,14 @@ pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
 
     files_page(
+        ctx,
         "Shares",
-        &config,
-        "/b/storage/admin/shares",
-        user.as_ref(),
         "Shares",
         Some("Public file share links"),
         body,
         msg,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -533,9 +496,6 @@ pub fn render_admin_quotas_table(rows: &[AdminQuotaRow]) -> Markup {
 pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let opts = ListOptions {
         sort: vec![SortField {
             field: "created_at".into(),
@@ -574,15 +534,14 @@ pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
     );
 
     files_page(
+        ctx,
         "Quotas",
-        &config,
-        "/b/storage/admin/quotas",
-        user.as_ref(),
         "Quotas",
         Some("Per-user storage limits"),
         body,
         msg,
     )
+    .await
 }
 
 fn format_bytes(bytes: i64) -> String {

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -104,10 +104,8 @@ use wafer_run::{context::Context, Message, OutputStream};
 use crate::ui::{
     self,
     components::{button, BtnVariant, CtrlSize},
-    nav_groups,
-    shell::{Crumb, Topbar},
+    shell::Crumb,
     templates::{list_page, PageHeader},
-    Page, SiteConfig, UserInfo,
 };
 
 /// Load the calling user's buckets, decorated with live object counts.
@@ -235,8 +233,6 @@ pub async fn bucket_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream 
     }
 
     let rows = list_buckets_for_user(ctx, &user_id).await;
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
 
     let new_bucket_btn = button(
         BtnVariant::Primary,
@@ -265,26 +261,22 @@ pub async fn bucket_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream 
         None,
     );
 
-    let groups = nav_groups::portal();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: "Files",
-            href: None,
-        }],
-        primary_action: Some(new_bucket_btn),
-        subtitle: Some("Your buckets and their object counts."),
-        show_palette: true,
-    };
-    Page {
-        config: &config,
-        title: "Files",
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: msg.path(),
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: "Files",
+            nav: ui::NavKind::Portal,
+            crumbs: vec![Crumb {
+                label: "Files",
+                href: None,
+            }],
+            subtitle: Some("Your buckets and their object counts."),
+            primary_action: Some(new_bucket_btn),
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 /// Object as the user sees it (key, size, modified timestamp).
@@ -555,9 +547,6 @@ pub async fn object_list_page(
     let all_objects = list_objects_in_bucket(ctx, bucket).await;
     let listing = group_objects_by_prefix(&all_objects, current_prefix);
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let title = if current_prefix.is_empty() {
         bucket.to_string()
     } else {
@@ -585,38 +574,34 @@ pub async fn object_list_page(
         None,
     );
 
-    let groups = nav_groups::portal();
     let upload_btn = crate::ui::components::button(
         crate::ui::components::BtnVariant::Primary,
         crate::ui::components::CtrlSize::Sm,
         "+ Upload",
         maud::PreEscaped(r#"type="button" data-action="open-upload""#.to_string()),
     );
-    let topbar = Topbar {
-        crumbs: vec![
-            Crumb {
-                label: "Files",
-                href: Some("/b/storage/"),
-            },
-            Crumb {
-                label: bucket,
-                href: None,
-            },
-        ],
-        primary_action: Some(upload_btn),
-        subtitle: Some("Drag files here to upload, or use the Upload button."),
-        show_palette: true,
-    };
-    Page {
-        config: &config,
-        title: &title,
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: msg.path(),
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: &title,
+            nav: ui::NavKind::Portal,
+            crumbs: vec![
+                Crumb {
+                    label: "Files",
+                    href: Some("/b/storage/"),
+                },
+                Crumb {
+                    label: bucket,
+                    href: None,
+                },
+            ],
+            subtitle: Some("Drag files here to upload, or use the Upload button."),
+            primary_action: Some(upload_btn),
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 #[derive(Clone, Debug)]
@@ -776,9 +761,6 @@ pub async fn cloudstorage_page(ctx: &dyn Context, msg: &Message) -> OutputStream
             .max_storage_bytes,
     };
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let shares_with_js = html! {
         (render_shares_table(&shares))
         (render_bootstrap_script("", ""))
@@ -795,26 +777,22 @@ pub async fn cloudstorage_page(ctx: &dyn Context, msg: &Message) -> OutputStream
         None,
     );
 
-    let groups = nav_groups::portal();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: "Shares",
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: Some("Public links you've created and your storage quota."),
-        show_palette: true,
-    };
-    Page {
-        config: &config,
-        title: "Shares",
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: msg.path(),
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: "Shares",
+            nav: ui::NavKind::Portal,
+            crumbs: vec![Crumb {
+                label: "Shares",
+                href: None,
+            }],
+            subtitle: Some("Public links you've created and your storage quota."),
+            primary_action: None,
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -20,6 +20,37 @@ use crate::{
     ui::{self, templates, SiteConfig},
 };
 
+/// The legalpages block's own declared config vars. Single source of truth for
+/// both `BlockInfo::config_keys` and the admin settings page (rendered via
+/// `ui::settings_form`, not a parallel tuple table that had drifted on the
+/// `BG_COLOR` default).
+pub(crate) fn config_vars() -> Vec<ConfigVar> {
+    vec![
+        ConfigVar::new(
+            "SUPPERS_AI__LEGALPAGES__BG_COLOR",
+            "Background color for public legal pages (empty = use design token default)",
+            "",
+        )
+        .name("Background Color")
+        .input_type(InputType::Color)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__LEGALPAGES__BACK_URL",
+            "Back button URL in the header (e.g., your website homepage)",
+            "/",
+        )
+        .name("Back Button URL")
+        .input_type(InputType::Url),
+        ConfigVar::new(
+            "SUPPERS_AI__LEGALPAGES__FOOTER",
+            "Custom footer text (HTML allowed)",
+            "",
+        )
+        .name("Footer Text")
+        .optional(),
+    ]
+}
+
 pub struct LegalPagesBlock;
 
 impl LegalPagesBlock {
@@ -468,18 +499,7 @@ impl Block for LegalPagesBlock {
                 BlockEndpoint::patch("/b/legalpages/api/documents/{id}").summary("Update document").auth(AuthLevel::Admin),
                 BlockEndpoint::post("/b/legalpages/api/documents/{id}/publish").summary("Publish document").auth(AuthLevel::Admin),
             ])
-            .config_keys(vec![
-                ConfigVar::new("SUPPERS_AI__LEGALPAGES__BG_COLOR", "Background color for public legal pages (empty = use design token default)", "")
-                    .name("Background Color")
-                    .input_type(InputType::Color)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__LEGALPAGES__BACK_URL", "Back button URL in the header (e.g., your website homepage)", "/")
-                    .name("Back Button URL")
-                    .input_type(InputType::Url),
-                ConfigVar::new("SUPPERS_AI__LEGALPAGES__FOOTER", "Custom footer text (HTML allowed)", "")
-                    .name("Footer Text")
-                    .optional(),
-            ])
+            .config_keys(config_vars())
             .admin_url("/b/legalpages/admin")
             .can_disable(true)
             .default_enabled(false)

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -16,46 +16,10 @@ use crate::{
         self, err_bad_request, err_internal, err_not_found, json_map, ok_json, RecordExt,
         ResponseBuilder,
     },
-    ui::{
-        components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    ui::{self, components, icons, settings_form},
 };
 
 const COLLECTION: &str = super::COLLECTION;
-
-/// Wrap content in the legalpages portal shell (sidebar + layout).
-fn legalpages_page<'a>(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
-    crumb_label: &'a str,
-    content: Markup,
-    msg: &Message,
-) -> OutputStream {
-    let groups = nav_groups::portal();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
-}
 
 // ---------------------------------------------------------------------------
 // Document lookup
@@ -125,9 +89,6 @@ async fn find_current_doc(ctx: &dyn Context, doc_type: &str) -> Option<db::Recor
 // ---------------------------------------------------------------------------
 
 pub async fn editor_page(ctx: &dyn Context, msg: &Message, doc_type: &str) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let doc = find_current_doc(ctx, doc_type).await;
     let default_title = if doc_type == "privacy" {
         "Privacy Policy"
@@ -156,15 +117,13 @@ pub async fn editor_page(ctx: &dyn Context, msg: &Message, doc_type: &str) -> Ou
         doc_type, doc_id, title, content, status, updated_at, version,
     );
 
-    legalpages_page(
-        default_title,
-        &config,
-        &format!("/b/legalpages/admin/{doc_type}"),
-        user.as_ref(),
-        default_title,
-        page_content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple(default_title, ui::NavKind::Portal, default_title),
+        page_content,
     )
+    .await
 }
 
 /// Build the editor markup. Split out from `editor_page` so it can be
@@ -404,9 +363,6 @@ const EDITOR_JS: &str = r#"
 // ---------------------------------------------------------------------------
 
 pub async fn endpoints_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let content = html! {
         (components::page_header("API Endpoints", Some("Available endpoints for legal pages"), None))
 
@@ -540,15 +496,13 @@ pub async fn endpoints_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    legalpages_page(
-        "Endpoints",
-        &config,
-        "/b/legalpages/admin/endpoints",
-        user.as_ref(),
-        "Endpoints",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Endpoints", ui::NavKind::Portal, "Endpoints"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -675,39 +629,32 @@ pub async fn handle_publish(ctx: &dyn Context, msg: &Message, input: InputStream
 // Settings page
 // ---------------------------------------------------------------------------
 
-const SETTINGS_KEYS: &[(&str, &str, &str, &str)] = &[
-    (
-        "SUPPERS_AI__LEGALPAGES__BG_COLOR",
-        "Background Color",
-        "Background color for the public legal pages.",
-        "#f8fafc",
-    ),
-    (
-        "SUPPERS_AI__LEGALPAGES__BACK_URL",
-        "Back Button URL",
-        "Where the back arrow in the header links to (e.g., your website homepage).",
-        "/",
-    ),
-    (
-        "SUPPERS_AI__LEGALPAGES__FOOTER",
-        "Footer Text",
-        "Custom footer text (HTML allowed). Leave empty for default copyright.",
-        "",
-    ),
-];
-
 pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    use wafer_core::clients::config;
+    let vars = super::config_vars();
+    let sections = [settings_form::SettingsSection::new(
+        "Appearance",
+        icons::settings(),
+        &vars,
+    )];
 
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
-    // Load current values
-    let mut values = Vec::new();
-    for &(key, label, help, default) in SETTINGS_KEYS {
-        let value = config::get_default(ctx, key, default).await;
-        values.push((key, label, help, default, value));
-    }
+    // The live-preview links ride in the form's `extra` slot so they stay
+    // inside the settings form (above the Save button), as before.
+    let preview = html! {
+        div .card style="margin-bottom:1.25rem;padding:1rem" {
+            h4 style="font-size:0.9rem;font-weight:600;margin-bottom:0.5rem" { "Preview" }
+            p .text-muted style="font-size:0.8rem;margin-bottom:0.75rem" {
+                "See how your changes look on the public pages."
+            }
+            div style="display:flex;gap:0.5rem" {
+                a .btn .btn-sm .btn-ghost href="/b/legalpages/privacy" target="_blank" {
+                    (icons::eye()) " Privacy Policy"
+                }
+                a .btn .btn-sm .btn-ghost href="/b/legalpages/terms" target="_blank" {
+                    (icons::eye()) " Terms of Service"
+                }
+            }
+        }
+    };
 
     let saved = msg.query("saved") == "1";
 
@@ -720,115 +667,20 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
             }
         }
 
-        form #settings-form onsubmit="return submitSettings(event)" {
-            @for (key, label, help, _default, value) in &values {
-                div .form-group style="margin-bottom:1.25rem" {
-                    label .form-label for=(key) { (label) }
-                    @if *key == "SUPPERS_AI__LEGALPAGES__FOOTER" {
-                        textarea .form-input #(key) name=(key)
-                            rows="3"
-                            placeholder="Leave empty for default copyright text"
-                            style="font-family:monospace;font-size:0.9rem"
-                        { (value) }
-                    } @else if *key == "SUPPERS_AI__LEGALPAGES__BG_COLOR" {
-                        div style="display:flex;align-items:center;gap:0.75rem" {
-                            input .form-input #(key) name=(key)
-                                type="text"
-                                value=(value)
-                                style="flex:1";
-                            input type="color" value=(value)
-                                style="width:40px;height:36px;border:1px solid #e2e8f0;border-radius:6px;cursor:pointer;padding:2px"
-                                onchange={"document.getElementById('" (key) "').value=this.value"};
-                        }
-                    } @else {
-                        input .form-input #(key) name=(key)
-                            type="text"
-                            value=(value)
-                            placeholder=(*_default);
-                    }
-                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-                }
-            }
-
-            // Preview section
-            div .card style="margin-bottom:1.25rem;padding:1rem" {
-                h4 style="font-size:0.9rem;font-weight:600;margin-bottom:0.5rem" { "Preview" }
-                p .text-muted style="font-size:0.8rem;margin-bottom:0.75rem" {
-                    "See how your changes look on the public pages."
-                }
-                div style="display:flex;gap:0.5rem" {
-                    a .btn .btn-sm .btn-ghost href="/b/legalpages/privacy" target="_blank" {
-                        (icons::eye()) " Privacy Policy"
-                    }
-                    a .btn .btn-sm .btn-ghost href="/b/legalpages/terms" target="_blank" {
-                        (icons::eye()) " Terms of Service"
-                    }
-                }
-            }
-
-            button .btn .btn-primary type="submit" { "Save Settings" }
-        }
-
-        script { (PreEscaped(r#"
-        function submitSettings(e) {
-            e.preventDefault();
-            var form = document.getElementById('settings-form');
-            var data = {};
-            var inputs = form.querySelectorAll('input[name], textarea[name]');
-            inputs.forEach(function(el) { data[el.name] = el.value; });
-            var btn = form.querySelector('button[type="submit"]');
-            btn.disabled = true; btn.textContent = 'Saving...';
-            fetch('/b/legalpages/admin/settings', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            })
-            .then(function(r) { return r.json(); })
-            .then(function(d) {
-                document.body.dispatchEvent(new CustomEvent('showToast', {
-                    detail: { message: d.message || 'Saved', type: d.error ? 'error' : 'success' }
-                }));
-            })
-            .catch(function(err) {
-                document.body.dispatchEvent(new CustomEvent('showToast', {
-                    detail: { message: 'Error: ' + err.message, type: 'error' }
-                }));
-            })
-            .finally(function() { btn.disabled = false; btn.textContent = 'Save Settings'; });
-            return false;
-        }
-        "#)) }
+        (settings_form::settings_form(ctx, "/b/legalpages/admin/settings", &sections, preview).await)
     };
 
-    legalpages_page(
-        "Settings",
-        &site_config,
-        "/b/legalpages/admin/settings",
-        user.as_ref(),
-        "Settings",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Settings", ui::NavKind::Portal, "Settings"),
+        content,
     )
+    .await
 }
 
 pub async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> OutputStream {
-    use wafer_core::clients::config;
-
-    let raw = input.collect_to_bytes().await;
-    let body: std::collections::HashMap<String, String> = match serde_json::from_slice(&raw) {
-        Ok(b) => b,
-        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
-    };
-
-    for &(key, _, _, _) in SETTINGS_KEYS {
-        if let Some(value) = body.get(key) {
-            if let Err(e) = config::set(ctx, key, value).await {
-                tracing::warn!(error = %e, key = key, "legalpages: failed to set config value");
-            }
-        }
-    }
-
-    ok_json(&serde_json::json!({"message": "Settings saved"}))
+    settings_form::save_settings(ctx, input, &super::config_vars(), "legalpages").await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -18,11 +18,7 @@ use crate::{
     // without pulling in the messages block module — runtime WRAP grants
     // declared by `MessagesBlock` still authorize the cross-block read.
     messages_schema::{CONTEXTS_TABLE, ENTRIES_TABLE},
-    ui::{
-        components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    ui::{self, components, icons, shell::Crumb},
 };
 
 // ---------------------------------------------------------------------------
@@ -107,8 +103,6 @@ fn render_page_body(
 /// composer / right rail). The optional thread id from the URL drives
 /// composer enablement and message preloading.
 pub async fn page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let path = msg.path().to_string();
     let thread_id = parse_thread_id(&path);
 
@@ -190,24 +184,19 @@ pub async fn page(ctx: &dyn Context, msg: &Message) -> OutputStream {
             href: None,
         }],
     };
-    let topbar = Topbar {
-        crumbs,
-        primary_action: None,
-        subtitle: Some("Chat with a configured provider or local model"),
-        show_palette: true,
-    };
-
-    let groups = nav_groups::admin();
-    crate::ui::Page {
-        config: &site_config,
-        title: display_title,
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: &path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: display_title,
+            nav: ui::NavKind::Admin,
+            crumbs,
+            subtitle: Some("Chat with a configured provider or local model"),
+            primary_action: None,
+        },
+        content,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -391,10 +380,6 @@ fn render_right_rail(models: &[ModelInfo], default_model: &str) -> Markup {
 // ---------------------------------------------------------------------------
 
 pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let path = msg.path().to_string();
-
     let default_provider = config::get_default(ctx, DEFAULT_PROVIDER_VAR, DEFAULT_PROVIDER).await;
     let default_model = config::get_default(ctx, DEFAULT_MODEL_VAR, "").await;
 
@@ -514,26 +499,22 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: "Settings",
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: Some("LLM defaults and provider routing"),
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config: &config,
-        title: "LLM Settings",
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: &path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: "LLM Settings",
+            nav: ui::NavKind::Admin,
+            crumbs: vec![Crumb {
+                label: "Settings",
+                href: None,
+            }],
+            subtitle: Some("LLM defaults and provider routing"),
+            primary_action: None,
+        },
+        content,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -25,48 +25,8 @@ use super::{
 };
 use crate::{
     blocks::helpers::{self, err_internal},
-    ui::{
-        self, components, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    ui::{self, components},
 };
-
-// ---------------------------------------------------------------------------
-// Navigation
-// ---------------------------------------------------------------------------
-
-/// Wrap content in the admin shell for LLM admin pages (providers, models).
-fn llm_page(
-    title: &'static str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
-    crumb_label: &'static str,
-    content: Markup,
-    msg: &Message,
-) -> OutputStream {
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
-}
 
 // ---------------------------------------------------------------------------
 // Providers page
@@ -84,10 +44,6 @@ pub(super) async fn providers_page(
     if !helpers::is_admin(msg) {
         return ui::forbidden_response(msg);
     }
-
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let path = msg.path().to_string();
 
     // Load all provider rows (both enabled and disabled) — the admin UI
     // wants the full picture, not just the in-flight set.
@@ -121,15 +77,13 @@ pub(super) async fn providers_page(
         }
     };
 
-    llm_page(
-        "LLM Providers",
-        &site_config,
-        &path,
-        user.as_ref(),
-        "Providers",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("LLM Providers", ui::NavKind::Admin, "Providers"),
+        content,
     )
+    .await
 }
 
 /// Render the add-provider form. Separated out so the top-level page
@@ -362,10 +316,6 @@ pub(super) async fn models_page(
         return ui::forbidden_response(msg);
     }
 
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let path = msg.path().to_string();
-
     let models = match wafer_core::clients::llm::list_models(ctx).await {
         Ok(m) => m,
         Err(e) => return err_internal("llm list_models failed", e.message),
@@ -381,15 +331,13 @@ pub(super) async fn models_page(
         (render_models_table(&models))
     };
 
-    llm_page(
-        "LLM Models",
-        &site_config,
-        &path,
-        user.as_ref(),
-        "Models",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("LLM Models", ui::NavKind::Admin, "Models"),
+        content,
     )
+    .await
 }
 
 /// Render the models table. Pure function of the typed `ModelInfo` slice so

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -11,44 +11,8 @@ use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 use super::service::{self, ListContextsParams, ListEntriesParams};
 use crate::{
     blocks::helpers::{err_internal, path_param, RecordExt},
-    ui::{
-        self, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    ui::{self, shell::Crumb},
 };
-
-fn messages_page<'a>(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
-    crumb_label: &'a str,
-    subtitle: Option<&'a str>,
-    content: Markup,
-    msg: &Message,
-) -> OutputStream {
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action: None,
-        subtitle,
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
-}
 
 pub fn entry_card(record: &db::Record) -> Markup {
     let kind = record.str_field("kind");
@@ -108,10 +72,6 @@ pub fn entry_card(record: &db::Record) -> Markup {
 }
 
 pub async fn context_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let path = msg.path().to_string();
-
     let params = ListContextsParams {
         context_type: None,
         status: None,
@@ -177,23 +137,25 @@ pub async fn context_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream
         }
     };
 
-    messages_page(
-        "Messages",
-        &config,
-        &path,
-        user.as_ref(),
-        "Contexts",
-        Some("Conversations, tasks, and notifications"),
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell {
+            title: "Messages",
+            nav: ui::NavKind::Admin,
+            crumbs: vec![Crumb {
+                label: "Contexts",
+                href: None,
+            }],
+            subtitle: Some("Conversations, tasks, and notifications"),
+            primary_action: None,
+        },
+        content,
     )
+    .await
 }
 
 pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-    let path = msg.path().to_string();
-
     let context_id = path_param(msg, "id", "/b/messages/contexts/");
 
     if context_id.is_empty() {
@@ -249,9 +211,8 @@ pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStre
     // Build crumbs locally so the conversation branch can carry a working
     // [Messages] link back to /b/messages/. The default branch keeps a
     // single crumb (matches its inline "← Back" affordance in
-    // render_default_view). Inline Page::response here — parallel to
-    // T3's pages::page for LLM — so we don't have to teach messages_page
-    // about variable crumb shapes (it's still used by context_list_page).
+    // render_default_view). `shell_page` supports a full `Vec<Crumb>`, so
+    // the variable crumb shape rides through without a bespoke wrapper.
     let crumbs = if context.str_field("type") == "conversation" {
         vec![
             Crumb {
@@ -269,23 +230,19 @@ pub async fn context_detail_page(ctx: &dyn Context, msg: &Message) -> OutputStre
             href: None,
         }]
     };
-    let topbar = Topbar {
-        crumbs,
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    let groups = nav_groups::admin();
-    crate::ui::Page {
-        config: &config,
-        title: display_title,
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: &path,
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: display_title,
+            nav: ui::NavKind::Admin,
+            crumbs,
+            subtitle: None,
+            primary_action: None,
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 /// Pure render helper: branches on `context.type`. Conversation contexts

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -24,6 +24,53 @@ use wafer_run::{
 use super::rate_limit::{check_user_rate_limit, RateLimitOutcome, UserRateLimiter};
 use crate::blocks::helpers::{self, err_not_found};
 
+/// The products block's own declared config vars. Single source of truth for
+/// both `BlockInfo::config_keys` and the admin settings page (which renders
+/// these via `ui::settings_form` rather than a parallel tuple table).
+pub(crate) fn config_vars() -> Vec<ConfigVar> {
+    vec![
+        ConfigVar::new(
+            "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY",
+            "Stripe API secret key",
+            "",
+        )
+        .name("Stripe Secret Key")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__PRODUCTS__STRIPE_WEBHOOK_SECRET",
+            "Stripe webhook signing secret",
+            "",
+        )
+        .name("Stripe Webhook Secret")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__PRODUCTS__STRIPE_API_URL",
+            "Stripe API base URL",
+            "https://api.stripe.com",
+        )
+        .name("Stripe API URL")
+        .input_type(InputType::Url),
+        ConfigVar::new(
+            "SUPPERS_AI__PRODUCTS__WEBHOOK_URL",
+            "Webhook URL for billing events",
+            "",
+        )
+        .name("Billing Webhook URL")
+        .input_type(InputType::Url)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET",
+            "Webhook signing secret",
+            "",
+        )
+        .name("Billing Webhook Secret")
+        .input_type(InputType::Password)
+        .auto_generate(),
+    ]
+}
+
 pub struct ProductsBlock {
     limiter: UserRateLimiter,
 }
@@ -140,27 +187,7 @@ impl Block for ProductsBlock {
                 BlockEndpoint::post("/b/products/checkout").summary("Stripe checkout").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/products/subscription").summary("Subscription status").auth(AuthLevel::Authenticated),
             ])
-            .config_keys(vec![
-                ConfigVar::new("SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY", "Stripe API secret key", "")
-                    .name("Stripe Secret Key")
-                    .input_type(InputType::Password)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__PRODUCTS__STRIPE_WEBHOOK_SECRET", "Stripe webhook signing secret", "")
-                    .name("Stripe Webhook Secret")
-                    .input_type(InputType::Password)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__PRODUCTS__STRIPE_API_URL", "Stripe API base URL", "https://api.stripe.com")
-                    .name("Stripe API URL")
-                    .input_type(InputType::Url),
-                ConfigVar::new("SUPPERS_AI__PRODUCTS__WEBHOOK_URL", "Webhook URL for billing events", "")
-                    .name("Billing Webhook URL")
-                    .input_type(InputType::Url)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET", "Webhook signing secret", "")
-                    .name("Billing Webhook Secret")
-                    .input_type(InputType::Password)
-                    .auto_generate(),
-            ])
+            .config_keys(config_vars())
             .admin_url("/b/products/admin/")
             .can_disable(true)
     }

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -1,58 +1,22 @@
 //! SSR pages for the products block (admin + user views).
 
-use maud::{html, Markup, PreEscaped};
+use maud::html;
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
-use wafer_core::clients::{config, database as db};
+use wafer_core::clients::database as db;
 use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
 use super::{repo, GROUPS_TABLE, PRICING_TABLE, PRODUCTS_TABLE};
 use crate::{
-    blocks::helpers::{err_bad_request, ok_json, RecordExt},
-    ui::{
-        components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    blocks::helpers::RecordExt,
+    config_vars,
+    ui::{self, components, icons, settings_form, settings_form::SettingsSection},
 };
-
-fn products_page<'a>(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
-    crumb_label: &'a str,
-    content: Markup,
-    msg: &Message,
-) -> OutputStream {
-    let groups = nav_groups::portal();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
-}
 
 // ---------------------------------------------------------------------------
 // Admin: Overview (stats)
 // ---------------------------------------------------------------------------
 
 pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let products_count = db::count(ctx, PRODUCTS_TABLE, &[]).await.unwrap_or(0);
     let groups_count = db::count(ctx, GROUPS_TABLE, &[]).await.unwrap_or(0);
     let purchases_count = repo::purchases::count_all(ctx).await.unwrap_or(0);
@@ -68,15 +32,13 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    products_page(
-        "Products",
-        &config,
-        "/b/products/admin/",
-        user.as_ref(),
-        "Products",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Products", ui::NavKind::Portal, "Products"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -84,8 +46,6 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let (page, page_size, _) = msg.pagination_params(20);
     let search = msg.query("search").to_string();
 
@@ -122,39 +82,25 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #products-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead {
-                                tr {
-                                    th { "Name" }
-                                    th { "Status" }
-                                    th { "Price" }
-                                    th { "Group" }
-                                    th { "Created" }
-                                }
-                            }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="5" .text-center .text-muted style="padding:2rem;" { "No products found" } }
-                                }
-                                @for record in &list.records {
-                                    @let name = record.str_field("name");
-                                    @let status = record.str_field("status");
-                                    @let price = record.str_field("price");
-                                    @let currency = record.str_field("currency");
-                                    @let group_id = record.str_field("group_id");
-                                    @let created = record.str_field("created_at");
-                                    tr {
-                                        td .font-medium { (name) }
-                                        td { (components::status_badge(status)) }
-                                        td { (price) " " span .text-muted { (currency) } }
-                                        td .text-muted .text-sm { @if group_id.is_empty() { "—" } @else { (group_id.get(..8).unwrap_or(group_id)) } }
-                                        td .text-muted .text-sm { (created.get(..10).unwrap_or(created)) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "Name", width: None },
+                        components::TableCol { label: "Status", width: None },
+                        components::TableCol { label: "Price", width: None },
+                        components::TableCol { label: "Group", width: None },
+                        components::TableCol { label: "Created", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|record| {
+                        let group_id = record.str_field("group_id");
+                        let created = record.str_field("created_at");
+                        vec![
+                            html! { span .font-medium { (record.str_field("name")) } },
+                            components::status_badge(record.str_field("status")),
+                            html! { (record.str_field("price")) " " span .text-muted { (record.str_field("currency")) } },
+                            html! { span .text-muted .text-sm { @if group_id.is_empty() { "—" } @else { (group_id.get(..8).unwrap_or(group_id)) } } },
+                            html! { span .text-muted .text-sm { (created.get(..10).unwrap_or(created)) } },
+                        ]
+                    }).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No products found" } }))
                     (components::pagination(list.page as u32, list.page_size as u32, list.total_count as u32, "/b/products/admin/manage"))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
@@ -162,15 +108,13 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    products_page(
-        "Products",
-        &config,
-        "/b/products/admin/manage",
-        user.as_ref(),
-        "Products",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Products", ui::NavKind::Portal, "Products"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -178,8 +122,6 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn groups(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let opts = ListOptions {
         sort: vec![SortField {
             field: "name".into(),
@@ -196,39 +138,32 @@ pub async fn groups(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #groups-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead { tr { th { "Name" } th { "Description" } th { "Status" } th { "Created" } } }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="4" .text-center .text-muted style="padding:2rem;" { "No groups" } }
-                                }
-                                @for r in &list.records {
-                                    tr {
-                                        td .font-medium { (r.str_field("name")) }
-                                        td .text-muted .text-sm { (r.str_field("description")) }
-                                        td { (components::status_badge(r.str_field("status"))) }
-                                        td .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "Name", width: None },
+                        components::TableCol { label: "Description", width: None },
+                        components::TableCol { label: "Status", width: None },
+                        components::TableCol { label: "Created", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| vec![
+                        html! { span .font-medium { (r.str_field("name")) } },
+                        html! { span .text-muted .text-sm { (r.str_field("description")) } },
+                        components::status_badge(r.str_field("status")),
+                        html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
+                    ]).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No groups" } }))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
             }
         }
     };
 
-    products_page(
-        "Groups",
-        &config,
-        "/b/products/admin/groups",
-        user.as_ref(),
-        "Groups",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Groups", ui::NavKind::Portal, "Groups"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -236,8 +171,6 @@ pub async fn groups(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn pricing(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let opts = ListOptions {
         sort: vec![SortField {
             field: "name".into(),
@@ -254,38 +187,30 @@ pub async fn pricing(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #pricing-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead { tr { th { "Name" } th { "Formula" } th { "Created" } } }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="3" .text-center .text-muted style="padding:2rem;" { "No pricing templates" } }
-                                }
-                                @for r in &list.records {
-                                    tr {
-                                        td .font-medium { (r.str_field("name")) }
-                                        td .text-sm { code { (r.str_field("price_formula")) } }
-                                        td .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "Name", width: None },
+                        components::TableCol { label: "Formula", width: None },
+                        components::TableCol { label: "Created", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| vec![
+                        html! { span .font-medium { (r.str_field("name")) } },
+                        html! { span .text-sm { code { (r.str_field("price_formula")) } } },
+                        html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
+                    ]).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No pricing templates" } }))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
             }
         }
     };
 
-    products_page(
-        "Pricing",
-        &config,
-        "/b/products/admin/pricing",
-        user.as_ref(),
-        "Pricing",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Pricing", ui::NavKind::Portal, "Pricing"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -293,8 +218,6 @@ pub async fn pricing(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let (page, page_size, _) = msg.pagination_params(20);
     let status_filter = msg.query("status").to_string();
 
@@ -328,27 +251,25 @@ pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #purchases-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead { tr { th { "User" } th { "Status" } th { "Total" } th { "Provider" } th { "Date" } } }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="5" .text-center .text-muted style="padding:2rem;" { "No purchases" } }
-                                }
-                                @for r in &list.records {
-                                    @let total_cents = r.i64_field("total_cents");
-                                    @let amount = format!("{:.2}", total_cents as f64 / 100.0);
-                                    tr {
-                                        td .text-sm { (r.str_field("user_id").get(..8).unwrap_or("—")) }
-                                        td { (components::status_badge(r.str_field("status"))) }
-                                        td .font-medium { (amount) " " span .text-muted { (r.str_field("currency")) } }
-                                        td .text-muted .text-sm { (r.str_field("provider")) }
-                                        td .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "User", width: None },
+                        components::TableCol { label: "Status", width: None },
+                        components::TableCol { label: "Total", width: None },
+                        components::TableCol { label: "Provider", width: None },
+                        components::TableCol { label: "Date", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| {
+                        let total_cents = r.i64_field("total_cents");
+                        let amount = format!("{:.2}", total_cents as f64 / 100.0);
+                        vec![
+                            html! { span .text-sm { (r.str_field("user_id").get(..8).unwrap_or("—")) } },
+                            components::status_badge(r.str_field("status")),
+                            html! { span .font-medium { (amount) " " span .text-muted { (r.str_field("currency")) } } },
+                            html! { span .text-muted .text-sm { (r.str_field("provider")) } },
+                            html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
+                        ]
+                    }).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No purchases" } }))
                     (components::pagination(list.page as u32, list.page_size as u32, list.total_count as u32, "/b/products/admin/purchases"))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
@@ -356,15 +277,13 @@ pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    products_page(
-        "Purchases",
-        &config,
-        "/b/products/admin/purchases",
-        user.as_ref(),
-        "Purchases",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Purchases", ui::NavKind::Portal, "Purchases"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -372,8 +291,6 @@ pub async fn purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let user_id = msg.user_id().to_string();
     let (page, page_size, _) = msg.pagination_params(20);
 
@@ -409,24 +326,19 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #my-products-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead { tr { th { "Name" } th { "Status" } th { "Price" } th { "Created" } } }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="4" .text-center .text-muted style="padding:2rem;" { "No products yet" } }
-                                }
-                                @for r in &list.records {
-                                    tr {
-                                        td .font-medium { (r.str_field("name")) }
-                                        td { (components::status_badge(r.str_field("status"))) }
-                                        td { (r.str_field("price")) " " span .text-muted { (r.str_field("currency")) } }
-                                        td .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "Name", width: None },
+                        components::TableCol { label: "Status", width: None },
+                        components::TableCol { label: "Price", width: None },
+                        components::TableCol { label: "Created", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| vec![
+                        html! { span .font-medium { (r.str_field("name")) } },
+                        components::status_badge(r.str_field("status")),
+                        html! { (r.str_field("price")) " " span .text-muted { (r.str_field("currency")) } },
+                        html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
+                    ]).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No products yet" } }))
                     (components::pagination(list.page as u32, list.page_size as u32, list.total_count as u32, "/b/products/my-products"))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
@@ -434,15 +346,13 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    products_page(
-        "My Products",
-        &config,
-        "/b/products/my-products",
-        user.as_ref(),
-        "My Products",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("My Products", ui::NavKind::Portal, "My Products"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -450,8 +360,6 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
 // ---------------------------------------------------------------------------
 
 pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let user_id = msg.user_id().to_string();
     let (page, page_size, _) = msg.pagination_params(20);
 
@@ -468,26 +376,23 @@ pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         div #my-purchases-content {
             @match &result {
                 Ok(list) => {
-                    div .table-container {
-                        table .table {
-                            thead { tr { th { "Status" } th { "Total" } th { "Provider" } th { "Date" } } }
-                            tbody {
-                                @if list.records.is_empty() {
-                                    tr { td colspan="4" .text-center .text-muted style="padding:2rem;" { "No purchases yet" } }
-                                }
-                                @for r in &list.records {
-                                    @let total_cents = r.i64_field("total_cents");
-                                    @let amount = format!("{:.2}", total_cents as f64 / 100.0);
-                                    tr {
-                                        td { (components::status_badge(r.str_field("status"))) }
-                                        td .font-medium { (amount) " " span .text-muted { (r.str_field("currency")) } }
-                                        td .text-muted .text-sm { (r.str_field("provider")) }
-                                        td .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    @let cols = [
+                        components::TableCol { label: "Status", width: None },
+                        components::TableCol { label: "Total", width: None },
+                        components::TableCol { label: "Provider", width: None },
+                        components::TableCol { label: "Date", width: None },
+                    ];
+                    @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| {
+                        let total_cents = r.i64_field("total_cents");
+                        let amount = format!("{:.2}", total_cents as f64 / 100.0);
+                        vec![
+                            components::status_badge(r.str_field("status")),
+                            html! { span .font-medium { (amount) " " span .text-muted { (r.str_field("currency")) } } },
+                            html! { span .text-muted .text-sm { (r.str_field("provider")) } },
+                            html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
+                        ]
+                    }).collect();
+                    (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No purchases yet" } }))
                     (components::pagination(list.page as u32, list.page_size as u32, list.total_count as u32, "/b/products/my-purchases"))
                 }
                 Err(e) => { div .login-error { "Error: " (e.message) } }
@@ -495,197 +400,78 @@ pub async fn my_purchases(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     };
 
-    products_page(
-        "My Purchases",
-        &config,
-        "/b/products/my-purchases",
-        user.as_ref(),
-        "My Purchases",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("My Purchases", ui::NavKind::Portal, "My Purchases"),
+        content,
     )
+    .await
 }
 
 // ---------------------------------------------------------------------------
 // Admin: Settings
 // ---------------------------------------------------------------------------
 
-const SETTINGS_KEYS: &[(&str, &str, &str, &str, bool)] = &[
-    (
-        "SOLOBASE_SHARED__ALLOW_USER_PRODUCTS",
-        "Allow User Products",
-        "Allow users to create their own products.",
-        "false",
-        false,
-    ),
-    (
-        "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY",
-        "Stripe Secret Key",
-        "Stripe API secret key for payment processing.",
-        "",
-        true,
-    ),
-    (
-        "SUPPERS_AI__PRODUCTS__STRIPE_WEBHOOK_SECRET",
-        "Stripe Webhook Secret",
-        "Stripe webhook signing secret for verifying events.",
-        "",
-        true,
-    ),
-    (
-        "SUPPERS_AI__PRODUCTS__STRIPE_API_URL",
-        "Stripe API URL",
-        "Stripe API base URL (default is production).",
-        "https://api.stripe.com",
-        false,
-    ),
-    (
-        "SOLOBASE_SHARED__FRONTEND_URL",
-        "Frontend URL",
-        "Frontend URL for checkout success/cancel redirects.",
-        "http://localhost:5173",
-        false,
-    ),
-    (
-        "SUPPERS_AI__PRODUCTS__WEBHOOK_URL",
-        "Billing Webhook URL",
-        "Webhook URL for outbound billing events.",
-        "",
-        false,
-    ),
-    (
-        "SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET",
-        "Billing Webhook Secret",
-        "Signing secret for outbound billing webhooks.",
-        "",
-        true,
-    ),
-];
+/// The block + shared config vars rendered on the products settings page, in
+/// their on-page order. Pulled from the declared [`ConfigVar`] metadata — the
+/// block-owned ones from `super::config_vars()`, the shared ones from
+/// `config_vars::shared_var()` — so nothing is re-declared in a parallel tuple.
+fn settings_vars() -> SettingsVars {
+    let own = super::config_vars();
+    SettingsVars {
+        features: vec![config_vars::shared_var(
+            "SOLOBASE_SHARED__ALLOW_USER_PRODUCTS",
+        )],
+        stripe: vec![
+            config_vars::var_in(&own, "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY"),
+            config_vars::var_in(&own, "SUPPERS_AI__PRODUCTS__STRIPE_WEBHOOK_SECRET"),
+            config_vars::var_in(&own, "SUPPERS_AI__PRODUCTS__STRIPE_API_URL"),
+        ],
+        webhooks: vec![
+            config_vars::shared_var("SOLOBASE_SHARED__FRONTEND_URL"),
+            config_vars::var_in(&own, "SUPPERS_AI__PRODUCTS__WEBHOOK_URL"),
+            config_vars::var_in(&own, "SUPPERS_AI__PRODUCTS__WEBHOOK_SECRET"),
+        ],
+    }
+}
+
+struct SettingsVars {
+    features: Vec<wafer_run::ConfigVar>,
+    stripe: Vec<wafer_run::ConfigVar>,
+    webhooks: Vec<wafer_run::ConfigVar>,
+}
+
+impl SettingsVars {
+    /// Flatten to a single allowlist for the save handler.
+    fn all(&self) -> Vec<wafer_run::ConfigVar> {
+        let mut v = self.features.clone();
+        v.extend(self.stripe.iter().cloned());
+        v.extend(self.webhooks.iter().cloned());
+        v
+    }
+}
 
 pub async fn settings(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
-    let mut values = Vec::new();
-    for &(key, label, help, default, sensitive) in SETTINGS_KEYS {
-        let value = config::get_default(ctx, key, default).await;
-        values.push((key, label, help, default, value, sensitive));
-    }
-
+    let vars = settings_vars();
+    let sections = [
+        SettingsSection::new("Features", icons::settings(), &vars.features),
+        SettingsSection::new("Stripe", icons::dollar_sign(), &vars.stripe),
+        SettingsSection::new("Webhooks", icons::globe(), &vars.webhooks),
+    ];
     let content = html! {
         (components::page_header("Settings", Some("Configure payments and integrations"), None))
-
-        form #settings-form onsubmit="return submitSettings(event)" {
-            h3 style="font-size:1rem;font-weight:600;margin:0 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::settings()) " Features"
-            }
-            @for (key, label, help, _default, ref value, _sensitive) in values.iter().take(1) {
-                div .form-group style="margin-bottom:1.25rem" {
-                    label style="display:flex;align-items:center;gap:0.75rem;cursor:pointer" {
-                        input type="checkbox" name=(key)
-                            checked[value.as_str() == "true"]
-                            style="width:1.25rem;height:1.25rem;accent-color:var(--primary)";
-                        span .form-label style="margin:0" { (label) }
-                    }
-                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-                }
-            }
-
-            h3 style="font-size:1rem;font-weight:600;margin:1.5rem 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::dollar_sign()) " Stripe"
-            }
-            @for (key, label, help, default, ref value, sensitive) in values.iter().skip(1).take(3) {
-                @if *sensitive {
-                    (render_sensitive_field(key, label, help, value))
-                } @else {
-                    div .form-group style="margin-bottom:1.25rem" {
-                        label .form-label for=(key) { (label) }
-                        input .form-input #(key) name=(key) type="text" value=(value) placeholder=(default);
-                        p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-                    }
-                }
-            }
-
-            h3 style="font-size:1rem;font-weight:600;margin:1.5rem 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::globe()) " Webhooks"
-            }
-            @for (key, label, help, default, ref value, sensitive) in values.iter().skip(4) {
-                @if *sensitive {
-                    (render_sensitive_field(key, label, help, value))
-                } @else {
-                    div .form-group style="margin-bottom:1.25rem" {
-                        label .form-label for=(key) { (label) }
-                        input .form-input #(key) name=(key) type="text" value=(value) placeholder=(default);
-                        p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-                    }
-                }
-            }
-
-            button .btn .btn-primary type="submit" style="margin-top:1rem" { "Save Settings" }
-        }
-
-        script { (PreEscaped(r#"
-function submitSettings(e) {
-    e.preventDefault();
-    var form = document.getElementById('settings-form');
-    var data = {};
-    form.querySelectorAll('input[name]').forEach(function(el) {
-        if (el.type === 'checkbox') { data[el.name] = el.checked ? 'true' : 'false'; }
-        else { data[el.name] = el.value; }
-    });
-    var btn = form.querySelector('button[type="submit"]');
-    btn.disabled = true; btn.textContent = 'Saving...';
-    fetch('/b/products/admin/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
-    .then(function(r) { return r.json(); })
-    .then(function(d) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: d.message || 'Saved', type: d.error ? 'error' : 'success' } })); })
-    .catch(function(err) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: 'Error: ' + err.message, type: 'error' } })); })
-    .finally(function() { btn.disabled = false; btn.textContent = 'Save Settings'; });
-    return false;
-}
-"#)) }
+        (settings_form::settings_form(ctx, "/b/products/admin/settings", &sections, html! {}).await)
     };
-
-    products_page(
-        "Settings",
-        &site_config,
-        "/b/products/admin/settings",
-        user.as_ref(),
-        "Settings",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Settings", ui::NavKind::Portal, "Settings"),
+        content,
     )
+    .await
 }
 
 pub async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> OutputStream {
-    let raw = input.collect_to_bytes().await;
-    let body: std::collections::HashMap<String, String> = match serde_json::from_slice(&raw) {
-        Ok(b) => b,
-        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
-    };
-    for &(key, _, _, _, _) in SETTINGS_KEYS {
-        if let Some(value) = body.get(key) {
-            if let Err(e) = config::set(ctx, key, value).await {
-                tracing::warn!(error = %e, key = key, "products: failed to set config value");
-            }
-        }
-    }
-    ok_json(&serde_json::json!({"message": "Settings saved"}))
-}
-
-fn render_sensitive_field(key: &str, label: &str, help: &str, value: &str) -> Markup {
-    let has_value = !value.is_empty();
-    html! {
-        div .form-group style="margin-bottom:1.25rem" {
-            label .form-label for=(key) { (label) }
-            div style="display:flex;align-items:center;gap:0.5rem" {
-                input .form-input #(key) name=(key) type="password" value=(value)
-                    placeholder=(if has_value { "******** (set)" } else { "Not configured" })
-                    style="flex:1";
-                button type="button" .btn .btn-ghost .btn-sm
-                    onclick={"var i=document.getElementById('" (key) "');i.type=i.type==='password'?'text':'password'"}
-                { (icons::eye()) }
-            }
-            p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-        }
-    }
+    settings_form::save_settings(ctx, input, &settings_vars().all(), "products").await
 }

--- a/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
@@ -733,9 +733,14 @@ async fn overview_highlights_products_nav_via_request_path() {
     let (msg, _input) = admin_get_msg("/b/products/");
     let html = output_to_html(super::super::pages::overview(&ctx, &msg).await).await;
 
-    // Full shell chrome present (shell_page wrapped it).
-    assert!(html.contains("<!DOCTYPE html>"), "expected full document");
+    // Full shell chrome present (shell_page wrapped a non-htmx request in the
+    // sidebar+topbar document, not a bare fragment). The `.shell` wrapper only
+    // exists on the full page, so it's the distinguishing marker.
     assert!(html.contains(r#"class="shell""#), "expected shell chrome");
+    assert!(
+        html.contains(r#"class="sidebar"#),
+        "expected sidebar in full doc"
+    );
     // Products portal nav item is active because current_path == its href.
     assert!(
         html.contains(r#"href="/b/products/""#),

--- a/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
@@ -715,3 +715,61 @@ async fn unknown_user_route() {
     let out = handlers::handle_user(&ctx, &msg, input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
+
+// ============================================================
+// Page shell (ui::shell_page) + data_table adoption
+// ============================================================
+
+/// The products pages now render through `ui::shell_page`, which derives
+/// `current_path` from the request path. The overview page at `/b/products/`
+/// therefore correctly highlights the "Products" portal sidebar item — the old
+/// `products_page` wrapper hardcoded `current_path="/b/products/admin/"`, which
+/// never matched the `/b/products/` nav href, so the item rendered inactive.
+/// This is the one intended visual-baseline shift in S2-M's page-shell
+/// migration; pin it so it can't silently regress.
+#[tokio::test]
+async fn overview_highlights_products_nav_via_request_path() {
+    let ctx = ctx().await;
+    let (msg, _input) = admin_get_msg("/b/products/");
+    let html = output_to_html(super::super::pages::overview(&ctx, &msg).await).await;
+
+    // Full shell chrome present (shell_page wrapped it).
+    assert!(html.contains("<!DOCTYPE html>"), "expected full document");
+    assert!(html.contains(r#"class="shell""#), "expected shell chrome");
+    // Products portal nav item is active because current_path == its href.
+    assert!(
+        html.contains(r#"href="/b/products/""#),
+        "Products nav item should be present"
+    );
+    assert!(
+        html.contains("is-active"),
+        "the active sidebar item (Products) should carry is-active"
+    );
+}
+
+/// The products list pages adopt `ui::components::data_table`, which carries
+/// the PR #75 mobile card-collapse fix via `td[data-label]`. Assert the manage
+/// page renders the `.data-table` structure with per-cell data labels (so the
+/// mobile baseline collapse works) instead of the old `.table-container`.
+#[tokio::test]
+async fn manage_products_uses_data_table_with_mobile_labels() {
+    let ctx = ctx().await;
+    let (c, c_input) = admin_create_msg(
+        "/admin/b/products/products",
+        serde_json::json!({ "name": "Widget", "base_price": 5 }),
+    );
+    handlers::handle_admin(&ctx, &c, c_input).await;
+
+    let (msg, _input) = admin_get_msg("/b/products/admin/manage");
+    let html = output_to_html(super::super::pages::manage_products(&ctx, &msg).await).await;
+
+    assert!(
+        html.contains(r#"class="data-table""#),
+        "manage page should render the shared data_table component"
+    );
+    assert!(
+        html.contains(r#"data-label="Name""#),
+        "data_table cells should carry data-label for the mobile card collapse"
+    );
+    assert!(html.contains("Widget"), "the seeded product should render");
+}

--- a/crates/solobase-core/src/blocks/products/tests/harness.rs
+++ b/crates/solobase-core/src/blocks/products/tests/harness.rs
@@ -114,6 +114,15 @@ pub async fn output_to_json(out: OutputStream) -> serde_json::Value {
     }
 }
 
+/// Collect an `OutputStream`'s body and decode it as a UTF-8 string (for
+/// asserting on rendered SSR HTML). Empty string if the stream errored.
+pub async fn output_to_html(out: OutputStream) -> String {
+    match out.collect_buffered().await {
+        Ok(buf) => String::from_utf8(buf.body).unwrap_or_default(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Check if an `OutputStream` terminated with an error of the given code.
 pub async fn output_is_error(out: OutputStream, expected: ErrorCode) -> bool {
     use wafer_run::streams::output::TerminalNotResponse;

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -1,4 +1,4 @@
-use maud::{html, PreEscaped};
+use maud::html;
 use wafer_block::db::{ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{
@@ -8,12 +8,8 @@ use wafer_run::{
 
 use super::helpers::{self, parse_form_body, stamp_updated, RecordExt};
 use crate::{
-    blocks::helpers::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json},
-    ui::{
-        components, icons, nav_groups,
-        shell::{Crumb, Topbar},
-        SiteConfig, UserInfo,
-    },
+    blocks::helpers::{err_forbidden, err_internal, err_not_found, ok_json},
+    ui::{self, components, icons, settings_form},
 };
 
 pub(crate) mod migrations;
@@ -225,37 +221,6 @@ impl UserPortalBlock {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-fn render_page(
-    title: &str,
-    config: &SiteConfig,
-    path: &str,
-    user: Option<&UserInfo>,
-    crumb_label: &'static str,
-    content: maud::Markup,
-    msg: &Message,
-) -> OutputStream {
-    let groups = nav_groups::portal();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: crumb_label,
-            href: None,
-        }],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    crate::ui::Page {
-        config,
-        title,
-        nav: &groups,
-        user,
-        current_path: path,
-        topbar,
-        body: content,
-    }
-    .response(msg)
-}
-
 async fn load_buttons(ctx: &dyn Context) -> Vec<wafer_core::clients::database::Record> {
     db::list(
         ctx,
@@ -312,143 +277,46 @@ async fn handle_update_profile(
 // Admin: Branding Settings
 // ---------------------------------------------------------------------------
 
-fn portal_settings_keys() -> [(
-    &'static str,
-    &'static str,
-    &'static str,
-    &'static str,
-    &'static str,
-); 6] {
+/// The shared branding config vars rendered on the portal settings page,
+/// pulled from their central `config_vars::shared_var` declarations (single
+/// source of truth — no parallel tuple table that had drifted on the logo-URL
+/// input types and the favicon default).
+fn branding_vars() -> Vec<wafer_run::ConfigVar> {
     [
-        (
-            "SOLOBASE_SHARED__APP_NAME",
-            "Application Name",
-            "Display name shown in headers, emails, and login pages.",
-            "Solobase",
-            "text",
-        ),
-        (
-            "SOLOBASE_SHARED__LOGO_URL",
-            "Logo URL",
-            "URL of the logo image shown in the header and login pages.",
-            crate::ui::assets::logo_long_url(),
-            "text",
-        ),
-        (
-            "SOLOBASE_SHARED__LOGO_ICON_URL",
-            "Logo Icon URL",
-            "Small icon version of the logo (used in favicons and compact views).",
-            crate::ui::assets::logo_icon_url(),
-            "text",
-        ),
-        (
-            "SOLOBASE_SHARED__AUTH_LOGO_URL",
-            "Auth Logo URL",
-            "Override logo for login/signup pages. Falls back to Logo URL if empty.",
-            "",
-            "text",
-        ),
-        (
-            "SOLOBASE_SHARED__FAVICON_URL",
-            "Favicon URL",
-            "URL of the favicon for browser tabs.",
-            "",
-            "text",
-        ),
-        (
-            "SOLOBASE_SHARED__PRIMARY_COLOR",
-            "Primary Color",
-            "Primary brand color used for buttons, links, and accents.",
-            "#6366f1",
-            "color",
-        ),
+        "SOLOBASE_SHARED__APP_NAME",
+        "SOLOBASE_SHARED__LOGO_URL",
+        "SOLOBASE_SHARED__LOGO_ICON_URL",
+        "SOLOBASE_SHARED__AUTH_LOGO_URL",
+        "SOLOBASE_SHARED__FAVICON_URL",
+        "SOLOBASE_SHARED__PRIMARY_COLOR",
     ]
+    .into_iter()
+    .map(crate::config_vars::shared_var)
+    .collect()
 }
 
 async fn admin_settings_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
-    let mut values = Vec::new();
-    for &(key, label, help, default, input_type) in portal_settings_keys().iter() {
-        let value = config::get_default(ctx, key, default).await;
-        values.push((key, label, help, default, value, input_type));
-    }
-
+    let vars = branding_vars();
+    let sections = [settings_form::SettingsSection::new(
+        "Branding",
+        icons::settings(),
+        &vars,
+    )];
     let content = html! {
         (components::page_header("Branding Settings", Some("Customize your application appearance"), None))
-
-        form #settings-form onsubmit="return submitPortalSettings(event)" {
-            h3 style="font-size:1rem;font-weight:600;margin:0 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-                (icons::settings()) " Branding"
-            }
-
-            @for (key, label, help, default, ref value, input_type) in &values {
-                div .form-group style="margin-bottom:1.25rem" {
-                    label .form-label for=(key) { (label) }
-                    @if *input_type == "color" {
-                        div style="display:flex;align-items:center;gap:0.75rem" {
-                            input .form-input #(key) name=(key) type="text" value=(value) style="flex:1";
-                            input type="color" value=(value)
-                                style="width:40px;height:36px;border:1px solid #e2e8f0;border-radius:6px;cursor:pointer;padding:2px"
-                                onchange={"document.getElementById('" (key) "').value=this.value"};
-                        }
-                    } @else {
-                        input .form-input #(key) name=(key) type="text" value=(value) placeholder=(default);
-                    }
-                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (help) }
-                }
-            }
-
-            button .btn .btn-primary type="submit" style="margin-top:1rem" { "Save Settings" }
-        }
-
-        script { (PreEscaped(r#"
-function submitPortalSettings(e) {
-    e.preventDefault();
-    var form = document.getElementById('settings-form');
-    var data = {};
-    form.querySelectorAll('input[name]').forEach(function(el) { data[el.name] = el.value; });
-    var btn = form.querySelector('button[type="submit"]');
-    btn.disabled = true; btn.textContent = 'Saving...';
-    fetch('/b/userportal/admin/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
-    .then(function(r) { return r.json(); })
-    .then(function(d) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: d.message || 'Saved', type: d.error ? 'error' : 'success' } })); })
-    .catch(function(err) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: 'Error: ' + err.message, type: 'error' } })); })
-    .finally(function() { btn.disabled = false; btn.textContent = 'Save Settings'; });
-    return false;
-}
-"#)) }
+        (settings_form::settings_form(ctx, "/b/userportal/admin/settings", &sections, html! {}).await)
     };
-
-    render_page(
-        "Settings",
-        &site_config,
-        "/b/userportal/admin/settings",
-        user.as_ref(),
-        "Settings",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Settings", ui::NavKind::Portal, "Settings"),
+        content,
     )
+    .await
 }
 
 async fn handle_save_settings(ctx: &dyn Context, input: InputStream) -> OutputStream {
-    let raw = input.collect_to_bytes().await;
-    let body: std::collections::HashMap<String, String> = match serde_json::from_slice(&raw) {
-        Ok(b) => b,
-        // Previously returned 200 OK with an `error` key — clients would
-        // still treat that as success. Use the proper 4xx so the caller can
-        // branch on status alone (matches legalpages handle_save).
-        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
-    };
-    for &(key, _, _, _, _) in portal_settings_keys().iter() {
-        if let Some(value) = body.get(key) {
-            if let Err(e) = config::set(ctx, key, value).await {
-                tracing::warn!(error = %e, key = key, "userportal: failed to set config value");
-            }
-        }
-    }
-    ok_json(&serde_json::json!({"message": "Settings saved"}))
+    settings_form::save_settings(ctx, input, &branding_vars(), "userportal").await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
@@ -8,7 +8,7 @@ use maud::html;
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, InputStream, Message, OutputStream};
 
-use super::super::{load_buttons, render_page};
+use super::super::load_buttons;
 // Crate-rooted path (rather than `super::super::TABLE`) so the WRAP-grant
 // audit (scripts/audit-wrap-grants.sh) can statically resolve the constant
 // to this block's table.
@@ -18,7 +18,7 @@ use crate::{
         err_bad_request, err_internal, err_not_found, json_map, parse_form_body, stamp_created,
         stamp_updated, RecordExt,
     },
-    ui::{self, components, icons, sidebar::nav_icon, SiteConfig, UserInfo},
+    ui::{self, components, icons, sidebar::nav_icon},
 };
 
 /// Known icon names available for button configuration.
@@ -40,8 +40,6 @@ const ICON_OPTIONS: &[(&str, &str)] = &[
 ];
 
 pub async fn admin_buttons_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let site_config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
     let buttons = load_buttons(ctx).await;
 
     let content = html! {
@@ -93,15 +91,13 @@ pub async fn admin_buttons_page(ctx: &dyn Context, msg: &Message) -> OutputStrea
         (render_buttons_table(&buttons))
     };
 
-    render_page(
-        "Portal Buttons",
-        &site_config,
-        "/b/userportal/admin/buttons",
-        user.as_ref(),
-        "Portal Buttons",
-        content,
+    ui::shell_page(
+        ctx,
         msg,
+        ui::Shell::simple("Portal Buttons", ui::NavKind::Portal, "Portal Buttons"),
+        content,
     )
+    .await
 }
 
 fn render_buttons_table(buttons: &[db::Record]) -> maud::Markup {

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -8,10 +8,9 @@ use wafer_run::{context::Context, Message, OutputStream};
 
 use super::service::{display_index_name, IndexRow};
 use crate::ui::{
-    self, nav_groups,
-    shell::{Crumb, Topbar},
+    self,
+    shell::Crumb,
     templates::{detail_page, list_page, DetailHero, DetailMeta, PageHeader},
-    Page, SiteConfig, UserInfo,
 };
 
 /// htmx-friendly success render for `POST /b/vector/api/indexes` — re-loads
@@ -158,9 +157,6 @@ pub fn render_index_detail_sections(
 /// for unknown collections, so this only logs when something more serious
 /// happens.
 pub async fn index_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let rows = match super::service::list_index_rows(ctx).await {
         Ok(rs) => rs,
         Err(e) => {
@@ -207,37 +203,34 @@ pub async fn index_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
         None,
     );
 
-    let groups = nav_groups::admin();
-    let topbar = Topbar {
-        crumbs: vec![Crumb {
-            label: "Vector indexes",
-            href: None,
-        }],
-        primary_action: if backend_available {
-            Some(crate::ui::components::button(
-                crate::ui::components::BtnVariant::Primary,
-                crate::ui::components::CtrlSize::Sm,
-                "+ Create index",
-                maud::PreEscaped(
-                    r#"type="button" onclick="openModal('create-vector-index')""#.to_string(),
-                ),
-            ))
-        } else {
-            None
-        },
-        subtitle: Some("Per-index counts, model, dimensions"),
-        show_palette: true,
+    let primary_action = if backend_available {
+        Some(crate::ui::components::button(
+            crate::ui::components::BtnVariant::Primary,
+            crate::ui::components::CtrlSize::Sm,
+            "+ Create index",
+            maud::PreEscaped(
+                r#"type="button" onclick="openModal('create-vector-index')""#.to_string(),
+            ),
+        ))
+    } else {
+        None
     };
-    Page {
-        config: &config,
-        title: "Vector indexes",
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: msg.path(),
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: "Vector indexes",
+            nav: ui::NavKind::Admin,
+            crumbs: vec![Crumb {
+                label: "Vector indexes",
+                href: None,
+            }],
+            subtitle: Some("Per-index counts, model, dimensions"),
+            primary_action,
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 /// GET `/b/vector/{name}/` — admin-facing single-index detail page.
@@ -268,9 +261,6 @@ pub async fn index_detail_page(ctx: &dyn Context, msg: &Message, name: &str) -> 
         .await
         .unwrap_or_default();
 
-    let config = SiteConfig::load(ctx).await;
-    let user = UserInfo::from_message(msg);
-
     let display = display_index_name(&row.name);
     let subtitle = format!(
         "{} · {} dimensions",
@@ -295,32 +285,28 @@ pub async fn index_detail_page(ctx: &dyn Context, msg: &Message, name: &str) -> 
         Vec::<DetailMeta<'_>>::new(),
     );
 
-    let topbar = Topbar {
-        crumbs: vec![
-            Crumb {
-                label: "Vector indexes",
-                href: Some("/b/vector/"),
-            },
-            Crumb {
-                label: &display,
-                href: None,
-            },
-        ],
-        primary_action: None,
-        subtitle: None,
-        show_palette: true,
-    };
-    let groups = nav_groups::admin();
-    Page {
-        config: &config,
-        title: display,
-        nav: &groups,
-        user: user.as_ref(),
-        current_path: msg.path(),
-        topbar,
+    ui::shell_page(
+        ctx,
+        msg,
+        ui::Shell {
+            title: display,
+            nav: ui::NavKind::Admin,
+            crumbs: vec![
+                Crumb {
+                    label: "Vector indexes",
+                    href: Some("/b/vector/"),
+                },
+                Crumb {
+                    label: display,
+                    href: None,
+                },
+            ],
+            subtitle: None,
+            primary_action: None,
+        },
         body,
-    }
-    .response(msg)
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/config_vars.rs
+++ b/crates/solobase-core/src/config_vars.rs
@@ -137,6 +137,41 @@ pub fn shared_config_vars() -> Vec<ConfigVar> {
     vars
 }
 
+/// Look up a single `SOLOBASE_SHARED__*` config var by key.
+///
+/// The settings pages assemble their sections by pulling the exact
+/// [`ConfigVar`] metadata they want to show — shared vars come from here,
+/// block-owned vars come from the block's own `info().config_keys` (via
+/// [`var_in`]). This keeps [`ConfigVar`] the single source of truth: no page
+/// re-declares a key's label/default/input_type in a parallel tuple table.
+///
+/// Panics in debug if the key isn't a known shared var — that's a programming
+/// error (a settings page asking for a var that was never declared), caught at
+/// the first test run rather than silently rendering an empty field.
+pub fn shared_var(key: &str) -> ConfigVar {
+    shared_config_vars()
+        .into_iter()
+        .find(|v| v.key == key)
+        .unwrap_or_else(|| {
+            debug_assert!(false, "settings page requested unknown shared var: {key}");
+            ConfigVar::new(key, "", "")
+        })
+}
+
+/// Look up a single config var by key within a block's own declared
+/// `config_keys`. The companion to [`shared_var`] for block-owned vars.
+///
+/// Panics in debug if the key isn't declared by the block.
+pub fn var_in(vars: &[ConfigVar], key: &str) -> ConfigVar {
+    vars.iter()
+        .find(|v| v.key == key)
+        .cloned()
+        .unwrap_or_else(|| {
+            debug_assert!(false, "settings page requested undeclared block var: {key}");
+            ConfigVar::new(key, "", "")
+        })
+}
+
 /// Collect all known config variables: shared + all block-declared.
 pub fn collect_all_config_vars(block_infos: &[wafer_run::BlockInfo]) -> Vec<ConfigVar> {
     let mut all = shared_config_vars();

--- a/crates/solobase-core/src/ui/components.rs
+++ b/crates/solobase-core/src/ui/components.rs
@@ -436,6 +436,12 @@ pub struct TableCol<'a> {
 ///
 /// `rows` is a Vec because we need to know if it's empty. If empty, an
 /// `empty_state` is rendered in place of the table body.
+///
+/// Each `<td>` carries `data-label="{column label}"` so the mobile
+/// card-collapse CSS (`.data-table td::before { content: attr(data-label) }`,
+/// the PR #75 responsive fix) labels every stacked cell automatically. Cells
+/// are matched to columns positionally; a cell beyond the declared columns
+/// (shouldn't happen) gets an empty label.
 pub fn data_table<'a, F>(
     columns: &[TableCol<'a>],
     rows: Vec<Vec<maud::Markup>>,
@@ -464,7 +470,9 @@ where
                     @for (i, cells) in rows.into_iter().enumerate() {
                         @let href = row_href.as_ref().and_then(|f| f(i));
                         tr .(if href.is_some() { "data-table__row data-table__row--linked" } else { "data-table__row" }) {
-                            @for cell in cells { td { (cell) } }
+                            @for (j, cell) in cells.into_iter().enumerate() {
+                                td data-label=(columns.get(j).map(|c| c.label).unwrap_or("")) { (cell) }
+                            }
                             @if let Some(h) = href {
                                 td .data-table__row-href { a href=(h) aria-label="Open" { "›" } }
                             }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod icons;
 pub mod layout;
 pub mod nav_groups;
 pub mod palette;
+pub mod settings_form;
 pub mod shell;
 pub mod sidebar;
 pub mod templates;
@@ -187,6 +188,92 @@ impl<'a> Page<'a> {
         }
         html_response(self.render())
     }
+}
+
+/// Which audience's sidebar a shelled page should render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavKind {
+    /// End-user portal sidebar (Account / Apps).
+    Portal,
+    /// Admin sidebar (Workspace / Data / System).
+    Admin,
+}
+
+impl NavKind {
+    fn groups(self) -> Vec<NavGroup> {
+        match self {
+            NavKind::Portal => nav_groups::portal(),
+            NavKind::Admin => nav_groups::admin(),
+        }
+    }
+}
+
+/// Declarative inputs for [`shell_page`] — everything a block page needs to
+/// render the standard chrome, minus the body and the data ([`SiteConfig`] /
+/// [`UserInfo`] are loaded internally).
+pub struct Shell<'a> {
+    /// `<title>` text.
+    pub title: &'a str,
+    /// Which sidebar to render.
+    pub nav: NavKind,
+    /// Breadcrumb trail. A single `Crumb { label, href: None }` is the common case.
+    pub crumbs: Vec<shell::Crumb<'a>>,
+    /// Optional subtitle shown after the crumbs.
+    pub subtitle: Option<&'a str>,
+    /// Optional primary action button in the topbar.
+    pub primary_action: Option<maud::Markup>,
+}
+
+impl<'a> Shell<'a> {
+    /// The single-crumb, no-subtitle, no-action shell that almost every page uses.
+    pub fn simple(title: &'a str, nav: NavKind, crumb_label: &'a str) -> Self {
+        Self {
+            title,
+            nav,
+            crumbs: vec![shell::Crumb {
+                label: crumb_label,
+                href: None,
+            }],
+            subtitle: None,
+            primary_action: None,
+        }
+    }
+}
+
+/// Render `body` inside the standard page chrome (sidebar + topbar + ⌘K
+/// palette), loading [`SiteConfig`] and [`UserInfo`] internally and returning
+/// an htmx-aware [`OutputStream`]. This is the single shell constructor that
+/// replaced the six per-block `*_page` wrapper functions (`render_page`,
+/// `legalpages_page`, `messages_page`, `products_page`, `llm_page`,
+/// `files_page*`) and the inline `Page { .. }.response(msg)` reconstructions.
+///
+/// `current_path` is taken from the request path so the active sidebar item
+/// highlights correctly.
+pub async fn shell_page(
+    ctx: &dyn wafer_run::context::Context,
+    msg: &wafer_run::Message,
+    shell: Shell<'_>,
+    body: maud::Markup,
+) -> wafer_run::OutputStream {
+    let config = SiteConfig::load(ctx).await;
+    let user = UserInfo::from_message(msg);
+    let groups = shell.nav.groups();
+    let path = msg.path().to_string();
+    Page {
+        config: &config,
+        title: shell.title,
+        nav: &groups,
+        user: user.as_ref(),
+        current_path: &path,
+        topbar: shell::Topbar {
+            crumbs: shell.crumbs,
+            subtitle: shell.subtitle,
+            primary_action: shell.primary_action,
+            show_palette: true,
+        },
+        body,
+    }
+    .response(msg)
 }
 
 /// Minimal `SiteConfig` used by the status-page helpers. They render

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -1,0 +1,292 @@
+//! Shared, ConfigVar-driven admin settings form.
+//!
+//! Every block's admin settings page used to carry its own copy of: a
+//! stringly-typed tuple table re-declaring `(key, label, help, default,
+//! input_type)` that the block *already* declares as [`ConfigVar`] in its
+//! `BlockInfo::config_keys` (or that `config_vars.rs` declares centrally for
+//! `SOLOBASE_SHARED__*`), a maud form loop with a special-cased color picker
+//! and sensitive-field eye toggle, a copy-pasted inline-JS submit function,
+//! and a POST handler that walked the same tuple table to `config::set` each
+//! key. Five blocks, five drifting copies (verified live drifts: legalpages
+//! `BG_COLOR` default, userportal `FAVICON_URL`/logo-URL input types).
+//!
+//! This module is the single renderer + the single save handler, driven
+//! directly by [`ConfigVar`] metadata — the declared single source of truth.
+//! The widget is derived from [`InputType`]: `Password` → masked field with an
+//! eye toggle, `Color` → text input paired with a color picker, `Toggle` →
+//! checkbox, `Url`/`Text` → plain text input. Each block's settings page becomes
+//! "pick the ConfigVars to show, group them into sections, render".
+
+use std::collections::HashMap;
+
+use maud::{html, Markup, PreEscaped};
+use wafer_core::clients::config;
+use wafer_run::{context::Context, InputStream, OutputStream};
+pub use wafer_run::{ConfigVar, InputType};
+
+use crate::blocks::helpers::{err_bad_request, ok_json};
+
+/// One titled group of settings within a form (e.g. "Stripe", "OAuth Providers").
+pub struct SettingsSection<'a> {
+    /// Section heading text.
+    pub title: &'a str,
+    /// Section heading icon (a maud fragment, e.g. `icons::settings()`).
+    pub icon: Markup,
+    /// The config variables rendered in this section, in order.
+    pub vars: &'a [ConfigVar],
+}
+
+impl<'a> SettingsSection<'a> {
+    /// Construct a section from a title, icon, and its variables.
+    pub fn new(title: &'a str, icon: Markup, vars: &'a [ConfigVar]) -> Self {
+        Self { title, icon, vars }
+    }
+}
+
+/// Load the current value for every var in `sections` via the config client.
+async fn load_values(
+    ctx: &dyn Context,
+    sections: &[SettingsSection<'_>],
+) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+    for section in sections {
+        for var in section.vars {
+            // `entry`-guard so a key declared in two sections is only fetched once.
+            if !values.contains_key(&var.key) {
+                let value = config::get_default(ctx, &var.key, &var.default).await;
+                values.insert(var.key.clone(), value);
+            }
+        }
+    }
+    values
+}
+
+/// Render one field, deriving the widget from the var's [`InputType`].
+fn render_field(var: &ConfigVar, value: &str) -> Markup {
+    let label = if var.name.is_empty() {
+        var.key.as_str()
+    } else {
+        var.name.as_str()
+    };
+    match var.input_type {
+        InputType::Toggle => html! {
+            div .form-group style="margin-bottom:1.25rem" {
+                label style="display:flex;align-items:center;gap:0.75rem;cursor:pointer" {
+                    input type="checkbox" name=(var.key)
+                        checked[value == "true"]
+                        style="width:1.25rem;height:1.25rem;accent-color:var(--primary)";
+                    span .form-label style="margin:0" { (label) }
+                }
+                @if !var.description.is_empty() {
+                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (var.description) }
+                }
+            }
+        },
+        InputType::Password => {
+            let has_value = !value.is_empty();
+            html! {
+                div .form-group style="margin-bottom:1.25rem" {
+                    label .form-label for=(var.key) { (label) }
+                    div style="display:flex;align-items:center;gap:0.5rem" {
+                        input .form-input #(var.key) name=(var.key) type="password" value=(value)
+                            placeholder=(if has_value { "******** (set)" } else { "Not configured" })
+                            style="flex:1";
+                        button type="button" .btn .btn-ghost .btn-sm
+                            onclick={"var i=document.getElementById('" (var.key) "');i.type=i.type==='password'?'text':'password'"}
+                        { (super::icons::eye()) }
+                    }
+                    @if !var.description.is_empty() {
+                        p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (var.description) }
+                    }
+                }
+            }
+        }
+        InputType::Color => html! {
+            div .form-group style="margin-bottom:1.25rem" {
+                label .form-label for=(var.key) { (label) }
+                div style="display:flex;align-items:center;gap:0.75rem" {
+                    input .form-input #(var.key) name=(var.key) type="text" value=(value)
+                        placeholder=(var.default) style="flex:1";
+                    input type="color" value=(value)
+                        style="width:40px;height:36px;border:1px solid #e2e8f0;border-radius:6px;cursor:pointer;padding:2px"
+                        onchange={"document.getElementById('" (var.key) "').value=this.value"};
+                }
+                @if !var.description.is_empty() {
+                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (var.description) }
+                }
+            }
+        },
+        InputType::Url | InputType::Text => html! {
+            div .form-group style="margin-bottom:1.25rem" {
+                label .form-label for=(var.key) { (label) }
+                input .form-input #(var.key) name=(var.key) type="text" value=(value)
+                    placeholder=(var.default);
+                @if !var.description.is_empty() {
+                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (var.description) }
+                }
+            }
+        },
+    }
+}
+
+/// The single inline submit snippet shared by every settings form. Posts the
+/// form as a JSON object to `post_url` and shows a toast with the result.
+/// `post_url` is interpolated via `serde_json` so it can't break out of the
+/// JS string literal.
+fn submit_js(post_url: &str) -> String {
+    let url = serde_json::to_string(post_url).unwrap_or_else(|_| "\"\"".to_string());
+    format!(
+        r#"
+function submitSettings(e) {{
+    e.preventDefault();
+    var form = document.getElementById('settings-form');
+    var data = {{}};
+    form.querySelectorAll('input[name], select[name], textarea[name]').forEach(function(el) {{
+        if (el.type === 'checkbox') {{ data[el.name] = el.checked ? 'true' : 'false'; }}
+        else {{ data[el.name] = el.value; }}
+    }});
+    var btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true; btn.textContent = 'Saving...';
+    fetch({url}, {{ method: 'POST', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify(data) }})
+    .then(function(r) {{ return r.json(); }})
+    .then(function(d) {{ document.body.dispatchEvent(new CustomEvent('showToast', {{ detail: {{ message: d.message || 'Saved', type: d.error ? 'error' : 'success' }} }})); }})
+    .catch(function(err) {{ document.body.dispatchEvent(new CustomEvent('showToast', {{ detail: {{ message: 'Error: ' + err.message, type: 'error' }} }})); }})
+    .finally(function() {{ btn.disabled = false; btn.textContent = 'Save Settings'; }});
+    return false;
+}}
+"#
+    )
+}
+
+/// Render the full ConfigVar-driven settings form: a `#settings-form` posting
+/// JSON to `post_url`, with one titled section per [`SettingsSection`], a
+/// "Save Settings" button, and the shared submit snippet. Current values are
+/// loaded from the config client internally.
+///
+/// `extra` is appended after the last section and before the submit button —
+/// used by blocks that want an extra panel inside the form (e.g. legalpages'
+/// live-preview links).
+pub async fn settings_form(
+    ctx: &dyn Context,
+    post_url: &str,
+    sections: &[SettingsSection<'_>],
+    extra: Markup,
+) -> Markup {
+    let values = load_values(ctx, sections).await;
+    let empty = String::new();
+    html! {
+        form #settings-form onsubmit="return submitSettings(event)" {
+            @for (i, section) in sections.iter().enumerate() {
+                h3 style=(format!(
+                    "font-size:1rem;font-weight:600;margin:{} 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)",
+                    if i == 0 { "0" } else { "1.5rem" }
+                )) {
+                    (section.icon) " " (section.title)
+                }
+                @for var in section.vars {
+                    (render_field(var, values.get(&var.key).unwrap_or(&empty)))
+                }
+            }
+            (extra)
+            button .btn .btn-primary type="submit" style="margin-top:1rem" { "Save Settings" }
+        }
+        script { (PreEscaped(submit_js(post_url))) }
+    }
+}
+
+/// Generic settings save handler: parse the JSON body, and for every key in
+/// the `allowed` ConfigVar allowlist that the body carries, `config::set` it.
+/// Keys outside the allowlist are ignored (a block can only write the vars it
+/// declared). Parse failure returns a real `400` (htmx clients branch on the
+/// status, not a 200-with-`error`-key body — the residual finding folded in
+/// from S1-I).
+pub async fn save_settings(
+    ctx: &dyn Context,
+    input: InputStream,
+    allowed: &[ConfigVar],
+    block_label: &str,
+) -> OutputStream {
+    let raw = input.collect_to_bytes().await;
+    let body: HashMap<String, String> = match serde_json::from_slice(&raw) {
+        Ok(b) => b,
+        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
+    };
+    for var in allowed {
+        if let Some(value) = body.get(&var.key) {
+            if let Err(e) = config::set(ctx, &var.key, value).await {
+                tracing::warn!(error = %e, key = %var.key, block = block_label, "failed to set config value");
+            }
+        }
+    }
+    ok_json(&serde_json::json!({"message": "Settings saved"}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(key: &str, name: &str, input_type: InputType) -> ConfigVar {
+        ConfigVar::new(key, "desc text", "def")
+            .name(name)
+            .input_type(input_type)
+    }
+
+    #[test]
+    fn text_field_renders_text_input_with_label_and_help() {
+        let v = var("SOLOBASE_SHARED__APP_NAME", "App Name", InputType::Text);
+        let s = render_field(&v, "MyApp").into_string();
+        assert!(s.contains(r#"name="SOLOBASE_SHARED__APP_NAME""#));
+        assert!(s.contains(r#"type="text""#));
+        assert!(s.contains(r#"value="MyApp""#));
+        assert!(s.contains(">App Name<"));
+        assert!(s.contains("desc text"));
+    }
+
+    #[test]
+    fn password_field_is_masked_with_eye_toggle_and_no_value_echoed_when_empty() {
+        let v = var("X__PW", "Secret", InputType::Password);
+        let set = render_field(&v, "hunter2").into_string();
+        assert!(set.contains(r#"type="password""#));
+        assert!(set.contains("(set)"));
+        // eye toggle present
+        assert!(set.contains("i.type=i.type==='password'?'text':'password'"));
+
+        let empty = render_field(&v, "").into_string();
+        assert!(empty.contains("Not configured"));
+    }
+
+    #[test]
+    fn color_field_pairs_text_input_with_color_picker() {
+        let v = var("X__COLOR", "Brand", InputType::Color);
+        let s = render_field(&v, "#abcdef").into_string();
+        assert!(s.contains(r#"type="color""#));
+        assert!(s.contains("value=\"#abcdef\""));
+        assert!(s.contains("onchange="));
+    }
+
+    #[test]
+    fn toggle_field_renders_checkbox_checked_for_true() {
+        let v = var("X__FLAG", "Flag", InputType::Toggle);
+        let on = render_field(&v, "true").into_string();
+        assert!(on.contains(r#"type="checkbox""#));
+        assert!(on.contains("checked"));
+        let off = render_field(&v, "false").into_string();
+        assert!(!off.contains("checked"));
+    }
+
+    #[test]
+    fn field_falls_back_to_key_when_name_empty() {
+        let v = ConfigVar::new("X__NONAME", "", "").input_type(InputType::Text);
+        let s = render_field(&v, "").into_string();
+        assert!(s.contains(">X__NONAME<"));
+    }
+
+    #[test]
+    fn submit_js_interpolates_post_url_safely() {
+        let js = submit_js("/b/products/admin/settings");
+        assert!(js.contains(r#"fetch("/b/products/admin/settings""#));
+        // a quote in the url must not break out of the string literal
+        let js2 = submit_js(r#"/x"); alert(1);//"#);
+        assert!(!js2.contains(r#"fetch("/x");"#));
+    }
+}


### PR DESCRIPTION
S2-M (ui-shared-machinery), phase 2 Wave 2 of the solobase quality-fix program.

Two shared UI machinery pieces, then per-block migration. ConfigVar is the single settings metadata source (no hardcoded tuple tables). Adopts `components::data_table` (carries the PR #75 mobile fix) in products list pages.

## Findings addressed (plan section S2-M)
- [x] **Settings-page machinery triplicated … duplicating ConfigVar metadata** — built `ui::settings_form` (ConfigVar-driven form + generic `save_settings`; widget from `InputType`: Password→masked+eye, Color→picker, Toggle→checkbox, Url/Text→text; one shared submit JS). Deleted the five drifting tuple tables (products 7-row, auth_ui 11-row, legalpages 3-row, userportal 6-tuple) + the duplicated `render_sensitive_field`/`render_setting_field` copies.
- [x] **Admin settings page duplicated across 5 blocks** — products/auth_ui/legalpages/userportal settings pages + save handlers collapse onto `settings_form`.
- [x] **Per-block admin settings pages: ConfigVar re-declared in drifting tuples (scaffolding lens)** — each block now exposes `config_vars()` (single source for BlockInfo + settings page); shared vars pulled via `config_vars::shared_var`. Fixes the verified drifts: legalpages `BG_COLOR` default, userportal logo-URL input types + `FAVICON_URL` default.
- [x] **err_bad_request-on-parse-failure (S1-I residual)** — folded into `settings_form::save_settings` (real 400, not 200-with-error-key).
- [x] **Page-shell wrapper copy-pasted into 6+ blocks** — built `ui::shell_page(ctx, msg, Shell{…}, body)` loading SiteConfig/UserInfo internally; deleted `products_page`, `legalpages_page`, `messages_page`, `llm_page`, `files_page*`, userportal `render_page`.
- [x] **Page-shell assembly repeated 6x in files/vector; 9-positional-arg variant** — migrated the files (pages_admin + 3 pages_user inline) and vector (2 inline) reconstructions; files wrappers are now thin `shell_page` delegates.
- [x] **Per-block portal page-shell + 8 inline reconstructions (scaffolding lens)** — messages/llm inline Page reconstructions (variable Vec<Crumb>) migrated; Shell carries crumbs.
- [x] **`ui::components::data_table` has zero callers** — adopted in the 6 products list pages; `data_table` now emits `td[data-label]` so the PR #75 mobile card-collapse labels every adopter automatically.
- [x] No-hardcoded-lists: declared `REQUIRE_VERIFICATION` / `ALLOWED_EMAIL_DOMAINS` as ConfigVars (`auth::config::auth_identity_config_vars`) — previously read only via env.

## Local verification (CI is the final gate)
- `cargo +nightly fmt --all -- --check`: clean
- clippy (`-p solobase-core`): zero NEW warnings in changed code (pre-existing format!/let-else warnings only, in untouched helpers)
- `cargo test -p solobase-core --lib`: 754 passed
- guards: `grep-guard-html.sh` OK, `audit-wrap-grants.sh` OK
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown`: clean (solobase-core is wasm-safe)

## Visual baselines
Only one captured baseline shifts: **portal-products** (desktop+mobile). The products overview at `/b/products/` now correctly highlights the Products sidebar item — `shell_page` derives `current_path` from the request path, where the old wrapper hardcoded `/b/products/admin/` (never matched the nav href). Pinned by two new render regression tests (`overview_highlights_products_nav_via_request_path`, `manage_products_uses_data_table_with_mobile_labels`). The settings pages with intended drift fixes are NOT captured by the baseline suite. Regen-visual-baselines workflow dispatched against this branch; re-run CI after the orchestrator rebases onto main (GITHUB_TOKEN-pushed baselines don't auto-retrigger).

## Decisions / notes
- auth_ui: Microsoft OAuth creds + OAuth redirect URI now render on the settings page (declared config_keys the old tuple omitted); the bootstrap-admin password moves from "OAuth Providers" (an old `skip(5)` slice bug) to the "Admin" section. Both intended, both on the (uncaptured) settings page.
- legalpages FOOTER renders as a text input (was a 3-row textarea). **Proposed wafer-run follow-up**: add `InputType::Textarea` so the widget stays ConfigVar-driven; text input is functionally equivalent meanwhile (wafer-run worktree is read-only here).
- No block-SQL/seed change → no `SOLOBASE_RUN_MIGRATIONS=1` requirement.
- Shared-file overlap with sibling wave-2 packages (S2-N mod.rs path_param/dispatch, S2-L auth_ui/mod.rs rate-limit + files hunk, S2-Q llm data-fetch): this package owns only page/settings rendering; edits are localized to shell tails + settings, trivial rebases expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)