### PR TITLE
feat(legalpages): render FOOTER as a textarea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5815,7 +5815,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5896,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5933,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "futures",
@@ -5950,7 +5950,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5971,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5981,7 +5981,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6019,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6040,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "serde",
  "serde_json",
@@ -6084,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "serde",
  "serde_json",
@@ -6124,7 +6124,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#312d857fb715a7fe5b1381eab70009efffefbf1c"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -151,6 +151,7 @@ pub(crate) fn config_vars() -> Vec<ConfigVar> {
             "",
         )
         .name("Footer Text")
+        .input_type(InputType::Textarea)
         .optional(),
     ]
 }

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -116,6 +116,16 @@ fn render_field(var: &ConfigVar, value: &str) -> Markup {
                 }
             }
         },
+        InputType::Textarea => html! {
+            div .form-group style="margin-bottom:1.25rem" {
+                label .form-label for=(var.key) { (label) }
+                textarea .form-input #(var.key) name=(var.key) rows="4"
+                    placeholder=(var.default) { (value) }
+                @if !var.description.is_empty() {
+                    p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (var.description) }
+                }
+            }
+        },
         InputType::Url | InputType::Text => html! {
             div .form-group style="margin-bottom:1.25rem" {
                 label .form-label for=(var.key) { (label) }
@@ -272,6 +282,21 @@ mod tests {
         assert!(on.contains("checked"));
         let off = render_field(&v, "false").into_string();
         assert!(!off.contains("checked"));
+    }
+
+    #[test]
+    fn textarea_field_renders_multiline_with_value_as_content() {
+        let v = var("X__FOOTER", "Footer Text", InputType::Textarea);
+        let s = render_field(&v, "© 2026 Me").into_string();
+        assert!(s.contains("<textarea"), "should render a textarea: {s}");
+        assert!(s.contains(r#"name="X__FOOTER""#));
+        // A textarea carries its value as element content, not a value= attr.
+        assert!(s.contains("© 2026 Me"));
+        assert!(
+            !s.contains(r#"type="text""#),
+            "textarea must not be a text input: {s}"
+        );
+        assert!(s.contains(">Footer Text<"));
     }
 
     #[test]


### PR DESCRIPTION
## What
Declares the legalpages **Footer Text** config var as `InputType::Textarea` and renders it as a `<textarea>` in the admin settings form.

## Why
Consumer half of deferred follow-up #2. The footer holds multi-line HTML but S2-M left it a single-line text input. wafer-run #235 added the `Textarea` variant; this wires it through.

## Changes
- [x] `blocks/legalpages/mod.rs` — FOOTER var `.input_type(InputType::Textarea)`.
- [x] `ui/settings_form.rs` — new `Textarea` match arm (renders `<textarea>` with value as element content) + a render test. The submit JS already handles `textarea[name]`.
- [x] `Cargo.lock` — bump wafer-run git dep to main `@4906202`.

## Verification (local, against wafer-run @4906202)
- [x] `cargo test -p solobase-core --lib settings_form` → **7 passed** (incl. new `textarea_field_renders_multiline_with_value_as_content`).
- [x] `cargo +nightly fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)