### PR TITLE
fix(S5-V): feature-block-macro — declarative macro + one registration manifest

### DIFF
--- a/crates/solobase-core/src/blocks/admin/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/migrations/mod.rs
@@ -1,4 +1,5 @@
-//! Admin block migrations. Applied from the block's `Init` lifecycle.
+//! Admin block migrations. Applied from the block's `Init` lifecycle via
+//! [`crate::migration_helper::lifecycle_init`].
 //!
 //! SQL files are embedded with `include_str!`. Backend dispatch + concat +
 //! the `current_hash` / `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate
@@ -6,10 +7,6 @@
 //! versions of this module called `db::ddl` directly in a loop, bypassing
 //! the gate and re-running every DDL on every cold isolate (~2,800 D1
 //! queries/day on wafer.run — see the 2026-05-14 config-snapshot spec).
-
-use wafer_run::context::Context;
-
-const ADMIN_BLOCK_NAME: &str = "suppers-ai/admin";
 
 const SQL_001_SQLITE: &str = include_str!("001_admin_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_admin_schema.postgres.sql");
@@ -19,44 +16,48 @@ const SQL_003_SQLITE: &str = include_str!("003_block_settings_seed_hash.sqlite.s
 const SQL_003_POSTGRES: &str = include_str!("003_block_settings_seed_hash.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`). Order here
-/// is the apply order.
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
+/// Order here is the apply order.
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
     ("001_admin_schema", SQL_001_SQLITE),
     ("002_variables_block_column", SQL_002_SQLITE),
     ("003_block_settings_seed_hash", SQL_003_SQLITE),
 ];
 
-/// Apply all admin migrations through the shared migration-state gate.
-/// Idempotent across cold starts: once the gate stamps a `current_hash` row
-/// in `block_settings`, subsequent boots short-circuit before issuing any
-/// DDL. Schema changes require a `--run-migrations` redeploy (see
-/// `migration-state-workflow` in user memory).
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`] one
+/// for one. Selected at runtime by `apply_migrations` and reused by
+/// [`ddl_files`] for the pre-wafer native CLI path.
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES];
+
+/// Apply the admin schema through the shared migration-state gate.
+///
+/// Production no longer calls this: `AdminBlock::lifecycle(Init)` applies the
+/// admin schema via [`crate::migration_helper::lifecycle_init`]. This thin
+/// forwarder exists for the `tests/admin/*` + `tests/auth/*` integration
+/// suites, which bootstrap `suppers_ai__admin__block_settings` (the tracking
+/// table every other block's gate upserts into) in their fixtures —
+/// test-fixture setup is an explicit exception to the no-raw-migration-runner
+/// rule (CLAUDE.md).
+pub async fn apply(ctx: &dyn wafer_run::context::Context) -> Result<(), String> {
     let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    crate::migration_helper::apply_migrations(
-        ctx,
-        ADMIN_BLOCK_NAME,
-        &sqlite,
-        &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES],
-    )
-    .await
+    crate::migration_helper::apply_migrations(ctx, "suppers-ai/admin", &sqlite, POSTGRES_MIGRATIONS)
+        .await
 }
 
 /// The admin migration SQL files for the given `db_type`, in apply order —
-/// the same constants [`apply`] feeds the gated runner. `"postgres"`
+/// the same constants the gated `lifecycle_init` runner feeds. `"postgres"`
 /// (case-insensitive) selects the postgres dialect; everything else selects
 /// SQLite, matching [`crate::migration_helper::db_backend`].
 ///
 /// Exposed so the native CLI can create the admin tables *before* the wafer
 /// exists (it seeds the JWT secret + block_settings pre-build), via
 /// [`crate::migration_helper::apply_ddl_via_service`]. Cloudflare and browser
-/// don't need this — their seeders run after the gated `apply` has already
+/// don't need this — their seeders run after the gated apply has already
 /// created the tables at `init_block(admin)`.
 pub fn ddl_files(db_type: &str) -> &'static [&'static str] {
     if db_type.eq_ignore_ascii_case("postgres") {
-        &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES]
+        POSTGRES_MIGRATIONS
     } else {
         &[SQL_001_SQLITE, SQL_002_SQLITE, SQL_003_SQLITE]
     }

--- a/crates/solobase-core/src/blocks/admin/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/migrations/mod.rs
@@ -28,7 +28,8 @@ pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
 /// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`] one
 /// for one. Selected at runtime by `apply_migrations` and reused by
 /// [`ddl_files`] for the pre-wafer native CLI path.
-pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES];
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] =
+    &[SQL_001_POSTGRES, SQL_002_POSTGRES, SQL_003_POSTGRES];
 
 /// Apply the admin schema through the shared migration-state gate.
 ///

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -24,30 +24,16 @@ pub const ADMIN_BLOCK_ID: &str = "suppers-ai/admin";
 pub(crate) const WRAP_GRANTS_TABLE: &str = "suppers_ai__admin__wrap_grants";
 
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ErrorCode, InputStream, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, BlockEndpoint, BlockInfo, InputStream, InstanceMode, Message, OutputStream,
 };
 
 use crate::blocks::helpers::{err_not_found, ok_json};
 
-pub struct AdminBlock;
-
-impl AdminBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for AdminBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for AdminBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Admin panel: users, database, IAM, logs, settings (`suppers-ai/admin`).
+    pub struct AdminBlock;
+    name: "suppers-ai/admin",
+    info: |_this| {
         use wafer_run::{AuthLevel, CollectionSchema};
 
         BlockInfo::new("suppers-ai/admin", "0.0.1", "http-handler@v1", "Admin panel: users, database, IAM, logs, settings")
@@ -127,14 +113,8 @@ impl Block for AdminBlock {
                 BlockEndpoint::get("/b/admin/api/settings").summary("List variables API").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/admin/api/logs").summary("Audit logs API").auth(AuthLevel::Admin),
             ])
-    }
-
-    async fn handle(
-        &self,
-        ctx: &dyn Context,
-        mut msg: Message,
-        input: InputStream,
-    ) -> OutputStream {
+    },
+    handle: |_this, ctx, msg, input| {
         use route::AdminRoute;
 
         let path_owned = msg.path().to_string();
@@ -254,25 +234,24 @@ impl Block for AdminBlock {
 
             AdminRoute::NotFound => err_not_found("not found"),
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            if let Err(e) = migrations::apply(ctx).await {
-                return Err(WaferError::new(
-                    ErrorCode::Internal,
-                    format!("admin migrations: {e}"),
-                ));
-            }
+    },
+    lifecycle: |_this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/admin",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await?;
+        // Seed default roles/permissions + shared/default variables after the
+        // schema is in place, only on Init.
+        if matches!(event.event_type, wafer_run::LifecycleType::Init) {
             iam::seed_defaults(ctx).await;
             settings::seed_defaults(ctx).await;
         }
         Ok(())
-    }
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -337,9 +316,6 @@ async fn handle_delete_wrap_grant(
     msg.set_meta("req.query.subtab", "database");
     pages::permissions_page(ctx, &msg).await
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/admin", AdminBlock);
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -1,12 +1,11 @@
-//! Auth block migrations. Delegated to `crate::migration_helper`.
+//! Auth block migrations. Applied from the framework auth service's
+//! `AuthService::init` (the framework `suppers-ai/auth` block's
+//! `lifecycle(Init)` delegates to it) via
+//! [`crate::migration_helper::apply_migrations`].
 //!
 //! Hash-gated apply — runs only when the SQL hash differs from the recorded
 //! `current_hash` in `suppers_ai__admin__block_settings`. Concatenated SQL of
 //! all migration scripts is hashed and tracked.
-
-use wafer_run::context::Context;
-
-use crate::migration_helper;
 
 const SQL_001_SQLITE: &str = include_str!("001_auth_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_auth_schema.postgres.sql");
@@ -24,9 +23,9 @@ const SQL_007_SQLITE: &str = include_str!("007_api_keys.sqlite.sql");
 const SQL_007_POSTGRES: &str = include_str!("007_api_keys.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`). Order here
-/// is the apply order — keep it identical to `apply()`'s sqlite slice.
+/// pairs. Single source for both the runtime apply (auth's `init`) and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
+/// Order here is the apply order.
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
     ("001_auth_schema", SQL_001_SQLITE),
     ("002_reserved_orgs", SQL_002_SQLITE),
@@ -37,21 +36,29 @@ pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
     ("007_api_keys", SQL_007_SQLITE),
 ];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`] one
+/// for one. Selected at runtime by `apply_migrations`.
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[
+    SQL_001_POSTGRES,
+    SQL_002_POSTGRES,
+    SQL_003_POSTGRES,
+    SQL_004_POSTGRES,
+    SQL_005_POSTGRES,
+    SQL_006_POSTGRES,
+    SQL_007_POSTGRES,
+];
+
+/// Apply the auth schema through the shared migration-state gate.
+///
+/// Production no longer calls this: the framework auth service applies these
+/// migrations inside [`AuthService::init`](super::service) (via
+/// `apply_migrations` directly, because it needs an `AuthError` return).
+/// This thin forwarder exists for the `tests/auth/*` integration suite, which
+/// applies the auth schema against an in-memory fixture before exercising the
+/// repo layer — test-fixture setup is an explicit exception to the
+/// no-raw-migration-runner rule (CLAUDE.md).
+pub async fn apply(ctx: &dyn wafer_run::context::Context) -> Result<(), String> {
     let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(
-        ctx,
-        "suppers-ai/auth",
-        &sqlite,
-        &[
-            SQL_001_POSTGRES,
-            SQL_002_POSTGRES,
-            SQL_003_POSTGRES,
-            SQL_004_POSTGRES,
-            SQL_005_POSTGRES,
-            SQL_006_POSTGRES,
-            SQL_007_POSTGRES,
-        ],
-    )
-    .await
+    crate::migration_helper::apply_migrations(ctx, "suppers-ai/auth", &sqlite, POSTGRES_MIGRATIONS)
+        .await
 }

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -212,8 +212,7 @@ pub fn auth_grants() -> Vec<wafer_block::types::ResourceGrant> {
     ]
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[wafer_block::wafer_async_trait]
 impl AuthService for AuthServiceImpl {
     /// Apply auth migrations and run the bootstrap admin step. Invoked by the
     /// framework `AuthBlock::lifecycle(Init)` (wafer-run #41/#45) once at
@@ -229,9 +228,23 @@ impl AuthService for AuthServiceImpl {
         // same shared snapshots.
         let _ = self.state.ctx.set(ctx.clone_arc());
 
-        super::migrations::apply(ctx)
-            .await
-            .map_err(|e| AuthError::Internal(format!("auth migrations: {e}")))?;
+        // Auth's migrations run here (not in a `Block::lifecycle`) because the
+        // service `init` needs an `AuthError` return shape, not the
+        // `WaferError` that `migration_helper::lifecycle_init` produces — so
+        // this calls the shared `apply_migrations` directly with the block's
+        // single-source migration consts.
+        let sqlite: Vec<&str> = super::migrations::SQLITE_MIGRATIONS
+            .iter()
+            .map(|(_, sql)| *sql)
+            .collect();
+        crate::migration_helper::apply_migrations(
+            ctx,
+            "suppers-ai/auth",
+            &sqlite,
+            super::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+        .map_err(|e| AuthError::Internal(format!("auth migrations: {e}")))?;
         let cfg = super::config::AuthConfig::from_ctx(ctx).await;
         super::bootstrap::run(ctx, &cfg)
             .await

--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -23,9 +23,7 @@ pub mod oauth;
 pub mod pages;
 pub mod redirect;
 
-use wafer_run::{
-    AuthLevel, BlockEndpoint, BlockInfo, ConfigVar, InputType, InstanceMode,
-};
+use wafer_run::{AuthLevel, BlockEndpoint, BlockInfo, ConfigVar, InputType, InstanceMode};
 
 use super::rate_limit::{
     check_route_limits, LimitKey, RateLimit, RateLimitOutcome, RouteLimit, UserRateLimiter,

--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -24,8 +24,7 @@ pub mod pages;
 pub mod redirect;
 
 use wafer_run::{
-    context::Context, AuthLevel, Block, BlockEndpoint, BlockInfo, ConfigVar, InputStream,
-    InputType, InstanceMode, LifecycleEvent, Message, OutputStream, WaferError,
+    AuthLevel, BlockEndpoint, BlockInfo, ConfigVar, InputType, InstanceMode,
 };
 
 use super::rate_limit::{
@@ -157,28 +156,14 @@ pub(crate) fn config_vars() -> Vec<ConfigVar> {
     ]
 }
 
-pub struct AuthUiBlock {
-    limiter: UserRateLimiter,
-}
-
-impl Default for AuthUiBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AuthUiBlock {
-    pub fn new() -> Self {
-        Self {
-            limiter: UserRateLimiter::new(),
-        }
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for AuthUiBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Solobase auth HTTP surface — SSR pages + JSON API + OAuth + bootstrap
+    /// (`suppers-ai/auth-ui`). The auth *service* primitive lives in the
+    /// framework `suppers-ai/auth` block.
+    pub struct AuthUiBlock;
+    fields: { limiter: UserRateLimiter },
+    name: "suppers-ai/auth-ui",
+    info: |_this| {
         BlockInfo::new(
             AUTH_UI_BLOCK_ID,
             "0.0.1",
@@ -245,9 +230,8 @@ impl Block for AuthUiBlock {
         ])
         .config_keys(config_vars())
         .admin_url("/b/auth/admin/settings")
-    }
-
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         let action = msg.action().to_string();
         // Normalize: /b/auth/... → /auth/...
         let raw_path = msg.path().to_string();
@@ -264,7 +248,7 @@ impl Block for AuthUiBlock {
         // X-RateLimit-* response headers needs a streaming-middleware shape we
         // don't have yet. Tracked as a single follow-up, not a per-route TODO.
         if let Some(RateLimitOutcome::Limited(r)) = check_route_limits(
-            &self.limiter,
+            &this.limiter,
             ctx,
             &msg,
             action.as_str(),
@@ -345,18 +329,8 @@ impl Block for AuthUiBlock {
             ("create", "/auth/api/bootstrap") => api::bootstrap::handle(ctx, input).await,
             _ => err_not_found("not found"),
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        Ok(())
-    }
+    },
+    // No `lifecycle`: auth-ui owns no schema (auth tables belong to the
+    // framework `suppers-ai/auth` block), so the `Block` no-op default
+    // applies.
 }
-
-// PR 5 Task 7: framework AuthBlock now owns `suppers-ai/auth` (the auth
-// service primitive); auth-ui owns the `/b/auth/*` HTTP surface.
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/auth-ui", AuthUiBlock);

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -12,8 +12,8 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 use wafer_core::clients::{config, network as net};
 use wafer_run::{
-    context::Context, Block, BlockInfo, ConfigVar, InputStream, InputType, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, BlockInfo, ConfigVar, InputStream, InputType, InstanceMode, LifecycleType,
+    OutputStream,
 };
 
 use super::rate_limit::{RateLimit, UserRateLimiter};
@@ -41,28 +41,12 @@ pub(crate) fn resolve_base_url(configured: &str) -> &str {
     }
 }
 
-pub struct EmailBlock {
-    limiter: UserRateLimiter,
-}
-
-impl EmailBlock {
-    pub fn new() -> Self {
-        Self {
-            limiter: UserRateLimiter::new(),
-        }
-    }
-}
-
-impl Default for EmailBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for EmailBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Email sending via the Mailgun HTTP API (`suppers-ai/email`).
+    pub struct EmailBlock;
+    fields: { limiter: UserRateLimiter },
+    name: "suppers-ai/email",
+    info: |_this| {
         BlockInfo::new("suppers-ai/email", "0.0.1", "service@v1", "Email sending via Mailgun")
             .instance_mode(InstanceMode::Singleton)
             .requires(vec!["wafer-run/network".into(), "wafer-run/config".into()])
@@ -112,21 +96,18 @@ impl Block for EmailBlock {
                 .name("Allowed Recipient Patterns")
                 .optional(),
             ])
-    }
-
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         match msg.kind.as_str() {
-            "email.send" => handle_send(&self.limiter, ctx, input).await,
-            "email.send_template" => handle_send_template(&self.limiter, ctx, input).await,
+            "email.send" => handle_send(&this.limiter, ctx, input).await,
+            "email.send_template" => handle_send_template(&this.limiter, ctx, input).await,
             _ => err_not_found(&format!("unknown email op: {}", msg.kind)),
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
+    },
+    lifecycle: |_this, ctx, event| {
+        // No schema — the email block is stateless. The only Init work is a
+        // config sanity warning (no migrations, so this does NOT go through
+        // `migration_helper::lifecycle_init`).
         if event.event_type == LifecycleType::Init {
             let patterns =
                 config::get_default(ctx, "SUPPERS_AI__EMAIL__ALLOWED_RECIPIENT_PATTERNS", "").await;
@@ -138,7 +119,7 @@ impl Block for EmailBlock {
             }
         }
         Ok(())
-    }
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -576,9 +557,6 @@ async fn check_caller_rate_limit(
         Err(retry_after) => Err(super::rate_limit::rate_limited_response(retry_after)),
     }
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/email", EmailBlock);
 
 // ---------------------------------------------------------------------------
 // Tests — SEC-051 rate limit + recipient allow-list + validation.

--- a/crates/solobase-core/src/blocks/fastembed.rs
+++ b/crates/solobase-core/src/blocks/fastembed.rs
@@ -26,8 +26,7 @@ use std::sync::{Arc, OnceLock};
 use wafer_block_fastembed::FastembedService;
 use wafer_core::interfaces::vector::handler::handle_embedding_message;
 use wafer_run::{
-    context::Context, Block, BlockInfo, InputStream, InstanceMode, LifecycleEvent, Message,
-    OutputStream, WaferError,
+    context::Context, Block, BlockInfo, InputStream, InstanceMode, Message, OutputStream,
 };
 
 use crate::blocks::helpers::err_internal;
@@ -78,8 +77,15 @@ impl Default for FastembedBlock {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl FastembedBlock {
+    /// The block's registered name. Mirrors the `BLOCK_NAME` const the
+    /// `solobase_feature_block!` macro generates for the zero-arg feature
+    /// blocks, so the `(feature, name, constructor)` manifest in
+    /// [`crate::blocks`] can reference `FastembedBlock::BLOCK_NAME` uniformly.
+    pub const BLOCK_NAME: &'static str = "suppers-ai/fastembed";
+}
+
+#[wafer_block::wafer_async_trait]
 impl Block for FastembedBlock {
     fn info(&self) -> BlockInfo {
         BlockInfo::new(
@@ -88,6 +94,10 @@ impl Block for FastembedBlock {
             "embedding@v1",
             "Native ONNX text embedding via fastembed-rs",
         )
+        // Singleton: the wrapped `FastembedService` lazily loads one ONNX
+        // model and caches it in the `OnceLock` for the block's lifetime —
+        // a per-node/per-flow instance would reload the model needlessly.
+        // Kept deliberately in lockstep with `TransformersEmbedBlock`.
         .instance_mode(InstanceMode::Singleton)
         .category(wafer_run::BlockCategory::Service)
     }
@@ -98,17 +108,10 @@ impl Block for FastembedBlock {
             Ok(s) => s,
             Err(e) => return err_internal("fastembed service unavailable", e),
         };
+        // Op validation (EMBEDDING_EMBED / EMBEDDING_COUNT_TOKENS, plus an
+        // `Unimplemented` terminal for anything else) lives in
+        // `handle_embedding_message`. Both embedding wrappers delegate the
+        // whole message here — neither carries its own `ServiceOp` check.
         handle_embedding_message(svc, &msg, &body).await
     }
-
-    async fn lifecycle(
-        &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        Ok(())
-    }
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/fastembed", FastembedBlock);

--- a/crates/solobase-core/src/blocks/feature_block.rs
+++ b/crates/solobase-core/src/blocks/feature_block.rs
@@ -59,11 +59,11 @@
 /// detail, not public API.
 #[doc(hidden)]
 pub mod __private {
+    pub use wafer_block::wafer_async_trait;
     pub use wafer_run::{
         context::Context, Block, BlockInfo, InputStream, LifecycleEvent, Message, OutputStream,
         WaferError,
     };
-    pub use wafer_block::wafer_async_trait;
 }
 
 /// Generate a solobase feature block's struct, constructor, `Default`, and

--- a/crates/solobase-core/src/blocks/feature_block.rs
+++ b/crates/solobase-core/src/blocks/feature_block.rs
@@ -1,0 +1,153 @@
+//! `solobase_feature_block!` — declarative scaffolding for solobase feature
+//! blocks.
+//!
+//! Every `suppers-ai/*` feature block repeated the same boilerplate around its
+//! genuinely-custom `info()` / `handle()` bodies:
+//!
+//! - a unit (or single-field) struct + `new()` + `Default` delegating to `new()`;
+//! - the two-line `#[cfg_attr(..., async_trait::async_trait)]` /
+//!   `#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]`
+//!   pair on the `impl Block` (now collapsed to wafer-block-macro's
+//!   [`wafer_async_trait`](wafer_block::wafer_async_trait));
+//! - a `lifecycle(Init)` body that runs the block's migrations (now folded into
+//!   [`crate::migration_helper::lifecycle_init`]).
+//!
+//! This macro is the solobase analogue of wafer-core's `service_block!`
+//! (W3-O): it owns the scaffolding so each block file carries only its `info`,
+//! `handle`, and (optional) `lifecycle` expressions. Registration is **not**
+//! generated here — it comes from the single `(feature, name, constructor)`
+//! manifest in [`crate::blocks`] (see `register_feature_blocks` /
+//! `all_block_infos`), so there is exactly one place enumerating the block set.
+//!
+//! # Forms
+//!
+//! ```ignore
+//! // Unit-struct block. `info`/`handle` are expression bindings inlined into
+//! // the generated method bodies, so `.await` / `?` work directly.
+//! solobase_feature_block! {
+//!     /// Doc comment for the struct.
+//!     pub struct VectorBlock;
+//!     name: "suppers-ai/vector",
+//!     info: |this| { /* -> BlockInfo */ },
+//!     handle: |this, ctx, msg, input| { /* -> OutputStream */ },
+//!     lifecycle: |this, ctx, event| { /* -> Result<(), WaferError> */ },
+//! }
+//!
+//! // Field-bearing block. `fields` become private struct fields, initialized
+//! // from `Default::default()` in `new()`.
+//! solobase_feature_block! {
+//!     pub struct FilesBlock;
+//!     fields: { limiter: UserRateLimiter },
+//!     name: "suppers-ai/files",
+//!     info: |this| { /* ... */ },
+//!     handle: |this, ctx, msg, input| { /* ... */ },
+//!     lifecycle: |this, ctx, event| { /* ... */ },
+//! }
+//! ```
+//!
+//! The `info`/`handle`/`lifecycle` bindings look like closures but are not:
+//! each is inlined into the generated method body, so the block module's own
+//! `use` imports are in scope and `?`/`.await` resolve against the method's
+//! signature. Bindings the body doesn't use must be spelled with a leading
+//! underscore (`_this`, `_ctx`), exactly like unused function parameters.
+//!
+//! `lifecycle` is optional; when omitted the `Block` trait's no-op default is
+//! used (the embedding wrappers, which have no migrations, rely on this).
+
+/// Support module re-exporting every item the [`solobase_feature_block!`]
+/// expansion references through `$crate::…` paths. Hidden: it is an expansion
+/// detail, not public API.
+#[doc(hidden)]
+pub mod __private {
+    pub use wafer_run::{
+        context::Context, Block, BlockInfo, InputStream, LifecycleEvent, Message, OutputStream,
+        WaferError,
+    };
+    pub use wafer_block::wafer_async_trait;
+}
+
+/// Generate a solobase feature block's struct, constructor, `Default`, and
+/// `impl Block` scaffolding. See the [module docs](self) for the forms and the
+/// binding semantics.
+#[macro_export]
+macro_rules! solobase_feature_block {
+    (
+        $(#[$attr:meta])*
+        $vis:vis struct $block:ident;
+        $(fields: { $($field:ident : $fty:ty),+ $(,)? },)?
+        name: $name:literal,
+        info: |$ithis:ident| $iexpr:expr,
+        handle: |$hthis:ident, $hctx:ident, $hmsg:ident, $hinput:ident| $hexpr:expr,
+        $(lifecycle: |$lthis:ident, $lctx:ident, $levent:ident| $lexpr:expr,)?
+    ) => {
+        $(#[$attr])*
+        $vis struct $block {
+            $($($field: $fty,)+)?
+        }
+
+        impl $block {
+            #[doc = concat!("Construct a [`", stringify!($block), "`].")]
+            pub fn new() -> Self {
+                Self {
+                    $($($field: ::core::default::Default::default(),)+)?
+                }
+            }
+        }
+
+        impl ::core::default::Default for $block {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        #[$crate::blocks::feature_block::__private::wafer_async_trait]
+        impl $crate::blocks::feature_block::__private::Block for $block {
+            fn info(&self) -> $crate::blocks::feature_block::__private::BlockInfo {
+                let $ithis = self;
+                $iexpr
+            }
+
+            async fn handle(
+                &self,
+                ctx: &dyn $crate::blocks::feature_block::__private::Context,
+                msg: $crate::blocks::feature_block::__private::Message,
+                input: $crate::blocks::feature_block::__private::InputStream,
+            ) -> $crate::blocks::feature_block::__private::OutputStream {
+                let $hthis = self;
+                let $hctx = ctx;
+                // Some blocks mutate `msg` in their dispatch (e.g. messages'
+                // `endpoint_match::dispatch(&mut msg, …)`); others don't. Bind
+                // `mut` unconditionally and silence the lint for the
+                // non-mutating blocks.
+                #[allow(unused_mut)]
+                let mut $hmsg = msg;
+                let $hinput = input;
+                $hexpr
+            }
+
+            $(
+                async fn lifecycle(
+                    &self,
+                    ctx: &dyn $crate::blocks::feature_block::__private::Context,
+                    event: $crate::blocks::feature_block::__private::LifecycleEvent,
+                ) -> ::std::result::Result<
+                    (),
+                    $crate::blocks::feature_block::__private::WaferError,
+                > {
+                    let $lthis = self;
+                    let $lctx = ctx;
+                    let $levent = event;
+                    $lexpr
+                }
+            )?
+        }
+
+        impl $block {
+            /// The block's registered name (`{org}/{block}`). The single
+            /// `(feature, name, constructor)` manifest in [`crate::blocks`]
+            /// references this so a block's declared `info().name` and its
+            /// registration key can't drift.
+            pub const BLOCK_NAME: &'static str = $name;
+        }
+    };
+}

--- a/crates/solobase-core/src/blocks/files/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/files/migrations/mod.rs
@@ -1,18 +1,13 @@
-//! Files block migrations. Delegated to `crate::migration_helper`.
-
-use wafer_run::context::Context;
-
-use crate::migration_helper;
+//! Files block migrations. Applied from the block's `Init` lifecycle via
+//! [`crate::migration_helper::lifecycle_init`].
 
 const SQL_001_SQLITE: &str = include_str!("001_initial_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_initial_schema.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_initial_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, "suppers-ai/files", &sqlite, &[SQL_001_POSTGRES]).await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -16,36 +16,17 @@ pub(crate) use storage::{BUCKETS_TABLE, OBJECTS_TABLE};
 /// (`record_view`) — so the constant lives in mod.rs.
 pub(crate) const VIEWS_TABLE: &str = "suppers_ai__files__views";
 
-use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, InputStream, InstanceMode, LifecycleEvent,
-    LifecycleType, Message, OutputStream, WaferError,
-};
+use wafer_run::{BlockEndpoint, BlockInfo, InstanceMode};
 
 use super::rate_limit::{check_user_rate_limit_with, RateLimit, RateLimitOutcome, UserRateLimiter};
 use crate::blocks::helpers::err_not_found;
 
-pub struct FilesBlock {
-    limiter: UserRateLimiter,
-}
-
-impl Default for FilesBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl FilesBlock {
-    pub fn new() -> Self {
-        Self {
-            limiter: UserRateLimiter::new(),
-        }
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for FilesBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// File storage: buckets, objects, shares, quotas (`suppers-ai/files`).
+    pub struct FilesBlock;
+    fields: { limiter: UserRateLimiter },
+    name: "suppers-ai/files",
+    info: |_this| {
         use wafer_run::{AuthLevel, CollectionSchema};
 
         BlockInfo::new("suppers-ai/files", "0.0.1", "http-handler@v1", "File storage, sharing, quotas, and access logging")
@@ -103,9 +84,8 @@ impl Block for FilesBlock {
             ])
             .admin_url("/b/storage/admin/")
             .can_disable(true)
-    }
-
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         let path = msg.path().to_string();
 
         // Admin-block delegation: when the Admin block routes a request for
@@ -140,7 +120,7 @@ impl Block for FilesBlock {
         // per remote IP inside the handler to stop token enumeration / DOS.
         // Matches the REAL on-the-wire path (no `req.resource` rewrite).
         if path.starts_with("/b/storage/direct/") {
-            return share::handle_direct_access(ctx, &msg, &self.limiter).await;
+            return share::handle_direct_access(ctx, &msg, &this.limiter).await;
         }
 
         // Require authentication for all non-public endpoints
@@ -155,7 +135,7 @@ impl Block for FilesBlock {
         // to a streaming response would need platform-side middleware to
         // inject the headers after the handler returns its OutputStream.
         if let RateLimitOutcome::Limited(r) = check_user_rate_limit_with(
-            &self.limiter,
+            &this.limiter,
             ctx,
             &msg,
             Some((RateLimit::UPLOAD, "upload")),
@@ -214,27 +194,18 @@ impl Block for FilesBlock {
         }
 
         err_not_found("not found")
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("files migrations: {e}"),
-                )
-            })?;
-        }
-        Ok(())
-    }
+    },
+    lifecycle: |_this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/files",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/files", FilesBlock);
 
 #[cfg(test)]
 mod schema_tests {

--- a/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/migrations/mod.rs
@@ -1,19 +1,13 @@
-//! Legalpages block migrations. Delegated to `crate::migration_helper`.
-
-use wafer_run::context::Context;
-
-use crate::migration_helper;
+//! Legalpages block migrations. Applied from the block's `Init` lifecycle via
+//! [`crate::migration_helper::lifecycle_init`].
 
 const SQL_001_SQLITE: &str = include_str!("001_legalpages_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_legalpages_schema.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_legalpages_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, "suppers-ai/legalpages", &sqlite, &[SQL_001_POSTGRES])
-        .await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -6,9 +6,8 @@ use maud::{html, Markup, PreEscaped};
 use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, ErrorCode, HttpMethod,
-    InputStream, InputType, InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream,
-    WaferError,
+    context::Context, BlockEndpoint, BlockInfo, ConfigVar, ErrorCode, HttpMethod, InputStream,
+    InputType, InstanceMode, Message, OutputStream,
 };
 
 use crate::{
@@ -157,20 +156,6 @@ pub(crate) fn config_vars() -> Vec<ConfigVar> {
         .name("Footer Text")
         .optional(),
     ]
-}
-
-pub struct LegalPagesBlock;
-
-impl LegalPagesBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for LegalPagesBlock {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 pub(crate) const COLLECTION: &str = "suppers_ai__legalpages__documents";
@@ -587,10 +572,11 @@ fn safe_url(url: pulldown_cmark::CowStr<'_>) -> pulldown_cmark::CowStr<'_> {
 // Block trait implementation
 // ---------------------------------------------------------------------------
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for LegalPagesBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Legal pages management with versioning and publishing (`suppers-ai/legalpages`).
+    pub struct LegalPagesBlock;
+    name: "suppers-ai/legalpages",
+    info: |_this| {
         use wafer_run::AuthLevel;
 
         BlockInfo::new("suppers-ai/legalpages", "0.0.1", "http-handler@v1", "Legal pages management with versioning and publishing")
@@ -626,14 +612,8 @@ impl Block for LegalPagesBlock {
             .admin_url("/b/legalpages/admin")
             .can_disable(true)
             .default_enabled(false)
-    }
-
-    async fn handle(
-        &self,
-        ctx: &dyn Context,
-        mut msg: Message,
-        input: InputStream,
-    ) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         // Auth is enforced centrally by `route_to_block` from the declared
         // endpoint `AuthLevel` (public reads, admin everything else) — the
         // block holds no `is_admin` preamble. Dispatch matches the same
@@ -642,8 +622,8 @@ impl Block for LegalPagesBlock {
             return ui::not_found_response(&msg);
         };
         match route {
-            Route::PublicTerms => self.handle_get_public(ctx, "terms").await,
-            Route::PublicPrivacy => self.handle_get_public(ctx, "privacy").await,
+            Route::PublicTerms => this.handle_get_public(ctx, "terms").await,
+            Route::PublicPrivacy => this.handle_get_public(ctx, "privacy").await,
             Route::EditorPrivacy => pages::editor_page(ctx, &msg, "privacy").await,
             Route::EditorTerms => pages::editor_page(ctx, &msg, "terms").await,
             Route::SettingsPage => pages::settings_page(ctx, &msg).await,
@@ -652,12 +632,12 @@ impl Block for LegalPagesBlock {
             Route::AdminRenderPreview => pages::handle_render_preview(ctx, input).await,
             Route::AdminPublish => pages::handle_publish(ctx, &msg, input).await,
             Route::AdminSaveSettings => pages::handle_save_settings(ctx, input).await,
-            Route::ApiList => self.handle_admin_list(ctx, &msg).await,
+            Route::ApiList => this.handle_admin_list(ctx, &msg).await,
             Route::ApiGet => {
                 crud::crud_get(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
             }
-            Route::ApiCreate => self.handle_admin_create(ctx, &msg, input).await,
-            Route::ApiPublish => self.handle_admin_publish(ctx, &msg).await,
+            Route::ApiCreate => this.handle_admin_create(ctx, &msg, input).await,
+            Route::ApiPublish => this.handle_admin_publish(ctx, &msg).await,
             Route::ApiUpdate => {
                 crud::crud_update(ctx, &msg, input, COLLECTION, API_DOC_PREFIX, "Document").await
             }
@@ -665,28 +645,23 @@ impl Block for LegalPagesBlock {
                 crud::crud_delete(ctx, &msg, COLLECTION, API_DOC_PREFIX, "Document").await
             }
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("legalpages migrations: {e}"),
-                )
-            })?;
-            self.seed_defaults(ctx).await;
+    },
+    lifecycle: |this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/legalpages",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await?;
+        // Seed the default draft documents after migrations, only on Init.
+        if matches!(event.event_type, wafer_run::LifecycleType::Init) {
+            this.seed_defaults(ctx).await;
         }
         Ok(())
-    }
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/legalpages", LegalPagesBlock);
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/legalpages/service.rs
+++ b/crates/solobase-core/src/blocks/legalpages/service.rs
@@ -168,10 +168,20 @@ mod tests {
     use crate::test_support::TestContext;
 
     async fn ctx_with_schema() -> TestContext {
+        use super::super::migrations;
         let ctx = TestContext::with_admin().await;
-        super::super::migrations::apply(&ctx)
-            .await
-            .expect("apply legalpages migrations");
+        let sqlite: Vec<&str> = migrations::SQLITE_MIGRATIONS
+            .iter()
+            .map(|(_, sql)| *sql)
+            .collect();
+        crate::migration_helper::apply_migrations(
+            &ctx,
+            "suppers-ai/legalpages",
+            &sqlite,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+        .expect("apply legalpages migrations");
         ctx
     }
 

--- a/crates/solobase-core/src/blocks/llm/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/migrations/mod.rs
@@ -15,29 +15,21 @@
 
 pub(in crate::blocks::llm) mod legacy_providers;
 
-use wafer_run::context::Context;
-
-use crate::migration_helper;
-
-const LLM_BLOCK_NAME: &str = "suppers-ai/llm";
-
 const SQL_001_SQLITE: &str = include_str!("001_llm_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_llm_schema.postgres.sql");
 
-/// Apply LLM schema migrations through the shared migration-state gate.
-/// Idempotent across cold starts: once the gate stamps a `current_hash`
-/// row in `block_settings`, subsequent boots short-circuit before issuing
-/// any DDL. Schema changes require a `--run-migrations` redeploy (see
-/// `migration-state-workflow` in user memory).
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
+///
+/// Application is gated by the shared migration-state gate
+/// ([`crate::migration_helper::apply_if_blessed`]): idempotent across cold
+/// starts, and schema changes require a `--run-migrations` redeploy (see
+/// `migration-state-workflow` in user memory).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_llm_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, LLM_BLOCK_NAME, &sqlite, &[SQL_001_POSTGRES]).await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/llm/mod.rs
+++ b/crates/solobase-core/src/blocks/llm/mod.rs
@@ -386,8 +386,7 @@ impl LlmBlock {
 // Block trait implementation
 // ---------------------------------------------------------------------------
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[wafer_block::wafer_async_trait]
 impl Block for LlmBlock {
     fn info(&self) -> BlockInfo {
         use wafer_run::AuthLevel;
@@ -551,16 +550,19 @@ impl Block for LlmBlock {
         ctx: &dyn Context,
         event: LifecycleEvent,
     ) -> std::result::Result<(), WaferError> {
+        // Schema migrations first — must run before any row-level work below,
+        // otherwise the legacy-row copy + reload would hit ensure_table
+        // fallback paths instead of the indexed table. `lifecycle_init`
+        // no-ops on non-Init events.
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/llm",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await?;
         if matches!(event.event_type, LifecycleType::Init) {
-            // Schema migrations first — must run before any row-level work
-            // below, otherwise the legacy-row copy + reload would hit
-            // ensure_table fallback paths instead of the indexed table.
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("llm migrations: {e}"),
-                )
-            })?;
             // One-shot row copy from `suppers_ai__provider_llm__providers`.
             // Idempotent: if the legacy table is gone, returns immediately.
             // Any per-row failure is logged, not fatal — admins can inspect

--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -1251,9 +1251,21 @@ mod tests {
         use crate::test_support::TestContext;
 
         let mut ctx = TestContext::with_admin().await;
-        crate::blocks::llm::migrations::apply(&ctx)
+        {
+            use crate::blocks::llm::migrations;
+            let sqlite: Vec<&str> = migrations::SQLITE_MIGRATIONS
+                .iter()
+                .map(|(_, sql)| *sql)
+                .collect();
+            crate::migration_helper::apply_migrations(
+                &ctx,
+                "suppers-ai/llm",
+                &sqlite,
+                migrations::POSTGRES_MIGRATIONS,
+            )
             .await
             .expect("apply llm migrations");
+        }
 
         let config_svc = Arc::new(EnvConfigService::new());
         config_svc.set("SUPPERS_AI__LLM__OPENAI_KEY", "sk-resolved");

--- a/crates/solobase-core/src/blocks/messages/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/migrations/mod.rs
@@ -1,23 +1,19 @@
-//! Messages block migrations. Backend dispatch + apply gating live in
-//! [`crate::migration_helper::apply_migrations`].
-
-use wafer_run::context::Context;
-
-use crate::migration_helper;
+//! Messages block migrations. The block's `lifecycle(Init)` runs these via
+//! [`crate::migration_helper::lifecycle_init`], which dispatches the dialect +
+//! gates the apply through [`crate::migration_helper::apply_migrations`].
 
 const SQL_001_SQLITE: &str = include_str!("001_messages_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_messages_schema.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_messages_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, "suppers-ai/messages", &sqlite, &[SQL_001_POSTGRES])
-        .await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`] one
+/// for one. Selected at runtime by `apply_migrations` when the deployment's
+/// `SOLOBASE_SHARED__DATABASE__BACKEND` is `postgres`.
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/messages/mod.rs
+++ b/crates/solobase-core/src/blocks/messages/mod.rs
@@ -4,10 +4,7 @@ pub mod pages;
 pub mod rest;
 pub mod service;
 
-use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, HttpMethod, InputStream, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
-};
+use wafer_run::{BlockEndpoint, BlockInfo, HttpMethod, InstanceMode};
 
 use crate::{
     blocks::helpers::err_not_found,
@@ -88,24 +85,11 @@ const ROUTES: &[EndpointRoute<Route>] = &[
     ),
 ];
 
-pub struct MessagesBlock;
-
-impl MessagesBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for MessagesBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for MessagesBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Unified message and context system (`suppers-ai/messages`).
+    pub struct MessagesBlock;
+    name: "suppers-ai/messages",
+    info: |_this| {
         use wafer_block::types::ResourceGrant;
         use wafer_run::{AuthLevel, CollectionSchema};
 
@@ -267,14 +251,8 @@ impl Block for MessagesBlock {
         ])
         .can_disable(true)
         .default_enabled(true)
-    }
-
-    async fn handle(
-        &self,
-        ctx: &dyn Context,
-        mut msg: Message,
-        input: InputStream,
-    ) -> OutputStream {
+    },
+    handle: |_this, ctx, msg, input| {
         // A2A JSON-RPC endpoint — protocol-public (auth handled by the
         // JSON-RPC method handlers themselves). It does NOT pass through the
         // central router's prefix table: the shared pipeline dispatches `/a2a`
@@ -305,24 +283,15 @@ impl Block for MessagesBlock {
             Route::GetEntry => rest::get_entry(ctx, &msg).await,
             Route::DeleteEntry => rest::delete_entry(ctx, &msg).await,
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("messages migrations: {e}"),
-                )
-            })?;
-        }
-        Ok(())
-    }
+    },
+    lifecycle: |_this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/messages",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/messages", MessagesBlock);

--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -4,6 +4,8 @@ pub mod auth_ui;
 pub mod crud;
 pub mod email;
 pub mod errors;
+#[macro_use]
+pub mod feature_block;
 // `native-embedding` always implies `block-fastembed` (see Cargo.toml), so
 // the native build still gets this module. wafer-site / wasm32 builds with
 // neither feature drop the ONNX-runtime dep entirely.
@@ -41,64 +43,111 @@ pub mod userportal;
 #[cfg(feature = "block-vector")]
 pub mod vector;
 
-/// Return `BlockInfo` for every solobase block.
+/// The single `(feature-cfg, name, constructor)` manifest of solobase feature
+/// blocks whose constructors take **no arguments** (every `suppers-ai/*` block
+/// except the three special cases below).
 ///
-/// This is the single canonical source of truth for both native and wasm32.
-/// Previously, native used `linkme`/`STATIC_BLOCK_REGISTRATIONS` iteration
-/// and wasm32 had a separate manual list — see audit finding #13.
+/// This macro is the one place enumerating that block set. It generates, from
+/// the same entries:
 ///
-/// The two lists had diverged: the native linkme sweep also picked up
-/// `wafer-run/*` framework blocks (cors, inspector, etc.) that were never
-/// relevant to `collect_all_config_vars`, and the wasm32 list included the
-/// framework `AuthBlock` whose config vars are declared via
-/// `shared_config_vars()` → `auth_config_vars()` rather than
-/// `BlockInfo::config_keys`, making it redundant there too. This function
-/// enumerates only the solobase feature blocks, consistently on both targets.
+/// - [`all_block_infos`] — `.info()` over every entry (config-var discovery,
+///   inspector route granularity, the route/auth policy table);
+/// - [`register_feature_blocks`] — `register_block(name, Arc::new(Ctor::new()))`
+///   over every entry, called from `SolobaseBuilder::build` on **both** native
+///   and wasm32.
 ///
-/// Used by `collect_all_config_vars()` to discover declared config
-/// variables before block registration runs.
-pub fn all_block_infos() -> Vec<wafer_run::BlockInfo> {
-    use wafer_run::Block as _;
+/// Replaces the three formerly hand-synced lists (per-block `register_static_block!`
+/// linkme sites on native, the `register_all_static_blocks` wasm32 list, and
+/// the `all_block_infos` push list) — audit findings #12/#13. A block is now
+/// added in exactly one place.
+///
+/// Each entry's `cfg` gates the block on its `block-*` Cargo feature; the
+/// dual-target blocks compile with no `cfg` (always on). `fastembed` carries
+/// `feature = "block-fastembed"`, which is never enabled on wasm32 (it pulls
+/// ONNX Runtime — see the `pub mod fastembed` cfg above), so the same gate
+/// covers "native-only" without a redundant `not(target_arch = "wasm32")`.
+///
+/// Special cases stay **out** of the manifest and are registered explicitly by
+/// `SolobaseBuilder::build`, because their constructors are not zero-argument:
+/// `suppers-ai/llm` (`Arc<dyn ProviderAdmin>`, via [`register_llm`]),
+/// `suppers-ai/auth` (framework `AuthBlock` wrapping `AuthServiceImpl`, via
+/// [`register_auth`]), and `suppers-ai/transformers-embed` (wasm32-only,
+/// injected `Arc<dyn EmbeddingService>`). `llm`'s `BlockInfo` is still added to
+/// [`all_block_infos`] below via a `NoopProviderAdmin` handle (info is
+/// declarative and never drives the provider surface).
+macro_rules! feature_block_manifest {
+    ( $( $(#[$cfg:meta])? $ctor:path ),+ $(,)? ) => {
+        /// `BlockInfo` for every zero-arg solobase feature block, plus the
+        /// `suppers-ai/llm` block (constructed with a `NoopProviderAdmin`).
+        ///
+        /// Used by `collect_all_config_vars()` to discover declared config
+        /// variables, by the inspector route table, and by the routing/auth
+        /// policy, before block registration runs.
+        pub fn all_block_infos() -> Vec<wafer_run::BlockInfo> {
+            use wafer_run::Block as _;
+            #[allow(unused_mut)]
+            let mut infos: Vec<wafer_run::BlockInfo> = Vec::new();
+            $(
+                $(#[$cfg])?
+                infos.push(<$ctor>::new().info());
+            )+
 
-    // `unused_mut` fires when every optional feature is off and no later
-    // `.push(...)` exists to mutate the vec.
-    #[allow(unused_mut)]
-    let mut infos: Vec<wafer_run::BlockInfo> = vec![
-        admin::AdminBlock::new().info(),
-        auth_ui::AuthUiBlock::default().info(),
-        email::EmailBlock::new().info(),
-        system::SystemBlock::new().info(),
-    ];
+            // `suppers-ai/llm` is registered separately (its ctor takes
+            // `Arc<dyn ProviderAdmin>`), but its declarative `info()` belongs
+            // in the discovery set. A no-op provider-admin handle suffices.
+            #[cfg(feature = "block-llm")]
+            infos.push(
+                llm::LlmBlock::new(std::sync::Arc::new(llm::provider_admin::NoopProviderAdmin))
+                    .info(),
+            );
 
+            infos
+        }
+
+        /// Register every zero-arg solobase feature block on the runtime.
+        ///
+        /// Called from `SolobaseBuilder::build` on **both** native and wasm32 —
+        /// there is no longer a native (linkme) / wasm32 (manual list) split.
+        /// The `suppers-ai/llm`, `suppers-ai/auth`, and (wasm32)
+        /// `suppers-ai/transformers-embed` blocks are registered explicitly by
+        /// the builder afterwards (non-zero-arg constructors).
+        pub fn register_feature_blocks(
+            wafer: &mut wafer_run::Wafer,
+        ) -> Result<(), wafer_run::RuntimeError> {
+            use std::sync::Arc;
+            $(
+                $(#[$cfg])?
+                wafer.register_block(
+                    <$ctor>::BLOCK_NAME,
+                    Arc::new(<$ctor>::new()),
+                )?;
+            )+
+            Ok(())
+        }
+    };
+}
+
+feature_block_manifest! {
+    admin::AdminBlock,
+    auth_ui::AuthUiBlock,
+    email::EmailBlock,
+    system::SystemBlock,
     #[cfg(feature = "block-files")]
-    infos.push(files::FilesBlock::new().info());
+    files::FilesBlock,
     #[cfg(feature = "block-legalpages")]
-    infos.push(legalpages::LegalPagesBlock::new().info());
+    legalpages::LegalPagesBlock,
     #[cfg(feature = "block-messages")]
-    infos.push(messages::MessagesBlock::new().info());
+    messages::MessagesBlock,
     #[cfg(feature = "block-products")]
-    infos.push(products::ProductsBlock::new().info());
+    products::ProductsBlock,
     #[cfg(feature = "block-userportal")]
-    infos.push(userportal::UserPortalBlock::new().info());
+    userportal::UserPortalBlock,
     #[cfg(feature = "block-vector")]
-    infos.push(vector::VectorBlock::new().info());
-
-    // fastembed is native-only: it requires ONNX Runtime which is not
-    // available on wasm32.
+    vector::VectorBlock,
+    // Native-only: fastembed pulls ONNX Runtime; `block-fastembed` is never
+    // enabled on wasm32, so this gate doubles as "not wasm32".
     #[cfg(feature = "block-fastembed")]
-    infos.push(fastembed::FastembedBlock::new().info());
-
-    // LlmBlock cannot self-register because its constructor takes
-    // Arc<dyn ProviderAdmin>. A no-op provider-admin handle is enough here
-    // since info() is declarative and never drives the provider surface.
-    #[cfg(feature = "block-llm")]
-    {
-        use std::sync::Arc;
-        let provider_admin = Arc::new(llm::provider_admin::NoopProviderAdmin);
-        infos.push(llm::LlmBlock::new(provider_admin).info());
-    }
-
-    infos
+    fastembed::FastembedBlock,
 }
 
 /// Collect every compiled block's ordered SQLite migration scripts for the
@@ -160,9 +209,9 @@ pub fn all_sqlite_migrations() -> Vec<(String, &'static str)> {
 
 /// Register the LLM feature block with the WAFER runtime.
 ///
-/// LlmBlock cannot self-register via `register_static_block!` because its
-/// constructor takes `Arc<dyn ProviderAdmin>`. Call this after the LLM
-/// service router is registered in `SolobaseBuilder::build()`.
+/// LlmBlock is not in the feature-block manifest because its constructor takes
+/// `Arc<dyn ProviderAdmin>`. Call this after the LLM service router is
+/// registered in `SolobaseBuilder::build()`.
 ///
 /// `provider_admin` is the provider-management seam: the concrete
 /// `ProviderLlmService` on native (`feature = "llm"`) or a `NoopProviderAdmin`
@@ -182,10 +231,10 @@ pub fn register_llm(
 /// Register the framework `suppers-ai/auth` block — wafer-core's `AuthBlock`
 /// wrapping solobase's `AuthServiceImpl`.
 ///
-/// Cannot self-register via `register_static_block!` because the framework
-/// `AuthBlock::new` takes `Arc<dyn AuthService>`. Call this from
-/// `SolobaseBuilder::build` (native) or `register_all_static_blocks` (wasm32)
-/// to install both the block and the service.
+/// Cannot self-register via the feature-block manifest because the framework
+/// `AuthBlock::new` takes `Arc<dyn AuthService>`. Called explicitly from
+/// `SolobaseBuilder::build` (both targets) to install both the block and the
+/// service.
 ///
 /// The `AuthServiceImpl`'s context cell starts empty here; it gets populated
 /// when the runtime fires the framework AuthBlock's `lifecycle(Init)` event,
@@ -196,79 +245,6 @@ pub fn register_auth(wafer: &mut wafer_run::Wafer) -> Result<(), wafer_run::Runt
     let state = auth::service::BlockState::new();
     let svc = Arc::new(auth::service::AuthServiceImpl::new(state));
     wafer_core::service_blocks::auth::register_with(wafer, svc)
-}
-
-/// Register every solobase feature block on wasm32 builds.
-///
-/// On native, each block self-registers via `register_static_block!` (gated
-/// `cfg(not(target_arch = "wasm32"))` because linkme's distributed_slice
-/// only emits on ELF/Mach-O/PE — see `wafer_run::builder::WaferBuilder::build`).
-/// On wasm32 that path is a no-op, so the runtime starts with zero
-/// `suppers-ai/*` blocks and the SolobaseRouter dispatches into a void —
-/// every feature route returns `block 'suppers-ai/<name>' not found`.
-///
-/// This helper mirrors the linkme manifest so wasm builds get the same
-/// block set. Keep this list in sync with the `register_static_block!`
-/// invocations across `crate::blocks::*` and with the `all_block_infos`
-/// wasm32 fallback above.
-///
-/// Excludes `suppers-ai/fastembed` (native-only, requires
-/// `feature = "native-embedding"`). `suppers-ai/llm` IS registered here when
-/// `block-llm` is on: the block now holds `Arc<dyn ProviderAdmin>`, so the
-/// wasm32 build installs it with a `NoopProviderAdmin` (the browser's
-/// `BrowserLlmService` on the shared router serves chat; provider CRUD /
-/// discovery are admin-only and degrade to no-ops).
-#[cfg(target_arch = "wasm32")]
-pub fn register_all_static_blocks(
-    wafer: &mut wafer_run::Wafer,
-) -> Result<(), wafer_run::RuntimeError> {
-    use std::sync::Arc;
-
-    wafer.register_block("suppers-ai/admin", Arc::new(admin::AdminBlock::new()))?;
-    // Framework `suppers-ai/auth` is registered unconditionally by
-    // `SolobaseBuilder::build` (after this fn returns) — don't duplicate
-    // here, the second register_block would fail with "block already
-    // registered" and abort the wasm boot.
-    wafer.register_block(
-        "suppers-ai/auth-ui",
-        Arc::new(auth_ui::AuthUiBlock::default()),
-    )?;
-    wafer.register_block("suppers-ai/email", Arc::new(email::EmailBlock::new()))?;
-    wafer.register_block("suppers-ai/system", Arc::new(system::SystemBlock::new()))?;
-
-    #[cfg(feature = "block-files")]
-    wafer.register_block("suppers-ai/files", Arc::new(files::FilesBlock::new()))?;
-    #[cfg(feature = "block-legalpages")]
-    wafer.register_block(
-        "suppers-ai/legalpages",
-        Arc::new(legalpages::LegalPagesBlock::new()),
-    )?;
-    #[cfg(feature = "block-messages")]
-    wafer.register_block(
-        "suppers-ai/messages",
-        Arc::new(messages::MessagesBlock::new()),
-    )?;
-    #[cfg(feature = "block-products")]
-    wafer.register_block(
-        "suppers-ai/products",
-        Arc::new(products::ProductsBlock::new()),
-    )?;
-    #[cfg(feature = "block-userportal")]
-    wafer.register_block(
-        "suppers-ai/userportal",
-        Arc::new(userportal::UserPortalBlock::new()),
-    )?;
-    #[cfg(feature = "block-vector")]
-    wafer.register_block("suppers-ai/vector", Arc::new(vector::VectorBlock::new()))?;
-
-    // The LLM block runs on wasm32 against a browser-supplied `LlmService`
-    // (registered on the router via `SolobaseBuilder::llm_service`). Provider
-    // CRUD / discovery have no browser surface, so a `NoopProviderAdmin`
-    // stands in for the native HTTP `ProviderLlmService`.
-    #[cfg(feature = "block-llm")]
-    register_llm(wafer, Arc::new(llm::provider_admin::NoopProviderAdmin))?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/products/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/products/migrations/mod.rs
@@ -1,4 +1,5 @@
-//! Products block migrations. Delegated to `crate::migration_helper`.
+//! Products block migrations. Applied from the block's `Init` lifecycle via
+//! [`crate::migration_helper::lifecycle_init`].
 //!
 //! Mirrors the auth/files migration pattern. SQL is embedded via
 //! `include_str!`. Backend selection reads the
@@ -11,33 +12,19 @@
 //! `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate, and stamps a row in
 //! `suppers_ai__admin__block_settings` once applied.
 
-use wafer_run::context::Context;
-
-use crate::migration_helper;
-
-const PRODUCTS_BLOCK_NAME: &str = "suppers-ai/products";
-
 const SQL_001_SQLITE: &str = include_str!("001_products_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_products_schema.postgres.sql");
 const SQL_002_SQLITE: &str = include_str!("002_default_templates.sqlite.sql");
 const SQL_002_POSTGRES: &str = include_str!("002_default_templates.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`). Order here
-/// is the apply order.
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
+/// Order here is the apply order.
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
     ("001_products_schema", SQL_001_SQLITE),
     ("002_default_templates", SQL_002_SQLITE),
 ];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(
-        ctx,
-        PRODUCTS_BLOCK_NAME,
-        &sqlite,
-        &[SQL_001_POSTGRES, SQL_002_POSTGRES],
-    )
-    .await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES, SQL_002_POSTGRES];

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -16,10 +16,7 @@ pub(crate) use handlers::{
 pub(crate) use pricing::TABLE as PRICING_TABLE;
 pub(crate) use repo::purchases::{LINE_ITEMS_TABLE, PURCHASES_TABLE};
 pub(crate) use variables::TABLE as VARIABLES_TABLE;
-use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, ConfigVar, InputStream, InputType,
-    InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
-};
+use wafer_run::{BlockEndpoint, BlockInfo, ConfigVar, InputType, InstanceMode};
 
 use super::rate_limit::{check_user_rate_limit, RateLimitOutcome, UserRateLimiter};
 use crate::blocks::helpers::err_not_found;
@@ -71,28 +68,12 @@ pub(crate) fn config_vars() -> Vec<ConfigVar> {
     ]
 }
 
-pub struct ProductsBlock {
-    limiter: UserRateLimiter,
-}
-
-impl Default for ProductsBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ProductsBlock {
-    pub fn new() -> Self {
-        Self {
-            limiter: UserRateLimiter::new(),
-        }
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for ProductsBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Products, groups, pricing, purchases, subscriptions (`suppers-ai/products`).
+    pub struct ProductsBlock;
+    fields: { limiter: UserRateLimiter },
+    name: "suppers-ai/products",
+    info: |_this| {
         use wafer_run::{AuthLevel, CollectionSchema};
 
         BlockInfo::new("suppers-ai/products", "0.0.1", "http-handler@v1", "Products, pricing, purchases, and payment integration")
@@ -188,14 +169,8 @@ impl Block for ProductsBlock {
             .config_keys(config_vars())
             .admin_url("/b/products/admin/")
             .can_disable(true)
-    }
-
-    async fn handle(
-        &self,
-        ctx: &dyn Context,
-        mut msg: Message,
-        input: InputStream,
-    ) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         let path = msg.path().to_string();
         let action = msg.action().to_string();
 
@@ -241,7 +216,7 @@ impl Block for ProductsBlock {
         // would need platform-side middleware to inject headers after the
         // handler returns. Limits are still enforced, just not surfaced.
         if let RateLimitOutcome::Limited(out) =
-            check_user_rate_limit(&self.limiter, ctx, &msg).await
+            check_user_rate_limit(&this.limiter, ctx, &msg).await
         {
             return out;
         }
@@ -270,29 +245,20 @@ impl Block for ProductsBlock {
         }
 
         err_not_found("not found")
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if event.event_type == LifecycleType::Init {
-            // Apply block-owned schema migrations. Migration 002 seeds the
-            // default group/product templates (the static FK-parent rows the
-            // groups/products tables require) via idempotent INSERTs, so there
-            // is no longer a per-request runtime existence-check + seed here —
-            // the hash-gate short-circuits in memory once applied.
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("products migrations: {e}"),
-                )
-            })?;
-        }
-        Ok(())
-    }
+    },
+    lifecycle: |_this, ctx, event| {
+        // Apply block-owned schema migrations. Migration 002 seeds the default
+        // group/product templates (the static FK-parent rows the
+        // groups/products tables require) via idempotent INSERTs, so there is
+        // no per-request runtime existence-check + seed — the hash-gate
+        // short-circuits in memory once applied.
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/products",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/products", ProductsBlock);

--- a/crates/solobase-core/src/blocks/router.rs
+++ b/crates/solobase-core/src/blocks/router.rs
@@ -56,8 +56,7 @@ impl SolobaseRouterBlock {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[wafer_block::wafer_async_trait]
 impl Block for SolobaseRouterBlock {
     fn info(&self) -> BlockInfo {
         BlockInfo::new(

--- a/crates/solobase-core/src/blocks/storage.rs
+++ b/crates/solobase-core/src/blocks/storage.rs
@@ -250,8 +250,7 @@ fn rewrite_request_body(
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[wafer_block::wafer_async_trait]
 impl Block for SolobaseStorageBlock {
     fn info(&self) -> BlockInfo {
         self.inner.info()

--- a/crates/solobase-core/src/blocks/system.rs
+++ b/crates/solobase-core/src/blocks/system.rs
@@ -1,31 +1,15 @@
-use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, InputStream, InstanceMode, LifecycleEvent,
-    Message, OutputStream, WaferError,
-};
+use wafer_run::{BlockEndpoint, BlockInfo, InstanceMode};
 
 use crate::{
     blocks::helpers::{err_not_found, ok_json, ResponseBuilder},
     ui,
 };
 
-pub struct SystemBlock;
-
-impl SystemBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for SystemBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for SystemBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// System health checks and embedded static assets (`suppers-ai/system`).
+    pub struct SystemBlock;
+    name: "suppers-ai/system",
+    info: |_this| {
         BlockInfo::new("suppers-ai/system", "0.0.1", "http-handler@v1", "System health and embedded static assets")
             .instance_mode(InstanceMode::Singleton)
             .category(wafer_run::BlockCategory::Infrastructure)
@@ -42,9 +26,8 @@ impl Block for SystemBlock {
                 BlockEndpoint::get("/b/static/solobase-logo-long-{hash}.png").summary("Embedded Solobase wordmark logo"),
                 BlockEndpoint::get("/b/static/favicon-{hash}.ico").summary("Embedded Solobase favicon"),
             ])
-    }
-
-    async fn handle(&self, _ctx: &dyn Context, msg: Message, _input: InputStream) -> OutputStream {
+    },
+    handle: |_this, _ctx, msg, _input| {
         let path = msg.path();
 
         if path == "/health" {
@@ -110,23 +93,14 @@ impl Block for SystemBlock {
         }
 
         err_not_found("not found")
-    }
-
-    async fn lifecycle(
-        &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        Ok(())
-    }
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/system", SystemBlock);
 
 #[cfg(test)]
 mod tests {
-    use wafer_run::META_RESP_CONTENT_TYPE;
+    use wafer_run::{
+        context::Context, Block, InputStream, Message, OutputStream, META_RESP_CONTENT_TYPE,
+    };
 
     use super::*;
     use crate::ui::assets;
@@ -156,7 +130,7 @@ mod tests {
 
     #[tokio::test]
     async fn system_handle_serves_llm_chat_js() {
-        let block = SystemBlock;
+        let block = SystemBlock::new();
         let url = assets::llm_chat_js_url();
         let mut msg = Message::new(format!("retrieve:{url}"));
         msg.set_meta(wafer_run::META_REQ_ACTION, "retrieve");
@@ -183,7 +157,7 @@ mod tests {
 
     #[tokio::test]
     async fn system_handle_serves_files_browser_js() {
-        let block = SystemBlock;
+        let block = SystemBlock::new();
         let url = assets::files_browser_js_url();
         let mut msg = Message::new(format!("retrieve:{url}"));
         msg.set_meta(wafer_run::META_REQ_ACTION, "retrieve");

--- a/crates/solobase-core/src/blocks/transformers_embed.rs
+++ b/crates/solobase-core/src/blocks/transformers_embed.rs
@@ -11,11 +11,8 @@ use wafer_core::interfaces::vector::{
     handler::handle_embedding_message, service::EmbeddingService,
 };
 use wafer_run::{
-    common::ServiceOp, context::Context, Block, BlockInfo, InputStream, LifecycleEvent, Message,
-    OutputStream, WaferError,
+    context::Context, Block, BlockInfo, InputStream, InstanceMode, Message, OutputStream,
 };
-
-use crate::blocks::helpers::err_internal;
 
 /// Browser-side embedding block backed by an injected `EmbeddingService`.
 ///
@@ -31,8 +28,7 @@ impl TransformersEmbedBlock {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[wafer_block::wafer_async_trait]
 impl Block for TransformersEmbedBlock {
     fn info(&self) -> BlockInfo {
         BlockInfo::new(
@@ -41,24 +37,22 @@ impl Block for TransformersEmbedBlock {
             "embedding@v1",
             "Browser text embedding via Transformers.js",
         )
+        // Singleton, in lockstep with `FastembedBlock`: the injected
+        // `BrowserEmbeddingService` wraps a single Transformers.js model
+        // instance and must not be re-created per node/flow. Previously this
+        // declaration was omitted (defaulting to per-node) — the drift this
+        // package closes.
+        .instance_mode(InstanceMode::Singleton)
         .category(wafer_run::BlockCategory::Service)
     }
 
     async fn handle(&self, _ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
         let body = input.collect_to_bytes().await;
-        match msg.kind.as_str() {
-            ServiceOp::EMBEDDING_EMBED => {
-                handle_embedding_message(self.service.as_ref(), &msg, &body).await
-            }
-            other => err_internal("unsupported op", other),
-        }
-    }
-
-    async fn lifecycle(
-        &self,
-        _ctx: &dyn Context,
-        _event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        Ok(())
+        // Delegate the whole message — `handle_embedding_message` validates the
+        // op (EMBEDDING_EMBED / EMBEDDING_COUNT_TOKENS, `Unimplemented`
+        // otherwise). The previous hand-rolled `ServiceOp::EMBEDDING_EMBED`-only
+        // match rejected the valid `EMBEDDING_COUNT_TOKENS` op and diverged from
+        // `FastembedBlock`; both wrappers now delegate identically.
+        handle_embedding_message(self.service.as_ref(), &msg, &body).await
     }
 }

--- a/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/migrations/mod.rs
@@ -1,28 +1,20 @@
-//! User portal block migrations. Applied from the block's `Init` lifecycle.
+//! User portal block migrations. Applied from the block's `Init` lifecycle
+//! via [`crate::migration_helper::lifecycle_init`].
 //!
 //! SQL files are embedded with `include_str!`. Backend dispatch + the
 //! `current_hash` / `blessed_hash` / `SOLOBASE_RUN_MIGRATIONS` gate live
 //! in [`crate::migration_helper::apply_migrations`].
 
-use wafer_run::context::Context;
-
-use crate::migration_helper;
-
-const USERPORTAL_BLOCK_NAME: &str = "suppers-ai/userportal";
-
 const SQL_001_SQLITE: &str = include_str!("001_userportal_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_userportal_schema.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_userportal_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, USERPORTAL_BLOCK_NAME, &sqlite, &[SQL_001_POSTGRES])
-        .await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -2,8 +2,8 @@ use maud::html;
 use wafer_block::db::{ListOptions, SortField};
 use wafer_core::clients::{config, database as db};
 use wafer_run::{
-    context::Context, Block, BlockEndpoint, BlockInfo, CollectionSchema, InputStream, InstanceMode,
-    LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
+    context::Context, BlockEndpoint, BlockInfo, CollectionSchema, InputStream, InstanceMode,
+    Message, OutputStream,
 };
 
 use super::helpers::{self, parse_form_body, stamp_updated, RecordExt};
@@ -17,24 +17,11 @@ mod pages;
 
 const TABLE: &str = "suppers_ai__userportal__buttons";
 
-pub struct UserPortalBlock;
-
-impl UserPortalBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for UserPortalBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for UserPortalBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// User-facing portal dashboard + admin button config (`suppers-ai/userportal`).
+    pub struct UserPortalBlock;
+    name: "suppers-ai/userportal",
+    info: |_this| {
         use wafer_run::AuthLevel;
 
         BlockInfo::new(
@@ -76,14 +63,13 @@ impl Block for UserPortalBlock {
         .admin_url("/b/userportal/admin/settings")
         .can_disable(true)
         .default_enabled(false)
-    }
-
-    async fn handle(&self, ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
+    },
+    handle: |this, ctx, msg, input| {
         let path = msg.path().to_string();
         let action = msg.action().to_string();
 
         if !path.starts_with("/b/userportal") {
-            return self.handle_config(ctx).await;
+            return this.handle_config(ctx).await;
         }
 
         let sub = path
@@ -96,7 +82,7 @@ impl Block for UserPortalBlock {
         // check is needed; the normalized `sub` path is still passed
         // explicitly to the admin sub-dispatcher (no `req.resource` rewrite).
         if sub.starts_with("/admin/") {
-            return self.handle_admin(ctx, msg, input, &action, &sub).await;
+            return this.handle_admin(ctx, msg, input, &action, &sub).await;
         }
 
         match (action.as_str(), sub.as_str()) {
@@ -108,27 +94,21 @@ impl Block for UserPortalBlock {
             ("delete", s) if s.starts_with("/sessions/") => {
                 pages::sessions::handle_revoke(ctx, &msg, s).await
             }
-            ("retrieve", "/config") => self.handle_config(ctx).await,
-            ("retrieve", "/internal/list-buttons") => self.handle_list_buttons(ctx).await,
+            ("retrieve", "/config") => this.handle_config(ctx).await,
+            ("retrieve", "/internal/list-buttons") => this.handle_list_buttons(ctx).await,
             _ => err_not_found("not found"),
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("userportal migrations: {e}"),
-                )
-            })?;
-        }
-        Ok(())
-    }
+    },
+    lifecycle: |_this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/userportal",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+    },
 }
 
 impl UserPortalBlock {
@@ -373,7 +353,7 @@ mod cross_block_tests {
         .await
         .expect("seed second button");
 
-        let block = UserPortalBlock;
+        let block = UserPortalBlock::new();
         let msg = anon_msg("retrieve", "/b/userportal/internal/list-buttons");
         let resp = block
             .handle(&ctx, msg, wafer_run::InputStream::empty())
@@ -392,7 +372,7 @@ mod cross_block_tests {
     #[tokio::test]
     async fn list_buttons_action_returns_empty_array_when_none_configured() {
         let ctx = TestContext::new().await;
-        let block = UserPortalBlock;
+        let block = UserPortalBlock::new();
         let msg = anon_msg("retrieve", "/b/userportal/internal/list-buttons");
         let resp = block
             .handle(&ctx, msg, wafer_run::InputStream::empty())
@@ -401,6 +381,3 @@ mod cross_block_tests {
         assert_eq!(parsed.as_array().unwrap().len(), 0);
     }
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/userportal", UserPortalBlock);

--- a/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/dashboard.rs
@@ -97,7 +97,7 @@ mod tests {
 
     async fn ctx_with_userportal() -> TestContext {
         let mut ctx = TestContext::with_userportal().await;
-        ctx.register_block("suppers-ai/userportal", Arc::new(UserPortalBlock));
+        ctx.register_block("suppers-ai/userportal", Arc::new(UserPortalBlock::new()));
         ctx
     }
 

--- a/crates/solobase-core/src/blocks/vector/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/migrations/mod.rs
@@ -13,22 +13,16 @@
 //! and so cannot be expressed as a static SQL migration. See the SQL file
 //! header for the long-form rationale.
 
-use wafer_run::context::Context;
-
-use crate::migration_helper;
-
 const SQL_001_SQLITE: &str = include_str!("001_vector_schema.sqlite.sql");
 const SQL_001_POSTGRES: &str = include_str!("001_vector_schema.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
-/// pairs. Single source for both the runtime `apply()` below and the
-/// Cloudflare-build D1 migration registry (`crate::migrations`).
+/// pairs. Single source for both the runtime `lifecycle_init` apply and the
+/// Cloudflare-build D1 migration registry (`crate::blocks::all_sqlite_migrations`).
 pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[("001_vector_schema", SQL_001_SQLITE)];
 
-pub async fn apply(ctx: &dyn Context) -> Result<(), String> {
-    let sqlite: Vec<&str> = SQLITE_MIGRATIONS.iter().map(|(_, sql)| *sql).collect();
-    migration_helper::apply_migrations(ctx, "suppers-ai/vector", &sqlite, &[SQL_001_POSTGRES]).await
-}
+/// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`].
+pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[SQL_001_POSTGRES];
 
 #[cfg(test)]
 mod tests {

--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -4,10 +4,7 @@ pub mod pages;
 pub mod pages_ui;
 pub mod service;
 
-use wafer_run::{
-    context::Context, AuthLevel, Block, BlockEndpoint, BlockInfo, HttpMethod, InputStream,
-    InstanceMode, LifecycleEvent, LifecycleType, Message, OutputStream, WaferError,
-};
+use wafer_run::{AuthLevel, BlockEndpoint, BlockInfo, HttpMethod, InstanceMode};
 
 use crate::endpoint_match::{self, EndpointRoute};
 
@@ -63,24 +60,11 @@ const ROUTES: &[EndpointRoute<Route>] = &[
     ),
 ];
 
-pub struct VectorBlock;
-
-impl VectorBlock {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for VectorBlock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl Block for VectorBlock {
-    fn info(&self) -> BlockInfo {
+crate::solobase_feature_block! {
+    /// Vector search, RAG ingestion, and embedding generation (`suppers-ai/vector`).
+    pub struct VectorBlock;
+    name: "suppers-ai/vector",
+    info: |_this| {
         BlockInfo::new(
             "suppers-ai/vector",
             "0.0.1",
@@ -127,14 +111,8 @@ impl Block for VectorBlock {
         ])
         .can_disable(true)
         .default_enabled(true)
-    }
-
-    async fn handle(
-        &self,
-        ctx: &dyn Context,
-        mut msg: Message,
-        input: InputStream,
-    ) -> OutputStream {
+    },
+    handle: |_this, ctx, msg, input| {
         // Auth is enforced centrally by `route_to_block` from the declared
         // endpoint `AuthLevel` (UI pages → Admin, JSON API → Authenticated),
         // so the block holds no `user_id`/`is_admin` preamble. The matcher
@@ -158,24 +136,15 @@ impl Block for VectorBlock {
             Route::ApiStats => pages::stats(ctx).await,
             Route::ApiDeleteSingle => pages::delete_single(ctx, &msg).await,
         }
-    }
-
-    async fn lifecycle(
-        &self,
-        ctx: &dyn Context,
-        event: LifecycleEvent,
-    ) -> std::result::Result<(), WaferError> {
-        if matches!(event.event_type, LifecycleType::Init) {
-            migrations::apply(ctx).await.map_err(|e| {
-                WaferError::new(
-                    wafer_run::ErrorCode::Internal,
-                    format!("vector migrations: {e}"),
-                )
-            })?;
-        }
-        Ok(())
-    }
+    },
+    lifecycle: |_this, ctx, event| {
+        crate::migration_helper::lifecycle_init(
+            ctx,
+            &event,
+            "suppers-ai/vector",
+            migrations::SQLITE_MIGRATIONS,
+            migrations::POSTGRES_MIGRATIONS,
+        )
+        .await
+    },
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-::wafer_block::register_static_block!("suppers-ai/vector", VectorBlock);

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -421,9 +421,9 @@ impl SolobaseBuilder {
             }
         }
 
-        // 5. All middleware blocks (cors, inspector, readonly-guard, router,
-        // security-headers, web) self-register via register_static_block! in
-        // their respective wafer-block-* crates. The `use wafer_block_xxx as _`
+        // 5. The wafer-run/* middleware blocks (cors, inspector, readonly-guard,
+        // router, security-headers, web) self-register via `register_static_block!`
+        // in their respective wafer-block-* crates. The `use wafer_block_xxx as _`
         // anchors at the top of this file ensure the linker includes those crate
         // .o files so the linkme distributed-slice entries land in the binary.
         //
@@ -454,15 +454,17 @@ impl SolobaseBuilder {
                 Arc::new(wafer_block_security_headers::SecurityHeadersBlock::new()),
             )?;
             wafer.register_block("wafer-run/web", Arc::new(wafer_block_web::WebBlock::new()))?;
-
-            // Solobase feature blocks (suppers-ai/*) self-register via
-            // `register_static_block!` on native, but linkme's distributed_slice
-            // doesn't emit on wasm32 — see `crate::blocks::register_all_static_blocks`
-            // for the full reasoning. Without this call the wasm runtime has only
-            // wafer-run/* middleware and the SolobaseRouter resolves every feature
-            // route to a `block 'suppers-ai/<name>' not found` error.
-            crate::blocks::register_all_static_blocks(&mut wafer)?;
         }
+
+        // 5a. Register every zero-arg solobase feature block (`suppers-ai/*`)
+        // from the single manifest in `crate::blocks`. The same call runs on
+        // native and wasm32 — there is no longer a linkme (native) /
+        // hand-synced-list (wasm32) split. Previously native relied on
+        // per-block `register_static_block!` (linkme) and wasm32 on a separate
+        // `register_all_static_blocks` list; both are gone. The three
+        // non-zero-arg blocks (`llm`, framework `auth`, wasm32
+        // `transformers-embed`) are registered explicitly below.
+        crate::blocks::register_feature_blocks(&mut wafer)?;
 
         wafer.add_block_config(
             "wafer-run/inspector",
@@ -474,22 +476,19 @@ impl SolobaseBuilder {
             wafer.add_block_config(&name, config);
         }
 
-        // 6. Register the framework AuthBlock — it can't self-register via
-        //    register_static_block! because its constructor takes
-        //    Arc<dyn AuthService>. The wrapped AuthServiceImpl picks up its
-        //    Context handle when the runtime fires the block's
-        //    lifecycle(Init) event.
+        // 6. Register the framework AuthBlock — not in the feature-block
+        //    manifest because its constructor takes `Arc<dyn AuthService>`. The
+        //    wrapped AuthServiceImpl picks up its Context handle when the
+        //    runtime fires the block's lifecycle(Init) event.
         crate::blocks::register_auth(&mut wafer)?;
 
-        // 6b. Register LlmBlock — it can't self-register via register_static_block!
-        //     because its constructor takes Arc<dyn ProviderAdmin>. All other solobase
-        //     blocks self-register via register_static_block! at link time.
+        // 6b. Register LlmBlock — not in the feature-block manifest because its
+        //     constructor takes `Arc<dyn ProviderAdmin>`.
         //
-        //     On wasm32 the block is registered inside `register_all_static_blocks`
-        //     above (with a `NoopProviderAdmin`); here we cover the native path.
-        //     With `feature = "llm"` the concrete `ProviderLlmService` (already on
-        //     the router under `"provider"`) doubles as the provider-admin handle;
-        //     a native `block-llm`-without-`llm` build falls back to the no-op.
+        //     Native (`not(wasm32)`): with `feature = "llm"` the concrete
+        //     `ProviderLlmService` (already on the router under `"provider"`)
+        //     doubles as the provider-admin handle; a native
+        //     `block-llm`-without-`llm` build falls back to the no-op.
         #[cfg(all(feature = "block-llm", not(target_arch = "wasm32")))]
         {
             use crate::blocks::llm::provider_admin::ProviderAdmin;
@@ -503,6 +502,17 @@ impl SolobaseBuilder {
                 Arc::new(crate::blocks::llm::provider_admin::NoopProviderAdmin);
             crate::blocks::register_llm(&mut wafer, provider_admin)?;
         }
+
+        // 6c. Register LlmBlock on wasm32 against a browser-supplied
+        //     `LlmService` (installed on the router via
+        //     `SolobaseBuilder::llm_service`). Provider CRUD / discovery have no
+        //     browser surface, so a `NoopProviderAdmin` stands in for the native
+        //     HTTP `ProviderLlmService`.
+        #[cfg(all(feature = "block-llm", target_arch = "wasm32"))]
+        crate::blocks::register_llm(
+            &mut wafer,
+            Arc::new(crate::blocks::llm::provider_admin::NoopProviderAdmin),
+        )?;
 
         // 7. Extra platform-specific blocks
         for (name, block) in self.extra_blocks {

--- a/crates/solobase-core/src/migration_helper.rs
+++ b/crates/solobase-core/src/migration_helper.rs
@@ -17,7 +17,7 @@
 
 use sha2::{Digest, Sha256};
 use wafer_core::clients::{config, database as db};
-use wafer_run::context::Context;
+use wafer_run::{context::Context, ErrorCode, LifecycleEvent, LifecycleType, WaferError};
 use wafer_sql_utils::Backend;
 
 use crate::{
@@ -103,6 +103,46 @@ pub async fn apply_migrations(
     };
     let sql = files.join("\n");
     apply_if_blessed(ctx, block_name, &sql).await
+}
+
+/// `lifecycle(Init)` body shared by every solobase feature block: on the
+/// [`Init`](LifecycleType::Init) event, apply the block's migrations and wrap
+/// any failure in a [`WaferError`] tagged with the block name. Non-`Init`
+/// events are a no-op.
+///
+/// Folds the three things every block's `lifecycle` open-coded around its
+/// migrations:
+///
+/// 1. `if matches!(event.event_type, LifecycleType::Init) { … }`,
+/// 2. deriving the SQLite `&[&str]` from the block's `SQLITE_MIGRATIONS`
+///    `(basename, content)` pairs — the S3-S single schema source that also
+///    feeds the Cloudflare D1 registry,
+/// 3. mapping the `apply_migrations` `Err(String)` onto
+///    `WaferError::new(ErrorCode::Internal, "<block> migrations: …")`.
+///
+/// `sqlite_migrations` is the block's `migrations::SQLITE_MIGRATIONS`
+/// (`(basename, content)`); only the content half is executed (the basename is
+/// for the D1 filename). `postgres_files` is the matching ordered list of
+/// PostgreSQL-dialect scripts. The active dialect is selected inside
+/// [`apply_migrations`] from `SOLOBASE_SHARED__DATABASE__BACKEND`.
+///
+/// Blocks with extra `Init` work (admin's seed steps, llm's legacy-provider
+/// copy + reload) call this first, then run their extra steps; blocks with no
+/// migrations at all (the embedding wrappers) simply omit `lifecycle`.
+pub async fn lifecycle_init(
+    ctx: &dyn Context,
+    event: &LifecycleEvent,
+    block_name: &str,
+    sqlite_migrations: &[(&str, &str)],
+    postgres_files: &[&str],
+) -> Result<(), WaferError> {
+    if !matches!(event.event_type, LifecycleType::Init) {
+        return Ok(());
+    }
+    let sqlite: Vec<&str> = sqlite_migrations.iter().map(|(_, sql)| *sql).collect();
+    apply_migrations(ctx, block_name, &sqlite, postgres_files)
+        .await
+        .map_err(|e| WaferError::new(ErrorCode::Internal, format!("{block_name} migrations: {e}")))
 }
 
 /// Apply `sql` against `db::ddl` iff the operator has blessed it or

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -119,6 +119,28 @@ impl TestContext {
         self
     }
 
+    /// Apply one block's migrations into this fixture through the same gated
+    /// path the runtime uses ([`crate::migration_helper::apply_migrations`]),
+    /// sourcing the SQL from the block's single-source `SQLITE_MIGRATIONS` /
+    /// `POSTGRES_MIGRATIONS` consts.
+    ///
+    /// Replaces the per-block `migrations::apply()` wrappers (deleted when the
+    /// `solobase_feature_block!` macro folded each block's `lifecycle(Init)`
+    /// into `migration_helper::lifecycle_init`). Test-fixture setup is an
+    /// explicit exception to the no-raw-migration-runner rule; it mirrors the
+    /// production gate exactly so fixtures exercise the real schema.
+    async fn apply_block_migrations(
+        &self,
+        block_name: &str,
+        sqlite: &[(&str, &str)],
+        postgres: &[&str],
+    ) {
+        let sqlite_sql: Vec<&str> = sqlite.iter().map(|(_, sql)| *sql).collect();
+        crate::migration_helper::apply_migrations(self, block_name, &sqlite_sql, postgres)
+            .await
+            .unwrap_or_else(|e| panic!("apply {block_name} migrations in test fixture: {e}"));
+    }
+
     /// Build a `TestContext` with admin + auth block migrations applied.
     ///
     /// Convenience constructor for tests that need the
@@ -128,16 +150,16 @@ impl TestContext {
     /// Admin migrations run first so that the
     /// `suppers_ai__admin__block_settings` tracking table exists before
     /// auth's `apply_if_blessed` upserts its `current_hash` row. In
-    /// production this ordering is guaranteed by `register_all_static_blocks`
+    /// production this ordering is guaranteed by `register_feature_blocks`
     /// (admin is registered first); here we enforce it explicitly.
     pub async fn with_auth() -> Self {
-        let ctx = Self::new().await;
-        crate::blocks::admin::migrations::apply(&ctx)
-            .await
-            .expect("apply admin migrations in test fixture");
-        crate::blocks::auth::migrations::apply(&ctx)
-            .await
-            .expect("apply auth migrations in test fixture");
+        let ctx = Self::with_admin().await;
+        ctx.apply_block_migrations(
+            "suppers-ai/auth",
+            crate::blocks::auth::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::auth::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 
@@ -149,9 +171,12 @@ impl TestContext {
     /// upsert its tracking row.
     pub async fn with_admin() -> Self {
         let ctx = Self::new().await;
-        crate::blocks::admin::migrations::apply(&ctx)
-            .await
-            .expect("apply admin migrations in test fixture");
+        ctx.apply_block_migrations(
+            "suppers-ai/admin",
+            crate::blocks::admin::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::admin::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 
@@ -159,9 +184,12 @@ impl TestContext {
     #[cfg(feature = "block-files")]
     pub async fn with_files() -> Self {
         let ctx = Self::with_auth().await;
-        crate::blocks::files::migrations::apply(&ctx)
-            .await
-            .expect("apply files migrations in test fixture");
+        ctx.apply_block_migrations(
+            "suppers-ai/files",
+            crate::blocks::files::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::files::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 
@@ -169,9 +197,12 @@ impl TestContext {
     #[cfg(feature = "block-userportal")]
     pub async fn with_userportal() -> Self {
         let ctx = Self::with_auth().await;
-        crate::blocks::userportal::migrations::apply(&ctx)
-            .await
-            .expect("apply userportal migrations in test fixture");
+        ctx.apply_block_migrations(
+            "suppers-ai/userportal",
+            crate::blocks::userportal::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::userportal::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 
@@ -179,9 +210,12 @@ impl TestContext {
     #[cfg(feature = "block-vector")]
     pub async fn with_vector() -> Self {
         let ctx = Self::with_auth().await;
-        crate::blocks::vector::migrations::apply(&ctx)
-            .await
-            .expect("apply vector migrations in test fixture");
+        ctx.apply_block_migrations(
+            "suppers-ai/vector",
+            crate::blocks::vector::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::vector::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 
@@ -195,9 +229,12 @@ impl TestContext {
     #[cfg(feature = "block-products")]
     pub async fn with_products() -> Self {
         let ctx = Self::with_admin().await;
-        crate::blocks::products::migrations::apply(&ctx)
-            .await
-            .expect("apply products migrations in test fixture");
+        ctx.apply_block_migrations(
+            "suppers-ai/products",
+            crate::blocks::products::migrations::SQLITE_MIGRATIONS,
+            crate::blocks::products::migrations::POSTGRES_MIGRATIONS,
+        )
+        .await;
         ctx
     }
 

--- a/crates/solobase-core/tests/auth/login_session_row.rs
+++ b/crates/solobase-core/tests/auth/login_session_row.rs
@@ -212,7 +212,7 @@ async fn userportal_sessions_page_renders_row_after_login() {
 
     let _ = invoke_login(&ctx, "diana@example.com", "diana-password").await;
 
-    let block = UserPortalBlock;
+    let block = UserPortalBlock::new();
     let mut msg = Message::new("http.request");
     msg.set_meta("req.action", "retrieve");
     msg.set_meta("req.resource", "/b/userportal/sessions");

--- a/crates/solobase-core/tests/autoreg_smoke.rs
+++ b/crates/solobase-core/tests/autoreg_smoke.rs
@@ -1,71 +1,128 @@
-//! Smoke test for linkme-based block auto-registration.
+//! Registration-completeness test for the `feature_block_manifest!` set.
 //!
-//! Asserts that zero-arg `suppers-ai/*` blocks self-register at link time
-//! via `register_static_block!` and that blocks whose constructors take
-//! arguments (`LlmBlock` / framework `AuthBlock`) do NOT auto-register —
-//! they're installed by helpers (`register_llm` / `register_auth`) called
-//! from `solobase::SolobaseBuilder::build()`.
+//! S5-V replaced the three hand-synced registration lists (native linkme
+//! `register_static_block!`, the wasm32 `register_all_static_blocks` list, and
+//! the `all_block_infos` push list) with ONE `(feature, name, constructor)`
+//! manifest in `blocks/mod.rs`. This test pins the exact block set the manifest
+//! must register, on the host target, so a block silently dropped from the
+//! manifest (a missing block at runtime) fails CI here.
+//!
+//! `register_feature_blocks` is called from `SolobaseBuilder::build()` on BOTH
+//! native and wasm32; there is no longer a link-time linkme step, so a bare
+//! `Wafer::new()` starts with zero `suppers-ai/*` blocks until the builder runs
+//! it — this test drives `register_feature_blocks` directly.
 
-// Force solobase_core's object files to be linked so that the
-// register_static_block! distributed-slice entries inside each block module
-// are included in the test binary.  Without this import the linker would
-// strip the crate's code entirely (no other symbols referenced) and
-// STATIC_BLOCK_REGISTRATIONS would be empty.
 use std::sync::Arc;
 
-use solobase_core as _;
+use solobase_core::blocks;
 use wafer_run::{StaticConfigSource, Wafer};
 
+/// Zero-arg blocks the manifest registers on every host build (none of these
+/// is feature-gated off by default). `fastembed` is feature-gated under
+/// `native-embedding` and checked separately; `llm` / framework `auth` /
+/// `transformers-embed` take non-zero-arg constructors and are NOT in the
+/// manifest (the builder installs them explicitly).
+const MANIFEST_ZERO_ARG_BLOCKS: &[&str] = &[
+    "suppers-ai/admin",
+    "suppers-ai/auth-ui",
+    "suppers-ai/email",
+    "suppers-ai/files",
+    "suppers-ai/legalpages",
+    "suppers-ai/messages",
+    "suppers-ai/products",
+    "suppers-ai/system",
+    "suppers-ai/userportal",
+    "suppers-ai/vector",
+];
+
 #[test]
-fn all_zero_arg_blocks_auto_register() {
-    let w = Wafer::new(Arc::new(StaticConfigSource::default()))
+fn register_feature_blocks_installs_exactly_the_manifest_set() {
+    let mut w = Wafer::new(Arc::new(StaticConfigSource::default()))
         .expect("Wafer::new should succeed with no lockfile present");
 
-    // Zero-arg blocks. `vector` is unconditionally registered (its
-    // `pub mod vector;` in blocks/mod.rs has no cfg gate). `fastembed` is
-    // feature-gated under `native-embedding` and checked in the test below.
-    // `llm` requires `Arc<dyn ProviderAdmin>` and `auth` (framework) wraps
-    // `Arc<dyn AuthService>`; both are checked separately.
-    let always_on = [
-        "suppers-ai/admin",
-        "suppers-ai/auth-ui",
-        "suppers-ai/email",
-        "suppers-ai/files",
-        "suppers-ai/legalpages",
-        "suppers-ai/messages",
-        "suppers-ai/products",
-        "suppers-ai/system",
-        "suppers-ai/userportal",
-        "suppers-ai/vector",
-    ];
-
-    for name in always_on {
+    // Before registration the runtime has no solobase feature blocks (the
+    // old link-time linkme registration is gone).
+    for name in MANIFEST_ZERO_ARG_BLOCKS {
         assert!(
-            w.has_block(name),
-            "expected block {name} to be auto-registered via register_static_block!"
+            !w.has_block(name),
+            "block {name} must NOT be present before register_feature_blocks runs \
+             (no link-time auto-registration anymore)"
         );
     }
 
-    // LlmBlock requires Arc<dyn ProviderAdmin>; can't auto-register.
-    // It's only present once SolobaseBuilder::build() calls register_llm().
+    blocks::register_feature_blocks(&mut w).expect("register_feature_blocks should succeed");
+
+    for name in MANIFEST_ZERO_ARG_BLOCKS {
+        assert!(
+            w.has_block(name),
+            "block {name} must be registered by the feature-block manifest"
+        );
+    }
+
+    // `fastembed` (native-only) is in the manifest only under its feature.
+    #[cfg(feature = "native-embedding")]
     assert!(
-        !w.has_block("suppers-ai/llm"),
-        "LlmBlock should not be auto-registered (constructor needs ProviderAdmin)"
+        w.has_block("suppers-ai/fastembed"),
+        "fastembed must register from the manifest when native-embedding is on"
     );
 
-    // The framework AuthBlock wraps `Arc<dyn AuthService>`; can't
-    // auto-register. It's only present once SolobaseBuilder::build() calls
-    // `crate::blocks::register_auth()`.
+    // Special cases are NOT in the manifest — their constructors are not
+    // zero-argument, so the builder installs them explicitly afterwards.
+    assert!(
+        !w.has_block("suppers-ai/llm"),
+        "LlmBlock (Arc<dyn ProviderAdmin>) must not be in the feature-block manifest"
+    );
     assert!(
         !w.has_block("suppers-ai/auth"),
-        "framework AuthBlock should not be auto-registered (constructor needs Arc<dyn AuthService>)"
+        "framework AuthBlock (Arc<dyn AuthService>) must not be in the feature-block manifest"
     );
 }
 
-#[cfg(feature = "native-embedding")]
+/// `all_block_infos()` must enumerate the SAME zero-arg manifest set (so
+/// config-var discovery / inspector route granularity / the routing-auth
+/// policy see every block), PLUS `suppers-ai/llm` (its declarative `info()`
+/// belongs in the discovery set even though its constructor is special).
+///
+/// This is the before/after block-set proof: the manifest, the registration
+/// fn, and the info discovery set can no longer drift.
 #[test]
-fn fastembed_block_auto_registers_when_feature_enabled() {
-    let w = Wafer::new(Arc::new(StaticConfigSource::default()))
-        .expect("Wafer::new with native-embedding feature");
-    assert!(w.has_block("suppers-ai/fastembed"));
+fn all_block_infos_covers_the_manifest_set_plus_llm() {
+    let infos = blocks::all_block_infos();
+    let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
+
+    for name in MANIFEST_ZERO_ARG_BLOCKS {
+        assert!(
+            names.contains(name),
+            "all_block_infos() is missing manifest block {name}"
+        );
+    }
+
+    // `llm` is the one block registered outside the manifest whose info() is
+    // still discovered (via a NoopProviderAdmin handle).
+    #[cfg(feature = "block-llm")]
+    assert!(
+        names.contains(&"suppers-ai/llm"),
+        "all_block_infos() must include suppers-ai/llm"
+    );
+
+    #[cfg(feature = "native-embedding")]
+    assert!(
+        names.contains(&"suppers-ai/fastembed"),
+        "all_block_infos() must include suppers-ai/fastembed under native-embedding"
+    );
+
+    // No duplicates — a block listed twice would double-register at boot.
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    let before = sorted.len();
+    sorted.dedup();
+    assert_eq!(before, sorted.len(), "all_block_infos() has duplicate block names");
+
+    // The framework auth block declares its config vars via
+    // `shared_config_vars()` (not `BlockInfo::config_keys`), so it is
+    // deliberately absent from this discovery set.
+    assert!(
+        !names.contains(&"suppers-ai/auth"),
+        "framework auth block must not be in all_block_infos() (its vars come from shared_config_vars)"
+    );
 }

--- a/crates/solobase-core/tests/autoreg_smoke.rs
+++ b/crates/solobase-core/tests/autoreg_smoke.rs
@@ -116,7 +116,11 @@ fn all_block_infos_covers_the_manifest_set_plus_llm() {
     sorted.sort_unstable();
     let before = sorted.len();
     sorted.dedup();
-    assert_eq!(before, sorted.len(), "all_block_infos() has duplicate block names");
+    assert_eq!(
+        before,
+        sorted.len(),
+        "all_block_infos() has duplicate block names"
+    );
 
     // The framework auth block declares its config vars via
     // `shared_config_vars()` (not `BlockInfo::config_keys`), so it is


### PR DESCRIPTION
WIP — S5-V (feature-block-macro, wave 5a). Collapses per-block scaffolding into a declarative macro + one registration manifest (the solobase analogue of phase-1 W3-O \`service_block!\`).

## Plan-section findings (checklist)
- [x] **Per-block Block-impl scaffolding repeated across ~13 blocks** — `solobase_feature_block!` macro generates struct+new()+Default + `#[wafer_async_trait]` plumbing + impl Block wrapper. ~18 hand-written cfg_attr pairs collapsed.
- [x] **Solobase registration manifest maintained in three hand-synced places** — `feature_block_manifest!` const table generates `all_block_infos()` + `register_feature_blocks()`; native linkme `register_static_block!` sites + wasm32 `register_all_static_blocks` list deleted; registration unified on both targets.
- [x] **Block registration requires keeping three manual lists in sync** (merged dup) — same manifest.
- [x] **Per-block migrations/mod.rs + lifecycle(Init) boilerplate repeated 9x** — `migration_helper::lifecycle_init`; 9 `apply()` wrappers removed; `SQLITE_MIGRATIONS` single-source (S3-S) preserved + `POSTGRES_MIGRATIONS` const added.
- [x] **Embedding block pair drift** — transformers-embed redundant ServiceOp check removed (it wrongly rejected the valid `EMBEDDING_COUNT_TOKENS` op); both wrappers delegate to `handle_embedding_message` (which already validates ops); `InstanceMode::Singleton` declared on both.

## RE-CHECK-AFTER-ADAPTATION dispositions
- The `use_static_blocks!` inversion: confirmed native solobase feature blocks self-registered via linkme `register_static_block!` (inside `Wafer::new`), wasm32 via `register_all_static_blocks`. Both replaced by one manifest-driven `register_feature_blocks` called on BOTH targets from `build()`.
- S3-S `all_sqlite_migrations()` head/tail ordering: untouched — kept as a separate adjacent list (it converges on `SQLITE_MIGRATIONS`, not the registration manifest).
- S4-U `routing::ROUTES` (URL-prefix→block table): untouched — NOT merged into the manifest (different cardinality + access tiers per the plan's "do not force unrelated lists together").

## Registration completeness
Manifest enumerates the exact same block set the three lists did, on both targets (proof + pinning test in a follow-up commit).

## Special cases (stay explicit, non-zero-arg ctors)
`suppers-ai/llm` (`Arc<dyn ProviderAdmin>`), framework `suppers-ai/auth` (`AuthServiceImpl`), wasm32 `suppers-ai/transformers-embed` (`Arc<dyn EmbeddingService>`).

## No schema change
Purely structural — no block-SQL/migration content changed, so no `SOLOBASE_RUN_MIGRATIONS=1` deploy requirement.

## Verification (in progress)
- [x] `cargo check --workspace --exclude solobase-web --exclude solobase-cloudflare`
- [x] `cargo test -p solobase-core` compiles
- [ ] full `cargo test -p solobase-core`
- [ ] `cargo +nightly fmt --all -- --check`
- [ ] clippy
- [ ] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` (MANDATORY — macro cfg_attr + wasm32 registration)
- [ ] guard scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)