### PR TITLE
refactor(native-boot): route native boot through the shared builder::boot funnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,6 +4608,7 @@ name = "solobase"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "getrandom 0.2.17",
  "glob",
@@ -4622,6 +4623,7 @@ dependencies = [
  "toml",
  "tracing",
  "uuid",
+ "wafer-block",
  "wafer-core",
  "wafer-run",
 ]

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -661,13 +661,14 @@ pub trait BootHooks {
 /// registration) onto `wafer` before calling this. After it returns, the
 /// caller dispatches requests / stores the runtime handle as appropriate.
 ///
-/// Native uses `Wafer::start_with_priority` instead of this funnel: its
+/// Native uses this funnel too, then runs the native-only
+/// [`Wafer::run_start_lifecycle`] + [`Wafer::bind_all`] steps afterwards: its
 /// HTTP-listener block binds the TCP socket in the `Start`-lifecycle `bind()`
-/// pass that `start_with_priority` performs atomically, and its immutable
-/// `Argon2JwtCryptoService` needs the JWT secret before `build()` — so native
-/// seeds pre-wafer and there is no public hook to inject a seed step mid-way
-/// through `start_with_priority`. Native still shares the seed *functions*
-/// above; only its lifecycle differs.
+/// pass, which the stateless targets omit (they dispatch per-request via
+/// `wafer.run`). Native still seeds pre-wafer — its immutable
+/// `Argon2JwtCryptoService` and config snapshot need the variables before
+/// `build()` — so its `seed_after_admin_init` is a no-op, mirroring how
+/// Cloudflare reads its config pre-build and only runs the auto-gen pass here.
 pub async fn boot(
     wafer: &mut Wafer,
     storage_block: &SolobaseStorageBlock,

--- a/crates/solobase/Cargo.toml
+++ b/crates/solobase/Cargo.toml
@@ -70,6 +70,10 @@ solobase-bundle = { path = "../solobase-bundle" }
 # WAFER runtime
 wafer-run = { workspace = true, features = ["full"] }
 wafer-core = { workspace = true }
+# `wafer_async_trait` macro for the native `BootHooks` impl (the macro's
+# expansion references the `async-trait` crate directly).
+wafer-block = { workspace = true }
+async-trait = { workspace = true }
 
 # Native config service
 

--- a/crates/solobase/src/cli/server.rs
+++ b/crates/solobase/src/cli/server.rs
@@ -54,13 +54,13 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
     let env_vars = filter_to_declared_keys(collect_app_env_vars());
 
     // 5. Construct the platform database service up front. Native seeds the
-    //    variables / block_settings tables BEFORE the wafer exists — it needs
-    //    the JWT secret to construct its immutable crypto service, and
-    //    `start_with_priority` (which binds the HTTP socket in the atomic
-    //    Start pass) leaves no public hook to seed mid-lifecycle the way the
-    //    stateless targets do via `solobase_core::builder::boot`. The same
-    //    `Arc` is handed to the builder below, so seeding and the runtime
-    //    share one connection/pool.
+    //    variables / block_settings tables BEFORE the wafer exists because its
+    //    immutable crypto service + config snapshot need the JWT secret and the
+    //    seeded values at `build()` time — exactly like the Cloudflare target
+    //    reads its config pre-build. Boot then runs through the shared
+    //    `solobase_core::builder::boot` funnel (below), so the post-admin-init
+    //    seed hook is a no-op. The same `Arc` is handed to the builder below,
+    //    so seeding and the runtime share one connection/pool.
     let database = solobase_native::make_database_service(
         &infra.db_type,
         &infra.db_path,
@@ -192,26 +192,29 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
         wafer.add_wrap_grants(db_grants);
     }
 
-    // 11. Start runtime. We init the admin block first so its migrations
-    //     (which create suppers_ai__admin__block_settings + the variables
-    //     table) finish before any other block's Init tries to write to
-    //     block_settings via migration_helper. Without this, HashMap key-
+    // 11. Boot through the shared funnel, then run the native-only Start
+    //     lifecycle + socket bind. `builder::boot` owns the invariant
+    //     seal → init_block(admin) → seed-hook → init_all_blocks → post_start
+    //     ordering shared with the Cloudflare/browser targets, replacing the
+    //     bespoke `start_with_priority(&[admin])`. Admin-first init guarantees
+    //     admin's migrations (which create suppers_ai__admin__block_settings +
+    //     the variables table) run before any other block's Init writes to
+    //     block_settings via migration_helper. Without it, HashMap key-
     //     iteration order could put another block first, hit a hard
-    //     'no such table' error (since solobase #182 made write_state
-    //     propagate strictly), and the cascade would skip auth's bootstrap
-    //     — manifesting as a login 401 on the freshly-booted server in
-    //     CI E2E.
+    //     'no such table' error (solobase #182 made write_state propagate
+    //     strictly), skip auth's bootstrap, and surface as a login 401 on the
+    //     freshly-booted server in CI E2E.
     //
-    //     Mirrors the CF runner's seal → init_block(admin) → init_all_blocks
-    //     sequence (solobase #186); the runtime API for this ordering hook
-    //     landed in wafer-run #143.
-    let wafer = wafer
-        .start_with_priority(&[solobase_core::blocks::admin::ADMIN_BLOCK_ID])
+    //     `boot` runs `post_start` (WRAP-grant injection into storage) for us.
+    //     Native then runs the Start lifecycle and binds the HTTP socket — the
+    //     steps `boot` deliberately omits because the stateless targets
+    //     dispatch per-request instead of binding (wafer-run #239 exposed them
+    //     as `run_start_lifecycle` + `bind_all`).
+    builder::boot(&mut wafer, &storage_block, &NativeBootHooks)
         .await
-        .context("start WAFER runtime")?;
-
-    // 12. Inject WRAP grants into storage block
-    builder::post_start(&wafer, &storage_block);
+        .context("boot WAFER runtime")?;
+    wafer.run_start_lifecycle().await;
+    let wafer = wafer.bind_all();
     tracing::info!("WAFER runtime started — all blocks resolved");
 
     // 13. Wait for shutdown signal, then graceful shutdown
@@ -221,4 +224,21 @@ pub async fn run(repo_root: &Path, run_migrations: bool) -> anyhow::Result<()> {
     tracing::info!("solobase shutdown complete");
 
     Ok(())
+}
+
+/// Native [`BootHooks`](builder::BootHooks). Native seeds the variables /
+/// block_settings tables pre-wafer (its immutable crypto service and config
+/// snapshot need the values at `build()` time), so — like the Cloudflare hook
+/// after its eager pre-build config reads — there is nothing left to seed once
+/// admin's `Init` has run. The shared `boot` funnel still owns the admin-first
+/// ordering and `post_start`; native only needs an empty hook to satisfy the
+/// signature, plus the native-only `run_start_lifecycle` + `bind_all` steps
+/// it runs after `boot` returns.
+struct NativeBootHooks;
+
+#[wafer_block::wafer_async_trait]
+impl builder::BootHooks for NativeBootHooks {
+    async fn seed_after_admin_init(&self, _wafer: &wafer_run::Wafer) -> Result<(), String> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What
Native boot now goes through `solobase_core::builder::boot` (the shared funnel used by Cloudflare/browser) + the new native-only `Wafer::run_start_lifecycle()` + `bind_all()` steps, replacing the bespoke `start_with_priority(&[admin])`.

```rust
builder::boot(&mut wafer, &storage_block, &NativeBootHooks).await?; // seal → init(admin) → seed-hook → init_all → post_start
wafer.run_start_lifecycle().await;   // native-only: Start lifecycle
let wafer = wafer.bind_all();        // native-only: bind the HTTP socket
```

## Why
Consumer half of deferred follow-up #4 (S3-R native-boot unification). The producer step (wafer-run #239) exposed `run_start_lifecycle`/`bind_all`; this collapses native onto the shared ordering so admin-first init + `post_start` are owned in one place for all three targets, removing the "Native uses start_with_priority instead of this funnel" carve-out.

## Design note (corrects the original plan)
The plan said move native's seed into the hook. The **Cloudflare** runner shows that's unnecessary: CF reads config/block_settings *pre-build* (its immutable crypto + snapshot need them) and its hook only runs the idempotent auto-gen pass. Native is the same — it must seed pre-wafer for crypto+snapshot — so `NativeBootHooks::seed_after_admin_init` is a **no-op**, and pre-wafer seeding is unchanged. No `set_jwt_secret` needed.

## Behavior note
`boot` runs `post_start` (storage WRAP-grant injection) *before* the Start lifecycle, vs. after in the old path. This is strictly safer (grants active during Start) and no native block accesses storage during Start. The `wafer.runtime`/`starting` boot-event (consumed only by `wafer dev`) is no longer emitted on native boot — solobase runs standalone (`solobase serve`), not under `wafer dev`, so this is a non-issue; noted for completeness.

## Changes
- [x] `cli/server.rs` — swap start path for `boot` + `run_start_lifecycle` + `bind_all`; add `NativeBootHooks`; update rationale comments.
- [x] `builder.rs` — update the `boot` doc (native is now a funnel consumer).
- [x] `crates/solobase/Cargo.toml` — add `wafer-block` + `async-trait` for the `wafer_async_trait` macro.
- [x] `Cargo.lock` — wafer-run @4906202.

## Verification (local)
- [x] `cargo check -p solobase` / `-p solobase-core` → Finished.
- [x] `cargo test -p solobase-native --test factory_smoke` (7), `cargo test -p solobase --test flow_sealed_native --test cli_args --test mode_detect` (all pass).
- [x] Full native server boot + login is exercised by CI **E2E smoke / visual baselines (native server)**.
- [x] `cargo +nightly fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)