### PR TITLE
fix(S4-U): routing-auth-policy — one route+auth declaration, one enforcement point, one in-block dispatch

### DIFF
--- a/crates/solobase-core/src/blocks/admin/database.rs
+++ b/crates/solobase-core/src/blocks/admin/database.rs
@@ -117,9 +117,15 @@ pub(in crate::blocks::admin) async fn introspect_columns(
     (cols, row_count)
 }
 
-pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+/// `path` is the normalized `/admin/database/...` sub-path, passed explicitly
+/// (no `req.resource` rewrite). `handle_columns` extracts the table name from it.
+pub async fn handle(
+    ctx: &dyn Context,
+    msg: &Message,
+    path: &str,
+    input: InputStream,
+) -> OutputStream {
     let action = msg.action();
-    let path = msg.path();
 
     match (action, path) {
         ("retrieve", "/admin/database/info") => handle_info(ctx).await,
@@ -127,7 +133,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
         ("retrieve", _)
             if path.starts_with("/admin/database/tables/") && path.ends_with("/columns") =>
         {
-            handle_columns(ctx, msg).await
+            handle_columns(ctx, path).await
         }
         ("create", "/admin/database/query") => handle_query(ctx, input).await,
         _ => err_not_found("not found"),
@@ -177,8 +183,7 @@ async fn handle_tables(ctx: &dyn Context) -> OutputStream {
     ok_json(&serde_json::json!(table_info))
 }
 
-async fn handle_columns(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_columns(ctx: &dyn Context, path: &str) -> OutputStream {
     // Extract table name from /admin/database/tables/{name}/columns
     let table_name = path
         .strip_prefix("/admin/database/tables/")

--- a/crates/solobase-core/src/blocks/admin/iam.rs
+++ b/crates/solobase-core/src/blocks/admin/iam.rs
@@ -18,31 +18,37 @@ pub(crate) const PERMISSIONS_TABLE: &str = "suppers_ai__admin__permissions";
 /// User → role assignment table (many-to-many via row per pair).
 pub(crate) const USER_ROLES_TABLE: &str = "suppers_ai__admin__user_roles";
 
-pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+/// `path` is the normalized `/admin/iam/...` sub-path, passed explicitly (no
+/// `req.resource` rewrite). Id-bearing leaves take their id from it.
+pub async fn handle(
+    ctx: &dyn Context,
+    msg: &Message,
+    path: &str,
+    input: InputStream,
+) -> OutputStream {
     let action = msg.action();
-    let path = msg.path();
 
     match (action, path) {
         // Roles
         ("retrieve", "/admin/iam/roles") => handle_list_roles(ctx).await,
         ("create", "/admin/iam/roles") => handle_create_role(ctx, msg, input).await,
         ("update", _) if path.starts_with("/admin/iam/roles/") => {
-            handle_update_role(ctx, msg, input).await
+            handle_update_role(ctx, path, input).await
         }
         ("delete", _) if path.starts_with("/admin/iam/roles/") => {
-            handle_delete_role(ctx, msg).await
+            handle_delete_role(ctx, msg, path).await
         }
         // Permissions
         ("retrieve", "/admin/iam/permissions") => handle_list_permissions(ctx).await,
         ("create", "/admin/iam/permissions") => handle_create_permission(ctx, input).await,
         ("delete", _) if path.starts_with("/admin/iam/permissions/") => {
-            handle_delete_permission(ctx, msg).await
+            handle_delete_permission(ctx, path).await
         }
         // User-role assignments
         ("retrieve", "/admin/iam/user-roles") => handle_list_user_roles(ctx, msg).await,
         ("create", "/admin/iam/user-roles") => handle_assign_role(ctx, msg, input).await,
         ("delete", _) if path.starts_with("/admin/iam/user-roles/") => {
-            handle_remove_role(ctx, msg).await
+            handle_remove_role(ctx, msg, path).await
         }
         _ => err_not_found("not found"),
     }
@@ -90,8 +96,7 @@ async fn handle_create_role(ctx: &dyn Context, msg: &Message, input: InputStream
     }
 }
 
-async fn handle_update_role(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let path = msg.path();
+async fn handle_update_role(ctx: &dyn Context, path: &str, input: InputStream) -> OutputStream {
     let id = path.strip_prefix("/admin/iam/roles/").unwrap_or("");
     if id.is_empty() {
         return err_bad_request("Missing role ID");
@@ -137,8 +142,7 @@ async fn handle_update_role(ctx: &dyn Context, msg: &Message, input: InputStream
     }
 }
 
-async fn handle_delete_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_delete_role(ctx: &dyn Context, msg: &Message, path: &str) -> OutputStream {
     let id = path.strip_prefix("/admin/iam/roles/").unwrap_or("");
     // System-role guard, delete, and audit-log write live in the shared ops
     // layer (the JSON path previously logged nothing).
@@ -187,8 +191,7 @@ async fn handle_create_permission(ctx: &dyn Context, input: InputStream) -> Outp
     }
 }
 
-async fn handle_delete_permission(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_delete_permission(ctx: &dyn Context, path: &str) -> OutputStream {
     let id = path.strip_prefix("/admin/iam/permissions/").unwrap_or("");
     if id.is_empty() {
         return err_bad_request("Missing permission ID");
@@ -275,8 +278,7 @@ async fn handle_assign_role(ctx: &dyn Context, msg: &Message, input: InputStream
     }
 }
 
-async fn handle_remove_role(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_remove_role(ctx: &dyn Context, msg: &Message, path: &str) -> OutputStream {
     let id = path.strip_prefix("/admin/iam/user-roles/").unwrap_or("");
     if id.is_empty() {
         return err_bad_request("Missing user-role ID");

--- a/crates/solobase-core/src/blocks/admin/logs.rs
+++ b/crates/solobase-core/src/blocks/admin/logs.rs
@@ -16,9 +16,10 @@ pub(crate) use crate::admin_schema::REQUEST_LOGS_TABLE;
 /// Storage access log entries (one row per object read/write).
 pub(crate) const STORAGE_ACCESS_LOGS_TABLE: &str = "suppers_ai__admin__storage_access_logs";
 
-pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
+/// `path` is the normalized `/admin/logs` sub-path, passed explicitly (no
+/// `req.resource` rewrite).
+pub async fn handle(ctx: &dyn Context, msg: &Message, path: &str) -> OutputStream {
     let action = msg.action();
-    let path = msg.path();
 
     match (action, path) {
         ("retrieve", "/admin/logs") => handle_list(ctx, msg).await,

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -137,27 +137,28 @@ impl Block for AdminBlock {
     ) -> OutputStream {
         use route::AdminRoute;
 
-        // Capture path + action BEFORE any meta mutation. msg.path() reads from
-        // get_meta("req.resource") which the API normalization below mutates;
-        // without these captures the routing classifier would see the normalized
-        // path and miss the /b/admin/api prefix.
         let path_owned = msg.path().to_string();
         let action_owned = msg.action().to_string();
 
-        // API path normalization: downstream sub-handlers (users::handle,
-        // database::handle, etc.) expect req.resource as /admin/... instead
-        // of /b/admin/api/... — preserve that contract exactly as the
-        // pre-refactor handler did.
-        if let Some(api_rest) = path_owned.strip_prefix("/b/admin/api") {
-            msg.set_meta("req.resource", &format!("/admin{}", api_rest));
-        }
+        // The JSON sub-handlers (users::handle, database::handle, …) match on
+        // the normalized `/admin/...` form of the path. That normalized path is
+        // computed here and passed to them as an EXPLICIT argument — no
+        // `req.resource` mutation. `req.resource` is reserved for the genuine
+        // cross-block `call_block` delegations below (StorageDelegate /
+        // CloudStorageDelegate), where the receiving files block reads it as a
+        // fresh request boundary.
+        let api_norm = path_owned
+            .strip_prefix("/b/admin/api")
+            .map(|rest| format!("/admin{rest}"))
+            .unwrap_or_else(|| path_owned.clone());
+
         match route::route(&path_owned, &action_owned) {
             // --- /b/admin/api/... ---
-            AdminRoute::UsersApi => users::handle(ctx, &msg, input).await,
-            AdminRoute::DatabaseApi => database::handle(ctx, &msg, input).await,
-            AdminRoute::IamApi => iam::handle(ctx, &msg, input).await,
-            AdminRoute::LogsApi => logs::handle(ctx, &msg).await,
-            AdminRoute::SettingsApi => settings::handle(ctx, &msg, input).await,
+            AdminRoute::UsersApi => users::handle(ctx, &msg, &api_norm, input).await,
+            AdminRoute::DatabaseApi => database::handle(ctx, &msg, &api_norm, input).await,
+            AdminRoute::IamApi => iam::handle(ctx, &msg, &api_norm, input).await,
+            AdminRoute::LogsApi => logs::handle(ctx, &msg, &api_norm).await,
+            AdminRoute::SettingsApi => settings::handle(ctx, &msg, &api_norm, input).await,
             AdminRoute::ExtensionsApi => {
                 let blocks: Vec<_> = ctx
                     .registered_blocks()

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -100,9 +100,15 @@ pub mod block_settings {
 // `super::BLOCK_SETTINGS_TABLE` references keep resolving.
 pub use crate::admin_schema::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE};
 
-pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+/// `path` is the normalized `/admin/settings[...]` sub-path, passed explicitly
+/// (no `req.resource` rewrite). Id-bearing leaves take the key from it.
+pub async fn handle(
+    ctx: &dyn Context,
+    msg: &Message,
+    path: &str,
+    input: InputStream,
+) -> OutputStream {
     let action = msg.action();
-    let path = msg.path();
 
     match (action, path) {
         ("retrieve", "/admin/settings/all") => handle_list_full(ctx).await,
@@ -110,11 +116,13 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
         ("retrieve", _)
             if path.starts_with("/admin/settings/") || path.starts_with("/settings/") =>
         {
-            handle_get(ctx, msg).await
+            handle_get(ctx, path).await
         }
-        ("update", _) if path.starts_with("/admin/settings/") => handle_set(ctx, msg, input).await,
+        ("update", _) if path.starts_with("/admin/settings/") => {
+            handle_set(ctx, msg, path, input).await
+        }
         ("create", "/admin/settings") => handle_create(ctx, msg, input).await,
-        ("delete", _) if path.starts_with("/admin/settings/") => handle_delete(ctx, msg).await,
+        ("delete", _) if path.starts_with("/admin/settings/") => handle_delete(ctx, path).await,
         _ => err_not_found("not found"),
     }
 }
@@ -179,8 +187,7 @@ async fn handle_list(ctx: &dyn Context) -> OutputStream {
     }
 }
 
-async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_get(ctx: &dyn Context, path: &str) -> OutputStream {
     let key = path
         .strip_prefix("/admin/settings/")
         .or_else(|| path.strip_prefix("/settings/"))
@@ -215,8 +222,12 @@ async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 }
 
-async fn handle_set(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let path = msg.path();
+async fn handle_set(
+    ctx: &dyn Context,
+    msg: &Message,
+    path: &str,
+    input: InputStream,
+) -> OutputStream {
     let key = path.strip_prefix("/admin/settings/").unwrap_or("");
     if key.is_empty() {
         return err_bad_request("Missing setting key");
@@ -290,8 +301,7 @@ async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
     }
 }
 
-async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
+async fn handle_delete(ctx: &dyn Context, path: &str) -> OutputStream {
     let key = path.strip_prefix("/admin/settings/").unwrap_or("");
     if key.is_empty() {
         return err_bad_request("Missing setting key");
@@ -736,7 +746,8 @@ mod tests {
             .expect("seed secret var");
 
         let msg = admin_msg("retrieve", "/admin/settings/STRIPE_SECRET");
-        let out = handle(&ctx, &msg, InputStream::empty()).await;
+        let path = msg.path().to_string();
+        let out = handle(&ctx, &msg, &path, InputStream::empty()).await;
         let body = output_json(out).await;
         // `Record` serializes as `{ id, data: { value, ... } }`.
         assert_eq!(

--- a/crates/solobase-core/src/blocks/admin/users.rs
+++ b/crates/solobase-core/src/blocks/admin/users.rs
@@ -10,16 +10,38 @@ use crate::blocks::{
     helpers::{err_bad_request, err_internal, err_not_found, ok_json},
 };
 
-pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+/// `path` is the normalized `/admin/users[...]` sub-path passed explicitly by
+/// the admin dispatcher (no `req.resource` rewrite). The leaf handlers read the
+/// user id from `req.param.id`, which this dispatcher binds from `path`.
+pub async fn handle(
+    ctx: &dyn Context,
+    msg: &Message,
+    path: &str,
+    input: InputStream,
+) -> OutputStream {
     let action = msg.action();
-    let path = msg.path();
 
     match (action, path) {
         ("retrieve", "/admin/users") => handle_list(ctx, msg).await,
-        ("retrieve", _) if path.starts_with("/admin/users/") => handle_get(ctx, msg).await,
-        ("update", _) if path.starts_with("/admin/users/") => handle_update(ctx, msg, input).await,
-        ("delete", _) if path.starts_with("/admin/users/") => handle_delete(ctx, msg).await,
+        ("retrieve", _) if path.starts_with("/admin/users/") => {
+            handle_get(ctx, msg, user_id_from(path)).await
+        }
+        ("update", _) if path.starts_with("/admin/users/") => {
+            handle_update(ctx, msg, user_id_from(path), input).await
+        }
+        ("delete", _) if path.starts_with("/admin/users/") => {
+            handle_delete(ctx, msg, user_id_from(path)).await
+        }
         _ => err_not_found("not found"),
+    }
+}
+
+/// Extract the first `/`-bounded user-id segment after `/admin/users/`.
+fn user_id_from(path: &str) -> &str {
+    let rest = path.strip_prefix("/admin/users/").unwrap_or("");
+    match rest.find('/') {
+        Some(idx) => &rest[..idx],
+        None => rest,
     }
 }
 
@@ -74,18 +96,11 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 }
 
-async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let id = msg.var("id").to_string();
+async fn handle_get(ctx: &dyn Context, _msg: &Message, id: &str) -> OutputStream {
     if id.is_empty() {
-        // Extract from path
-        let path = msg.path().to_string();
-        let id = path.strip_prefix("/admin/users/").unwrap_or("").to_string();
-        if id.is_empty() {
-            return err_bad_request("Missing user ID");
-        }
-        return get_user(ctx, &id).await;
+        return err_bad_request("Missing user ID");
     }
-    get_user(ctx, &id).await
+    get_user(ctx, id).await
 }
 
 async fn get_user(ctx: &dyn Context, id: &str) -> OutputStream {
@@ -111,14 +126,12 @@ async fn get_user(ctx: &dyn Context, id: &str) -> OutputStream {
     }
 }
 
-async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let path = msg.path();
-    let id = msg.var("id");
-    let id = if id.is_empty() {
-        path.strip_prefix("/admin/users/").unwrap_or("")
-    } else {
-        id
-    };
+async fn handle_update(
+    ctx: &dyn Context,
+    msg: &Message,
+    id: &str,
+    input: InputStream,
+) -> OutputStream {
     if id.is_empty() {
         return err_bad_request("Missing user ID");
     }
@@ -137,21 +150,7 @@ async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream) -> 
     }
 }
 
-async fn handle_delete(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let id = msg.var("id");
-    let id = if id.is_empty() {
-        // `strip_prefix` returns everything after `/admin/users/`, including
-        // any trailing path segments. Take only the first `/`-bounded segment
-        // so e.g. `/admin/users/u123/foo` resolves to `u123`, not `u123/foo`.
-        let rest = path.strip_prefix("/admin/users/").unwrap_or("");
-        match rest.find('/') {
-            Some(idx) => &rest[..idx],
-            None => rest,
-        }
-    } else {
-        id
-    };
+async fn handle_delete(ctx: &dyn Context, msg: &Message, id: &str) -> OutputStream {
     if id.is_empty() {
         return err_bad_request("Missing user ID");
     }

--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -31,7 +31,7 @@ use wafer_run::{
 use super::rate_limit::{
     check_route_limits, LimitKey, RateLimit, RateLimitOutcome, RouteLimit, UserRateLimiter,
 };
-use crate::blocks::helpers::err_not_found;
+use crate::{blocks::helpers::err_not_found, endpoint_match};
 
 pub const AUTH_UI_BLOCK_ID: &str = "suppers-ai/auth-ui";
 
@@ -201,6 +201,12 @@ impl Block for AuthUiBlock {
              grant. Calls suppers-ai/auth via auth@v1 for require_user/role/token.",
         )
         .endpoints(vec![
+            // Admin settings — declared `Admin` so the central router enforces
+            // the tier; the handler no longer re-checks `is_admin`. (The
+            // auth-ui prefix route is Public, so this declared level is the
+            // gate for the admin settings surface.)
+            BlockEndpoint::get("/b/auth/admin/settings").summary("Auth settings page").auth(AuthLevel::Admin),
+            BlockEndpoint::post("/b/auth/admin/settings").summary("Save auth settings").auth(AuthLevel::Admin),
             // SSR pages
             BlockEndpoint::get("/b/auth/login").summary("Login page"),
             BlockEndpoint::get("/b/auth/signup").summary("Signup page"),
@@ -268,18 +274,10 @@ impl Block for AuthUiBlock {
 
         match (action.as_str(), path.as_str()) {
             // ── Admin settings ───────────────────────────────────────
-            ("retrieve", "/auth/admin/settings") => {
-                if !crate::blocks::helpers::is_admin(&msg) {
-                    return crate::ui::forbidden_response(&msg);
-                }
-                pages::settings::handle_get(ctx, &msg).await
-            }
-            ("create", "/auth/admin/settings") => {
-                if !crate::blocks::helpers::is_admin(&msg) {
-                    return crate::ui::forbidden_response(&msg);
-                }
-                pages::settings::handle_post(ctx, input).await
-            }
+            // Admin tier enforced centrally from the declared
+            // `AuthLevel::Admin` on `GET|POST /b/auth/admin/settings`.
+            ("retrieve", "/auth/admin/settings") => pages::settings::handle_get(ctx, &msg).await,
+            ("create", "/auth/admin/settings") => pages::settings::handle_post(ctx, input).await,
             // ── SSR pages (HTML) ──────────────────────────────────────
             ("retrieve", "/auth/login") => pages::login::handle(ctx, &msg).await,
             ("retrieve", "/auth/signup") => pages::signup::handle(ctx, &msg).await,
@@ -312,10 +310,10 @@ impl Block for AuthUiBlock {
             ("create", "/auth/api/api-keys") => {
                 api::api_keys::handle_create(ctx, &msg, input).await
             }
-            ("update", _) if path.starts_with("/auth/api/api-keys/") => {
+            ("update", p) if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() => {
                 api::api_keys::handle_revoke(ctx, &msg).await
             }
-            ("delete", _) if path.starts_with("/auth/api/api-keys/") => {
+            ("delete", p) if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() => {
                 api::api_keys::handle_delete(ctx, &msg).await
             }
             // Email verification

--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -205,8 +205,12 @@ impl Block for AuthUiBlock {
             // the tier; the handler no longer re-checks `is_admin`. (The
             // auth-ui prefix route is Public, so this declared level is the
             // gate for the admin settings surface.)
-            BlockEndpoint::get("/b/auth/admin/settings").summary("Auth settings page").auth(AuthLevel::Admin),
-            BlockEndpoint::post("/b/auth/admin/settings").summary("Save auth settings").auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/auth/admin/settings")
+                .summary("Auth settings page")
+                .auth(AuthLevel::Admin),
+            BlockEndpoint::post("/b/auth/admin/settings")
+                .summary("Save auth settings")
+                .auth(AuthLevel::Admin),
             // SSR pages
             BlockEndpoint::get("/b/auth/login").summary("Login page"),
             BlockEndpoint::get("/b/auth/signup").summary("Signup page"),
@@ -310,10 +314,14 @@ impl Block for AuthUiBlock {
             ("create", "/auth/api/api-keys") => {
                 api::api_keys::handle_create(ctx, &msg, input).await
             }
-            ("update", p) if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() => {
+            ("update", p)
+                if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() =>
+            {
                 api::api_keys::handle_revoke(ctx, &msg).await
             }
-            ("delete", p) if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() => {
+            ("delete", p)
+                if endpoint_match::match_template("/auth/api/api-keys/{id}", p).is_some() =>
+            {
                 api::api_keys::handle_delete(ctx, &msg).await
             }
             // Email verification

--- a/crates/solobase-core/src/blocks/crud.rs
+++ b/crates/solobase-core/src/blocks/crud.rs
@@ -21,7 +21,17 @@ use super::helpers::{
 
 /// Extract the record id that follows `path_prefix` in the request path.
 /// Returns `""` when the prefix doesn't match or nothing follows it.
+/// Extract the record id for a CRUD route. Prefers the router-populated
+/// `req.param.id` (set by `endpoint_match::dispatch` when the block uses the
+/// shared matcher) and falls back to stripping `path_prefix` off the resource
+/// path for callers/tests that build the message by hand. Mirrors
+/// [`crate::blocks::helpers::path_param`] but keeps the trailing-segment
+/// behaviour of the old prefix-strip for the fallback.
 fn id_from_path<'m>(msg: &'m Message, path_prefix: &str) -> &'m str {
+    let var = msg.var("id");
+    if !var.is_empty() {
+        return var;
+    }
     msg.path().strip_prefix(path_prefix).unwrap_or("")
 }
 

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -85,6 +85,17 @@ impl Block for FilesBlock {
                 // Admin SSR pages — declared `Admin` so the central router
                 // enforces the tier (the block dropped its inline `is_admin`
                 // check for `/b/storage/admin/*`).
+                //
+                // The overview is served by `handle()` for BOTH the canonical
+                // slash form (`/b/storage/admin/`, the `admin_url`) and the
+                // bare no-slash form (`/b/storage/admin`) via its
+                // `"" | "/" => overview` dispatch arm. The central router's
+                // matcher is trailing-slash-significant, so BOTH must be
+                // declared `Admin` — declaring only the slash form would leave
+                // the no-slash form governed solely by the Public `/b/storage/`
+                // prefix tier, letting an anonymous request reach the storage
+                // admin overview.
+                BlockEndpoint::get("/b/storage/admin").summary("Storage admin overview").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/storage/admin/").summary("Storage admin overview").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/storage/admin/buckets").summary("All buckets (admin)").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/storage/admin/shares").summary("All shares (admin)").auth(AuthLevel::Admin),

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -22,7 +22,7 @@ use wafer_run::{
 };
 
 use super::rate_limit::{check_user_rate_limit_with, RateLimit, RateLimitOutcome, UserRateLimiter};
-use crate::blocks::helpers::{self, err_not_found};
+use crate::blocks::helpers::err_not_found;
 
 pub struct FilesBlock {
     limiter: UserRateLimiter,
@@ -82,13 +82,19 @@ impl Block for FilesBlock {
                 BlockEndpoint::delete("/b/storage/api/buckets/{name}/objects/{key}").summary("Delete file").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/storage/direct/{token}").summary("Access shared file"),
                 BlockEndpoint::get("/b/cloudstorage/").summary("Shares + quota page").auth(AuthLevel::Authenticated),
+                // Admin SSR pages — declared `Admin` so the central router
+                // enforces the tier (the block dropped its inline `is_admin`
+                // check for `/b/storage/admin/*`).
+                BlockEndpoint::get("/b/storage/admin/").summary("Storage admin overview").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/storage/admin/buckets").summary("All buckets (admin)").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/storage/admin/shares").summary("All shares (admin)").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/storage/admin/quotas").summary("Quotas (admin)").auth(AuthLevel::Admin),
             ])
             .admin_url("/b/storage/admin/")
             .can_disable(true)
     }
 
     async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        let mut msg = msg;
         let path = msg.path().to_string();
 
         // Admin-block delegation: when the Admin block routes a request for
@@ -105,12 +111,10 @@ impl Block for FilesBlock {
             return cloud::handle(ctx, msg, input).await;
         }
 
-        // Admin SSR pages at /b/storage/admin/...
+        // Admin SSR pages at /b/storage/admin/... — Admin tier enforced
+        // centrally from the declared `/b/storage/admin/*` endpoints (no
+        // inline `is_admin` re-check).
         if path.starts_with("/b/storage/admin") && msg.action() == "retrieve" {
-            let is_admin = helpers::is_admin(&msg);
-            if !is_admin {
-                return crate::ui::forbidden_response(&msg);
-            }
             let sub = path.strip_prefix("/b/storage/admin").unwrap_or("/");
             return match sub {
                 "" | "/" => pages_admin::overview(ctx, &msg).await,
@@ -121,19 +125,10 @@ impl Block for FilesBlock {
             };
         }
 
-        // Normalize: /b/storage/... → /storage/..., /b/cloudstorage/... stays as-is
-        let normalized = if let Some(rest) = path.strip_prefix("/b/storage") {
-            format!("/storage{rest}")
-        } else {
-            path.clone()
-        };
-        if normalized != path {
-            msg.set_meta("req.resource", &normalized);
-        }
-
         // Direct share access (public, no auth required) — still rate-limited
         // per remote IP inside the handler to stop token enumeration / DOS.
-        if normalized.starts_with("/storage/direct/") {
+        // Matches the REAL on-the-wire path (no `req.resource` rewrite).
+        if path.starts_with("/b/storage/direct/") {
             return share::handle_direct_access(ctx, &msg, &self.limiter).await;
         }
 
@@ -194,16 +189,16 @@ impl Block for FilesBlock {
             return pages_user::cloudstorage_page(ctx, &msg).await;
         }
 
-        // Cloud storage routes (/b/cloudstorage/...)
-        if normalized.starts_with("/b/cloudstorage") {
+        // Cloud storage routes (/b/cloudstorage/...) — `cloud::handle` matches
+        // the real on-the-wire path directly.
+        if path.starts_with("/b/cloudstorage") {
             return cloud::handle(ctx, msg, input).await;
         }
 
-        // User storage API routes (/b/storage/api/... → /storage/api/...)
-        if normalized.starts_with("/storage/api/") || normalized == "/storage/api" {
-            // Normalize for sub-module: /storage/api/buckets → /storage/buckets
-            let api_path = normalized.replacen("/storage/api", "/storage", 1);
-            msg.set_meta("req.resource", &api_path);
+        // User storage API routes (/b/storage/api/...) — `storage::handle`
+        // matches the real on-the-wire suffixes directly (the previous
+        // double `req.resource` rewrite is gone).
+        if path.starts_with("/b/storage/api/") || path == "/b/storage/api" {
             return storage::handle(ctx, msg, input).await;
         }
 

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -43,8 +43,10 @@ pub async fn handle_direct_access(
     msg: &Message,
     limiter: &UserRateLimiter,
 ) -> OutputStream {
+    // The real on-the-wire path (no `req.resource` rewrite in the parent
+    // dispatcher anymore).
     let path = msg.path();
-    let token = path.strip_prefix("/storage/direct/").unwrap_or("");
+    let token = path.strip_prefix("/b/storage/direct/").unwrap_or("");
     if token.is_empty() {
         return err_bad_request("Missing share token");
     }

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -38,8 +38,16 @@ enum Route {
 /// resolves them like the old `contains("/objects/")` guards. `{name}` and
 /// `{key}` bind into `req.param.*`.
 const ROUTES: &[EndpointRoute<Route>] = &[
-    EndpointRoute::new(HttpMethod::Get, "/b/storage/api/buckets", Route::ListBuckets),
-    EndpointRoute::new(HttpMethod::Post, "/b/storage/api/buckets", Route::CreateBucket),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/storage/api/buckets",
+        Route::ListBuckets,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/storage/api/buckets",
+        Route::CreateBucket,
+    ),
     EndpointRoute::new(HttpMethod::Get, "/b/storage/api/search", Route::Search),
     EndpointRoute::new(HttpMethod::Get, "/b/storage/api/recent", Route::Recent),
     EndpointRoute::new(

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -1,9 +1,12 @@
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{database as db, storage as store};
-use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
+use wafer_run::{context::Context, ErrorCode, HttpMethod, InputStream, Message, OutputStream};
 
-use crate::blocks::helpers::{
-    self, err_bad_request, err_forbidden, err_internal, err_not_found, ok_json, ResponseBuilder,
+use crate::{
+    blocks::helpers::{
+        self, err_bad_request, err_forbidden, err_internal, err_not_found, ok_json, ResponseBuilder,
+    },
+    endpoint_match::{self, EndpointRoute},
 };
 
 /// Buckets table — user-created storage containers (one row per bucket).
@@ -14,39 +17,81 @@ pub(crate) const BUCKETS_TABLE: &str = "suppers_ai__files__buckets";
 /// uploader and timestamps.
 pub(crate) const OBJECTS_TABLE: &str = "suppers_ai__files__objects";
 
-pub async fn handle(ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-    let action = msg.action();
-    let path = msg.path();
+/// In-block dispatch targets for the user storage API.
+#[derive(Clone, Copy)]
+enum Route {
+    ListBuckets,
+    CreateBucket,
+    ListObjects,
+    GetObject,
+    UploadObject,
+    DeleteObject,
+    DeleteBucket,
+    Search,
+    Recent,
+}
 
-    match (action, path) {
-        ("retrieve", "/storage/buckets") => handle_list_buckets(ctx, &msg).await,
-        ("create", "/storage/buckets") => handle_create_bucket(ctx, &msg, input).await,
-        ("retrieve", _) if path.starts_with("/storage/buckets/") && path.contains("/objects") => {
-            if path.contains("/objects/") {
-                handle_get_object(ctx, &msg).await
-            } else {
-                handle_list_objects(ctx, &msg).await
-            }
-        }
-        ("create", _) if path.starts_with("/storage/buckets/") && path.contains("/objects") => {
-            handle_upload_object(ctx, &msg, input).await
-        }
-        ("delete", _) if path.starts_with("/storage/buckets/") && path.contains("/objects/") => {
-            handle_delete_object(ctx, &msg).await
-        }
-        ("delete", _) if path.starts_with("/storage/buckets/") => {
-            handle_delete_bucket(ctx, &msg).await
-        }
-        ("retrieve", "/storage/search") => handle_search(ctx, &msg).await,
-        ("retrieve", "/storage/recent") => handle_recent(ctx, &msg).await,
-        _ => err_not_found("not found"),
+/// Dispatch table over the REAL on-the-wire `/b/storage/api/...` suffixes —
+/// no path rewrite. The object-key routes use a trailing `{key...}` rest
+/// param (keys may contain `/`); the more-specific `.../objects/{key...}`
+/// templates precede the bare `.../objects` and `.../{name}` ones so ordering
+/// resolves them like the old `contains("/objects/")` guards. `{name}` and
+/// `{key}` bind into `req.param.*`.
+const ROUTES: &[EndpointRoute<Route>] = &[
+    EndpointRoute::new(HttpMethod::Get, "/b/storage/api/buckets", Route::ListBuckets),
+    EndpointRoute::new(HttpMethod::Post, "/b/storage/api/buckets", Route::CreateBucket),
+    EndpointRoute::new(HttpMethod::Get, "/b/storage/api/search", Route::Search),
+    EndpointRoute::new(HttpMethod::Get, "/b/storage/api/recent", Route::Recent),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/storage/api/buckets/{name}/objects/{key...}",
+        Route::GetObject,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/storage/api/buckets/{name}/objects/{key...}",
+        Route::DeleteObject,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/storage/api/buckets/{name}/objects",
+        Route::ListObjects,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/storage/api/buckets/{name}/objects",
+        Route::UploadObject,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/storage/api/buckets/{name}",
+        Route::DeleteBucket,
+    ),
+];
+
+pub async fn handle(ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+    let Some(route) = endpoint_match::dispatch(&mut msg, ROUTES) else {
+        return err_not_found("not found");
+    };
+    match route {
+        Route::ListBuckets => handle_list_buckets(ctx, &msg).await,
+        Route::CreateBucket => handle_create_bucket(ctx, &msg, input).await,
+        Route::ListObjects => handle_list_objects(ctx, &msg).await,
+        Route::GetObject => handle_get_object(ctx, &msg).await,
+        Route::UploadObject => handle_upload_object(ctx, &msg, input).await,
+        Route::DeleteObject => handle_delete_object(ctx, &msg).await,
+        Route::DeleteBucket => handle_delete_bucket(ctx, &msg).await,
+        Route::Search => handle_search(ctx, &msg).await,
+        Route::Recent => handle_recent(ctx, &msg).await,
     }
 }
 
+/// Admin storage API, delegated from the admin block via `call_block` on the
+/// real `/admin/storage/...` paths. Authorization is enforced by the admin
+/// block's central tier before delegation.
 pub async fn handle_admin(ctx: &dyn Context, msg: Message, _input: InputStream) -> OutputStream {
     let action = msg.action();
     let path = msg.path();
-
     match (action, path) {
         ("retrieve", "/admin/storage/buckets") => handle_list_buckets(ctx, &msg).await,
         ("retrieve", "/admin/storage/stats") => handle_stats(ctx, &msg).await,
@@ -54,23 +99,35 @@ pub async fn handle_admin(ctx: &dyn Context, msg: Message, _input: InputStream) 
     }
 }
 
-fn extract_bucket_name(path: &str) -> &str {
+/// Extract the bucket name. Prefers the matcher-bound `{name}` path var, with a
+/// prefix-strip fallback for the admin delegation path and hand-built tests.
+fn extract_bucket_name(msg: &Message) -> String {
+    let var = msg.var("name");
+    if !var.is_empty() {
+        return var.to_string();
+    }
+    let path = msg.path();
     let rest = path
-        .strip_prefix("/storage/buckets/")
+        .strip_prefix("/b/storage/api/buckets/")
         .or_else(|| path.strip_prefix("/admin/storage/buckets/"))
         .unwrap_or("");
-    if let Some(idx) = rest.find('/') {
-        &rest[..idx]
-    } else {
-        rest
+    match rest.find('/') {
+        Some(idx) => rest[..idx].to_string(),
+        None => rest.to_string(),
     }
 }
 
-fn extract_object_key(path: &str) -> &str {
-    if let Some(idx) = path.find("/objects/") {
-        &path[idx + 9..]
-    } else {
-        ""
+/// Extract the object key (may contain `/`). Prefers the matcher-bound
+/// `{key...}` rest param, falling back to the substring after `/objects/`.
+fn extract_object_key(msg: &Message) -> String {
+    let var = msg.var("key");
+    if !var.is_empty() {
+        return var.to_string();
+    }
+    let path = msg.path();
+    match path.find("/objects/") {
+        Some(idx) => path[idx + 9..].to_string(),
+        None => String::new(),
     }
 }
 
@@ -299,8 +356,8 @@ async fn handle_create_bucket(
 }
 
 async fn handle_delete_bucket(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let bucket = extract_bucket_name(path);
+    let bucket = extract_bucket_name(msg);
+    let bucket = bucket.as_str();
     if bucket.is_empty() {
         return err_bad_request("Missing bucket name");
     }
@@ -337,8 +394,8 @@ async fn handle_delete_bucket(ctx: &dyn Context, msg: &Message) -> OutputStream 
 }
 
 async fn handle_list_objects(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let bucket = extract_bucket_name(path);
+    let bucket = extract_bucket_name(msg);
+    let bucket = bucket.as_str();
     if bucket.is_empty() {
         return err_bad_request("Missing bucket name");
     }
@@ -365,9 +422,10 @@ async fn handle_list_objects(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn handle_get_object(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let bucket = extract_bucket_name(path);
-    let key = extract_object_key(path);
+    let bucket = extract_bucket_name(msg);
+    let bucket = bucket.as_str();
+    let key = extract_object_key(msg);
+    let key = key.as_str();
     if bucket.is_empty() || key.is_empty() {
         return err_bad_request("Missing bucket name or object key");
     }
@@ -401,8 +459,8 @@ async fn handle_upload_object(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    let path = msg.path();
-    let bucket = extract_bucket_name(path);
+    let bucket = extract_bucket_name(msg);
+    let bucket = bucket.as_str();
     if bucket.is_empty() {
         return err_bad_request("Missing bucket name");
     }
@@ -493,9 +551,10 @@ async fn handle_upload_object(
 }
 
 async fn handle_delete_object(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let bucket = extract_bucket_name(path);
-    let key = extract_object_key(path);
+    let bucket = extract_bucket_name(msg);
+    let bucket = bucket.as_str();
+    let key = extract_object_key(msg);
+    let key = key.as_str();
     if bucket.is_empty() || key.is_empty() {
         return err_bad_request("Missing bucket name or object key");
     }
@@ -603,39 +662,73 @@ async fn handle_recent(ctx: &dyn Context, msg: &Message) -> OutputStream {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_extract_bucket_name() {
-        assert_eq!(
-            extract_bucket_name("/storage/buckets/my-bucket"),
-            "my-bucket"
-        );
-        assert_eq!(
-            extract_bucket_name("/storage/buckets/my-bucket/objects"),
-            "my-bucket"
-        );
-        assert_eq!(
-            extract_bucket_name("/storage/buckets/my-bucket/objects/file.txt"),
-            "my-bucket"
-        );
-        assert_eq!(
-            extract_bucket_name("/admin/storage/buckets/admin-bucket"),
-            "admin-bucket"
-        );
-        assert_eq!(extract_bucket_name("/other/path"), "");
+    /// Build a message carrying `path` on `req.resource` and, optionally, the
+    /// matcher-bound `{name}`/`{key}` path vars in `req.param.*`.
+    fn msg_with(path: &str, params: &[(&str, &str)]) -> Message {
+        let mut m = Message::new("test");
+        m.set_meta("req.resource", path);
+        for (k, v) in params {
+            m.set_meta(format!("req.param.{k}"), *v);
+        }
+        m
     }
 
     #[test]
-    fn test_extract_object_key() {
+    fn test_extract_bucket_name_from_param() {
+        // Router-populated path var wins (the normal dispatch path).
+        let m = msg_with(
+            "/b/storage/api/buckets/my-bucket/objects",
+            &[("name", "my-bucket")],
+        );
+        assert_eq!(extract_bucket_name(&m), "my-bucket");
+    }
+
+    #[test]
+    fn test_extract_bucket_name_prefix_fallback() {
+        // Fallback for the admin delegation path / hand-built messages.
         assert_eq!(
-            extract_object_key("/storage/buckets/b/objects/file.txt"),
+            extract_bucket_name(&msg_with("/b/storage/api/buckets/my-bucket", &[])),
+            "my-bucket"
+        );
+        assert_eq!(
+            extract_bucket_name(&msg_with("/b/storage/api/buckets/my-bucket/objects", &[])),
+            "my-bucket"
+        );
+        assert_eq!(
+            extract_bucket_name(&msg_with("/admin/storage/buckets/admin-bucket", &[])),
+            "admin-bucket"
+        );
+        assert_eq!(extract_bucket_name(&msg_with("/other/path", &[])), "");
+    }
+
+    #[test]
+    fn test_extract_object_key_from_param() {
+        // Rest param preserves embedded slashes.
+        let m = msg_with(
+            "/b/storage/api/buckets/b/objects/dir/file.txt",
+            &[("key", "dir/file.txt")],
+        );
+        assert_eq!(extract_object_key(&m), "dir/file.txt");
+    }
+
+    #[test]
+    fn test_extract_object_key_prefix_fallback() {
+        assert_eq!(
+            extract_object_key(&msg_with("/b/storage/api/buckets/b/objects/file.txt", &[])),
             "file.txt"
         );
         assert_eq!(
-            extract_object_key("/storage/buckets/b/objects/dir/file.txt"),
+            extract_object_key(&msg_with(
+                "/b/storage/api/buckets/b/objects/dir/file.txt",
+                &[]
+            )),
             "dir/file.txt"
         );
-        assert_eq!(extract_object_key("/storage/buckets/b"), "");
-        assert_eq!(extract_object_key("/other/path"), "");
+        assert_eq!(
+            extract_object_key(&msg_with("/b/storage/api/buckets/b", &[])),
+            ""
+        );
+        assert_eq!(extract_object_key(&msg_with("/other/path", &[])), "");
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -6,8 +6,9 @@ use maud::{html, Markup, PreEscaped};
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, ErrorCode, InputStream,
-    InputType, InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, ErrorCode, HttpMethod,
+    InputStream, InputType, InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream,
+    WaferError,
 };
 
 use crate::{
@@ -17,8 +18,115 @@ use crate::{
             self, err_bad_request, err_internal, err_not_found, json_map, ok_json, ResponseBuilder,
         },
     },
+    endpoint_match::{self, EndpointRoute},
     ui::{self, templates, SiteConfig},
 };
+
+/// In-block dispatch targets, one per declared HTTP endpoint.
+#[derive(Clone, Copy)]
+enum Route {
+    PublicTerms,
+    PublicPrivacy,
+    EditorPrivacy,
+    EditorTerms,
+    SettingsPage,
+    EndpointsPage,
+    AdminSave,
+    AdminRenderPreview,
+    AdminPublish,
+    AdminSaveSettings,
+    ApiList,
+    ApiGet,
+    ApiCreate,
+    ApiPublish,
+    ApiUpdate,
+    ApiDelete,
+}
+
+/// Method + path-template dispatch table, mirroring `info().endpoints`. The
+/// JSON `.../{id}/publish` template precedes the generic `.../{id}` so the
+/// specific publish route wins (replacing the old `ends_with("/publish")`
+/// guard). The JSON publish is a PATCH (`update`) on the wire, matching the
+/// handler's historical dispatch.
+const ROUTES: &[EndpointRoute<Route>] = &[
+    EndpointRoute::new(HttpMethod::Get, "/b/legalpages/terms", Route::PublicTerms),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/privacy",
+        Route::PublicPrivacy,
+    ),
+    EndpointRoute::new(HttpMethod::Get, "/b/legalpages/admin", Route::EditorPrivacy),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/admin/privacy",
+        Route::EditorPrivacy,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/admin/terms",
+        Route::EditorTerms,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/admin/settings",
+        Route::SettingsPage,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/admin/endpoints",
+        Route::EndpointsPage,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/legalpages/admin/save",
+        Route::AdminSave,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/legalpages/admin/render-preview",
+        Route::AdminRenderPreview,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/legalpages/admin/publish",
+        Route::AdminPublish,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/legalpages/admin/settings",
+        Route::AdminSaveSettings,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/api/documents",
+        Route::ApiList,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/legalpages/api/documents",
+        Route::ApiCreate,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/legalpages/api/documents/{id}/publish",
+        Route::ApiPublish,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/legalpages/api/documents/{id}",
+        Route::ApiGet,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/legalpages/api/documents/{id}",
+        Route::ApiUpdate,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/legalpages/api/documents/{id}",
+        Route::ApiDelete,
+    ),
+];
 
 /// The legalpages block's own declared config vars. Single source of truth for
 /// both `BlockInfo::config_keys` and the admin settings page (rendered via
@@ -490,14 +598,29 @@ impl Block for LegalPagesBlock {
             .requires(vec!["wafer-run/database".into()])
             .category(wafer_run::BlockCategory::Feature)
             .description("Legal document management with versioning and publishing. Create and manage terms of service, privacy policies, and other legal documents. Supports draft/published workflow with version tracking.")
+            // The admin SSR sub-pages and mutations are declared in full so
+            // the central router enforces their `Admin` tier from the declared
+            // `AuthLevel` — not merely from the `/b/legalpages/admin` prefix's
+            // route-table ordering, which was the sole gate before (the #1
+            // regression hazard this package closes).
             .endpoints(vec![
                 BlockEndpoint::get("/b/legalpages/terms").summary("Published terms of service"),
                 BlockEndpoint::get("/b/legalpages/privacy").summary("Published privacy policy"),
-                BlockEndpoint::get("/b/legalpages/admin").summary("Admin editor").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/admin").summary("Admin editor (privacy)").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/admin/privacy").summary("Admin editor (privacy)").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/admin/terms").summary("Admin editor (terms)").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/admin/settings").summary("Admin settings page").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/admin/endpoints").summary("Endpoints reference").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/legalpages/admin/save").summary("Save draft").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/legalpages/admin/render-preview").summary("Render markdown preview").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/legalpages/admin/publish").summary("Publish from editor").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/legalpages/admin/settings").summary("Save settings").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/legalpages/api/documents").summary("List documents").auth(AuthLevel::Admin),
                 BlockEndpoint::post("/b/legalpages/api/documents").summary("Create document").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/legalpages/api/documents/{id}").summary("Get document").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/legalpages/api/documents/{id}/publish").summary("Publish document").auth(AuthLevel::Admin),
                 BlockEndpoint::patch("/b/legalpages/api/documents/{id}").summary("Update document").auth(AuthLevel::Admin),
-                BlockEndpoint::post("/b/legalpages/api/documents/{id}/publish").summary("Publish document").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/legalpages/api/documents/{id}").summary("Delete document").auth(AuthLevel::Admin),
             ])
             .config_keys(config_vars())
             .admin_url("/b/legalpages/admin")
@@ -505,55 +628,35 @@ impl Block for LegalPagesBlock {
             .default_enabled(false)
     }
 
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        let action = msg.action().to_string();
-        let path = msg.path().to_string();
-
-        match (action.as_str(), path.as_str()) {
-            // Public endpoints
-            ("retrieve", "/b/legalpages/terms") => self.handle_get_public(ctx, "terms").await,
-            ("retrieve", "/b/legalpages/privacy") => self.handle_get_public(ctx, "privacy").await,
-
-            // Admin UI pages (SSR)
-            ("retrieve", "/b/legalpages/admin") | ("retrieve", "/b/legalpages/admin/privacy") => {
-                pages::editor_page(ctx, &msg, "privacy").await
-            }
-            ("retrieve", "/b/legalpages/admin/terms") => {
-                pages::editor_page(ctx, &msg, "terms").await
-            }
-            ("retrieve", "/b/legalpages/admin/settings") => pages::settings_page(ctx, &msg).await,
-            ("retrieve", "/b/legalpages/admin/endpoints") => pages::endpoints_page(ctx, &msg).await,
-
-            // Admin UI mutations (from editor save/publish)
-            ("create", "/b/legalpages/admin/save") => pages::handle_save(ctx, &msg, input).await,
-            ("create", "/b/legalpages/admin/render-preview") => {
-                pages::handle_render_preview(ctx, input).await
-            }
-            ("create", "/b/legalpages/admin/publish") => {
-                pages::handle_publish(ctx, &msg, input).await
-            }
-            ("create", "/b/legalpages/admin/settings") => {
-                pages::handle_save_settings(ctx, input).await
-            }
-
-            // JSON API at /b/legalpages/api/documents/...
-            ("retrieve", "/b/legalpages/api/documents") => self.handle_admin_list(ctx, &msg).await,
-            ("retrieve", _) if path.starts_with(API_DOC_PREFIX) => {
-                crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
-            }
-            ("create", "/b/legalpages/api/documents") => {
-                self.handle_admin_create(ctx, &msg, input).await
-            }
-            ("update", _) if path.starts_with(API_DOC_PREFIX) && path.ends_with("/publish") => {
-                self.handle_admin_publish(ctx, &msg).await
-            }
-            ("update", _) if path.starts_with(API_DOC_PREFIX) => {
+    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+        // Auth is enforced centrally by `route_to_block` from the declared
+        // endpoint `AuthLevel` (public reads, admin everything else) — the
+        // block holds no `is_admin` preamble. Dispatch matches the same
+        // declared templates, extracting `{id}` into `req.param.id`.
+        let Some(route) = endpoint_match::dispatch(&mut msg, ROUTES) else {
+            return ui::not_found_response(&msg);
+        };
+        match route {
+            Route::PublicTerms => self.handle_get_public(ctx, "terms").await,
+            Route::PublicPrivacy => self.handle_get_public(ctx, "privacy").await,
+            Route::EditorPrivacy => pages::editor_page(ctx, &msg, "privacy").await,
+            Route::EditorTerms => pages::editor_page(ctx, &msg, "terms").await,
+            Route::SettingsPage => pages::settings_page(ctx, &msg).await,
+            Route::EndpointsPage => pages::endpoints_page(ctx, &msg).await,
+            Route::AdminSave => pages::handle_save(ctx, &msg, input).await,
+            Route::AdminRenderPreview => pages::handle_render_preview(ctx, input).await,
+            Route::AdminPublish => pages::handle_publish(ctx, &msg, input).await,
+            Route::AdminSaveSettings => pages::handle_save_settings(ctx, input).await,
+            Route::ApiList => self.handle_admin_list(ctx, &msg).await,
+            Route::ApiGet => crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await,
+            Route::ApiCreate => self.handle_admin_create(ctx, &msg, input).await,
+            Route::ApiPublish => self.handle_admin_publish(ctx, &msg).await,
+            Route::ApiUpdate => {
                 crud::crud_update(ctx, &msg, input, COLLECTION, API_DOC_PREFIX, "Document").await
             }
-            ("delete", _) if path.starts_with(API_DOC_PREFIX) => {
+            Route::ApiDelete => {
                 crud::crud_delete(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
             }
-            _ => ui::not_found_response(&msg),
         }
     }
 

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -628,7 +628,12 @@ impl Block for LegalPagesBlock {
             .default_enabled(false)
     }
 
-    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+    async fn handle(
+        &self,
+        ctx: &dyn Context,
+        mut msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
         // Auth is enforced centrally by `route_to_block` from the declared
         // endpoint `AuthLevel` (public reads, admin everything else) — the
         // block holds no `is_admin` preamble. Dispatch matches the same
@@ -648,7 +653,9 @@ impl Block for LegalPagesBlock {
             Route::AdminPublish => pages::handle_publish(ctx, &msg, input).await,
             Route::AdminSaveSettings => pages::handle_save_settings(ctx, input).await,
             Route::ApiList => self.handle_admin_list(ctx, &msg).await,
-            Route::ApiGet => crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await,
+            Route::ApiGet => {
+                crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
+            }
             Route::ApiCreate => self.handle_admin_create(ctx, &msg, input).await,
             Route::ApiPublish => self.handle_admin_publish(ctx, &msg).await,
             Route::ApiUpdate => {

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -14,10 +14,95 @@ use wafer_run::{
     LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
 };
 
+use wafer_run::HttpMethod;
+
 use self::provider_admin::ProviderAdmin;
-use crate::blocks::helpers::{
-    self, err_bad_request, err_internal, err_not_found, json_map, ok_json,
+use crate::{
+    blocks::helpers::{self, err_bad_request, err_internal, err_not_found, json_map, ok_json},
+    endpoint_match::{self, EndpointRoute},
 };
+
+/// In-block dispatch targets, one per declared HTTP endpoint.
+#[derive(Clone, Copy)]
+enum Route {
+    ChatPage,
+    ThreadPage,
+    SettingsPage,
+    ProvidersPage,
+    ModelsPage,
+    Chat,
+    ChatStream,
+    DiscoverModels,
+    ListProviders,
+    CreateProvider,
+    UpdateProvider,
+    DeleteProvider,
+    ModelStatus,
+    LoadModel,
+    UnloadModel,
+    ListModels,
+    GetConfig,
+    PostConfig,
+}
+
+/// Method + path-template dispatch table, mirroring `info().endpoints`.
+/// Sub-resource templates (`.../discover-models`, `.../load`, `.../status`)
+/// precede the generic `.../{id}` / `.../models` templates so the specific
+/// route wins (the old `ends_with` ordering). `{id}`/`{backend_id}`/
+/// `{model_id}` are bound into `req.param.*`.
+const ROUTES: &[EndpointRoute<Route>] = &[
+    // UI pages
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/", Route::ChatPage),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/threads/{id}", Route::ThreadPage),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/settings", Route::SettingsPage),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/providers", Route::ProvidersPage),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/models", Route::ModelsPage),
+    // Chat API
+    EndpointRoute::new(HttpMethod::Post, "/b/llm/api/chat", Route::Chat),
+    EndpointRoute::new(HttpMethod::Post, "/b/llm/api/chat/stream", Route::ChatStream),
+    // Provider CRUD (specific sub-resource first)
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/llm/api/providers/{id}/discover-models",
+        Route::DiscoverModels,
+    ),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/api/providers", Route::ListProviders),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/llm/api/providers",
+        Route::CreateProvider,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/llm/api/providers/{id}",
+        Route::UpdateProvider,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/llm/api/providers/{id}",
+        Route::DeleteProvider,
+    ),
+    // Models endpoints (specific sub-resources first)
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/llm/api/models/{backend_id}/{model_id}/status",
+        Route::ModelStatus,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/llm/api/models/{backend_id}/{model_id}/load",
+        Route::LoadModel,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/llm/api/models/{backend_id}/{model_id}/unload",
+        Route::UnloadModel,
+    ),
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/api/models", Route::ListModels),
+    // Config
+    EndpointRoute::new(HttpMethod::Get, "/b/llm/api/config", Route::GetConfig),
+    EndpointRoute::new(HttpMethod::Post, "/b/llm/api/config", Route::PostConfig),
+];
 
 /// LLM feature block. Owns the provider admin UI + chat thread persistence.
 ///
@@ -364,9 +449,19 @@ impl Block for LlmBlock {
             BlockEndpoint::post("/b/llm/api/config")
                 .summary("Update per-thread provider/model override")
                 .auth(AuthLevel::Authenticated),
+            // Chat UI is reached from the ADMIN sidebar (nav_groups::admin
+            // "Communication" group); the pre-refactor `handle()` gated every
+            // non-API page on `is_admin`, so the chat UI was admin-only in
+            // practice. Declaring it `Admin` (and the thread permalink too)
+            // makes that the single declared, centrally-enforced policy —
+            // preserving the exact prior auth outcome (the declared
+            // `Authenticated` was drift the old blanket gate overrode).
             BlockEndpoint::get("/b/llm/")
                 .summary("Chat UI")
-                .auth(AuthLevel::Authenticated),
+                .auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/llm/threads/{id}")
+                .summary("Chat UI (thread permalink)")
+                .auth(AuthLevel::Admin),
             BlockEndpoint::get("/b/llm/settings")
                 .summary("LLM settings page")
                 .auth(AuthLevel::Admin),
@@ -396,94 +491,47 @@ impl Block for LlmBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        let action = msg.action();
-        let path = msg.path();
-        let is_api = path.contains("/api/");
-        let user_id = msg.user_id().to_string();
-
+    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
         // Inter-block discovery endpoint: returns the configured default
         // `(provider, model)` target. Only accessible from another block (the
         // caller_id is set by `ctx.call_block`); never reachable from external
-        // HTTP because the shared pipeline strips the caller id.
-        if action == "retrieve" && path == "/b/llm/api/internal/default-target" {
+        // HTTP because the shared pipeline strips the caller id. It is NOT a
+        // declared HTTP endpoint, so it stays a handler-owned guard ahead of
+        // the matcher.
+        if msg.action() == "retrieve" && msg.path() == "/b/llm/api/internal/default-target" {
             if ctx.caller_id().is_none() {
                 return crate::blocks::helpers::err_not_found("not found");
             }
             return self.handle_default_target(ctx).await;
         }
 
-        // All endpoints require authentication
-        if user_id.is_empty() {
-            return crate::ui::forbidden_response(&msg);
-        }
-
-        // UI pages require admin role
-        if !is_api {
-            let is_admin = helpers::is_admin(&msg);
-            if !is_admin {
-                return crate::ui::forbidden_response(&msg);
-            }
-        }
-
-        match (action, path) {
-            // UI pages
-            ("retrieve", "/b/llm/") | ("retrieve", "/b/llm") => pages::page(ctx, &msg).await,
-            ("retrieve", _) if path.starts_with("/b/llm/threads/") => pages::page(ctx, &msg).await,
-            ("retrieve", "/b/llm/settings") => pages::settings_page(ctx, &msg).await,
-            ("retrieve", "/b/llm/providers") => ui::providers_page(self, ctx, &msg).await,
-            ("retrieve", "/b/llm/models") => ui::models_page(self, ctx, &msg).await,
-
-            // Chat API
-            ("create", "/b/llm/api/chat") => routes::handle_chat(self, ctx, &msg, input).await,
-            ("create", "/b/llm/api/chat/stream") => {
-                routes::handle_chat_stream(self, ctx, &msg, input).await
-            }
-
-            // Provider CRUD (admin-only — guard enforced inside handler).
-            // Sub-resource paths (`.../discover-models`) are matched first so
-            // the catch-all `update`/`delete` arms only fire for bare `:id`.
-            ("create", _)
-                if path.starts_with("/b/llm/api/providers/")
-                    && path.ends_with("/discover-models") =>
-            {
-                routes::discover_models(self, ctx, &msg).await
-            }
-            ("retrieve", "/b/llm/api/providers") => routes::list_providers(self, ctx, &msg).await,
-            ("create", "/b/llm/api/providers") => {
-                routes::create_provider(self, ctx, &msg, input).await
-            }
-            ("update", _) if path.starts_with("/b/llm/api/providers/") => {
-                routes::update_provider(self, ctx, &msg, input).await
-            }
-            ("delete", _) if path.starts_with("/b/llm/api/providers/") => {
-                routes::delete_provider(self, ctx, &msg).await
-            }
-
-            // Models endpoints — service-block-backed aggregation and
-            // per-(backend,model) ops. Sub-resource arms (`/status`,
-            // `/load`, `/unload`) must match BEFORE the generic
-            // `/b/llm/api/models` arm so suffix dispatch wins.
-            ("retrieve", _)
-                if path.starts_with("/b/llm/api/models/") && path.ends_with("/status") =>
-            {
-                routes::model_status(self, ctx, &msg).await
-            }
-            ("create", _) if path.starts_with("/b/llm/api/models/") && path.ends_with("/load") => {
-                routes::load_model(self, ctx, &msg).await
-            }
-            ("create", _)
-                if path.starts_with("/b/llm/api/models/") && path.ends_with("/unload") =>
-            {
-                routes::unload_model(self, ctx, &msg).await
-            }
-            ("retrieve", "/b/llm/api/models") => routes::list_models(self, ctx, &msg).await,
-
-            // Config
-            ("retrieve", "/b/llm/api/config") => self.handle_get_config(ctx).await,
-            ("create", "/b/llm/api/config") => self.handle_post_config(ctx, input).await,
-
-            _ => err_not_found("not found"),
+        // Auth is enforced centrally by `route_to_block` from the declared
+        // endpoint `AuthLevel` (chat/config/models-list → Authenticated; UI
+        // pages, provider CRUD, model load/unload → Admin). The block holds
+        // no `user_id`/`is_admin` preamble and the provider/model handlers no
+        // longer re-check `is_admin`. `{id}`/`{backend_id}`/`{model_id}` are
+        // bound into `req.param.*` for the handlers' `path_param` readers.
+        let Some(route) = endpoint_match::dispatch(&mut msg, ROUTES) else {
+            return err_not_found("not found");
+        };
+        match route {
+            Route::ChatPage | Route::ThreadPage => pages::page(ctx, &msg).await,
+            Route::SettingsPage => pages::settings_page(ctx, &msg).await,
+            Route::ProvidersPage => ui::providers_page(self, ctx, &msg).await,
+            Route::ModelsPage => ui::models_page(self, ctx, &msg).await,
+            Route::Chat => routes::handle_chat(self, ctx, &msg, input).await,
+            Route::ChatStream => routes::handle_chat_stream(self, ctx, &msg, input).await,
+            Route::DiscoverModels => routes::discover_models(self, ctx, &msg).await,
+            Route::ListProviders => routes::list_providers(self, ctx, &msg).await,
+            Route::CreateProvider => routes::create_provider(self, ctx, &msg, input).await,
+            Route::UpdateProvider => routes::update_provider(self, ctx, &msg, input).await,
+            Route::DeleteProvider => routes::delete_provider(self, ctx, &msg).await,
+            Route::ModelStatus => routes::model_status(self, ctx, &msg).await,
+            Route::LoadModel => routes::load_model(self, ctx, &msg).await,
+            Route::UnloadModel => routes::unload_model(self, ctx, &msg).await,
+            Route::ListModels => routes::list_models(self, ctx, &msg).await,
+            Route::GetConfig => self.handle_get_config(ctx).await,
+            Route::PostConfig => self.handle_post_config(ctx, input).await,
         }
     }
 

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -10,11 +10,9 @@ use std::sync::Arc;
 
 use wafer_core::clients::{config, database as db};
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, InputStream, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, HttpMethod, InputStream,
+    InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
 };
-
-use wafer_run::HttpMethod;
 
 use self::provider_admin::ProviderAdmin;
 use crate::{
@@ -59,14 +57,22 @@ const ROUTES: &[EndpointRoute<Route>] = &[
     EndpointRoute::new(HttpMethod::Get, "/b/llm/models", Route::ModelsPage),
     // Chat API
     EndpointRoute::new(HttpMethod::Post, "/b/llm/api/chat", Route::Chat),
-    EndpointRoute::new(HttpMethod::Post, "/b/llm/api/chat/stream", Route::ChatStream),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/llm/api/chat/stream",
+        Route::ChatStream,
+    ),
     // Provider CRUD (specific sub-resource first)
     EndpointRoute::new(
         HttpMethod::Post,
         "/b/llm/api/providers/{id}/discover-models",
         Route::DiscoverModels,
     ),
-    EndpointRoute::new(HttpMethod::Get, "/b/llm/api/providers", Route::ListProviders),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/llm/api/providers",
+        Route::ListProviders,
+    ),
     EndpointRoute::new(
         HttpMethod::Post,
         "/b/llm/api/providers",
@@ -491,7 +497,12 @@ impl Block for LlmBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+    async fn handle(
+        &self,
+        ctx: &dyn Context,
+        mut msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
         // Inter-block discovery endpoint: returns the configured default
         // `(provider, model)` target. Only accessible from another block (the
         // caller_id is set by `ctx.call_block`); never reachable from external

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -28,7 +28,7 @@ use super::{
     LlmBlock, DEFAULT_PROVIDER,
 };
 use crate::blocks::helpers::{
-    self, err_bad_request, err_forbidden, err_internal, err_not_found, ok_json, path_param,
+    self, err_bad_request, err_internal, err_not_found, ok_json, path_param,
 };
 
 /// Legacy default provider block name that must be replaced with the first
@@ -469,11 +469,8 @@ async fn resolve_provider_key(ctx: &dyn Context, cfg: &mut ProviderConfig) {
 pub(super) async fn list_providers(
     _block: &LlmBlock,
     ctx: &dyn Context,
-    msg: &Message,
+    _msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let records = match db::list_all(ctx, PROVIDERS_TABLE, vec![]).await {
         Ok(r) => r,
         Err(e) => return err_internal("Database error", e),
@@ -494,12 +491,9 @@ pub(super) async fn list_providers(
 pub(super) async fn create_provider(
     block: &LlmBlock,
     ctx: &dyn Context,
-    msg: &Message,
+    _msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let raw = input.collect_to_bytes().await;
     let body: ProviderBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -564,9 +558,6 @@ pub(super) async fn update_provider(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let id = path_param(msg, "id", PROVIDERS_PREFIX).to_string();
     if id.is_empty() {
         return err_bad_request("Missing provider ID");
@@ -641,9 +632,6 @@ pub(super) async fn delete_provider(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let id = path_param(msg, "id", PROVIDERS_PREFIX).to_string();
     if id.is_empty() {
         return err_bad_request("Missing provider ID");
@@ -734,9 +722,6 @@ pub(super) async fn load_model(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let (backend_id, model_id) = extract_model_path(msg);
     if backend_id.is_empty() || model_id.is_empty() {
         return err_bad_request("Missing backend_id or model_id");
@@ -760,9 +745,6 @@ pub(super) async fn unload_model(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let (backend_id, model_id) = extract_model_path(msg);
     if backend_id.is_empty() || model_id.is_empty() {
         return err_bad_request("Missing backend_id or model_id");
@@ -785,9 +767,6 @@ pub(super) async fn discover_models(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return err_forbidden("admin role required");
-    }
     let id = path_param(msg, "id", PROVIDERS_PREFIX).to_string();
     if id.is_empty() {
         return err_bad_request("Missing provider ID");
@@ -987,83 +966,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_provider_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("create", "/b/llm/api/providers");
-        let input = InputStream::from_bytes(b"{}".to_vec());
-
-        let out = create_provider(&block, &ctx, &msg, input).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn update_provider_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("update", "/b/llm/api/providers/abc");
-        let input = InputStream::from_bytes(b"{}".to_vec());
-
-        let out = update_provider(&block, &ctx, &msg, input).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn delete_provider_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("delete", "/b/llm/api/providers/abc");
-
-        let out = delete_provider(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn list_providers_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("retrieve", "/b/llm/api/providers");
-
-        let out = list_providers(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn discover_models_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("create", "/b/llm/api/providers/abc/discover-models");
-
-        let out = discover_models(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
     async fn create_provider_returns_bad_request_on_invalid_json() {
         let block = stub_block();
         let ctx = PanicCtx;
@@ -1217,36 +1119,6 @@ mod tests {
     // These cover the paths that don't need a live `wafer-run/llm`
     // dispatch: admin-guard denial for `load`/`unload`, bad-request on
     // missing path vars, and the path-extraction helper.
-
-    #[tokio::test]
-    async fn load_model_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("create", "/b/llm/api/models/openai/gpt-4o/load");
-
-        let out = load_model(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn unload_model_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("create", "/b/llm/api/models/openai/gpt-4o/unload");
-
-        let out = unload_model(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
 
     #[tokio::test]
     async fn load_model_requires_path_vars() {

--- a/crates/solobase-core/src/blocks/llm/ui.rs
+++ b/crates/solobase-core/src/blocks/llm/ui.rs
@@ -24,7 +24,7 @@ use super::{
     LlmBlock,
 };
 use crate::{
-    blocks::helpers::{self, err_internal},
+    blocks::helpers::err_internal,
     ui::{self, components},
 };
 
@@ -41,9 +41,8 @@ pub(super) async fn providers_page(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return ui::forbidden_response(msg);
-    }
+    // Admin gate enforced centrally from the declared `AuthLevel::Admin` on
+    // `GET /b/llm/providers` (no per-handler `is_admin` re-check).
 
     // Load all provider rows (both enabled and disabled) — the admin UI
     // wants the full picture, not just the in-flight set.
@@ -312,9 +311,8 @@ pub(super) async fn models_page(
     ctx: &dyn Context,
     msg: &Message,
 ) -> OutputStream {
-    if !helpers::is_admin(msg) {
-        return ui::forbidden_response(msg);
-    }
+    // Admin gate enforced centrally from the declared `AuthLevel::Admin` on
+    // `GET /b/llm/models` (no per-handler `is_admin` re-check).
 
     let models = match wafer_core::clients::llm::list_models(ctx).await {
         Ok(m) => m,
@@ -465,91 +463,14 @@ fn model_row(model: &ModelInfo) -> Markup {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use wafer_run::{
-        context::Context, streams::output::TerminalNotResponse, ErrorCode, InputStream,
-    };
-
     use super::*;
-    use crate::blocks::llm::{
-        provider_admin::NoopProviderAdmin, providers::config::ProviderProtocol,
-    };
+    use crate::blocks::llm::providers::config::ProviderProtocol;
 
-    /// Minimal Context that panics on `call_block` — UI handlers should
-    /// never invoke block dispatch when the auth guard rejects first.
-    #[derive(Clone)]
-    struct PanicCtx;
-
-    #[async_trait::async_trait]
-    impl Context for PanicCtx {
-        async fn call_block(
-            &self,
-            _block_name: &str,
-            _msg: Message,
-            _input: InputStream,
-        ) -> OutputStream {
-            panic!("call_block must not be invoked on the forbidden path");
-        }
-        fn is_cancelled(&self) -> bool {
-            false
-        }
-        fn config_get(&self, _key: &str) -> Option<&str> {
-            None
-        }
-        fn clone_arc(&self) -> std::sync::Arc<dyn Context> {
-            std::sync::Arc::new(self.clone())
-        }
-    }
-
-    fn stub_block() -> LlmBlock {
-        // The forbidden-path tests never reach the provider-admin surface, so
-        // the no-op handle suffices and keeps the test independent of the
-        // native `llm` provider feature.
-        LlmBlock::new(Arc::new(NoopProviderAdmin))
-    }
-
-    fn user_msg(path: &str) -> Message {
-        let mut m = Message::new(format!("retrieve:{path}"));
-        m.set_meta(wafer_run::META_REQ_ACTION, "retrieve");
-        m.set_meta(wafer_run::META_REQ_RESOURCE, path);
-        m.set_meta(wafer_run::META_AUTH_USER_ID, "regular-user");
-        m.set_meta("auth.user_roles", "user");
-        // Prefer JSON 403 over the styled HTML page so the test can
-        // assert on the error code directly.
-        m.set_meta("http.header.accept", "application/json");
-        m
-    }
-
-    #[tokio::test]
-    async fn providers_page_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("/b/llm/providers");
-
-        let out = providers_page(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn models_page_rejects_non_admin() {
-        let block = stub_block();
-        let ctx = PanicCtx;
-        let msg = user_msg("/b/llm/models");
-
-        let out = models_page(&block, &ctx, &msg).await;
-        match out.collect_buffered().await {
-            Err(TerminalNotResponse::Error(e)) => {
-                assert_eq!(e.code, ErrorCode::PermissionDenied);
-            }
-            other => panic!("expected PermissionDenied, got {other:?}"),
-        }
-    }
+    // The provider/model admin pages are gated centrally by the declared
+    // `AuthLevel::Admin` on `GET /b/llm/providers` + `GET /b/llm/models`; the
+    // non-admin rejection is pinned at the enforcement point in
+    // `tests/extra_routes_test.rs` (llm_admin_ui_*), not here, so these page
+    // renderers no longer carry their own `is_admin` re-check.
 
     #[test]
     fn render_providers_table_empty_shows_hint() {

--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -5,14 +5,88 @@ pub mod rest;
 pub mod service;
 
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, InputStream, InstanceMode, LifecycleEvent,
-    LifecycleType, Message, OutputStream, WaferError,
+    context::Context, Block, BlockEndpoint, BlockInfo, HttpMethod, InputStream, InstanceMode,
+    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
 };
 
 use crate::{
-    blocks::helpers::{self, err_not_found},
-    ui,
+    blocks::helpers::err_not_found,
+    endpoint_match::{self, EndpointRoute},
 };
+
+/// In-block dispatch targets, one per declared HTTP endpoint.
+#[derive(Clone, Copy)]
+enum Route {
+    ContextListPage,
+    ContextDetailPage,
+    ListContexts,
+    CreateContext,
+    GetContext,
+    UpdateContext,
+    DeleteContext,
+    ListEntries,
+    AddEntry,
+    GetEntry,
+    DeleteEntry,
+}
+
+/// Method + path-template dispatch table. Templates mirror the declared
+/// `info().endpoints`; the matcher extracts `{id}` into `req.param.id`.
+/// More-specific templates (`.../{id}/entries`) precede generic ones
+/// (`.../{id}`) so ordering resolves them like the old `ends_with` guards.
+const ROUTES: &[EndpointRoute<Route>] = &[
+    EndpointRoute::new(HttpMethod::Get, "/b/messages/", Route::ContextListPage),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/messages/contexts/{id}",
+        Route::ContextDetailPage,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/messages/api/contexts",
+        Route::ListContexts,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/messages/api/contexts",
+        Route::CreateContext,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/messages/api/contexts/{id}/entries",
+        Route::ListEntries,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/messages/api/contexts/{id}/entries",
+        Route::AddEntry,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/messages/api/contexts/{id}",
+        Route::GetContext,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/messages/api/contexts/{id}",
+        Route::UpdateContext,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/messages/api/contexts/{id}",
+        Route::DeleteContext,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/messages/api/entries/{id}",
+        Route::GetEntry,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/messages/api/entries/{id}",
+        Route::DeleteEntry,
+    ),
+];
 
 pub struct MessagesBlock;
 
@@ -69,6 +143,17 @@ impl Block for MessagesBlock {
              primitive (messages, artifacts, notifications, status changes).",
         )
         .endpoints(vec![
+            // UI pages — admin-only (the chat/context inspector SSR pages).
+            // Declared here so the central router enforces the admin tier
+            // before dispatch; the block no longer hand-checks `is_admin`.
+            BlockEndpoint::get("/b/messages/")
+                .summary("Context list page")
+                .auth(AuthLevel::Admin)
+                .tags(&["ui"]),
+            BlockEndpoint::get("/b/messages/contexts/{id}")
+                .summary("Context detail page")
+                .auth(AuthLevel::Admin)
+                .tags(&["ui"]),
             // Contexts
             BlockEndpoint::get("/b/messages/api/contexts")
                 .summary("List contexts")
@@ -184,84 +269,36 @@ impl Block for MessagesBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        let action = msg.action().to_string();
-        let path = msg.path().to_string();
-        let is_api = path.contains("/api/");
-        let user_id = msg.user_id().to_string();
-
+    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
         // A2A JSON-RPC endpoint — protocol-public (auth handled by the
-        // JSON-RPC method handlers themselves). Routed from the shared
-        // pipeline via `ctx.call_block("suppers-ai/messages", ...)`.
-        if path == "/a2a" {
+        // JSON-RPC method handlers themselves). It does NOT pass through the
+        // central router's prefix table: the shared pipeline dispatches `/a2a`
+        // straight here via `ctx.call_block("suppers-ai/messages", ...)`, so
+        // the block keeps this entry point.
+        if msg.path() == "/a2a" {
             return a2a::handle_a2a(ctx, msg, input).await;
         }
 
-        // All other endpoints require authentication
-        if user_id.is_empty() {
-            return ui::forbidden_response(&msg);
-        }
-
-        // UI pages require admin role
-        if !is_api {
-            let is_admin = helpers::is_admin(&msg);
-            if !is_admin {
-                return ui::forbidden_response(&msg);
-            }
-        }
-
-        match (action.as_str(), path.as_str()) {
-            // UI pages
-            ("retrieve", "/b/messages/") => pages::context_list_page(ctx, &msg).await,
-            ("retrieve", _)
-                if path.starts_with("/b/messages/contexts/") && !path.contains("/api/") =>
-            {
-                pages::context_detail_page(ctx, &msg).await
-            }
-
-            // Context CRUD
-            ("retrieve", "/b/messages/api/contexts") => rest::list_contexts(ctx, &msg).await,
-            ("create", "/b/messages/api/contexts") => rest::create_context(ctx, input).await,
-            ("retrieve", _)
-                if path.starts_with("/b/messages/api/contexts/")
-                    && !path["/b/messages/api/contexts/".len()..].contains('/') =>
-            {
-                rest::get_context(ctx, &msg).await
-            }
-            ("update", _)
-                if path.starts_with("/b/messages/api/contexts/")
-                    && !path["/b/messages/api/contexts/".len()..].contains('/') =>
-            {
-                rest::update_context(ctx, &msg, input).await
-            }
-            ("delete", _)
-                if path.starts_with("/b/messages/api/contexts/")
-                    && !path["/b/messages/api/contexts/".len()..].contains('/') =>
-            {
-                rest::delete_context(ctx, &msg).await
-            }
-
-            // Entries within a context
-            ("retrieve", _)
-                if path.starts_with("/b/messages/api/contexts/") && path.ends_with("/entries") =>
-            {
-                rest::list_entries(ctx, &msg).await
-            }
-            ("create", _)
-                if path.starts_with("/b/messages/api/contexts/") && path.ends_with("/entries") =>
-            {
-                rest::add_entry(ctx, &msg, input).await
-            }
-
-            // Direct entry access
-            ("retrieve", _) if path.starts_with("/b/messages/api/entries/") => {
-                rest::get_entry(ctx, &msg).await
-            }
-            ("delete", _) if path.starts_with("/b/messages/api/entries/") => {
-                rest::delete_entry(ctx, &msg).await
-            }
-
-            _ => err_not_found("not found"),
+        // Auth is enforced centrally by `route_to_block` from the declared
+        // endpoint `AuthLevel` (UI pages → Admin, API → Authenticated), so no
+        // per-handler `user_id`/`is_admin` preamble is needed here. Dispatch
+        // matches the same declared endpoint templates, extracting `{id}` into
+        // `req.param.id` for the sub-handlers.
+        let Some(route) = endpoint_match::dispatch(&mut msg, ROUTES) else {
+            return err_not_found("not found");
+        };
+        match route {
+            Route::ContextListPage => pages::context_list_page(ctx, &msg).await,
+            Route::ContextDetailPage => pages::context_detail_page(ctx, &msg).await,
+            Route::ListContexts => rest::list_contexts(ctx, &msg).await,
+            Route::CreateContext => rest::create_context(ctx, input).await,
+            Route::GetContext => rest::get_context(ctx, &msg).await,
+            Route::UpdateContext => rest::update_context(ctx, &msg, input).await,
+            Route::DeleteContext => rest::delete_context(ctx, &msg).await,
+            Route::ListEntries => rest::list_entries(ctx, &msg).await,
+            Route::AddEntry => rest::add_entry(ctx, &msg, input).await,
+            Route::GetEntry => rest::get_entry(ctx, &msg).await,
+            Route::DeleteEntry => rest::delete_entry(ctx, &msg).await,
         }
     }
 

--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -269,7 +269,12 @@ impl Block for MessagesBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+    async fn handle(
+        &self,
+        ctx: &dyn Context,
+        mut msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
         // A2A JSON-RPC endpoint — protocol-public (auth handled by the
         // JSON-RPC method handlers themselves). It does NOT pass through the
         // central router's prefix table: the shared pipeline dispatches `/a2a`

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -12,14 +12,161 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
+use wafer_run::HttpMethod;
+
 use super::PRICING_TABLE;
-use crate::blocks::{
-    crud,
-    helpers::{
-        err_bad_request, err_forbidden, err_internal, err_not_found, err_unauthorized,
-        field_as_string, ok_json, stamp_created, RecordExt,
+use crate::{
+    blocks::{
+        crud,
+        helpers::{
+            err_bad_request, err_forbidden, err_internal, err_not_found, err_unauthorized,
+            field_as_string, ok_json, stamp_created, RecordExt,
+        },
     },
+    endpoint_match::{self, EndpointRoute},
 };
+
+/// Admin JSON-API dispatch targets (normalized `/admin/b/products/...`).
+#[derive(Clone, Copy)]
+pub(crate) enum AdminRoute {
+    ListProducts,
+    GetProduct,
+    CreateProduct,
+    UpdateProduct,
+    DeleteProduct,
+    ListGroups,
+    CreateGroup,
+    UpdateGroup,
+    DeleteGroup,
+    ListTypes,
+    CreateType,
+    DeleteType,
+    ListPricing,
+    CreatePricing,
+    UpdatePricing,
+    DeletePricing,
+    ListVariables,
+    CreateVariable,
+    UpdateVariable,
+    DeleteVariable,
+    ListPurchases,
+    RefundPurchase,
+    GetPurchase,
+    Stats,
+}
+
+/// Admin dispatch table over the normalized `/admin/b/products/...` paths.
+/// The `purchases/{id}/refund` template precedes the generic
+/// `purchases/{id}` so the refund route wins (the old `ends_with("/refund")`
+/// guard).
+const ADMIN_ROUTES: &[EndpointRoute<AdminRoute>] = &[
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/products", AdminRoute::ListProducts),
+    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/products", AdminRoute::CreateProduct),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/products/{id}", AdminRoute::GetProduct),
+    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/products/{id}", AdminRoute::UpdateProduct),
+    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/products/{id}", AdminRoute::DeleteProduct),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/groups", AdminRoute::ListGroups),
+    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/groups", AdminRoute::CreateGroup),
+    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/groups/{id}", AdminRoute::UpdateGroup),
+    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/groups/{id}", AdminRoute::DeleteGroup),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/types", AdminRoute::ListTypes),
+    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/types", AdminRoute::CreateType),
+    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/types/{id}", AdminRoute::DeleteType),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/pricing", AdminRoute::ListPricing),
+    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/pricing", AdminRoute::CreatePricing),
+    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/pricing/{id}", AdminRoute::UpdatePricing),
+    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/pricing/{id}", AdminRoute::DeletePricing),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/variables", AdminRoute::ListVariables),
+    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/variables", AdminRoute::CreateVariable),
+    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/variables/{id}", AdminRoute::UpdateVariable),
+    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/variables/{id}", AdminRoute::DeleteVariable),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/purchases", AdminRoute::ListPurchases),
+    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/purchases/{id}/refund", AdminRoute::RefundPurchase),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/purchases/{id}", AdminRoute::GetPurchase),
+    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/stats", AdminRoute::Stats),
+];
+
+/// User-facing dispatch targets (normalized `/b/products/...`).
+#[derive(Clone, Copy)]
+pub(crate) enum UserRoute {
+    ListProducts,
+    GetProduct,
+    CreateProduct,
+    UpdateProduct,
+    DeleteProduct,
+    ListGroups,
+    GetGroup,
+    CreateGroup,
+    UpdateGroup,
+    DeleteGroup,
+    GroupProducts,
+    ListTypes,
+    GroupTemplates,
+    Catalog,
+    CatalogItem,
+    CalculatePrice,
+    CreatePurchase,
+    ListPurchases,
+    GetPurchase,
+    Checkout,
+    Subscription,
+}
+
+impl UserRoute {
+    /// Routes that operate on a user's OWN product/group rows and are gated on
+    /// `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS` (matching the old
+    /// `starts_with("/b/products/products"|"groups")` 403 fallback).
+    fn requires_user_products(self) -> bool {
+        matches!(
+            self,
+            UserRoute::ListProducts
+                | UserRoute::GetProduct
+                | UserRoute::CreateProduct
+                | UserRoute::UpdateProduct
+                | UserRoute::DeleteProduct
+                | UserRoute::ListGroups
+                | UserRoute::GetGroup
+                | UserRoute::CreateGroup
+                | UserRoute::UpdateGroup
+                | UserRoute::DeleteGroup
+                | UserRoute::GroupProducts
+        )
+    }
+}
+
+/// User dispatch table over the normalized `/b/products/...` paths. The
+/// `groups/{id}/products` template precedes the generic `groups/{id}` so the
+/// "products in a group" route wins (the old `ends_with("/products")` guard);
+/// `catalog` precedes `catalog/{id}`, and `purchases` precedes
+/// `purchases/{id}`.
+const USER_ROUTES: &[EndpointRoute<UserRoute>] = &[
+    // Own products
+    EndpointRoute::new(HttpMethod::Get, "/b/products/products", UserRoute::ListProducts),
+    EndpointRoute::new(HttpMethod::Post, "/b/products/products", UserRoute::CreateProduct),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/products/{id}", UserRoute::GetProduct),
+    EndpointRoute::new(HttpMethod::Patch, "/b/products/products/{id}", UserRoute::UpdateProduct),
+    EndpointRoute::new(HttpMethod::Delete, "/b/products/products/{id}", UserRoute::DeleteProduct),
+    // Own groups (group-products before the generic {id})
+    EndpointRoute::new(HttpMethod::Get, "/b/products/groups", UserRoute::ListGroups),
+    EndpointRoute::new(HttpMethod::Post, "/b/products/groups", UserRoute::CreateGroup),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/groups/{id}/products", UserRoute::GroupProducts),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/groups/{id}", UserRoute::GetGroup),
+    EndpointRoute::new(HttpMethod::Patch, "/b/products/groups/{id}", UserRoute::UpdateGroup),
+    EndpointRoute::new(HttpMethod::Delete, "/b/products/groups/{id}", UserRoute::DeleteGroup),
+    // Read-only taxonomy
+    EndpointRoute::new(HttpMethod::Get, "/b/products/types", UserRoute::ListTypes),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/group-templates", UserRoute::GroupTemplates),
+    // Catalog (public)
+    EndpointRoute::new(HttpMethod::Get, "/b/products/catalog", UserRoute::Catalog),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/catalog/{id}", UserRoute::CatalogItem),
+    // Pricing / purchases / checkout
+    EndpointRoute::new(HttpMethod::Post, "/b/products/calculate-price", UserRoute::CalculatePrice),
+    EndpointRoute::new(HttpMethod::Post, "/b/products/purchases", UserRoute::CreatePurchase),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/purchases", UserRoute::ListPurchases),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/purchases/{id}", UserRoute::GetPurchase),
+    EndpointRoute::new(HttpMethod::Post, "/b/products/checkout", UserRoute::Checkout),
+    EndpointRoute::new(HttpMethod::Get, "/b/products/subscription", UserRoute::Subscription),
+];
 
 /// Products catalog table — one row per product offering.
 pub(crate) const PRODUCTS_TABLE: &str = "suppers_ai__products__products";
@@ -123,168 +270,98 @@ const USER_GROUP: crud::OwnedResource<'static> = crud::OwnedResource {
     label: "Group",
 };
 
-pub async fn handle_admin(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let action = msg.action();
-    let path = msg.path();
-
-    match (action, path) {
-        // Products
-        ("retrieve", "/admin/b/products/products") => handle_list_products(ctx, msg).await,
-        ("retrieve", _) if path.starts_with("/admin/b/products/products/") => {
-            handle_get_product(ctx, msg).await
-        }
-        ("create", "/admin/b/products/products") => handle_create_product(ctx, msg, input).await,
-        ("update", _) if path.starts_with("/admin/b/products/products/") => {
-            handle_update_product(ctx, msg, input).await
-        }
-        ("delete", _) if path.starts_with("/admin/b/products/products/") => {
-            handle_delete_product(ctx, msg).await
-        }
-        // Groups
-        ("retrieve", "/admin/b/products/groups") => handle_list_groups(ctx, msg).await,
-        ("create", "/admin/b/products/groups") => handle_create_group(ctx, msg, input).await,
-        ("update", _) if path.starts_with("/admin/b/products/groups/") => {
-            handle_update_group(ctx, msg, input).await
-        }
-        ("delete", _) if path.starts_with("/admin/b/products/groups/") => {
-            handle_delete_group(ctx, msg).await
-        }
-        // Types
-        ("retrieve", "/admin/b/products/types") => handle_list_types(ctx, msg).await,
-        ("create", "/admin/b/products/types") => handle_create_type(ctx, msg, input).await,
-        ("delete", _) if path.starts_with("/admin/b/products/types/") => {
-            handle_delete_type(ctx, msg).await
-        }
-        // Pricing templates
-        ("retrieve", "/admin/b/products/pricing") => handle_list_pricing(ctx, msg).await,
-        ("create", "/admin/b/products/pricing") => handle_create_pricing(ctx, msg, input).await,
-        ("update", _) if path.starts_with("/admin/b/products/pricing/") => {
-            handle_update_pricing(ctx, msg, input).await
-        }
-        ("delete", _) if path.starts_with("/admin/b/products/pricing/") => {
-            handle_delete_pricing(ctx, msg).await
-        }
-        // Variables
-        ("retrieve", "/admin/b/products/variables") => {
-            super::variables::handle_list(ctx, msg).await
-        }
-        ("create", "/admin/b/products/variables") => {
-            super::variables::handle_create(ctx, msg, input).await
-        }
-        ("update", _) if path.starts_with("/admin/b/products/variables/") => {
-            super::variables::handle_update(ctx, msg, input).await
-        }
-        ("delete", _) if path.starts_with("/admin/b/products/variables/") => {
-            super::variables::handle_delete(ctx, msg).await
-        }
-        // Purchases (admin view)
-        ("retrieve", "/admin/b/products/purchases") => {
-            super::purchase::handle_list_admin(ctx, msg).await
-        }
-        ("retrieve", _) if path.starts_with("/admin/b/products/purchases/") => {
-            super::purchase::handle_get(ctx, msg).await
-        }
-        ("update", _)
-            if path.starts_with("/admin/b/products/purchases/") && path.ends_with("/refund") =>
-        {
-            super::purchase::handle_refund(ctx, msg, input).await
-        }
-        // Stats
-        ("retrieve", "/admin/b/products/stats") => handle_stats(ctx, msg).await,
-        _ => err_not_found("not found"),
+/// Admin JSON-API dispatch.
+///
+/// `norm` is the normalized admin sub-path (`/admin/b/products/...`), passed
+/// as an explicit argument by `ProductsBlock::handle` rather than written
+/// back onto `req.resource` (the old in-band routing mutation). The matcher
+/// binds `{id}` into `req.param.id` so the `crud::*` helpers read it.
+pub async fn handle_admin(
+    ctx: &dyn Context,
+    msg: &mut Message,
+    norm: &str,
+    input: InputStream,
+) -> OutputStream {
+    let action = msg.action().to_string();
+    let Some(route) = endpoint_match::dispatch_path(msg, &action, norm, ADMIN_ROUTES) else {
+        return err_not_found("not found");
+    };
+    match route {
+        AdminRoute::ListProducts => handle_list_products(ctx, msg).await,
+        AdminRoute::GetProduct => handle_get_product(ctx, msg).await,
+        AdminRoute::CreateProduct => handle_create_product(ctx, msg, input).await,
+        AdminRoute::UpdateProduct => handle_update_product(ctx, msg, input).await,
+        AdminRoute::DeleteProduct => handle_delete_product(ctx, msg).await,
+        AdminRoute::ListGroups => handle_list_groups(ctx, msg).await,
+        AdminRoute::CreateGroup => handle_create_group(ctx, msg, input).await,
+        AdminRoute::UpdateGroup => handle_update_group(ctx, msg, input).await,
+        AdminRoute::DeleteGroup => handle_delete_group(ctx, msg).await,
+        AdminRoute::ListTypes => handle_list_types(ctx, msg).await,
+        AdminRoute::CreateType => handle_create_type(ctx, msg, input).await,
+        AdminRoute::DeleteType => handle_delete_type(ctx, msg).await,
+        AdminRoute::ListPricing => handle_list_pricing(ctx, msg).await,
+        AdminRoute::CreatePricing => handle_create_pricing(ctx, msg, input).await,
+        AdminRoute::UpdatePricing => handle_update_pricing(ctx, msg, input).await,
+        AdminRoute::DeletePricing => handle_delete_pricing(ctx, msg).await,
+        AdminRoute::ListVariables => super::variables::handle_list(ctx, msg).await,
+        AdminRoute::CreateVariable => super::variables::handle_create(ctx, msg, input).await,
+        AdminRoute::UpdateVariable => super::variables::handle_update(ctx, msg, input).await,
+        AdminRoute::DeleteVariable => super::variables::handle_delete(ctx, msg).await,
+        AdminRoute::ListPurchases => super::purchase::handle_list_admin(ctx, msg).await,
+        AdminRoute::RefundPurchase => super::purchase::handle_refund(ctx, msg, input).await,
+        AdminRoute::GetPurchase => super::purchase::handle_get(ctx, msg).await,
+        AdminRoute::Stats => handle_stats(ctx, msg).await,
     }
 }
 
-pub async fn handle_user(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let action = msg.action();
-    let path = msg.path();
-    let user_products = user_products_enabled(ctx).await;
+/// User-facing dispatch (own products/groups under `ALLOW_USER_PRODUCTS`, plus
+/// the public catalog, purchases, checkout, subscription).
+///
+/// `norm` is the normalized user sub-path passed explicitly by
+/// `ProductsBlock::handle`. The own-products/groups routes are gated on
+/// `ALLOW_USER_PRODUCTS` *after* matching, preserving the prior "feature
+/// disabled → 403" behaviour for those paths while leaving catalog/purchase
+/// routes always available.
+pub async fn handle_user(
+    ctx: &dyn Context,
+    msg: &mut Message,
+    norm: &str,
+    input: InputStream,
+) -> OutputStream {
+    let action = msg.action().to_string();
+    let Some(route) = endpoint_match::dispatch_path(msg, &action, norm, USER_ROUTES) else {
+        return err_not_found("not found");
+    };
 
-    match (action, path) {
-        // User's own products (requires ALLOW_USER_PRODUCTS)
-        ("retrieve", "/b/products/products") if user_products => {
-            handle_user_list_products(ctx, msg).await
-        }
-        ("retrieve", _) if user_products && path.starts_with("/b/products/products/") => {
-            handle_user_get_product(ctx, msg).await
-        }
-        ("create", "/b/products/products") if user_products => {
-            handle_user_create_product(ctx, msg, input).await
-        }
-        ("update", _) if user_products && path.starts_with("/b/products/products/") => {
-            handle_user_update_product(ctx, msg, input).await
-        }
-        ("delete", _) if user_products && path.starts_with("/b/products/products/") => {
-            handle_user_delete_product(ctx, msg).await
-        }
-        // User's own groups (requires ALLOW_USER_PRODUCTS)
-        ("retrieve", "/b/products/groups") if user_products => {
-            handle_user_list_groups(ctx, msg).await
-        }
-        ("retrieve", _)
-            if user_products
-                && path.starts_with("/b/products/groups/")
-                && !path.ends_with("/products") =>
-        {
-            handle_user_get_group(ctx, msg).await
-        }
-        ("create", "/b/products/groups") if user_products => {
-            handle_user_create_group(ctx, msg, input).await
-        }
-        ("update", _)
-            if user_products
-                && path.starts_with("/b/products/groups/")
-                && !path.ends_with("/products") =>
-        {
-            handle_user_update_group(ctx, msg, input).await
-        }
-        ("delete", _)
-            if user_products
-                && path.starts_with("/b/products/groups/")
-                && !path.ends_with("/products") =>
-        {
-            handle_user_delete_group(ctx, msg).await
-        }
-        // Products in a group (requires ALLOW_USER_PRODUCTS)
-        ("retrieve", _)
-            if user_products
-                && path.starts_with("/b/products/groups/")
-                && path.ends_with("/products") =>
-        {
-            handle_user_group_products(ctx, msg).await
-        }
-        // Read-only: types and group templates
-        ("retrieve", "/b/products/types") => handle_list_types(ctx, msg).await,
-        ("retrieve", "/b/products/group-templates") => {
-            handle_user_list_group_templates(ctx, msg).await
-        }
-        // Catalog (public)
-        ("retrieve", "/b/products/catalog") => handle_catalog(ctx, msg).await,
-        ("retrieve", _) if path.starts_with("/b/products/catalog/") => {
-            handle_get_product_public(ctx, msg).await
-        }
-        // Pricing, purchases, checkout
-        ("create", "/b/products/calculate-price") => {
-            super::pricing::handle_calculate(ctx, input).await
-        }
-        ("create", "/b/products/purchases") => {
-            super::purchase::handle_create(ctx, msg, input).await
-        }
-        ("retrieve", "/b/products/purchases") => super::purchase::handle_list_user(ctx, msg).await,
-        ("retrieve", _) if path.starts_with("/b/products/purchases/") => {
-            super::purchase::handle_get(ctx, msg).await
-        }
-        ("create", "/b/products/checkout") => super::stripe::handle_checkout(ctx, msg, input).await,
-        // Subscription status
-        ("retrieve", "/b/products/subscription") => handle_subscription(ctx, msg).await,
-        // User products/groups disabled
-        (_, _)
-            if path.starts_with("/b/products/products")
-                || path.starts_with("/b/products/groups") =>
-        {
-            err_forbidden("user products are not enabled")
-        }
-        _ => err_not_found("not found"),
+    // Own products/groups require ALLOW_USER_PRODUCTS; reject with the same
+    // 403 the old `(_, _) if starts_with("/b/products/products"|"groups")` arm
+    // produced when the feature is off.
+    if route.requires_user_products() && !user_products_enabled(ctx).await {
+        return err_forbidden("user products are not enabled");
+    }
+
+    match route {
+        UserRoute::ListProducts => handle_user_list_products(ctx, msg).await,
+        UserRoute::GetProduct => handle_user_get_product(ctx, msg).await,
+        UserRoute::CreateProduct => handle_user_create_product(ctx, msg, input).await,
+        UserRoute::UpdateProduct => handle_user_update_product(ctx, msg, input).await,
+        UserRoute::DeleteProduct => handle_user_delete_product(ctx, msg).await,
+        UserRoute::ListGroups => handle_user_list_groups(ctx, msg).await,
+        UserRoute::GetGroup => handle_user_get_group(ctx, msg).await,
+        UserRoute::CreateGroup => handle_user_create_group(ctx, msg, input).await,
+        UserRoute::UpdateGroup => handle_user_update_group(ctx, msg, input).await,
+        UserRoute::DeleteGroup => handle_user_delete_group(ctx, msg).await,
+        UserRoute::GroupProducts => handle_user_group_products(ctx, msg).await,
+        UserRoute::ListTypes => handle_list_types(ctx, msg).await,
+        UserRoute::GroupTemplates => handle_user_list_group_templates(ctx, msg).await,
+        UserRoute::Catalog => handle_catalog(ctx, msg).await,
+        UserRoute::CatalogItem => handle_get_product_public(ctx, msg).await,
+        UserRoute::CalculatePrice => super::pricing::handle_calculate(ctx, input).await,
+        UserRoute::CreatePurchase => super::purchase::handle_create(ctx, msg, input).await,
+        UserRoute::ListPurchases => super::purchase::handle_list_user(ctx, msg).await,
+        UserRoute::GetPurchase => super::purchase::handle_get(ctx, msg).await,
+        UserRoute::Checkout => super::stripe::handle_checkout(ctx, msg, input).await,
+        UserRoute::Subscription => handle_subscription(ctx, msg).await,
     }
 }
 
@@ -451,8 +528,16 @@ async fn handle_catalog(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn handle_get_product_public(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    let id = path.strip_prefix("/b/products/catalog/").unwrap_or("");
+    let id = {
+        let var = msg.var("id");
+        if var.is_empty() {
+            msg.path()
+                .strip_prefix("/b/products/catalog/")
+                .unwrap_or("")
+        } else {
+            var
+        }
+    };
     if id.is_empty() {
         return err_bad_request("Missing product ID");
     }
@@ -652,10 +737,19 @@ async fn handle_user_delete_group(ctx: &dyn Context, msg: &Message) -> OutputStr
 
 // Products in a user's group
 async fn handle_user_group_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    // Path: /b/products/groups/{id}/products
-    let rest = path.strip_prefix("/b/products/groups/").unwrap_or("");
-    let group_id = rest.strip_suffix("/products").unwrap_or("");
+    // Path: /b/products/groups/{id}/products — prefer the matcher-bound `{id}`.
+    let group_id = {
+        let var = msg.var("id");
+        if var.is_empty() {
+            msg.path()
+                .strip_prefix("/b/products/groups/")
+                .unwrap_or("")
+                .strip_suffix("/products")
+                .unwrap_or("")
+        } else {
+            var
+        }
+    };
     if group_id.is_empty() {
         return err_bad_request("Missing group ID");
     }

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -10,9 +10,7 @@ use std::collections::HashMap;
 
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
-use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
-
-use wafer_run::HttpMethod;
+use wafer_run::{context::Context, ErrorCode, HttpMethod, InputStream, Message, OutputStream};
 
 use super::PRICING_TABLE;
 use crate::{
@@ -60,30 +58,126 @@ pub(crate) enum AdminRoute {
 /// `purchases/{id}` so the refund route wins (the old `ends_with("/refund")`
 /// guard).
 const ADMIN_ROUTES: &[EndpointRoute<AdminRoute>] = &[
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/products", AdminRoute::ListProducts),
-    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/products", AdminRoute::CreateProduct),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/products/{id}", AdminRoute::GetProduct),
-    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/products/{id}", AdminRoute::UpdateProduct),
-    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/products/{id}", AdminRoute::DeleteProduct),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/groups", AdminRoute::ListGroups),
-    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/groups", AdminRoute::CreateGroup),
-    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/groups/{id}", AdminRoute::UpdateGroup),
-    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/groups/{id}", AdminRoute::DeleteGroup),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/types", AdminRoute::ListTypes),
-    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/types", AdminRoute::CreateType),
-    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/types/{id}", AdminRoute::DeleteType),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/pricing", AdminRoute::ListPricing),
-    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/pricing", AdminRoute::CreatePricing),
-    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/pricing/{id}", AdminRoute::UpdatePricing),
-    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/pricing/{id}", AdminRoute::DeletePricing),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/variables", AdminRoute::ListVariables),
-    EndpointRoute::new(HttpMethod::Post, "/admin/b/products/variables", AdminRoute::CreateVariable),
-    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/variables/{id}", AdminRoute::UpdateVariable),
-    EndpointRoute::new(HttpMethod::Delete, "/admin/b/products/variables/{id}", AdminRoute::DeleteVariable),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/purchases", AdminRoute::ListPurchases),
-    EndpointRoute::new(HttpMethod::Patch, "/admin/b/products/purchases/{id}/refund", AdminRoute::RefundPurchase),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/purchases/{id}", AdminRoute::GetPurchase),
-    EndpointRoute::new(HttpMethod::Get, "/admin/b/products/stats", AdminRoute::Stats),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/products",
+        AdminRoute::ListProducts,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/admin/b/products/products",
+        AdminRoute::CreateProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/products/{id}",
+        AdminRoute::GetProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/admin/b/products/products/{id}",
+        AdminRoute::UpdateProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/admin/b/products/products/{id}",
+        AdminRoute::DeleteProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/groups",
+        AdminRoute::ListGroups,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/admin/b/products/groups",
+        AdminRoute::CreateGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/admin/b/products/groups/{id}",
+        AdminRoute::UpdateGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/admin/b/products/groups/{id}",
+        AdminRoute::DeleteGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/types",
+        AdminRoute::ListTypes,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/admin/b/products/types",
+        AdminRoute::CreateType,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/admin/b/products/types/{id}",
+        AdminRoute::DeleteType,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/pricing",
+        AdminRoute::ListPricing,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/admin/b/products/pricing",
+        AdminRoute::CreatePricing,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/admin/b/products/pricing/{id}",
+        AdminRoute::UpdatePricing,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/admin/b/products/pricing/{id}",
+        AdminRoute::DeletePricing,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/variables",
+        AdminRoute::ListVariables,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/admin/b/products/variables",
+        AdminRoute::CreateVariable,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/admin/b/products/variables/{id}",
+        AdminRoute::UpdateVariable,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/admin/b/products/variables/{id}",
+        AdminRoute::DeleteVariable,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/purchases",
+        AdminRoute::ListPurchases,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/admin/b/products/purchases/{id}/refund",
+        AdminRoute::RefundPurchase,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/purchases/{id}",
+        AdminRoute::GetPurchase,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/admin/b/products/stats",
+        AdminRoute::Stats,
+    ),
 ];
 
 /// User-facing dispatch targets (normalized `/b/products/...`).
@@ -141,31 +235,103 @@ impl UserRoute {
 /// `purchases/{id}`.
 const USER_ROUTES: &[EndpointRoute<UserRoute>] = &[
     // Own products
-    EndpointRoute::new(HttpMethod::Get, "/b/products/products", UserRoute::ListProducts),
-    EndpointRoute::new(HttpMethod::Post, "/b/products/products", UserRoute::CreateProduct),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/products/{id}", UserRoute::GetProduct),
-    EndpointRoute::new(HttpMethod::Patch, "/b/products/products/{id}", UserRoute::UpdateProduct),
-    EndpointRoute::new(HttpMethod::Delete, "/b/products/products/{id}", UserRoute::DeleteProduct),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/products",
+        UserRoute::ListProducts,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/products/products",
+        UserRoute::CreateProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/products/{id}",
+        UserRoute::GetProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/products/products/{id}",
+        UserRoute::UpdateProduct,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/products/products/{id}",
+        UserRoute::DeleteProduct,
+    ),
     // Own groups (group-products before the generic {id})
     EndpointRoute::new(HttpMethod::Get, "/b/products/groups", UserRoute::ListGroups),
-    EndpointRoute::new(HttpMethod::Post, "/b/products/groups", UserRoute::CreateGroup),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/groups/{id}/products", UserRoute::GroupProducts),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/groups/{id}", UserRoute::GetGroup),
-    EndpointRoute::new(HttpMethod::Patch, "/b/products/groups/{id}", UserRoute::UpdateGroup),
-    EndpointRoute::new(HttpMethod::Delete, "/b/products/groups/{id}", UserRoute::DeleteGroup),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/products/groups",
+        UserRoute::CreateGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/groups/{id}/products",
+        UserRoute::GroupProducts,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/groups/{id}",
+        UserRoute::GetGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Patch,
+        "/b/products/groups/{id}",
+        UserRoute::UpdateGroup,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/products/groups/{id}",
+        UserRoute::DeleteGroup,
+    ),
     // Read-only taxonomy
     EndpointRoute::new(HttpMethod::Get, "/b/products/types", UserRoute::ListTypes),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/group-templates", UserRoute::GroupTemplates),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/group-templates",
+        UserRoute::GroupTemplates,
+    ),
     // Catalog (public)
     EndpointRoute::new(HttpMethod::Get, "/b/products/catalog", UserRoute::Catalog),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/catalog/{id}", UserRoute::CatalogItem),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/catalog/{id}",
+        UserRoute::CatalogItem,
+    ),
     // Pricing / purchases / checkout
-    EndpointRoute::new(HttpMethod::Post, "/b/products/calculate-price", UserRoute::CalculatePrice),
-    EndpointRoute::new(HttpMethod::Post, "/b/products/purchases", UserRoute::CreatePurchase),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/purchases", UserRoute::ListPurchases),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/purchases/{id}", UserRoute::GetPurchase),
-    EndpointRoute::new(HttpMethod::Post, "/b/products/checkout", UserRoute::Checkout),
-    EndpointRoute::new(HttpMethod::Get, "/b/products/subscription", UserRoute::Subscription),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/products/calculate-price",
+        UserRoute::CalculatePrice,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/products/purchases",
+        UserRoute::CreatePurchase,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/purchases",
+        UserRoute::ListPurchases,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/purchases/{id}",
+        UserRoute::GetPurchase,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/products/checkout",
+        UserRoute::Checkout,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/products/subscription",
+        UserRoute::Subscription,
+    ),
 ];
 
 /// Products catalog table — one row per product offering.

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -126,7 +126,19 @@ impl Block for ProductsBlock {
             // user-facing purchase/checkout/subscription routes are
             // `Authenticated`.
             .endpoints(vec![
-                // SSR admin pages
+                // SSR admin pages.
+                //
+                // The overview is served by `handle()` for BOTH the canonical
+                // slash form (`/b/products/admin/`, the `admin_url`) and the
+                // bare no-slash form (`/b/products/admin`) via its
+                // `"" | "/" => overview` dispatch arm. The central router's
+                // matcher is trailing-slash-significant, so BOTH forms must be
+                // declared `Admin` — declaring only the slash form would leave
+                // the no-slash form governed solely by the Public `/b/products`
+                // prefix tier, letting an anonymous request reach the admin
+                // overview (the dispatch table and the declared surface must
+                // agree on every path the block actually answers).
+                BlockEndpoint::get("/b/products/admin").summary("Overview").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/products/admin/").summary("Overview").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/products/admin/manage").summary("Manage products").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/products/admin/groups").summary("Manage groups").auth(AuthLevel::Admin),

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -22,7 +22,7 @@ use wafer_run::{
 };
 
 use super::rate_limit::{check_user_rate_limit, RateLimitOutcome, UserRateLimiter};
-use crate::blocks::helpers::{self, err_not_found};
+use crate::blocks::helpers::err_not_found;
 
 /// The products block's own declared config vars. Single source of truth for
 /// both `BlockInfo::config_keys` and the admin settings page (which renders
@@ -117,13 +117,60 @@ impl Block for ProductsBlock {
             ])
             .category(wafer_run::BlockCategory::Feature)
             .description("Product catalog, pricing engine, and payment processing. Manages products, groups, pricing templates with formula evaluation, purchases, and Stripe integration for checkout and recurring subscriptions.")
+            // Declared in full so the central router enforces each tier from
+            // the declared `AuthLevel` — the block dropped its in-handler
+            // `is_admin` preambles, so any admin path NOT declared here would
+            // silently fall back to the Public prefix tier (a regression). All
+            // `/b/products/admin/*` SSR pages and `/b/products/api/admin/*`
+            // JSON routes are `Admin`; the public catalog stays Public; the
+            // user-facing purchase/checkout/subscription routes are
+            // `Authenticated`.
             .endpoints(vec![
+                // SSR admin pages
                 BlockEndpoint::get("/b/products/admin/").summary("Overview").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/products/admin/manage").summary("Manage products").auth(AuthLevel::Admin),
-                BlockEndpoint::get("/b/products/api/admin/products").summary("List products API").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/admin/groups").summary("Manage groups").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/admin/pricing").summary("Pricing templates").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/admin/purchases").summary("Purchases").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/admin/settings").summary("Product settings").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/products/admin/settings").summary("Save product settings").auth(AuthLevel::Admin),
+                // JSON admin API — products
+                BlockEndpoint::get("/b/products/api/admin/products").summary("List products").auth(AuthLevel::Admin),
                 BlockEndpoint::post("/b/products/api/admin/products").summary("Create product").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/api/admin/products/{id}").summary("Get product").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/products/api/admin/products/{id}").summary("Update product").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/products/api/admin/products/{id}").summary("Delete product").auth(AuthLevel::Admin),
+                // JSON admin API — groups
+                BlockEndpoint::get("/b/products/api/admin/groups").summary("List groups").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/products/api/admin/groups").summary("Create group").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/products/api/admin/groups/{id}").summary("Update group").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/products/api/admin/groups/{id}").summary("Delete group").auth(AuthLevel::Admin),
+                // JSON admin API — types
+                BlockEndpoint::get("/b/products/api/admin/types").summary("List types").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/products/api/admin/types").summary("Create type").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/products/api/admin/types/{id}").summary("Delete type").auth(AuthLevel::Admin),
+                // JSON admin API — pricing
+                BlockEndpoint::get("/b/products/api/admin/pricing").summary("List pricing").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/products/api/admin/pricing").summary("Create pricing").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/products/api/admin/pricing/{id}").summary("Update pricing").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/products/api/admin/pricing/{id}").summary("Delete pricing").auth(AuthLevel::Admin),
+                // JSON admin API — variables
+                BlockEndpoint::get("/b/products/api/admin/variables").summary("List variables").auth(AuthLevel::Admin),
+                BlockEndpoint::post("/b/products/api/admin/variables").summary("Create variable").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/products/api/admin/variables/{id}").summary("Update variable").auth(AuthLevel::Admin),
+                BlockEndpoint::delete("/b/products/api/admin/variables/{id}").summary("Delete variable").auth(AuthLevel::Admin),
+                // JSON admin API — purchases + stats
+                BlockEndpoint::get("/b/products/api/admin/purchases").summary("List purchases").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/api/admin/purchases/{id}").summary("Get purchase").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/products/api/admin/purchases/{id}/refund").summary("Refund purchase").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/products/api/admin/stats").summary("Stats").auth(AuthLevel::Admin),
+                // Public + authenticated user surface
                 BlockEndpoint::get("/b/products/catalog").summary("Browse catalog"),
+                BlockEndpoint::get("/b/products/catalog/{id}").summary("Product detail"),
                 BlockEndpoint::post("/b/products/checkout").summary("Stripe checkout").auth(AuthLevel::Authenticated),
+                BlockEndpoint::post("/b/products/purchases").summary("Create purchase").auth(AuthLevel::Authenticated),
+                BlockEndpoint::get("/b/products/purchases").summary("List purchases").auth(AuthLevel::Authenticated),
+                BlockEndpoint::get("/b/products/purchases/{id}").summary("Get purchase").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/products/subscription").summary("Subscription status").auth(AuthLevel::Authenticated),
             ])
             .config_keys(config_vars())
@@ -140,24 +187,19 @@ impl Block for ProductsBlock {
         let path = msg.path().to_string();
         let action = msg.action().to_string();
 
-        // Settings save (POST to admin settings page)
+        // Settings save (POST to admin settings page). Admin tier enforced
+        // centrally from the declared `POST /b/products/admin/settings`
+        // endpoint — no in-handler `is_admin` re-check.
         if action == "create" && path == "/b/products/admin/settings" {
-            let is_admin = helpers::is_admin(&msg);
-            if !is_admin {
-                return crate::ui::forbidden_response(&msg);
-            }
             return pages::handle_save_settings(ctx, input).await;
         }
 
         // SSR pages (GET requests to specific page paths)
         if action == "retrieve" && path.starts_with("/b/products/") {
             let sub = path.strip_prefix("/b/products").unwrap_or("/");
-            // Admin pages under /b/products/admin/...
+            // Admin pages under /b/products/admin/... — Admin tier enforced
+            // centrally from the declared `/b/products/admin/*` endpoints.
             if sub.starts_with("/admin") {
-                let is_admin = helpers::is_admin(&msg);
-                if !is_admin {
-                    return crate::ui::forbidden_response(&msg);
-                }
                 let admin_sub = sub.strip_prefix("/admin").unwrap_or("/");
                 return match admin_sub {
                     "" | "/" => pages::overview(ctx, &msg).await,
@@ -192,25 +234,27 @@ impl Block for ProductsBlock {
             return out;
         }
 
-        // Admin API at /b/products/api/admin/... → normalize to /admin/b/products/...
+        // Admin API at /b/products/api/admin/... — dispatched against the
+        // normalized `/admin/b/products/...` sub-path passed EXPLICITLY (no
+        // `req.resource` rewrite). Admin tier enforced centrally from the
+        // declared `/b/products/api/admin/*` endpoints; the in-block
+        // `is_admin` preamble is gone.
         if let Some(rest) = path.strip_prefix("/b/products/api/admin") {
-            let is_admin = helpers::is_admin(&msg);
-            if !is_admin {
-                return crate::ui::forbidden_response(&msg);
-            }
-            msg.set_meta("req.resource", format!("/admin/b/products{rest}"));
-            return handlers::handle_admin(ctx, &msg, input).await;
+            let norm = format!("/admin/b/products{rest}");
+            return handlers::handle_admin(ctx, &mut msg, &norm, input).await;
         }
 
-        // User API at /b/products/api/... → normalize to /b/products/...
+        // User API at /b/products/api/... — normalized to /b/products/... and
+        // passed explicitly.
         if let Some(rest) = path.strip_prefix("/b/products/api") {
-            msg.set_meta("req.resource", format!("/b/products{rest}"));
-            return handlers::handle_user(ctx, &msg, input).await;
+            let norm = format!("/b/products{rest}");
+            return handlers::handle_user(ctx, &mut msg, &norm, input).await;
         }
 
-        // User endpoints at /b/products/... (catalog, checkout, subscription, etc.)
+        // User endpoints at /b/products/... (catalog, checkout, subscription,
+        // etc.) — the on-the-wire path is already normalized.
         if path.starts_with("/b/products/") || path == "/b/products" {
-            return handlers::handle_user(ctx, &msg, input).await;
+            return handlers::handle_user(ctx, &mut msg, &path, input).await;
         }
 
         err_not_found("not found")

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -281,14 +281,21 @@ pub async fn handle_list_admin(ctx: &dyn Context, msg: &Message) -> OutputStream
 }
 
 pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let path = msg.path();
-    // Strip the known prefixes so a stray slash, query string, or extra
-    // segment can't slip through the rsplit fallback.
-    let id = path
-        .strip_prefix("/admin/b/products/purchases/")
-        .or_else(|| path.strip_prefix("/b/products/purchases/"))
-        .unwrap_or("")
-        .trim_matches('/');
+    // Prefer the router-populated `{id}` path var (set by the endpoint
+    // matcher), falling back to stripping the known prefixes for hand-built
+    // test messages.
+    let id = {
+        let var = msg.var("id");
+        if !var.is_empty() {
+            var
+        } else {
+            msg.path()
+                .strip_prefix("/admin/b/products/purchases/")
+                .or_else(|| msg.path().strip_prefix("/b/products/purchases/"))
+                .unwrap_or("")
+                .trim_matches('/')
+        }
+    };
     if id.is_empty() {
         return err_bad_request("Missing purchase ID");
     }
@@ -317,13 +324,20 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 pub async fn handle_refund(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let path = msg.path();
-    // /admin/b/products/purchases/{id}/refund
-    let id = path
-        .strip_prefix("/admin/b/products/purchases/")
-        .and_then(|s| s.strip_suffix("/refund"))
-        .unwrap_or("")
-        .to_string();
+    // `/admin/b/products/purchases/{id}/refund` — prefer the matcher-bound
+    // `{id}`, falling back to prefix/suffix stripping for hand-built tests.
+    let id = {
+        let var = msg.var("id");
+        if !var.is_empty() {
+            var.to_string()
+        } else {
+            msg.path()
+                .strip_prefix("/admin/b/products/purchases/")
+                .and_then(|s| s.strip_suffix("/refund"))
+                .unwrap_or("")
+                .to_string()
+        }
+    };
     if id.is_empty() {
         return err_bad_request("Missing purchase ID");
     }

--- a/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use wafer_run::ErrorCode;
 
 use super::harness::*;
-use crate::blocks::products::handlers;
 
 // ============================================================
 // Admin Product CRUD
@@ -22,7 +21,7 @@ async fn admin_create_product() {
         }),
     );
 
-    let out = handlers::handle_admin(&ctx, &msg, input).await;
+    let out = dispatch_admin(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     assert!(body["id"].as_str().is_some());
     assert_eq!(body["data"]["name"], "Cloud Hosting");
@@ -41,17 +40,17 @@ async fn admin_list_products() {
             "name": "Product A", "base_price": 10
         }),
     );
-    handlers::handle_admin(&ctx, &msg1, input1).await;
+    dispatch_admin(&ctx, msg1, input1).await;
     let (msg2, input2) = admin_create_msg(
         "/admin/b/products/products",
         serde_json::json!({
             "name": "Product B", "base_price": 20
         }),
     );
-    handlers::handle_admin(&ctx, &msg2, input2).await;
+    dispatch_admin(&ctx, msg2, input2).await;
 
     let (list_msg, list_input) = admin_get_msg("/admin/b/products/products");
-    let out = handlers::handle_admin(&ctx, &list_msg, list_input).await;
+    let out = dispatch_admin(&ctx, list_msg, list_input).await;
     let body = output_to_json(out).await;
     assert!(body["records"].as_array().unwrap().len() >= 2);
 }
@@ -66,14 +65,14 @@ async fn admin_get_product() {
             "name": "Widget", "base_price": 5.0
         }),
     );
-    let create_out = handlers::handle_admin(&ctx, &create_msg_data, create_input).await;
+    let create_out = dispatch_admin(&ctx, create_msg_data, create_input).await;
     let id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
         .to_string();
 
     let (get_msg_data, get_input) = admin_get_msg(&format!("/admin/b/products/products/{}", id));
-    let out = handlers::handle_admin(&ctx, &get_msg_data, get_input).await;
+    let out = dispatch_admin(&ctx, get_msg_data, get_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["name"], "Widget");
 }
@@ -88,7 +87,7 @@ async fn admin_update_product() {
             "name": "Old Name", "base_price": 10
         }),
     );
-    let create_out = handlers::handle_admin(&ctx, &create, create_input).await;
+    let create_out = dispatch_admin(&ctx, create, create_input).await;
     let id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -103,7 +102,7 @@ async fn admin_update_product() {
         }),
     );
     update.set_meta("auth.user_roles", "admin");
-    let out = handlers::handle_admin(&ctx, &update, update_input).await;
+    let out = dispatch_admin(&ctx, update, update_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["name"], "New Name");
 }
@@ -118,7 +117,7 @@ async fn admin_delete_product() {
             "name": "To Delete"
         }),
     );
-    let create_out = handlers::handle_admin(&ctx, &create, create_input).await;
+    let create_out = dispatch_admin(&ctx, create, create_input).await;
     let id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -126,13 +125,13 @@ async fn admin_delete_product() {
 
     let (mut del, del_input) = delete_msg(&format!("/admin/b/products/products/{}", id), "admin_1");
     del.set_meta("auth.user_roles", "admin");
-    let out = handlers::handle_admin(&ctx, &del, del_input).await;
+    let out = dispatch_admin(&ctx, del, del_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["deleted"], true);
 
     // Verify it's gone
     let (get, get_input) = admin_get_msg(&format!("/admin/b/products/products/{}", id));
-    let out = handlers::handle_admin(&ctx, &get, get_input).await;
+    let out = dispatch_admin(&ctx, get, get_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -150,13 +149,13 @@ async fn admin_create_and_list_groups() {
             "name": "Electronics"
         }),
     );
-    let out = handlers::handle_admin(&ctx, &create, create_input).await;
+    let out = dispatch_admin(&ctx, create, create_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["name"], "Electronics");
     assert_eq!(body["data"]["user_id"], "admin_1");
 
     let (list, list_input) = admin_get_msg("/admin/b/products/groups");
-    let list_out = handlers::handle_admin(&ctx, &list, list_input).await;
+    let list_out = dispatch_admin(&ctx, list, list_input).await;
     let list_body = output_to_json(list_out).await;
     assert_eq!(list_body["records"].as_array().unwrap().len(), 1);
 }
@@ -175,10 +174,10 @@ async fn admin_create_and_list_types() {
             "name": "subscription", "display_name": "Subscription"
         }),
     );
-    handlers::handle_admin(&ctx, &create, create_input).await;
+    dispatch_admin(&ctx, create, create_input).await;
 
     let (list, list_input) = admin_get_msg("/admin/b/products/types");
-    let out = handlers::handle_admin(&ctx, &list, list_input).await;
+    let out = dispatch_admin(&ctx, list, list_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["records"].as_array().unwrap().len(), 1);
 }
@@ -199,7 +198,7 @@ async fn admin_pricing_template_crud() {
             "price_formula": "base * quantity * 0.9"
         }),
     );
-    let create_out = handlers::handle_admin(&ctx, &create, create_input).await;
+    let create_out = dispatch_admin(&ctx, create, create_input).await;
     let id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -215,7 +214,7 @@ async fn admin_pricing_template_crud() {
         }),
     );
     update.set_meta("auth.user_roles", "admin");
-    let update_out = handlers::handle_admin(&ctx, &update, update_input).await;
+    let update_out = dispatch_admin(&ctx, update, update_input).await;
     let update_body = output_to_json(update_out).await;
     assert_eq!(
         update_body["data"]["price_formula"],
@@ -225,7 +224,7 @@ async fn admin_pricing_template_crud() {
     // Delete
     let (mut del, del_input) = delete_msg(&format!("/admin/b/products/pricing/{}", id), "admin_1");
     del.set_meta("auth.user_roles", "admin");
-    let del_out = handlers::handle_admin(&ctx, &del, del_input).await;
+    let del_out = dispatch_admin(&ctx, del, del_input).await;
     assert_eq!(output_to_json(del_out).await["deleted"], true);
 }
 
@@ -262,7 +261,7 @@ async fn admin_stats() {
     .await;
 
     let (msg, input) = admin_get_msg("/admin/b/products/stats");
-    let out = handlers::handle_admin(&ctx, &msg, input).await;
+    let out = dispatch_admin(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["total_products"].as_i64().unwrap(), 2);
     assert_eq!(body["active_products"].as_i64().unwrap(), 1);
@@ -290,7 +289,7 @@ async fn user_create_product_in_own_group() {
             "name": "My Store"
         }),
     );
-    let group_out = handlers::handle_user(&ctx, &create_group, cg_input).await;
+    let group_out = dispatch_user(&ctx, create_group, cg_input).await;
     let group_id = output_to_json(group_out).await["id"]
         .as_str()
         .unwrap()
@@ -306,7 +305,7 @@ async fn user_create_product_in_own_group() {
             "group_id": group_id
         }),
     );
-    let out = handlers::handle_user(&ctx, &create_prod, cp_input).await;
+    let out = dispatch_user(&ctx, create_prod, cp_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["name"], "Widget");
     assert_eq!(body["data"]["created_by"], "user_1");
@@ -324,7 +323,7 @@ async fn user_cannot_create_product_in_other_users_group() {
             "name": "User1 Store"
         }),
     );
-    let group_out = handlers::handle_user(&ctx, &create_group, cg_input).await;
+    let group_out = dispatch_user(&ctx, create_group, cg_input).await;
     let group_id = output_to_json(group_out).await["id"]
         .as_str()
         .unwrap()
@@ -339,7 +338,7 @@ async fn user_cannot_create_product_in_other_users_group() {
             "group_id": group_id
         }),
     );
-    let out = handlers::handle_user(&ctx, &create_prod, cp_input).await;
+    let out = dispatch_user(&ctx, create_prod, cp_input).await;
     assert!(output_is_error(out, ErrorCode::InvalidArgument).await);
 }
 
@@ -355,7 +354,7 @@ async fn user_cannot_see_other_users_products() {
             "name": "Private Product"
         }),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let prod_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -363,7 +362,7 @@ async fn user_cannot_see_other_users_products() {
 
     // user_2 tries to get it
     let (get, get_input) = get_msg(&format!("/b/products/products/{}", prod_id), "user_2");
-    let out = handlers::handle_user(&ctx, &get, get_input).await;
+    let out = dispatch_user(&ctx, get, get_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -378,7 +377,7 @@ async fn user_cannot_update_other_users_products() {
             "name": "My Product"
         }),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let prod_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -391,7 +390,7 @@ async fn user_cannot_update_other_users_products() {
             "name": "Hijacked!"
         }),
     );
-    let out = handlers::handle_user(&ctx, &update, update_input).await;
+    let out = dispatch_user(&ctx, update, update_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -406,14 +405,14 @@ async fn user_cannot_delete_other_users_products() {
             "name": "My Product"
         }),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let prod_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
         .to_string();
 
     let (del, del_input) = delete_msg(&format!("/b/products/products/{}", prod_id), "user_2");
-    let out = handlers::handle_user(&ctx, &del, del_input).await;
+    let out = dispatch_user(&ctx, del, del_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -427,7 +426,7 @@ async fn user_list_only_own_products() {
         "user_1",
         serde_json::json!({"name": "U1 Product"}),
     );
-    handlers::handle_user(&ctx, &c1, c1_input).await;
+    dispatch_user(&ctx, c1, c1_input).await;
 
     // user_2 creates a product
     let (c2, c2_input) = create_msg(
@@ -435,11 +434,11 @@ async fn user_list_only_own_products() {
         "user_2",
         serde_json::json!({"name": "U2 Product"}),
     );
-    handlers::handle_user(&ctx, &c2, c2_input).await;
+    dispatch_user(&ctx, c2, c2_input).await;
 
     // user_1 lists — should only see their own
     let (list, list_input) = get_msg("/b/products/products", "user_1");
-    let out = handlers::handle_user(&ctx, &list, list_input).await;
+    let out = dispatch_user(&ctx, list, list_input).await;
     let body = output_to_json(out).await;
     let records = body["records"].as_array().unwrap();
     assert_eq!(records.len(), 1);
@@ -455,7 +454,7 @@ async fn user_update_prevents_ownership_change() {
         "user_1",
         serde_json::json!({"name": "Mine"}),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let prod_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -470,7 +469,7 @@ async fn user_update_prevents_ownership_change() {
             "created_by": "attacker"
         }),
     );
-    let out = handlers::handle_user(&ctx, &update, update_input).await;
+    let out = dispatch_user(&ctx, update, update_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["created_by"], "user_1");
 }
@@ -488,17 +487,17 @@ async fn user_list_only_own_groups() {
         "user_1",
         serde_json::json!({"name": "U1 Group"}),
     );
-    handlers::handle_user(&ctx, &g1, g1_input).await;
+    dispatch_user(&ctx, g1, g1_input).await;
 
     let (g2, g2_input) = create_msg(
         "/b/products/groups",
         "user_2",
         serde_json::json!({"name": "U2 Group"}),
     );
-    handlers::handle_user(&ctx, &g2, g2_input).await;
+    dispatch_user(&ctx, g2, g2_input).await;
 
     let (list, list_input) = get_msg("/b/products/groups", "user_1");
-    let out = handlers::handle_user(&ctx, &list, list_input).await;
+    let out = dispatch_user(&ctx, list, list_input).await;
     let body = output_to_json(out).await;
     let records = body["records"].as_array().unwrap();
     assert_eq!(records.len(), 1);
@@ -514,7 +513,7 @@ async fn user_cannot_update_other_users_group() {
         "user_1",
         serde_json::json!({"name": "My Group"}),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let group_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -527,7 +526,7 @@ async fn user_cannot_update_other_users_group() {
             "name": "Stolen"
         }),
     );
-    let out = handlers::handle_user(&ctx, &update, update_input).await;
+    let out = dispatch_user(&ctx, update, update_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -540,7 +539,7 @@ async fn user_group_update_prevents_ownership_change() {
         "user_1",
         serde_json::json!({"name": "My Group"}),
     );
-    let create_out = handlers::handle_user(&ctx, &create, create_input).await;
+    let create_out = dispatch_user(&ctx, create, create_input).await;
     let group_id = output_to_json(create_out).await["id"]
         .as_str()
         .unwrap()
@@ -554,7 +553,7 @@ async fn user_group_update_prevents_ownership_change() {
             "user_id": "attacker"
         }),
     );
-    let out = handlers::handle_user(&ctx, &update, update_input).await;
+    let out = dispatch_user(&ctx, update, update_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["user_id"], "user_1");
 }
@@ -578,7 +577,7 @@ async fn catalog_only_shows_active_products() {
     seed(&ctx, "suppers_ai__products__products", "p_draft", d2).await;
 
     let (msg, input) = get_msg("/b/products/catalog", "");
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     let records = body["records"].as_array().unwrap();
     assert_eq!(records.len(), 1);
@@ -595,7 +594,7 @@ async fn catalog_get_hides_non_active() {
     seed(&ctx, "suppers_ai__products__products", "p_hidden", d).await;
 
     let (msg, input) = get_msg("/b/products/catalog/p_hidden", "");
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -613,7 +612,7 @@ async fn user_group_products_list() {
         "user_1",
         serde_json::json!({"name": "Store"}),
     );
-    let gr = handlers::handle_user(&ctx, &cg, cg_input).await;
+    let gr = dispatch_user(&ctx, cg, cg_input).await;
     let gid = output_to_json(gr).await["id"].as_str().unwrap().to_string();
 
     // Create product in group
@@ -625,11 +624,11 @@ async fn user_group_products_list() {
             "group_id": gid
         }),
     );
-    handlers::handle_user(&ctx, &cp, cp_input).await;
+    dispatch_user(&ctx, cp, cp_input).await;
 
     // List products in group
     let (list, list_input) = get_msg(&format!("/b/products/groups/{}/products", gid), "user_1");
-    let out = handlers::handle_user(&ctx, &list, list_input).await;
+    let out = dispatch_user(&ctx, list, list_input).await;
     let body = output_to_json(out).await;
     assert!(body["records"].as_array().unwrap().len() >= 1);
 }
@@ -643,12 +642,12 @@ async fn user_cannot_list_other_users_group_products() {
         "user_1",
         serde_json::json!({"name": "Private"}),
     );
-    let gr = handlers::handle_user(&ctx, &cg, cg_input).await;
+    let gr = dispatch_user(&ctx, cg, cg_input).await;
     let gid = output_to_json(gr).await["id"].as_str().unwrap().to_string();
 
     // user_2 tries to list user_1's group products
     let (list, list_input) = get_msg(&format!("/b/products/groups/{}/products", gid), "user_2");
-    let out = handlers::handle_user(&ctx, &list, list_input).await;
+    let out = dispatch_user(&ctx, list, list_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -665,11 +664,11 @@ async fn user_products_rejected_when_disabled() {
         "user_1",
         serde_json::json!({"name": "Test"}),
     );
-    let out = handlers::handle_user(&ctx, &create, create_input).await;
+    let out = dispatch_user(&ctx, create, create_input).await;
     assert!(output_is_error(out, ErrorCode::PermissionDenied).await);
 
     let (list, list_input) = get_msg("/b/products/products", "user_1");
-    let out = handlers::handle_user(&ctx, &list, list_input).await;
+    let out = dispatch_user(&ctx, list, list_input).await;
     assert!(output_is_error(out, ErrorCode::PermissionDenied).await);
 
     let (group, group_input) = create_msg(
@@ -677,7 +676,7 @@ async fn user_products_rejected_when_disabled() {
         "user_1",
         serde_json::json!({"name": "Group"}),
     );
-    let out = handlers::handle_user(&ctx, &group, group_input).await;
+    let out = dispatch_user(&ctx, group, group_input).await;
     assert!(output_is_error(out, ErrorCode::PermissionDenied).await);
 }
 
@@ -691,7 +690,7 @@ async fn catalog_still_works_when_user_products_disabled() {
     seed(&ctx, "suppers_ai__products__products", "p1", d).await;
 
     let (msg, input) = get_msg("/b/products/catalog", "");
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["records"].as_array().unwrap().len(), 1);
 }
@@ -704,7 +703,7 @@ async fn catalog_still_works_when_user_products_disabled() {
 async fn unknown_admin_route() {
     let ctx = ctx().await;
     let (msg, input) = admin_get_msg("/admin/b/products/nonexistent");
-    let out = handlers::handle_admin(&ctx, &msg, input).await;
+    let out = dispatch_admin(&ctx, msg, input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -712,7 +711,7 @@ async fn unknown_admin_route() {
 async fn unknown_user_route() {
     let ctx = ctx().await;
     let (msg, input) = get_msg("/b/products/nonexistent", "user_1");
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
 
@@ -763,7 +762,7 @@ async fn manage_products_uses_data_table_with_mobile_labels() {
         "/admin/b/products/products",
         serde_json::json!({ "name": "Widget", "base_price": 5 }),
     );
-    handlers::handle_admin(&ctx, &c, c_input).await;
+    dispatch_admin(&ctx, c, c_input).await;
 
     let (msg, _input) = admin_get_msg("/b/products/admin/manage");
     let html = output_to_html(super::super::pages::manage_products(&ctx, &msg).await).await;

--- a/crates/solobase-core/src/blocks/products/tests/harness.rs
+++ b/crates/solobase-core/src/blocks/products/tests/harness.rs
@@ -105,6 +105,30 @@ pub fn admin_create_msg(path: &str, body: serde_json::Value) -> (Message, InputS
     (msg, input)
 }
 
+/// Dispatch an admin request the way `ProductsBlock::handle` does, but for
+/// tests that build the message with the normalized `/admin/b/products/...`
+/// path already in `req.resource`: the normalized sub-path is now an explicit
+/// argument (no `req.resource` rewrite), so here it equals `msg.path()`.
+pub async fn dispatch_admin(
+    ctx: &TestContext,
+    mut msg: Message,
+    input: InputStream,
+) -> OutputStream {
+    let norm = msg.path().to_string();
+    super::super::handlers::handle_admin(ctx, &mut msg, &norm, input).await
+}
+
+/// Dispatch a user request the same way (normalized `/b/products/...` path is
+/// already in `req.resource` for these tests).
+pub async fn dispatch_user(
+    ctx: &TestContext,
+    mut msg: Message,
+    input: InputStream,
+) -> OutputStream {
+    let norm = msg.path().to_string();
+    super::super::handlers::handle_user(ctx, &mut msg, &norm, input).await
+}
+
 /// Collect an `OutputStream`'s body and decode it as JSON.
 /// Returns `Value::Null` if the stream did not terminate with `Complete`.
 pub async fn output_to_json(out: OutputStream) -> serde_json::Value {

--- a/crates/solobase-core/src/blocks/products/tests/purchase_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/purchase_tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use wafer_run::ErrorCode;
 
 use super::harness::*;
-use crate::blocks::products::{handlers, purchase};
+use crate::blocks::products::purchase;
 
 // ============================================================
 // Purchase creation — happy path
@@ -490,7 +490,7 @@ async fn purchase_create_via_user_handler() {
         }),
     );
 
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["total_cents"].as_i64().unwrap(), 1000);
 }
@@ -505,7 +505,7 @@ async fn purchase_list_via_user_handler() {
     seed(&ctx, "suppers_ai__products__purchases", "pur_route", pd).await;
 
     let (msg, input) = get_msg("/b/products/purchases", "user_1");
-    let out = handlers::handle_user(&ctx, &msg, input).await;
+    let out = dispatch_user(&ctx, msg, input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["records"].as_array().unwrap().len(), 1);
 }

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -61,8 +61,16 @@ impl Block for UserPortalBlock {
             BlockEndpoint::delete("/b/userportal/sessions/:hash").summary("Revoke session").auth(AuthLevel::Authenticated),
             BlockEndpoint::get("/b/userportal/security").summary("Account security").auth(AuthLevel::Authenticated),
             BlockEndpoint::get("/b/userportal/config").summary("Portal configuration"),
+            // Admin surface — declared in full so the central router enforces
+            // the `Admin` tier (the block no longer hand-checks `is_admin` for
+            // the `/admin/` subtree).
+            BlockEndpoint::get("/b/userportal/admin/settings").summary("Branding settings").auth(AuthLevel::Admin),
+            BlockEndpoint::post("/b/userportal/admin/settings").summary("Save branding settings").auth(AuthLevel::Admin),
             BlockEndpoint::get("/b/userportal/admin/buttons").summary("Manage portal buttons").auth(AuthLevel::Admin),
             BlockEndpoint::post("/b/userportal/admin/buttons").summary("Create button").auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/userportal/admin/buttons/{id}/edit").summary("Edit button form").auth(AuthLevel::Admin),
+            BlockEndpoint::patch("/b/userportal/admin/buttons/{id}").summary("Update button").auth(AuthLevel::Admin),
+            BlockEndpoint::delete("/b/userportal/admin/buttons/{id}").summary("Delete button").auth(AuthLevel::Admin),
         ])
         .config_keys(vec![])
         .admin_url("/b/userportal/admin/settings")
@@ -83,11 +91,11 @@ impl Block for UserPortalBlock {
             .unwrap_or("/")
             .to_string();
 
-        // Admin routes — require admin role
+        // Admin routes. The `Admin` tier is enforced centrally from the
+        // declared `/b/userportal/admin/*` endpoints, so no inline `is_admin`
+        // check is needed; the normalized `sub` path is still passed
+        // explicitly to the admin sub-dispatcher (no `req.resource` rewrite).
         if sub.starts_with("/admin/") {
-            if !helpers::is_admin(&msg) {
-                return crate::ui::forbidden_response(&msg);
-            }
             return self.handle_admin(ctx, msg, input, &action, &sub).await;
         }
 

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -36,8 +36,16 @@ enum Route {
 const ROUTES: &[EndpointRoute<Route>] = &[
     EndpointRoute::new(HttpMethod::Get, "/b/vector/", Route::IndexListPage),
     EndpointRoute::new(HttpMethod::Get, "/b/vector/{name}/", Route::IndexDetailPage),
-    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/indexes", Route::ApiCreateIndex),
-    EndpointRoute::new(HttpMethod::Get, "/b/vector/api/indexes", Route::ApiListIndexes),
+    EndpointRoute::new(
+        HttpMethod::Post,
+        "/b/vector/api/indexes",
+        Route::ApiCreateIndex,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Get,
+        "/b/vector/api/indexes",
+        Route::ApiListIndexes,
+    ),
     EndpointRoute::new(HttpMethod::Post, "/b/vector/api/upsert", Route::ApiUpsert),
     EndpointRoute::new(HttpMethod::Post, "/b/vector/api/query", Route::ApiQuery),
     EndpointRoute::new(HttpMethod::Post, "/b/vector/api/ingest", Route::ApiIngest),
@@ -121,7 +129,12 @@ impl Block for VectorBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+    async fn handle(
+        &self,
+        ctx: &dyn Context,
+        mut msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
         // Auth is enforced centrally by `route_to_block` from the declared
         // endpoint `AuthLevel` (UI pages → Admin, JSON API → Authenticated),
         // so the block holds no `user_id`/`is_admin` preamble. The matcher

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -5,11 +5,55 @@ pub mod pages_ui;
 pub mod service;
 
 use wafer_run::{
-    context::Context, AuthLevel, Block, BlockEndpoint, BlockInfo, InputStream, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, AuthLevel, Block, BlockEndpoint, BlockInfo, HttpMethod, InputStream,
+    InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
 };
 
-use crate::blocks::helpers;
+use crate::endpoint_match::{self, EndpointRoute};
+
+/// In-block dispatch targets. UI pages and the JSON API now share ONE matcher
+/// table; the per-route access tier comes from the declared endpoint
+/// `AuthLevel` and is enforced centrally (UI → Admin, API → Authenticated).
+#[derive(Clone, Copy)]
+enum Route {
+    IndexListPage,
+    IndexDetailPage,
+    ApiCreateIndex,
+    ApiListIndexes,
+    ApiDeleteIndex,
+    ApiUpsert,
+    ApiQuery,
+    ApiIngest,
+    ApiEmbed,
+    ApiStats,
+    ApiDeleteSingle,
+}
+
+/// Method + path-template dispatch table, mirroring `info().endpoints`. The
+/// specific `api/indexes/{name}` delete precedes the generic
+/// `api/{index}/{id}` delete so index-deletes win (the old ordering
+/// invariant). The matcher binds `{name}`/`{index}`/`{id}` into `req.param.*`.
+const ROUTES: &[EndpointRoute<Route>] = &[
+    EndpointRoute::new(HttpMethod::Get, "/b/vector/", Route::IndexListPage),
+    EndpointRoute::new(HttpMethod::Get, "/b/vector/{name}/", Route::IndexDetailPage),
+    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/indexes", Route::ApiCreateIndex),
+    EndpointRoute::new(HttpMethod::Get, "/b/vector/api/indexes", Route::ApiListIndexes),
+    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/upsert", Route::ApiUpsert),
+    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/query", Route::ApiQuery),
+    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/ingest", Route::ApiIngest),
+    EndpointRoute::new(HttpMethod::Post, "/b/vector/api/embed", Route::ApiEmbed),
+    EndpointRoute::new(HttpMethod::Get, "/b/vector/api/stats", Route::ApiStats),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/vector/api/indexes/{name}",
+        Route::ApiDeleteIndex,
+    ),
+    EndpointRoute::new(
+        HttpMethod::Delete,
+        "/b/vector/api/{index}/{id}",
+        Route::ApiDeleteSingle,
+    ),
+];
 
 pub struct VectorBlock;
 
@@ -77,46 +121,30 @@ impl Block for VectorBlock {
         .default_enabled(true)
     }
 
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
-        // All endpoints require authentication. Task 15 fills in the indexes
-        // CRUD routes; remaining routes (upsert, query, ingest, embed, stats,
-        // delete-vector) still resolve to `Unimplemented` in `pages::route`.
-        let user_id = msg.user_id().to_string();
-        if user_id.is_empty() {
-            return helpers::err_unauthorized("authentication required");
-        }
-
-        // UI pages — admin-only. The JSON dispatch in `pages::route` handles
-        // all `/b/vector/api/...` paths; UI routes live alongside on the
-        // bare base path and on `/b/vector/{name}/`.
-        let action = msg.action();
-        let path = msg.path();
-        if action == "retrieve" {
-            let is_ui = path == "/b/vector/"
-                || path == "/b/vector"
-                || (path.starts_with("/b/vector/")
-                    && !path.starts_with("/b/vector/api/")
-                    && path != "/b/vector/api"
-                    && path != "/b/vector/api/");
-            if is_ui {
-                if !helpers::is_admin(&msg) {
-                    return crate::ui::forbidden_response(&msg);
-                }
-                if path == "/b/vector/" || path == "/b/vector" {
-                    return pages_ui::index_list_page(ctx, &msg).await;
-                }
-                // /b/vector/{name}[/...] → detail page. Strip the prefix and
-                // any trailing slashes; reject empty segments to avoid
-                // routing `/b/vector//` or similar.
-                let rest = path.trim_start_matches("/b/vector/").trim_matches('/');
-                if rest.is_empty() || rest.contains('/') {
-                    return crate::blocks::helpers::err_not_found("not found");
-                }
-                return pages_ui::index_detail_page(ctx, &msg, rest).await;
+    async fn handle(&self, ctx: &dyn Context, mut msg: Message, input: InputStream) -> OutputStream {
+        // Auth is enforced centrally by `route_to_block` from the declared
+        // endpoint `AuthLevel` (UI pages → Admin, JSON API → Authenticated),
+        // so the block holds no `user_id`/`is_admin` preamble. The matcher
+        // binds `{name}`/`{index}`/`{id}` into `req.param.*`.
+        let Some(route) = endpoint_match::dispatch(&mut msg, ROUTES) else {
+            return crate::blocks::helpers::err_not_found("not found");
+        };
+        match route {
+            Route::IndexListPage => pages_ui::index_list_page(ctx, &msg).await,
+            Route::IndexDetailPage => {
+                let name = msg.var("name").to_string();
+                pages_ui::index_detail_page(ctx, &msg, &name).await
             }
+            Route::ApiCreateIndex => pages::create_index(ctx, &msg, input).await,
+            Route::ApiListIndexes => pages::list_indexes(ctx).await,
+            Route::ApiDeleteIndex => pages::delete_index(ctx, &msg).await,
+            Route::ApiUpsert => pages::upsert(ctx, input).await,
+            Route::ApiQuery => pages::query(ctx, input).await,
+            Route::ApiIngest => pages::ingest(ctx, input).await,
+            Route::ApiEmbed => pages::embed(ctx, input).await,
+            Route::ApiStats => pages::stats(ctx).await,
+            Route::ApiDeleteSingle => pages::delete_single(ctx, &msg).await,
         }
-
-        pages::route(ctx, &msg, input).await
     }
 
     async fn lifecycle(

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -77,7 +77,11 @@ struct CreateIndexBody {
     keyword_search: bool,
 }
 
-pub(super) async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+pub(super) async fn create_index(
+    ctx: &dyn Context,
+    msg: &Message,
+    input: InputStream,
+) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     // Accept either JSON (programmatic clients) or URL-encoded form
     // (htmx modal). Parse via the shared helper, then map fields explicitly

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -56,39 +56,9 @@ use crate::blocks::helpers::{
     err_bad_request, err_internal, err_internal_no_cause, err_not_found, ok_json, path_param,
 };
 
-/// Route dispatcher for the `suppers-ai/vector` block.
-///
-/// Matches on the normalized action (GET→`retrieve`, POST→`create`,
-/// DELETE→`delete`, etc.) and the request path. Anything that does not
-/// match a handled route resolves to `Unimplemented`, which lets the block
-/// compile and be registered while the remaining handlers land in future
-/// tasks.
-pub async fn route(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let action = msg.action();
-    let path = msg.path();
-
-    match (action, path) {
-        ("create", "/b/vector/api/indexes") => create_index(ctx, msg, input).await,
-        ("retrieve", "/b/vector/api/indexes") => list_indexes(ctx).await,
-        ("create", "/b/vector/api/upsert") => upsert(ctx, input).await,
-        ("create", "/b/vector/api/query") => query(ctx, input).await,
-        ("create", "/b/vector/api/ingest") => ingest(ctx, input).await,
-        ("create", "/b/vector/api/embed") => embed(ctx, input).await,
-        ("retrieve", "/b/vector/api/stats") => stats(ctx).await,
-        // NOTE: the `indexes/` guard must come before the generic
-        // `{index}/{id}` guard so `/indexes/foo` resolves to `delete_index`
-        // rather than being matched as `index=indexes, id=foo`.
-        ("delete", p) if p.starts_with("/b/vector/api/indexes/") => delete_index(ctx, msg).await,
-        ("delete", p) if p.starts_with("/b/vector/api/") && p != "/b/vector/api/" => {
-            delete_single(ctx, msg).await
-        }
-        _ => OutputStream::error(WaferError {
-            code: ErrorCode::Unimplemented,
-            message: format!("vector route not yet implemented: {action} {path}"),
-            meta: vec![],
-        }),
-    }
-}
+// Per-route dispatch now lives in `VectorBlock::handle` via the shared
+// `endpoint_match` table; the JSON handlers below are called directly from
+// there (no in-block `route` shim, no `starts_with` ordering guards).
 
 // ---------------------------------------------------------------------------
 // POST /b/vector/api/indexes — create an index
@@ -107,7 +77,7 @@ struct CreateIndexBody {
     keyword_search: bool,
 }
 
-async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
+pub(super) async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     // Accept either JSON (programmatic clients) or URL-encoded form
     // (htmx modal). Parse via the shared helper, then map fields explicitly
@@ -237,7 +207,7 @@ async fn create_index(ctx: &dyn Context, msg: &Message, input: InputStream) -> O
 // GET /b/vector/api/indexes — list indexes
 // ---------------------------------------------------------------------------
 
-async fn list_indexes(ctx: &dyn Context) -> OutputStream {
+pub(super) async fn list_indexes(ctx: &dyn Context) -> OutputStream {
     match discover_indexes(ctx).await {
         Ok(indexes) => ok_json(&serde_json::json!({ "indexes": indexes })),
         Err(e) => err_internal("list indexes failed", e),
@@ -278,7 +248,7 @@ async fn discover_indexes(ctx: &dyn Context) -> Result<Vec<String>, WaferError> 
 // DELETE /b/vector/api/indexes/{name} — delete an index
 // ---------------------------------------------------------------------------
 
-async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
+pub(super) async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let name = path_param(msg, "name", "/b/vector/api/indexes/");
     if name.is_empty() {
         return err_bad_request("index name is required");
@@ -324,7 +294,7 @@ struct UpsertBody {
     entries: Vec<VectorEntry>,
 }
 
-async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStream {
+pub(super) async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     let body: UpsertBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -353,7 +323,7 @@ async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStream {
 // DELETE /b/vector/api/{index}/{id} — delete a single vector by ID
 // ---------------------------------------------------------------------------
 
-async fn delete_single(ctx: &dyn Context, msg: &Message) -> OutputStream {
+pub(super) async fn delete_single(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let (index, id) = extract_index_and_id(msg);
     if index.is_empty() {
         return err_bad_request("index is required");
@@ -397,7 +367,7 @@ fn extract_index_and_id(msg: &Message) -> (&str, &str) {
 // GET /b/vector/api/stats — per-index counts
 // ---------------------------------------------------------------------------
 
-async fn stats(ctx: &dyn Context) -> OutputStream {
+pub(super) async fn stats(ctx: &dyn Context) -> OutputStream {
     let indexes = match discover_indexes(ctx).await {
         Ok(v) => v,
         Err(e) => return err_internal("stats failed", e),
@@ -442,7 +412,7 @@ struct QueryBody {
 
 const DEFAULT_TOP_K: usize = 10;
 
-async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
+pub(super) async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     let mut body: QueryBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -643,7 +613,7 @@ struct IngestResponse {
 /// chunks for this `document_id` (re-ingestion safety), chunk the text,
 /// optionally add context summaries, embed, and upsert. The response tells
 /// the caller how many chunks landed.
-async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
+pub(super) async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     let body: IngestBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -811,7 +781,7 @@ struct EmbedResponse {
 /// Thin shim over `vclient::embed` — we look up which block serves the
 /// requested model on this runtime and dispatch. Empty `texts` is allowed
 /// (the embedding block returns an empty vector list).
-async fn embed(ctx: &dyn Context, input: InputStream) -> OutputStream {
+pub(super) async fn embed(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let raw = input.collect_to_bytes().await;
     let body: EmbedBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -519,6 +519,7 @@ impl SolobaseBuilder {
         // on `block_settings_handle()` for why this matters.
         let feature_config: Arc<dyn FeatureConfig> = self.block_settings.clone();
         let block_infos = wafer.block_infos();
+        let routes_cfg = crate::routing::routes_config(&block_infos);
         let router = SolobaseRouterBlock::with_extra_routes(
             jwt_secret,
             feature_config,
@@ -526,7 +527,7 @@ impl SolobaseBuilder {
             self.extra_routes,
         );
         wafer.register_block("suppers-ai/router", Arc::new(router))?;
-        wafer.add_block_config("suppers-ai/router", crate::routing::routes_config());
+        wafer.add_block_config("suppers-ai/router", routes_cfg);
 
         // 11. Auto-discover WASM blocks from cwd/blocks/**/target/block.wasm
         //     and flow JSON files from cwd/flows/**/*.json.

--- a/crates/solobase-core/src/endpoint_match.rs
+++ b/crates/solobase-core/src/endpoint_match.rs
@@ -1,0 +1,388 @@
+//! Shared request-to-endpoint matcher for solobase blocks.
+//!
+//! Blocks declare their HTTP surface once as [`wafer_run::BlockEndpoint`]s in
+//! `info().endpoints`. This module matches an incoming request (its
+//! [`RequestAction`]-style action plus resource path) against a slice of
+//! path templates, extracts `{name}` / `{rest...}` path variables into
+//! `req.param.*` meta, and yields the matched handler key. It replaces the
+//! per-block `path.starts_with(...)` / `strip_prefix(...)` guard chains and the
+//! manual single-segment param parsing that used to live in every `handle()`.
+//!
+//! ## Template syntax
+//!
+//! - A literal segment matches itself exactly.
+//! - `{name}` matches exactly one path segment and binds it to `req.param.name`.
+//! - `{name...}` (trailing, "rest") matches one or more remaining segments
+//!   (joined by `/`) and binds the whole remainder to `req.param.name`.
+//! - A trailing `/` in the template requires a trailing `/` in the path
+//!   (templates and paths are compared segment-by-segment, with the empty
+//!   trailing segment from a trailing slash preserved).
+//!
+//! The matcher is platform-neutral: it works the same on native, Cloudflare,
+//! and browser targets because it operates purely on the already-normalized
+//! `req.action` / `req.resource` meta.
+//!
+//! ## Why not `wafer_block::Router`?
+//!
+//! `wafer_block::Router` / `match_path` / `extract_path_vars` were deleted in
+//! the wafer-run quality program (phase 1) — they had zero consumers. This is
+//! the solobase-local replacement. The matcher is small and solobase-specific
+//! (it keys off solobase's `(action, path)` dispatch convention); if it ever
+//! needs to be shared with another wafer-run consumer it should be proposed as
+//! a fresh `wafer_block` module rather than resurrecting the old `Router`.
+
+use wafer_run::{AuthLevel, HttpMethod, Message};
+
+/// Map an [`HttpMethod`] to the canonical wire action string solobase routes on
+/// (`req.action`). Mirrors `wafer_block::http_codec::action_for_http_method`
+/// for the four methods endpoints declare, so a block's `[(method, template)]`
+/// table compares against the same action the pipeline already set.
+pub fn action_for_method(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::Get => "retrieve",
+        HttpMethod::Post => "create",
+        HttpMethod::Patch => "update",
+        HttpMethod::Delete => "delete",
+    }
+}
+
+/// Match `path` against `template`, returning the bound `{name}` path variables
+/// (in template order) when it matches, or `None` when it does not.
+///
+/// Both inputs are split on `/`; a trailing slash therefore yields a trailing
+/// empty segment that must match on both sides. `{name...}` (rest) is only
+/// valid as the final template segment and greedily binds the remainder.
+pub fn match_template<'p>(template: &str, path: &'p str) -> Option<Vec<(String, &'p str)>> {
+    let t_segs: Vec<&str> = template.split('/').collect();
+    let p_segs: Vec<&str> = path.split('/').collect();
+    let mut params: Vec<(String, &'p str)> = Vec::new();
+
+    for (i, t) in t_segs.iter().enumerate() {
+        // Trailing rest-parameter: bind every remaining path segment.
+        if let Some(name) = t.strip_suffix("...}").and_then(|s| s.strip_prefix('{')) {
+            // Must be the final template segment.
+            if i != t_segs.len() - 1 {
+                return None;
+            }
+            // Need at least one remaining segment, and it must be non-empty
+            // (so `/b/x/` does NOT match `/b/x/{rest...}`).
+            let rest_start = i;
+            if rest_start >= p_segs.len() {
+                return None;
+            }
+            let joined = &path[byte_offset_of_segment(path, rest_start)..];
+            if joined.is_empty() {
+                return None;
+            }
+            params.push((name.to_string(), joined));
+            return Some(params);
+        }
+
+        // Out of path segments: no match.
+        let Some(p) = p_segs.get(i) else {
+            return None;
+        };
+
+        if let Some(name) = t.strip_suffix('}').and_then(|s| s.strip_prefix('{')) {
+            // Single-segment variable — reject empty segments so `/b/x//` does
+            // not bind an empty id.
+            if p.is_empty() {
+                return None;
+            }
+            params.push((name.to_string(), p));
+        } else if t != p {
+            return None;
+        }
+    }
+
+    // Every template segment consumed; the path must not have extra segments.
+    if p_segs.len() != t_segs.len() {
+        return None;
+    }
+    Some(params)
+}
+
+/// Byte offset where the `n`-th `/`-split segment starts in `path`.
+fn byte_offset_of_segment(path: &str, n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    let mut seen = 0;
+    for (idx, b) in path.bytes().enumerate() {
+        if b == b'/' {
+            seen += 1;
+            if seen == n {
+                return idx + 1;
+            }
+        }
+    }
+    path.len()
+}
+
+/// One row of a block's dispatch table: the HTTP method, the path template
+/// (typically copied from the block's declared endpoint path), and an opaque
+/// handler key `H` the block matches on.
+pub struct EndpointRoute<H> {
+    /// HTTP method this route answers (mapped to a wire action internally).
+    pub method: HttpMethod,
+    /// Path template (`/b/x/{id}`, `/b/x/{rest...}`, …).
+    pub template: &'static str,
+    /// Block-defined handler discriminator returned to `handle()`.
+    pub handler: H,
+}
+
+impl<H: Copy> EndpointRoute<H> {
+    /// Convenience constructor.
+    pub const fn new(method: HttpMethod, template: &'static str, handler: H) -> Self {
+        Self {
+            method,
+            template,
+            handler,
+        }
+    }
+}
+
+/// Find the first route in `table` whose method+template matches the request,
+/// writing any extracted `{name}` path variables into `msg`'s `req.param.*`
+/// meta and returning the matched handler key.
+///
+/// Routes are tried in declaration order, so blocks list more-specific
+/// templates before generic ones (the same ordering discipline the old
+/// `starts_with` chains relied on). Returns `None` when nothing matches, so the
+/// caller emits its own 404.
+pub fn dispatch<H: Copy>(msg: &mut Message, table: &[EndpointRoute<H>]) -> Option<H> {
+    let action = msg.action().to_string();
+    let path = msg.path().to_string();
+    for route in table {
+        if action_for_method(route.method) != action {
+            continue;
+        }
+        if let Some(params) = match_template(route.template, &path) {
+            for (name, value) in params {
+                msg.set_meta(
+                    format!("{}{}", wafer_run::META_REQ_PARAM_PREFIX, name),
+                    value.to_string(),
+                );
+            }
+            return Some(route.handler);
+        }
+    }
+    None
+}
+
+/// The access policy a path resolves to for a single block, combining its
+/// declared endpoint [`AuthLevel`]s. Used by the central router to enforce the
+/// declared level before dispatch.
+///
+/// Returns the [`AuthLevel`] of the first declared endpoint whose method+path
+/// template matches `(action, path)`, or `None` when no declared endpoint
+/// covers the request (the caller then falls back to the coarse prefix tier).
+pub fn endpoint_auth(
+    endpoints: &[wafer_run::BlockEndpoint],
+    action: &str,
+    path: &str,
+) -> Option<AuthLevel> {
+    for ep in endpoints {
+        if action_for_method(ep.method) != action {
+            continue;
+        }
+        if match_template(&normalize_template(&ep.path), path).is_some() {
+            return Some(ep.auth);
+        }
+    }
+    None
+}
+
+/// Normalize a declared endpoint template to the matcher's `{rest...}` syntax.
+///
+/// Endpoint paths historically use a few spellings for a trailing
+/// rest-parameter (`{prefix...}`, `:hash`). The matcher's canonical form is
+/// `{name}` / `{name...}`; this converts the legacy `:name` colon style to
+/// `{name}` so declared endpoints and dispatch tables agree without forcing a
+/// rewrite of every `info()` block at once.
+fn normalize_template(template: &str) -> String {
+    template
+        .split('/')
+        .map(|seg| {
+            if let Some(name) = seg.strip_prefix(':') {
+                format!("{{{name}}}")
+            } else {
+                seg.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(params: &[(String, &str)]) -> Vec<(String, String)> {
+        params
+            .iter()
+            .map(|(k, v)| (k.clone(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn literal_exact_match() {
+        assert_eq!(match_template("/b/x/api", "/b/x/api"), Some(vec![]));
+    }
+
+    #[test]
+    fn literal_mismatch() {
+        assert!(match_template("/b/x/api", "/b/x/other").is_none());
+    }
+
+    #[test]
+    fn extra_path_segments_do_not_match() {
+        // The old `starts_with` matched `/b/x/api/extra`; the template matcher
+        // must not (it routes the suffix to a different, more-specific entry).
+        assert!(match_template("/b/x/api", "/b/x/api/extra").is_none());
+    }
+
+    #[test]
+    fn single_param_extracts_segment() {
+        let m = match_template("/b/x/api/contexts/{id}", "/b/x/api/contexts/abc").unwrap();
+        assert_eq!(names(&m), vec![("id".to_string(), "abc".to_string())]);
+    }
+
+    #[test]
+    fn single_param_rejects_extra_segment() {
+        // `{id}` is ONE segment — `/contexts/abc/entries` must not match the
+        // get-context template (it belongs to the entries template).
+        assert!(match_template("/b/x/api/contexts/{id}", "/b/x/api/contexts/abc/entries").is_none());
+    }
+
+    #[test]
+    fn nested_literal_after_param() {
+        let m = match_template(
+            "/b/x/api/contexts/{id}/entries",
+            "/b/x/api/contexts/abc/entries",
+        )
+        .unwrap();
+        assert_eq!(names(&m), vec![("id".to_string(), "abc".to_string())]);
+    }
+
+    #[test]
+    fn two_params() {
+        let m = match_template(
+            "/b/llm/api/models/{backend_id}/{model_id}/status",
+            "/b/llm/api/models/ollama/llama3/status",
+        )
+        .unwrap();
+        assert_eq!(
+            names(&m),
+            vec![
+                ("backend_id".to_string(), "ollama".to_string()),
+                ("model_id".to_string(), "llama3".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_param_segment_rejected() {
+        // `/b/x/api/contexts//` must not bind an empty id.
+        assert!(match_template("/b/x/api/contexts/{id}", "/b/x/api/contexts/").is_none());
+    }
+
+    #[test]
+    fn rest_param_binds_remaining_segments() {
+        let m = match_template("/b/storage/{bucket}/{prefix...}", "/b/storage/photos/2024/x").unwrap();
+        assert_eq!(
+            names(&m),
+            vec![
+                ("bucket".to_string(), "photos".to_string()),
+                ("prefix".to_string(), "2024/x".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn rest_param_requires_at_least_one_segment() {
+        assert!(match_template("/b/storage/{bucket}/{prefix...}", "/b/storage/photos/").is_none());
+    }
+
+    #[test]
+    fn trailing_slash_significant() {
+        assert!(match_template("/b/x/", "/b/x").is_none());
+        assert!(match_template("/b/x/", "/b/x/").is_some());
+    }
+
+    #[test]
+    fn dispatch_extracts_param_into_meta() {
+        let mut msg = Message::new("test");
+        msg.set_meta("req.action", "retrieve");
+        msg.set_meta("req.resource", "/b/messages/api/contexts/ctx-7");
+        let table = [EndpointRoute::new(
+            HttpMethod::Get,
+            "/b/messages/api/contexts/{id}",
+            1u8,
+        )];
+        let h = dispatch(&mut msg, &table);
+        assert_eq!(h, Some(1u8));
+        assert_eq!(msg.var("id"), "ctx-7");
+    }
+
+    #[test]
+    fn dispatch_respects_method() {
+        let mut msg = Message::new("test");
+        msg.set_meta("req.action", "create");
+        msg.set_meta("req.resource", "/b/messages/api/contexts");
+        let table = [
+            EndpointRoute::new(HttpMethod::Get, "/b/messages/api/contexts", 1u8),
+            EndpointRoute::new(HttpMethod::Post, "/b/messages/api/contexts", 2u8),
+        ];
+        assert_eq!(dispatch(&mut msg, &table), Some(2u8));
+    }
+
+    #[test]
+    fn dispatch_ordering_specific_first() {
+        // A specific template listed first must win over a generic one.
+        let mut msg = Message::new("test");
+        msg.set_meta("req.action", "delete");
+        msg.set_meta("req.resource", "/b/vector/api/indexes/my-index");
+        let table = [
+            EndpointRoute::new(HttpMethod::Delete, "/b/vector/api/indexes/{name}", 1u8),
+            EndpointRoute::new(HttpMethod::Delete, "/b/vector/api/{index}/{id}", 2u8),
+        ];
+        assert_eq!(dispatch(&mut msg, &table), Some(1u8));
+        assert_eq!(msg.var("name"), "my-index");
+    }
+
+    #[test]
+    fn endpoint_auth_reads_declared_level() {
+        use wafer_run::BlockEndpoint;
+        let eps = vec![
+            BlockEndpoint::get("/b/legalpages/terms").auth(AuthLevel::Public),
+            BlockEndpoint::get("/b/legalpages/admin").auth(AuthLevel::Admin),
+            BlockEndpoint::patch("/b/legalpages/api/documents/{id}").auth(AuthLevel::Admin),
+        ];
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/legalpages/terms"),
+            Some(AuthLevel::Public)
+        );
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/legalpages/admin"),
+            Some(AuthLevel::Admin)
+        );
+        assert_eq!(
+            endpoint_auth(&eps, "update", "/b/legalpages/api/documents/d-1"),
+            Some(AuthLevel::Admin)
+        );
+        // Undeclared path → None (caller falls back to prefix tier).
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/legalpages/api/documents"),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_colon_style() {
+        assert_eq!(
+            normalize_template("/b/userportal/sessions/:hash"),
+            "/b/userportal/sessions/{hash}"
+        );
+    }
+}

--- a/crates/solobase-core/src/endpoint_match.rs
+++ b/crates/solobase-core/src/endpoint_match.rs
@@ -180,7 +180,10 @@ pub fn dispatch_path<H: Copy>(
                 .map(|(k, v)| (k, v.to_string()))
                 .collect();
             for (name, value) in owned {
-                msg.set_meta(format!("{}{}", wafer_run::META_REQ_PARAM_PREFIX, name), value);
+                msg.set_meta(
+                    format!("{}{}", wafer_run::META_REQ_PARAM_PREFIX, name),
+                    value,
+                );
             }
             return Some(route.handler);
         }
@@ -270,7 +273,9 @@ mod tests {
     fn single_param_rejects_extra_segment() {
         // `{id}` is ONE segment — `/contexts/abc/entries` must not match the
         // get-context template (it belongs to the entries template).
-        assert!(match_template("/b/x/api/contexts/{id}", "/b/x/api/contexts/abc/entries").is_none());
+        assert!(
+            match_template("/b/x/api/contexts/{id}", "/b/x/api/contexts/abc/entries").is_none()
+        );
     }
 
     #[test]
@@ -307,7 +312,11 @@ mod tests {
 
     #[test]
     fn rest_param_binds_remaining_segments() {
-        let m = match_template("/b/storage/{bucket}/{prefix...}", "/b/storage/photos/2024/x").unwrap();
+        let m = match_template(
+            "/b/storage/{bucket}/{prefix...}",
+            "/b/storage/photos/2024/x",
+        )
+        .unwrap();
         assert_eq!(
             names(&m),
             vec![

--- a/crates/solobase-core/src/endpoint_match.rs
+++ b/crates/solobase-core/src/endpoint_match.rs
@@ -193,23 +193,54 @@ pub fn dispatch_path<H: Copy>(
 /// declared endpoint [`AuthLevel`]s. Used by the central router to enforce the
 /// declared level before dispatch.
 ///
-/// Returns the [`AuthLevel`] of the first declared endpoint whose method+path
-/// template matches `(action, path)`, or `None` when no declared endpoint
-/// covers the request (the caller then falls back to the coarse prefix tier).
+/// Returns the **strictest** [`AuthLevel`] (`Public < Authenticated < Admin`)
+/// among ALL declared endpoints whose method+path template matches `(action,
+/// path)`, or `None` when no declared endpoint covers the request (the caller
+/// then falls back to the coarse prefix tier).
+///
+/// Strictest-match — not first-match — is deliberate and load-bearing for
+/// security: a path can be covered by more than one template (e.g.
+/// `/b/storage/admin/` matches both the generic `/b/storage/{bucket}/` and the
+/// specific `/b/storage/admin/`). If this returned the *first* match, a
+/// permissive generic endpoint declared before a stricter specific one would
+/// silently weaken it — letting an authenticated non-admin reach an admin page
+/// purely because of endpoint declaration order. Taking the max means
+/// declaration order can never lower the required auth level; the worst a
+/// mis-ordered declaration can do is over-protect, which fails safe. This
+/// mirrors the `RouteAccess::max` discipline the router already applies between
+/// the prefix tier and the declared level.
 pub fn endpoint_auth(
     endpoints: &[wafer_run::BlockEndpoint],
     action: &str,
     path: &str,
 ) -> Option<AuthLevel> {
+    let mut strictest: Option<AuthLevel> = None;
     for ep in endpoints {
         if action_for_method(ep.method) != action {
             continue;
         }
         if match_template(&normalize_template(&ep.path), path).is_some() {
-            return Some(ep.auth);
+            strictest = Some(match strictest {
+                Some(cur) if auth_rank(cur) >= auth_rank(ep.auth) => cur,
+                _ => ep.auth,
+            });
         }
     }
-    None
+    strictest
+}
+
+/// Strictness rank for an [`AuthLevel`] (`Public < Authenticated < Admin`).
+///
+/// `AuthLevel` is defined upstream (wafer-block) without an `Ord` derive, so
+/// this is the local ordering used by [`endpoint_auth`] to pick the strictest
+/// matching endpoint. The numbers are an internal detail — only their relative
+/// order matters.
+fn auth_rank(level: AuthLevel) -> u8 {
+    match level {
+        AuthLevel::Public => 0,
+        AuthLevel::Authenticated => 1,
+        AuthLevel::Admin => 2,
+    }
 }
 
 /// Normalize a declared endpoint template to the matcher's `{rest...}` syntax.
@@ -400,6 +431,46 @@ mod tests {
         assert_eq!(
             endpoint_auth(&eps, "retrieve", "/b/legalpages/api/documents"),
             None
+        );
+    }
+
+    #[test]
+    fn endpoint_auth_takes_strictest_match_regardless_of_order() {
+        use wafer_run::BlockEndpoint;
+        // `/b/storage/admin/` matches BOTH the generic `{bucket}/`
+        // (Authenticated) and the specific `admin/` (Admin). The generic is
+        // declared FIRST — first-match would resolve to Authenticated and let a
+        // non-admin through. Strictest-match must resolve to Admin.
+        let eps = vec![
+            BlockEndpoint::get("/b/storage/{bucket}/").auth(AuthLevel::Authenticated),
+            BlockEndpoint::get("/b/storage/admin/").auth(AuthLevel::Admin),
+        ];
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/storage/admin/"),
+            Some(AuthLevel::Admin),
+            "a stricter specific endpoint must win over a permissive generic one \
+             declared earlier"
+        );
+        // A genuine bucket name still resolves to the generic Authenticated tier.
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/storage/photos/"),
+            Some(AuthLevel::Authenticated)
+        );
+    }
+
+    #[test]
+    fn endpoint_auth_strictest_independent_of_declaration_order() {
+        use wafer_run::BlockEndpoint;
+        // Same as above but with the Admin endpoint declared FIRST — the result
+        // must be identical (Admin), proving order-independence in both
+        // directions.
+        let eps = vec![
+            BlockEndpoint::get("/b/storage/admin/").auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/storage/{bucket}/").auth(AuthLevel::Authenticated),
+        ];
+        assert_eq!(
+            endpoint_auth(&eps, "retrieve", "/b/storage/admin/"),
+            Some(AuthLevel::Admin)
         );
     }
 

--- a/crates/solobase-core/src/endpoint_match.rs
+++ b/crates/solobase-core/src/endpoint_match.rs
@@ -153,16 +153,34 @@ impl<H: Copy> EndpointRoute<H> {
 pub fn dispatch<H: Copy>(msg: &mut Message, table: &[EndpointRoute<H>]) -> Option<H> {
     let action = msg.action().to_string();
     let path = msg.path().to_string();
+    dispatch_path(msg, &action, &path, table)
+}
+
+/// Like [`dispatch`], but matches against an explicitly supplied `action` +
+/// `path` rather than reading them from the message.
+///
+/// Used by blocks that mount their sub-handlers under a normalized sub-path
+/// (e.g. the products admin/user split): the caller passes the normalized path
+/// as an explicit argument instead of mutating `req.resource` in place, and
+/// extracted `{name}` vars still land in `req.param.*` so the sub-handlers'
+/// id readers work unchanged.
+pub fn dispatch_path<H: Copy>(
+    msg: &mut Message,
+    action: &str,
+    path: &str,
+    table: &[EndpointRoute<H>],
+) -> Option<H> {
     for route in table {
         if action_for_method(route.method) != action {
             continue;
         }
-        if let Some(params) = match_template(route.template, &path) {
-            for (name, value) in params {
-                msg.set_meta(
-                    format!("{}{}", wafer_run::META_REQ_PARAM_PREFIX, name),
-                    value.to_string(),
-                );
+        if let Some(params) = match_template(route.template, path) {
+            let owned: Vec<(String, String)> = params
+                .into_iter()
+                .map(|(k, v)| (k, v.to_string()))
+                .collect();
+            for (name, value) in owned {
+                msg.set_meta(format!("{}{}", wafer_run::META_REQ_PARAM_PREFIX, name), value);
             }
             return Some(route.handler);
         }

--- a/crates/solobase-core/src/endpoint_match.rs
+++ b/crates/solobase-core/src/endpoint_match.rs
@@ -79,9 +79,7 @@ pub fn match_template<'p>(template: &str, path: &'p str) -> Option<Vec<(String, 
         }
 
         // Out of path segments: no match.
-        let Some(p) = p_segs.get(i) else {
-            return None;
-        };
+        let p = p_segs.get(i)?;
 
         if let Some(name) = t.strip_suffix('}').and_then(|s| s.strip_prefix('{')) {
             // Single-segment variable — reject empty segments so `/b/x//` does

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cache_key;
 pub mod config_source;
 pub mod config_vars;
 pub mod crypto;
+pub mod endpoint_match;
 pub mod features;
 pub mod flows;
 pub mod messages_schema;

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -120,7 +120,8 @@ pub async fn handle_request(
     let start_ms = crate::blocks::helpers::now_millis();
 
     // 3. Route to block.
-    let mut stream = routing::route_to_block(ctx, msg, input, features, extra_routes).await;
+    let mut stream =
+        routing::route_to_block(ctx, msg, input, features, block_infos, extra_routes).await;
 
     // 3a. If the block declares a streaming Content-Type up front (SSE, raw
     //     byte stream), don't drain the response into memory just to grab a

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -4,9 +4,9 @@
 //! All solobase blocks are registered in the Wafer registry at boot; routing
 //! dispatches via `ctx.call_block` without any factory indirection.
 
-use wafer_run::{context::Context, InputStream, Message, OutputStream};
+use wafer_run::{context::Context, AuthLevel, BlockInfo, InputStream, Message, OutputStream};
 
-use crate::{blocks::helpers, features::FeatureConfig};
+use crate::{blocks::helpers, endpoint_match, features::FeatureConfig};
 
 /// URL prefix for embedded static assets, served by `suppers-ai/system`.
 ///
@@ -63,7 +63,7 @@ impl Route {
 ///
 /// Checked by [`route_to_block`] (via `check_access`) before dispatching to the
 /// target block, for both built-in [`Route`]s and runtime-added [`ExtraRoute`]s.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum RouteAccess {
     /// No auth check. Anyone can hit this route.
@@ -72,6 +72,30 @@ pub enum RouteAccess {
     Authenticated,
     /// User must have the `admin` role (per [`helpers::is_admin`]) or 403.
     Admin,
+}
+
+impl RouteAccess {
+    /// Bridge a block's declared per-endpoint [`AuthLevel`] (from
+    /// `BlockInfo::endpoints`) into the router's coarse [`RouteAccess`] tier.
+    /// The two enums are the same three-tier ladder; this is the single place
+    /// they are mapped so the declared level can be enforced by the same
+    /// `check_access` path as the prefix tier.
+    fn from_auth_level(level: AuthLevel) -> RouteAccess {
+        match level {
+            AuthLevel::Public => RouteAccess::Public,
+            AuthLevel::Authenticated => RouteAccess::Authenticated,
+            AuthLevel::Admin => RouteAccess::Admin,
+        }
+    }
+
+    /// The stricter of two tiers (`Public < Authenticated < Admin`). Used to
+    /// combine the coarse prefix tier with a matched endpoint's declared level
+    /// so neither can weaken the other: the prefix is a backstop for paths a
+    /// block has not (yet) declared an endpoint for, and the declared endpoint
+    /// level refines it where present.
+    fn max(self, other: RouteAccess) -> RouteAccess {
+        std::cmp::max(self, other)
+    }
 }
 
 /// A runtime-added route registered by a downstream project via
@@ -154,73 +178,75 @@ pub const ROUTES: &[Route] = &[
     Route::new("/b/llm", RouteAccess::Public, "suppers-ai/llm"),
     // Vector — similarity search, hybrid retrieval, RAG ingestion.
     //
-    // Each endpoint from `VectorBlock::info().endpoints` is registered as a
-    // separate entry so the inspector's routes document reflects the
-    // granularity the block exposes. The prefix matcher uses `starts_with`,
-    // so entries are ordered most-specific-first:
-    //   - `DELETE /b/vector/api/indexes/{name}` must be listed BEFORE the
-    //     generic `DELETE /b/vector/api/{index}/{id}` entry so the specific
-    //     "delete index" route wins over the generic "delete vector" route.
-    // All entries dispatch to `suppers-ai/vector`; per-method path-param
-    // matching happens inside the block's `pages::route` dispatcher.
-    Route::new(
-        "/b/vector/api/indexes/{name}",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/indexes",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/upsert",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/query",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/ingest",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/embed",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    Route::new(
-        "/b/vector/api/stats",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    // Generic `DELETE /b/vector/api/{index}/{id}` — MUST come after the
-    // more specific `/b/vector/api/indexes/{name}` entry above so that
-    // path-prefix ordering routes index-deletes to the correct handler.
-    Route::new(
-        "/b/vector/api/{index}/{id}",
-        RouteAccess::Public,
-        "suppers-ai/vector",
-    ),
-    // SSR pages and any other /b/vector/* paths.
+    // ONE prefix route. The previous nine decorative entries all shared the
+    // same access tier (`Public`) and dispatch target, differing only in
+    // path — pure duplication, since the block does its own per-method
+    // path-param matching in `pages::route`. The per-endpoint access tier
+    // now comes from `VectorBlock::info().endpoints` and is enforced
+    // centrally via `declared_access` (UI pages → Admin, JSON API →
+    // Authenticated), so the coarse prefix tier is `Public` and the declared
+    // level refines it. The inspector sources endpoint granularity from the
+    // same `info().endpoints` (see [`routes_config`]).
     Route::new("/b/vector/", RouteAccess::Public, "suppers-ai/vector"),
 ];
 
 /// Generate the routing table as JSON config (same format as wafer-run/router).
 /// Used to expose routes to the inspector.
-pub fn routes_config() -> serde_json::Value {
-    let routes: Vec<serde_json::Value> = ROUTES
+///
+/// Each coarse prefix [`Route`] contributes one `{prefix}**` entry. Endpoint
+/// granularity (the exact method+path templates a block exposes) is sourced
+/// from each block's `BlockInfo::endpoints` rather than from hand-maintained
+/// per-endpoint `Route` entries — this is what lets the vector block collapse
+/// to a single prefix route while the inspector still shows its nine
+/// endpoints. Endpoint entries are de-duplicated against the prefix entries.
+pub fn routes_config(block_infos: &[BlockInfo]) -> serde_json::Value {
+    let mut routes: Vec<serde_json::Value> = ROUTES
         .iter()
         .map(|r| {
             let path = format!("{}**", r.prefix);
             serde_json::json!({ "path": path, "block": r.block })
         })
         .collect();
+
+    // Per-endpoint granularity from the blocks themselves. Only emit entries
+    // for blocks that own a built-in prefix route (so we mirror the routing
+    // table, not the whole registry), and skip any whose exact `{prefix}**`
+    // form already covers them.
+    for info in block_infos {
+        if !ROUTES.iter().any(|r| r.block == info.name) {
+            continue;
+        }
+        for ep in &info.endpoints {
+            let entry = serde_json::json!({
+                "path": ep.path,
+                "method": ep.method.to_string(),
+                "block": info.name,
+                "auth": ep.auth.to_string(),
+            });
+            if !routes.contains(&entry) {
+                routes.push(entry);
+            }
+        }
+    }
+
     serde_json::json!({ "routes": routes })
+}
+
+/// Resolve the declared per-endpoint access tier for `(msg.action,
+/// msg.path)` from the target block's `BlockInfo::endpoints`, mapped into the
+/// router's [`RouteAccess`] ladder.
+///
+/// Returns [`RouteAccess::Public`] when no declared endpoint matches — the
+/// caller combines this with the coarse prefix tier via [`RouteAccess::max`],
+/// so an undeclared path is governed solely by its prefix tier (the backstop)
+/// and a declared path is governed by the stricter of prefix and endpoint.
+fn declared_access(block_infos: &[BlockInfo], block_name: &str, msg: &Message) -> RouteAccess {
+    let Some(info) = block_infos.iter().find(|i| i.name == block_name) else {
+        return RouteAccess::Public;
+    };
+    endpoint_match::endpoint_auth(&info.endpoints, msg.action(), msg.path())
+        .map(RouteAccess::from_auth_level)
+        .unwrap_or(RouteAccess::Public)
 }
 
 /// Enforce a route's [`RouteAccess`] tier against the request. Returns
@@ -248,6 +274,7 @@ pub async fn route_to_block(
     msg: Message,
     input: InputStream,
     features: &dyn FeatureConfig,
+    block_infos: &[BlockInfo],
     extra_routes: &[ExtraRoute],
 ) -> OutputStream {
     let path = msg.path().to_string();
@@ -280,8 +307,16 @@ pub async fn route_to_block(
             return crate::blocks::helpers::err_not_found("endpoint not found");
         }
 
-        // Access gate
-        if let Some(denied) = check_access(route.access, &msg) {
+        // Access gate. The coarse prefix tier is a backstop; if the target
+        // block declares an endpoint matching this exact (action, path) we
+        // also enforce that endpoint's declared `AuthLevel` — taking the
+        // stricter of the two. This is what makes `BlockEndpoint::auth`
+        // load-bearing instead of documentation-only, and lets blocks drop
+        // their per-handler `is_admin`/`user_id` preambles.
+        let access = route
+            .access
+            .max(declared_access(block_infos, route.block, &msg));
+        if let Some(denied) = check_access(access, &msg) {
             return denied;
         }
 
@@ -601,12 +636,37 @@ mod tests {
         // routes_config() must show the inspector as `suppers-ai/inspector`
         // (the display/feature name), not its `wafer-run/inspector` dispatch
         // target — the inspector UI keys its feature map on the former.
-        let cfg = super::routes_config();
+        let cfg = super::routes_config(&[]);
         let routes = cfg["routes"].as_array().expect("routes array");
         let inspector = routes
             .iter()
             .find(|r| r["path"] == "/b/inspector**")
             .expect("inspector route in config");
         assert_eq!(inspector["block"], "suppers-ai/inspector");
+    }
+
+    #[test]
+    fn routes_config_sources_endpoint_granularity_from_block_infos() {
+        use wafer_run::{AuthLevel, BlockEndpoint, BlockInfo};
+        // A block that owns a built-in prefix route ("/b/vector/") contributes
+        // its declared endpoints to the inspector view even though the route
+        // table has a single collapsed prefix entry.
+        let info = BlockInfo::new("suppers-ai/vector", "0.0.1", "http-handler@v1", "v")
+            .endpoints(vec![
+                BlockEndpoint::post("/b/vector/api/query").auth(AuthLevel::Authenticated),
+                BlockEndpoint::get("/b/vector/").auth(AuthLevel::Admin),
+            ]);
+        let cfg = super::routes_config(std::slice::from_ref(&info));
+        let routes = cfg["routes"].as_array().expect("routes array");
+        // The collapsed prefix entry is present.
+        assert!(routes.iter().any(|r| r["path"] == "/b/vector/**"));
+        // And the per-endpoint granularity is sourced from info().endpoints.
+        let query = routes
+            .iter()
+            .find(|r| r["path"] == "/b/vector/api/query")
+            .expect("endpoint-sourced query route");
+        assert_eq!(query["method"], "POST");
+        assert_eq!(query["auth"], "authenticated");
+        assert_eq!(query["block"], "suppers-ai/vector");
     }
 }

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -651,8 +651,8 @@ mod tests {
         // A block that owns a built-in prefix route ("/b/vector/") contributes
         // its declared endpoints to the inspector view even though the route
         // table has a single collapsed prefix entry.
-        let info = BlockInfo::new("suppers-ai/vector", "0.0.1", "http-handler@v1", "v")
-            .endpoints(vec![
+        let info =
+            BlockInfo::new("suppers-ai/vector", "0.0.1", "http-handler@v1", "v").endpoints(vec![
                 BlockEndpoint::post("/b/vector/api/query").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/vector/").auth(AuthLevel::Admin),
             ]);

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -449,6 +449,37 @@ async fn llm_admin_provider_crud_rejects_non_admin() {
 }
 
 #[tokio::test]
+async fn auth_ui_admin_settings_rejects_non_admin() {
+    // `/b/auth/admin/settings` is declared `Admin` while the auth-ui prefix is
+    // Public — so the declared level is the sole gate (the deleted inline
+    // `is_admin` check). A non-admin must be 403'd before dispatch.
+    let ctx = RecordingContext::new();
+    let infos = vec![BlockInfo::new(
+        "suppers-ai/auth-ui",
+        "0.0.1",
+        "http-handler@v1",
+        "auth-ui",
+    )
+    .endpoints(vec![
+        BlockEndpoint::get("/b/auth/admin/settings").auth(AuthLevel::Admin),
+        BlockEndpoint::get("/b/auth/login").auth(AuthLevel::Public),
+    ])];
+
+    let msg = make_msg_with_user("/b/auth/admin/settings", "user-1");
+    let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s).await, 403);
+    assert!(ctx.calls().is_empty());
+
+    // The public login page still dispatches anonymously.
+    let ctx2 = RecordingContext::new();
+    let login = make_msg("/b/auth/login");
+    let s2 =
+        routing::route_to_block(&ctx2, login, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s2).await, 200);
+    assert_eq!(ctx2.calls(), vec!["suppers-ai/auth-ui".to_string()]);
+}
+
+#[tokio::test]
 async fn llm_chat_allows_authenticated_non_admin() {
     let ctx = RecordingContext::new();
     let infos = llm_infos();

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -100,6 +100,9 @@ impl FeatureConfig for AllEnabled {
 fn make_msg(path: &str) -> Message {
     let mut msg = Message::new("http.request");
     msg.set_meta(META_REQ_RESOURCE, path);
+    // Default to a GET (`retrieve`) action so the per-endpoint matcher can
+    // resolve declared `AuthLevel`s; POST/DELETE cases override `req.action`.
+    msg.set_meta("req.action", "retrieve");
     msg
 }
 
@@ -384,4 +387,78 @@ async fn undeclared_path_falls_back_to_prefix_tier() {
         routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
     assert_eq!(response_status(stream).await, 403);
     assert!(ctx.calls().is_empty());
+}
+
+/// `block_infos` mirroring the llm block's mixed-tier declarations: chat is
+/// `Authenticated`, the provider/model-admin UI + CRUD are `Admin`. The llm
+/// prefix route (`/b/llm`) is `Public`, so these prove the declared level is
+/// what gates — the source of the deleted per-handler `is_admin` re-checks.
+fn llm_infos() -> Vec<BlockInfo> {
+    vec![
+        BlockInfo::new("suppers-ai/llm", "0.0.1", "http-handler@v1", "llm").endpoints(vec![
+            BlockEndpoint::post("/b/llm/api/chat").auth(AuthLevel::Authenticated),
+            BlockEndpoint::get("/b/llm/providers").auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/llm/models").auth(AuthLevel::Admin),
+            BlockEndpoint::post("/b/llm/api/providers").auth(AuthLevel::Admin),
+            BlockEndpoint::delete("/b/llm/api/providers/{id}").auth(AuthLevel::Admin),
+            BlockEndpoint::post("/b/llm/api/models/{backend_id}/{model_id}/load")
+                .auth(AuthLevel::Admin),
+        ]),
+    ]
+}
+
+#[tokio::test]
+async fn llm_admin_ui_rejects_non_admin() {
+    let ctx = RecordingContext::new();
+    let infos = llm_infos();
+    for path in ["/b/llm/providers", "/b/llm/models"] {
+        let msg = make_msg_with_user(path, "user-1");
+        let stream =
+            routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+        assert_eq!(response_status(stream).await, 403, "{path} must reject non-admin");
+    }
+    assert!(ctx.calls().is_empty());
+}
+
+#[tokio::test]
+async fn llm_admin_provider_crud_rejects_non_admin() {
+    let ctx = RecordingContext::new();
+    let infos = llm_infos();
+
+    // POST /b/llm/api/providers — declared Admin.
+    let mut create = make_msg_with_user("/b/llm/api/providers", "user-1");
+    create.set_meta("req.action", "create");
+    let s1 =
+        routing::route_to_block(&ctx, create, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s1).await, 403);
+
+    // DELETE /b/llm/api/providers/{id} — declared Admin, dynamic segment.
+    let mut del = make_msg_with_user("/b/llm/api/providers/p-9", "user-1");
+    del.set_meta("req.action", "delete");
+    let s2 = routing::route_to_block(&ctx, del, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s2).await, 403);
+
+    // POST /b/llm/api/models/{backend}/{model}/load — declared Admin.
+    let mut load = make_msg_with_user("/b/llm/api/models/ollama/llama3/load", "user-1");
+    load.set_meta("req.action", "create");
+    let s3 =
+        routing::route_to_block(&ctx, load, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s3).await, 403);
+
+    assert!(ctx.calls().is_empty());
+}
+
+#[tokio::test]
+async fn llm_chat_allows_authenticated_non_admin() {
+    let ctx = RecordingContext::new();
+    let infos = llm_infos();
+
+    // POST /b/llm/api/chat — declared Authenticated; a plain user passes and
+    // dispatches (proving the chat endpoint is NOT swept up by the admin gate).
+    let mut chat = make_msg_with_user("/b/llm/api/chat", "user-1");
+    chat.set_meta("req.action", "create");
+    let stream =
+        routing::route_to_block(&ctx, chat, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 200);
+    assert_eq!(ctx.calls(), vec!["suppers-ai/llm".to_string()]);
 }

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -449,6 +449,54 @@ async fn llm_admin_provider_crud_rejects_non_admin() {
 }
 
 #[tokio::test]
+async fn files_admin_pages_reject_non_admin_and_public_share_passes() {
+    // `/b/storage/admin/*` declared Admin; `/b/storage/` Authenticated;
+    // `/b/storage/direct/{token}` Public. The files prefix is Public, so the
+    // declared levels are the gate (the block dropped its inline `is_admin`).
+    let ctx = RecordingContext::new();
+    let infos = vec![BlockInfo::new(
+        "suppers-ai/files",
+        "0.0.1",
+        "http-handler@v1",
+        "files",
+    )
+    .endpoints(vec![
+        BlockEndpoint::get("/b/storage/admin/buckets").auth(AuthLevel::Admin),
+        BlockEndpoint::get("/b/storage/").auth(AuthLevel::Authenticated),
+        BlockEndpoint::get("/b/storage/direct/{token}").auth(AuthLevel::Public),
+    ])];
+
+    // Non-admin → 403 on admin page.
+    let admin_page = make_msg_with_user("/b/storage/admin/buckets", "user-1");
+    let s1 =
+        routing::route_to_block(&ctx, admin_page, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+    assert_eq!(response_status(s1).await, 403);
+
+    // Anonymous → 403 on the Authenticated bucket list.
+    let ctx2 = RecordingContext::new();
+    let bucket_list = make_msg("/b/storage/");
+    let s2 = routing::route_to_block(
+        &ctx2,
+        bucket_list,
+        InputStream::empty(),
+        &AllEnabled,
+        &infos,
+        &[],
+    )
+    .await;
+    assert_eq!(response_status(s2).await, 403);
+
+    // Anonymous → 200 dispatch on the Public direct-share link.
+    let ctx3 = RecordingContext::new();
+    let share = make_msg("/b/storage/direct/tok-abc");
+    let s3 =
+        routing::route_to_block(&ctx3, share, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s3).await, 200);
+    assert_eq!(ctx3.calls(), vec!["suppers-ai/files".to_string()]);
+}
+
+#[tokio::test]
 async fn products_admin_api_rejects_non_admin() {
     // The products prefix (`/b/products`) is Public, and the block dropped its
     // in-handler `is_admin` preambles, so every admin API path must be a

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -449,6 +449,52 @@ async fn llm_admin_provider_crud_rejects_non_admin() {
 }
 
 #[tokio::test]
+async fn products_admin_api_rejects_non_admin() {
+    // The products prefix (`/b/products`) is Public, and the block dropped its
+    // in-handler `is_admin` preambles, so every admin API path must be a
+    // declared `Admin` endpoint or it would fall back to Public. Spot-check a
+    // representative set across resources (incl. dynamic `{id}` and the nested
+    // refund route), plus the SSR admin page.
+    let ctx = RecordingContext::new();
+    let infos = vec![BlockInfo::new(
+        "suppers-ai/products",
+        "0.0.1",
+        "http-handler@v1",
+        "products",
+    )
+    .endpoints(vec![
+        BlockEndpoint::get("/b/products/admin/").auth(AuthLevel::Admin),
+        BlockEndpoint::get("/b/products/api/admin/groups").auth(AuthLevel::Admin),
+        BlockEndpoint::delete("/b/products/api/admin/products/{id}").auth(AuthLevel::Admin),
+        BlockEndpoint::patch("/b/products/api/admin/purchases/{id}/refund").auth(AuthLevel::Admin),
+        BlockEndpoint::get("/b/products/catalog").auth(AuthLevel::Public),
+    ])];
+
+    let cases: &[(&str, &str)] = &[
+        ("retrieve", "/b/products/admin/"),
+        ("retrieve", "/b/products/api/admin/groups"),
+        ("delete", "/b/products/api/admin/products/p-1"),
+        ("update", "/b/products/api/admin/purchases/o-9/refund"),
+    ];
+    for (action, path) in cases {
+        let mut msg = make_msg_with_user(path, "user-1");
+        msg.set_meta("req.action", *action);
+        let s =
+            routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+        assert_eq!(response_status(s).await, 403, "{action} {path} must reject non-admin");
+    }
+    assert!(ctx.calls().is_empty());
+
+    // The public catalog still dispatches anonymously.
+    let ctx2 = RecordingContext::new();
+    let cat = make_msg("/b/products/catalog");
+    let s2 =
+        routing::route_to_block(&ctx2, cat, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    assert_eq!(response_status(s2).await, 200);
+    assert_eq!(ctx2.calls(), vec!["suppers-ai/products".to_string()]);
+}
+
+#[tokio::test]
 async fn auth_ui_admin_settings_rejects_non_admin() {
     // `/b/auth/admin/settings` is declared `Admin` while the auth-ui prefix is
     // Public — so the declared level is the sole gate (the deleted inline

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -145,7 +145,7 @@ async fn built_in_route_wins_over_extra_with_same_prefix() {
 
     let msg = make_msg("/b/auth/login");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let _ = stream.collect_buffered().await;
 
     let calls = ctx.calls();
@@ -170,7 +170,7 @@ async fn public_extra_route_dispatches_without_auth() {
     // No user_id set on the message — Public access should allow it through.
     let msg = make_msg("/b/chat/hello");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 200);
 
@@ -191,7 +191,7 @@ async fn authenticated_extra_route_forbids_empty_user_id() {
 
     let msg = make_msg("/b/chat/hello"); // no user_id
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 403, "Authenticated + empty user_id should be 403");
 
@@ -214,7 +214,7 @@ async fn authenticated_extra_route_allows_user() {
 
     let msg = make_msg_with_user("/b/chat/hello", "user-123");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 200);
 
@@ -235,7 +235,7 @@ async fn admin_extra_route_forbids_non_admin() {
     // User is authenticated but lacks the admin role.
     let msg = make_msg_with_user("/b/gizza-admin/dash", "user-123");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 403, "Admin access + non-admin user should be 403");
 
@@ -255,7 +255,7 @@ async fn admin_extra_route_allows_admin() {
 
     let msg = make_msg_with_admin("/b/gizza-admin/dash", "admin-1");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 200);
 
@@ -275,9 +275,113 @@ async fn unmatched_path_falls_through_to_not_found() {
 
     let msg = make_msg("/some/other/path");
     let input = InputStream::empty();
-    let stream = routing::route_to_block(&ctx, msg, input, &features, &extras).await;
+    let stream = routing::route_to_block(&ctx, msg, input, &features, &[], &extras).await;
     let status = response_status(stream).await;
     assert_eq!(status, 404);
 
+    assert!(ctx.calls().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Central per-endpoint AuthLevel enforcement (S4-U).
+//
+// These pin the new behavior: the router enforces the *declared* endpoint
+// `AuthLevel` (from `BlockInfo::endpoints`) before dispatch, taking the
+// stricter of the coarse prefix tier and the declared level. This is what
+// lets blocks drop their per-handler `is_admin`/`user_id` preambles — and it
+// is the fix for the #1 regression risk (legalpages admin protection that
+// used to rest only on route-table ordering).
+// ---------------------------------------------------------------------------
+
+use wafer_run::{AuthLevel, BlockEndpoint, BlockInfo};
+
+/// A `block_infos` slice declaring the legalpages admin/api endpoints as
+/// `Admin` and the public terms page as `Public` — exactly as the block's
+/// `info()` does.
+fn legalpages_infos() -> Vec<BlockInfo> {
+    vec![
+        BlockInfo::new("suppers-ai/legalpages", "0.0.1", "http-handler@v1", "legal").endpoints(
+            vec![
+                BlockEndpoint::get("/b/legalpages/terms").auth(AuthLevel::Public),
+                BlockEndpoint::get("/b/legalpages/admin").auth(AuthLevel::Admin),
+                BlockEndpoint::patch("/b/legalpages/api/documents/{id}").auth(AuthLevel::Admin),
+            ],
+        ),
+    ]
+}
+
+#[tokio::test]
+async fn declared_admin_endpoint_rejects_non_admin_even_when_prefix_is_public() {
+    let ctx = RecordingContext::new();
+    let features = AllEnabled;
+    let infos = legalpages_infos();
+
+    // `/b/legalpages/admin` is declared Admin. An authenticated non-admin must
+    // be rejected centrally BEFORE the block runs — proving the admin gate no
+    // longer rests on route-table ordering.
+    let msg = make_msg_with_user("/b/legalpages/admin", "user-1");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 403);
+    assert!(ctx.calls().is_empty(), "must not dispatch to the block");
+}
+
+#[tokio::test]
+async fn declared_admin_endpoint_allows_admin() {
+    let ctx = RecordingContext::new();
+    let features = AllEnabled;
+    let infos = legalpages_infos();
+
+    let msg = make_msg_with_admin("/b/legalpages/admin", "admin-1");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 200);
+    assert_eq!(ctx.calls(), vec!["suppers-ai/legalpages".to_string()]);
+}
+
+#[tokio::test]
+async fn declared_admin_endpoint_with_path_param_enforced() {
+    let ctx = RecordingContext::new();
+    let features = AllEnabled;
+    let infos = legalpages_infos();
+
+    // PATCH /b/legalpages/api/documents/{id} is Admin — a non-admin is 403'd
+    // even though the `{id}` segment is dynamic.
+    let mut msg = make_msg_with_user("/b/legalpages/api/documents/doc-7", "user-1");
+    msg.set_meta("req.action", "update");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 403);
+    assert!(ctx.calls().is_empty());
+}
+
+#[tokio::test]
+async fn public_declared_endpoint_passes_without_auth() {
+    let ctx = RecordingContext::new();
+    let features = AllEnabled;
+    let infos = legalpages_infos();
+
+    // `/b/legalpages/terms` is declared Public — anonymous request dispatches.
+    let msg = make_msg("/b/legalpages/terms");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 200);
+    assert_eq!(ctx.calls(), vec!["suppers-ai/legalpages".to_string()]);
+}
+
+#[tokio::test]
+async fn undeclared_path_falls_back_to_prefix_tier() {
+    let ctx = RecordingContext::new();
+    let features = AllEnabled;
+    let infos = legalpages_infos();
+
+    // `/b/legalpages/api/documents` (no `{id}`) is NOT in the declared
+    // endpoint list above. The coarse prefix route for `/b/legalpages/api` is
+    // Admin (the backstop), so a non-admin is still rejected — an undeclared
+    // path can never be LESS protected than its prefix tier.
+    let msg = make_msg_with_user("/b/legalpages/api/documents", "user-1");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &features, &infos, &[]).await;
+    assert_eq!(response_status(stream).await, 403);
     assert!(ctx.calls().is_empty());
 }

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -414,8 +414,13 @@ async fn llm_admin_ui_rejects_non_admin() {
     for path in ["/b/llm/providers", "/b/llm/models"] {
         let msg = make_msg_with_user(path, "user-1");
         let stream =
-            routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
-        assert_eq!(response_status(stream).await, 403, "{path} must reject non-admin");
+            routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+                .await;
+        assert_eq!(
+            response_status(stream).await,
+            403,
+            "{path} must reject non-admin"
+        );
     }
     assert!(ctx.calls().is_empty());
 }
@@ -435,7 +440,8 @@ async fn llm_admin_provider_crud_rejects_non_admin() {
     // DELETE /b/llm/api/providers/{id} — declared Admin, dynamic segment.
     let mut del = make_msg_with_user("/b/llm/api/providers/p-9", "user-1");
     del.set_meta("req.action", "delete");
-    let s2 = routing::route_to_block(&ctx, del, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    let s2 =
+        routing::route_to_block(&ctx, del, InputStream::empty(), &AllEnabled, &infos, &[]).await;
     assert_eq!(response_status(s2).await, 403);
 
     // POST /b/llm/api/models/{backend}/{model}/load — declared Admin.
@@ -454,23 +460,25 @@ async fn files_admin_pages_reject_non_admin_and_public_share_passes() {
     // `/b/storage/direct/{token}` Public. The files prefix is Public, so the
     // declared levels are the gate (the block dropped its inline `is_admin`).
     let ctx = RecordingContext::new();
-    let infos = vec![BlockInfo::new(
-        "suppers-ai/files",
-        "0.0.1",
-        "http-handler@v1",
-        "files",
-    )
-    .endpoints(vec![
-        BlockEndpoint::get("/b/storage/admin/buckets").auth(AuthLevel::Admin),
-        BlockEndpoint::get("/b/storage/").auth(AuthLevel::Authenticated),
-        BlockEndpoint::get("/b/storage/direct/{token}").auth(AuthLevel::Public),
-    ])];
+    let infos = vec![
+        BlockInfo::new("suppers-ai/files", "0.0.1", "http-handler@v1", "files").endpoints(vec![
+            BlockEndpoint::get("/b/storage/admin/buckets").auth(AuthLevel::Admin),
+            BlockEndpoint::get("/b/storage/").auth(AuthLevel::Authenticated),
+            BlockEndpoint::get("/b/storage/direct/{token}").auth(AuthLevel::Public),
+        ]),
+    ];
 
     // Non-admin → 403 on admin page.
     let admin_page = make_msg_with_user("/b/storage/admin/buckets", "user-1");
-    let s1 =
-        routing::route_to_block(&ctx, admin_page, InputStream::empty(), &AllEnabled, &infos, &[])
-            .await;
+    let s1 = routing::route_to_block(
+        &ctx,
+        admin_page,
+        InputStream::empty(),
+        &AllEnabled,
+        &infos,
+        &[],
+    )
+    .await;
     assert_eq!(response_status(s1).await, 403);
 
     // Anonymous → 403 on the Authenticated bucket list.
@@ -527,9 +535,13 @@ async fn products_admin_api_rejects_non_admin() {
     for (action, path) in cases {
         let mut msg = make_msg_with_user(path, "user-1");
         msg.set_meta("req.action", *action);
-        let s =
-            routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
-        assert_eq!(response_status(s).await, 403, "{action} {path} must reject non-admin");
+        let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+        assert_eq!(
+            response_status(s).await,
+            403,
+            "{action} {path} must reject non-admin"
+        );
     }
     assert!(ctx.calls().is_empty());
 
@@ -548,19 +560,18 @@ async fn auth_ui_admin_settings_rejects_non_admin() {
     // Public — so the declared level is the sole gate (the deleted inline
     // `is_admin` check). A non-admin must be 403'd before dispatch.
     let ctx = RecordingContext::new();
-    let infos = vec![BlockInfo::new(
-        "suppers-ai/auth-ui",
-        "0.0.1",
-        "http-handler@v1",
-        "auth-ui",
-    )
-    .endpoints(vec![
-        BlockEndpoint::get("/b/auth/admin/settings").auth(AuthLevel::Admin),
-        BlockEndpoint::get("/b/auth/login").auth(AuthLevel::Public),
-    ])];
+    let infos = vec![
+        BlockInfo::new("suppers-ai/auth-ui", "0.0.1", "http-handler@v1", "auth-ui").endpoints(
+            vec![
+                BlockEndpoint::get("/b/auth/admin/settings").auth(AuthLevel::Admin),
+                BlockEndpoint::get("/b/auth/login").auth(AuthLevel::Public),
+            ],
+        ),
+    ];
 
     let msg = make_msg_with_user("/b/auth/admin/settings", "user-1");
-    let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
+    let s =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[]).await;
     assert_eq!(response_status(s).await, 403);
     assert!(ctx.calls().is_empty());
 

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -598,3 +598,125 @@ async fn llm_chat_allows_authenticated_non_admin() {
     assert_eq!(response_status(stream).await, 200);
     assert_eq!(ctx.calls(), vec!["suppers-ai/llm".to_string()]);
 }
+
+// ---------------------------------------------------------------------------
+// No-trailing-slash admin-overview regression guards (S4-U).
+//
+// These drive `route_to_block` with the **real** `blocks::all_block_infos()`
+// (not a hand-copied fixture) so the test can never drift from what the blocks
+// actually declare in `info()`. That drift is exactly why the original
+// regression slipped through: the existing products/files central-enforcement
+// tests above hand-copied the SLASH-only declaration, so they never exercised
+// the no-slash form the block's `"" | "/" => overview` dispatch arm serves.
+//
+// The bug class: a block answers BOTH `/b/x/admin` and `/b/x/admin/` for its
+// admin overview, the central matcher is trailing-slash-significant, and the
+// `/b/x` prefix tier is Public — so if `info()` declares only the slash form,
+// the no-slash form falls back to Public and an anonymous request reaches the
+// admin overview. Both forms must be declared `Admin` and enforced centrally.
+// ---------------------------------------------------------------------------
+
+/// The exact endpoints the named block declares in `info()`, pulled from the
+/// production registry (`blocks::all_block_infos()`) rather than re-typed here.
+fn real_block_info(name: &str) -> BlockInfo {
+    solobase_core::blocks::all_block_infos()
+        .into_iter()
+        .find(|i| i.name == name)
+        .unwrap_or_else(|| panic!("block {name} not in all_block_infos()"))
+}
+
+/// Assert that every variant of an admin overview path is gated `Admin`
+/// centrally (403 before dispatch) for both anonymous and authenticated
+/// non-admin callers, driving the block's REAL declared endpoints.
+async fn assert_admin_overview_gated(block_name: &str, paths: &[&str]) {
+    let infos = vec![real_block_info(block_name)];
+
+    // Anonymous.
+    for path in paths {
+        let ctx = RecordingContext::new();
+        let msg = make_msg(path);
+        let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+        assert_eq!(
+            response_status(s).await,
+            403,
+            "anonymous {path} ({block_name}) must be rejected (admin overview)"
+        );
+        assert!(
+            ctx.calls().is_empty(),
+            "{path} must NOT dispatch to {block_name}"
+        );
+    }
+
+    // Authenticated non-admin.
+    for path in paths {
+        let ctx = RecordingContext::new();
+        let msg = make_msg_with_user(path, "user-1");
+        let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+        assert_eq!(
+            response_status(s).await,
+            403,
+            "non-admin {path} ({block_name}) must be rejected"
+        );
+        assert!(ctx.calls().is_empty());
+    }
+}
+
+#[cfg(feature = "block-products")]
+#[tokio::test]
+async fn products_admin_overview_rejects_unauthorized_with_and_without_trailing_slash() {
+    assert_admin_overview_gated(
+        "suppers-ai/products",
+        &["/b/products/admin", "/b/products/admin/"],
+    )
+    .await;
+}
+
+#[cfg(feature = "block-files")]
+#[tokio::test]
+async fn files_admin_overview_rejects_unauthorized_with_and_without_trailing_slash() {
+    assert_admin_overview_gated(
+        "suppers-ai/files",
+        &["/b/storage/admin", "/b/storage/admin/"],
+    )
+    .await;
+}
+
+#[cfg(feature = "block-products")]
+#[tokio::test]
+async fn products_admin_overview_allows_admin_both_forms() {
+    // The admin still reaches the overview on both forms (the fix gates, it does
+    // not 404 the no-slash convenience path).
+    let infos = vec![real_block_info("suppers-ai/products")];
+    for path in ["/b/products/admin", "/b/products/admin/"] {
+        let ctx = RecordingContext::new();
+        let msg = make_msg_with_admin(path, "admin-1");
+        let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+        assert_eq!(
+            response_status(s).await,
+            200,
+            "admin {path} should dispatch"
+        );
+        assert_eq!(ctx.calls(), vec!["suppers-ai/products".to_string()]);
+    }
+}
+
+#[cfg(feature = "block-files")]
+#[tokio::test]
+async fn files_admin_overview_allows_admin_both_forms() {
+    let infos = vec![real_block_info("suppers-ai/files")];
+    for path in ["/b/storage/admin", "/b/storage/admin/"] {
+        let ctx = RecordingContext::new();
+        let msg = make_msg_with_admin(path, "admin-1");
+        let s = routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &infos, &[])
+            .await;
+        assert_eq!(
+            response_status(s).await,
+            200,
+            "admin {path} should dispatch"
+        );
+        assert_eq!(ctx.calls(), vec!["suppers-ai/files".to_string()]);
+    }
+}


### PR DESCRIPTION
WIP — S4-U routing-auth-policy (the big architectural package; runs alone in Wave 4).

## Goal
ONE route+auth declaration, ONE enforcement point, ONE in-block dispatch mechanism. Derive route table + access tier from `BlockInfo::endpoints` and enforce the declared `AuthLevel` centrally before dispatch (it stops being documentation-only). Kill the four coexisting dispatch styles + manual `starts_with`/`strip_prefix` param parsing. Kill `req.resource` in-band routing. Collapse the 9 decorative vector routes.

## Findings checklist (plan section S4-U)
- [x] Shared matcher in solobase-core (`endpoint_match`) — replaces `wafer_block::Router` (deleted phase 1; NOT resurrected)
- [ ] (1) ENFORCEMENT: central per-endpoint `AuthLevel` enforcement in `route_to_block`; delete per-block auth preambles where covered
- [ ] (2) SECURITY HAZARD: legalpages admin protection on declared `AuthLevel`, not route-table ordering
- [ ] (3) DISPATCH: blocks dispatch via `[(method, template, handler)]` tables (messages, llm, legalpages, vector, auth_ui, files, products, userportal); admin `AdminRoute` enum stays
- [ ] (4) KILL `req.resource` set_meta in-band routing (files double-rewrite, products, admin); reserve for cross-block `call_block`
- [ ] (5) Collapse 9 vector routes → one prefix route

## Auth-parity (filled as deletions land)
Each deleted per-block check + the central declared `AuthLevel` that now covers it.

## Verification
Filled before marking ready.