### PR TITLE
chore(auth): remove dead cli_exchange_codes table from migration 001

### DIFF
--- a/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.postgres.sql
@@ -71,15 +71,6 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__personal_access_tokens (
 CREATE INDEX IF NOT EXISTS suppers_ai__auth__personal_access_tokens_user_id_idx
     ON suppers_ai__auth__personal_access_tokens (user_id);
 
-CREATE TABLE IF NOT EXISTS suppers_ai__auth__cli_exchange_codes (
-    code_hash      BYTEA PRIMARY KEY,
-    user_id        TEXT NOT NULL REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
-    created_at     TEXT NOT NULL,
-    expires_at     TEXT NOT NULL
-);
-CREATE INDEX IF NOT EXISTS suppers_ai__auth__cli_exchange_codes_expires_at_idx
-    ON suppers_ai__auth__cli_exchange_codes (expires_at);
-
 CREATE TABLE IF NOT EXISTS suppers_ai__auth__bootstrap_tokens (
     id             TEXT PRIMARY KEY,
     token_hash     TEXT NOT NULL UNIQUE,

--- a/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/001_auth_schema.sqlite.sql
@@ -77,16 +77,6 @@ CREATE TABLE IF NOT EXISTS suppers_ai__auth__personal_access_tokens (
 CREATE INDEX IF NOT EXISTS suppers_ai__auth__personal_access_tokens_user_id_idx
     ON suppers_ai__auth__personal_access_tokens (user_id);
 
--- CLI exchange codes (15-min one-time)
-CREATE TABLE IF NOT EXISTS suppers_ai__auth__cli_exchange_codes (
-    code_hash      BLOB PRIMARY KEY,
-    user_id        TEXT NOT NULL REFERENCES suppers_ai__auth__users(id) ON DELETE CASCADE,
-    created_at     TEXT NOT NULL,
-    expires_at     TEXT NOT NULL
-);
-CREATE INDEX IF NOT EXISTS suppers_ai__auth__cli_exchange_codes_expires_at_idx
-    ON suppers_ai__auth__cli_exchange_codes (expires_at);
-
 -- Bootstrap tokens (first-run admin seeding). token_hash stored as hex-encoded
 -- TEXT (lowercase, 64 chars for sha256) so the typed db::* client can use the
 -- synthetic id PK; the hash is unique per token, indexed for is_valid lookups.

--- a/crates/solobase-core/tests/auth/migrations_001.rs
+++ b/crates/solobase-core/tests/auth/migrations_001.rs
@@ -21,7 +21,6 @@ const EXPECTED_TABLES: &[&str] = &[
     "suppers_ai__auth__orgs",
     "suppers_ai__auth__sessions",
     "suppers_ai__auth__personal_access_tokens",
-    "suppers_ai__auth__cli_exchange_codes",
     "suppers_ai__auth__bootstrap_tokens",
 ];
 


### PR DESCRIPTION
## What
Removes the dead `suppers_ai__auth__cli_exchange_codes` table (+ its index) from the auth block's migration 001 (sqlite + postgres), and drops it from the migration test's expected-tables list.

## Why
The CLI token-exchange flow this table backed was removed. It has **zero readers** — the only references were its own `CREATE TABLE` in 001 and the migration test asserting it exists. It was flagged as a deferred cosmetic cleanup in the quality-fix program (`docs/superpowers/handoffs/2026-06-13-solobase-quality-fix-RESUME.md`).

We're in active development with a wipeable DB (only wafer.run is live; drop + redeploy is acceptable), so the clean fix is to remove the `CREATE` from 001 directly — the schema is recreated clean on the next deploy — rather than an append-only `008_drop_*` migration that would create-then-drop the table on every fresh database.

## Test
- `migration_001_creates_all_tables` and `migration_001_is_idempotent` pass (the test runs the full migration chain and checks the resulting schema).
- Full `auth` integration target: **38 passed**.

## Not touched
The `exchange_code` fn in `auth_ui/oauth/callback.rs` is the unrelated OAuth authorization-code exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)