### PR TITLE
fix(settings): validate URL writes + stop swallowing save failures (M16/M24)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -45,75 +45,12 @@ pub(super) fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
     sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
 }
 
-/// Validate a URL-type config value against SSRF attacks.
-///
-/// Empty values are allowed (clears the setting). Relative paths starting with
-/// a single `/` are allowed. Otherwise the value must be HTTPS (or
-/// `http://localhost` for local development), must not contain newlines (header
-/// injection), and must not resolve to a private/internal/loopback IP.
-///
-/// Used by every variable create/update path — JSON **and** SSR — so a value an
-/// admin can't set through the API can't be smuggled in through the page form.
-pub(super) fn validate_url_value(value: &str) -> Result<(), String> {
-    if value.is_empty() {
-        return Ok(());
-    }
-    // Allow relative paths.
-    if value.starts_with('/') && !value.starts_with("//") {
-        return Ok(());
-    }
-    // Block newlines (header injection).
-    if value.contains('\n') || value.contains('\r') {
-        return Err("URL must not contain newlines".to_string());
-    }
-    // Must be https:// or http://localhost for dev.
-    let is_localhost = value.starts_with("http://localhost");
-    if !value.starts_with("https://") && !is_localhost {
-        return Err("URL must use HTTPS (or http://localhost for development)".to_string());
-    }
-    // Extract hostname and check for private/internal IPs.
-    let host = value
-        .split("://")
-        .nth(1)
-        .and_then(|rest| rest.split('/').next())
-        .and_then(|authority| {
-            // Handle [IPv6]:port
-            if authority.starts_with('[') {
-                authority.strip_prefix('[')?.split(']').next()
-            } else {
-                authority.split(':').next()
-            }
-        })
-        .unwrap_or("");
-
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        match ip {
-            std::net::IpAddr::V4(v4) => {
-                let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
-                    || v4.is_loopback()                // 127.x
-                    || v4.is_link_local()              // 169.254.x
-                    || v4.octets()[0] == 0; // 0.0.0.0/8
-                if is_blocked && !is_localhost {
-                    return Err("URL must not point to private/internal IP addresses".to_string());
-                }
-            }
-            std::net::IpAddr::V6(v6) => {
-                if v6.is_loopback() {
-                    return Err("URL must not point to loopback address".to_string());
-                }
-                // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
-                if let Some(v4) = v6.to_ipv4_mapped() {
-                    if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
-                        return Err(
-                            "URL must not point to private/internal IP addresses".to_string()
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
+/// SSRF URL validator for `InputType::Url` writes. The single implementation
+/// lives in [`crate::util::validate_url_value`]; re-exported here so the admin
+/// variable create/update paths and the generic settings form
+/// (`ui::settings_form::save_settings`) validate through the exact same impl and
+/// can't diverge on what a URL value is allowed to be.
+pub(super) use crate::util::validate_url_value;
 
 /// Bulk-fetch the roles assigned to each of `user_ids` in a single `In`-filter
 /// query, bucketed back into a `user_id -> [role]` map.
@@ -504,20 +441,6 @@ mod tests {
         assert!(is_sensitive_key("JWT_KEY", 0));
         // Neither flag nor suffix → not sensitive.
         assert!(!is_sensitive_key("SITE_NAME", 0));
-    }
-
-    #[test]
-    fn validate_url_value_blocks_ssrf_and_allows_safe() {
-        assert!(validate_url_value("").is_ok());
-        assert!(validate_url_value("/relative/path").is_ok());
-        assert!(validate_url_value("https://example.com/ok").is_ok());
-        assert!(validate_url_value("http://localhost:8080").is_ok());
-        // SSRF vectors.
-        assert!(validate_url_value("http://example.com").is_err()); // not https
-        assert!(validate_url_value("https://10.0.0.1/admin").is_err());
-        assert!(validate_url_value("https://192.168.1.1").is_err());
-        assert!(validate_url_value("https://127.0.0.1").is_err());
-        assert!(validate_url_value("https://example.com\r\nHost: evil").is_err());
     }
 
     // --- End-to-end regression tests for the security drifts this module

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -24,7 +24,10 @@ use wafer_core::clients::config;
 use wafer_run::{context::Context, InputStream, OutputStream};
 pub use wafer_run::{ConfigVar, InputType};
 
-use crate::http::{err_bad_request, ok_json};
+use crate::{
+    http::{err_bad_request, err_internal, ok_json},
+    util::validate_url_value,
+};
 
 /// One titled group of settings within a form (e.g. "Stripe", "OAuth Providers").
 pub struct SettingsSection<'a> {
@@ -221,10 +224,25 @@ pub async fn save_settings(
         Ok(b) => b,
         Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
     };
+    // Validate every URL-typed value up front so one bad URL can't leave a
+    // half-applied save. `is_url()` (InputType::Url) is the declared rule, and
+    // `validate_url_value` is the same SSRF check the admin variables page runs —
+    // shared so the two write surfaces can't accept divergent inputs.
+    for var in allowed {
+        if var.is_url() {
+            if let Some(value) = body.get(&var.key) {
+                if let Err(e) = validate_url_value(value) {
+                    return err_bad_request(&format!("{}: {e}", var.key));
+                }
+            }
+        }
+    }
     for var in allowed {
         if let Some(value) = body.get(&var.key) {
+            // Surface the first write failure instead of reporting a false
+            // "saved" — htmx clients branch on the status, not a 200 body.
             if let Err(e) = config::set(ctx, &var.key, value).await {
-                tracing::warn!(error = %e, key = %var.key, block = block_label, "failed to set config value");
+                return err_internal(&format!("Failed to save {block_label} settings"), e);
             }
         }
     }
@@ -313,5 +331,63 @@ mod tests {
         // a quote in the url must not break out of the string literal
         let js2 = submit_js(r#"/x"); alert(1);//"#);
         assert!(!js2.contains(r#"fetch("/x");"#));
+    }
+
+    // --- save_settings: URL validation (M16) + error surfacing (M24) ---
+    use wafer_run::{streams::output::TerminalNotResponse, InputStream};
+
+    use crate::test_support::TestContext;
+
+    async fn run_save(
+        ctx: &TestContext,
+        allowed: &[ConfigVar],
+        body: serde_json::Value,
+    ) -> OutputStream {
+        let input = InputStream::from_bytes(serde_json::to_vec(&body).unwrap());
+        save_settings(ctx, input, allowed, "test").await
+    }
+
+    #[tokio::test]
+    async fn save_settings_rejects_ssrf_url_for_url_typed_var() {
+        let ctx = TestContext::new().await;
+        let allowed = [var(
+            "SOLOBASE_SHARED__BRANDING__LOGO_URL",
+            "Logo",
+            InputType::Url,
+        )];
+        let out = run_save(
+            &ctx,
+            &allowed,
+            serde_json::json!({"SOLOBASE_SHARED__BRANDING__LOGO_URL": "https://10.0.0.1/logo.png"}),
+        )
+        .await;
+        assert!(
+            matches!(
+                out.collect_buffered().await,
+                Err(TerminalNotResponse::Error(_))
+            ),
+            "an SSRF/private-IP URL must be rejected, not silently saved"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_settings_surfaces_config_set_failure() {
+        // No `wafer-run/config` block registered → config::set fails. Before the
+        // fix the loop swallowed the error and reported success anyway.
+        let ctx = TestContext::new().await;
+        let allowed = [var("SOLOBASE_SHARED__APP_NAME", "App", InputType::Text)];
+        let out = run_save(
+            &ctx,
+            &allowed,
+            serde_json::json!({"SOLOBASE_SHARED__APP_NAME": "MyApp"}),
+        )
+        .await;
+        assert!(
+            matches!(
+                out.collect_buffered().await,
+                Err(TerminalNotResponse::Error(_))
+            ),
+            "a failed config::set must surface as an error, not a 'saved' success"
+        );
     }
 }

--- a/crates/solobase-core/src/util.rs
+++ b/crates/solobase-core/src/util.rs
@@ -204,6 +204,78 @@ pub fn url_path_encode(s: &str) -> String {
     percent_encoding::utf8_percent_encode(s, PATH_SEGMENT).to_string()
 }
 
+/// Validate a URL-type config value against SSRF attacks.
+///
+/// Empty values are allowed (clears the setting). Relative paths starting with
+/// a single `/` are allowed. Otherwise the value must be HTTPS (or
+/// `http://localhost` for local development), must not contain newlines (header
+/// injection), and must not resolve to a private/internal/loopback IP.
+///
+/// Single source of truth for the `InputType::Url` write rule, shared by every
+/// config-value write surface — the admin variables page (`blocks::admin::ops`)
+/// and the generic settings form (`ui::settings_form::save_settings`) — so a
+/// value one surface rejects can't be smuggled in through another.
+pub(crate) fn validate_url_value(value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    // Allow relative paths.
+    if value.starts_with('/') && !value.starts_with("//") {
+        return Ok(());
+    }
+    // Block newlines (header injection).
+    if value.contains('\n') || value.contains('\r') {
+        return Err("URL must not contain newlines".to_string());
+    }
+    // Must be https:// or http://localhost for dev.
+    let is_localhost = value.starts_with("http://localhost");
+    if !value.starts_with("https://") && !is_localhost {
+        return Err("URL must use HTTPS (or http://localhost for development)".to_string());
+    }
+    // Extract hostname and check for private/internal IPs.
+    let host = value
+        .split("://")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .and_then(|authority| {
+            // Handle [IPv6]:port
+            if authority.starts_with('[') {
+                authority.strip_prefix('[')?.split(']').next()
+            } else {
+                authority.split(':').next()
+            }
+        })
+        .unwrap_or("");
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        match ip {
+            std::net::IpAddr::V4(v4) => {
+                let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
+                    || v4.is_loopback()                // 127.x
+                    || v4.is_link_local()              // 169.254.x
+                    || v4.octets()[0] == 0; // 0.0.0.0/8
+                if is_blocked && !is_localhost {
+                    return Err("URL must not point to private/internal IP addresses".to_string());
+                }
+            }
+            std::net::IpAddr::V6(v6) => {
+                if v6.is_loopback() {
+                    return Err("URL must not point to loopback address".to_string());
+                }
+                // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
+                if let Some(v4) = v6.to_ipv4_mapped() {
+                    if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
+                        return Err(
+                            "URL must not point to private/internal IP addresses".to_string()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Percent-encode a string for use as an OAuth / `application/x-www-form-urlencoded`
 /// query parameter or form-body value. Delegates to
 /// [`url::form_urlencoded::byte_serialize`] which encodes spaces as `+` and
@@ -561,5 +633,19 @@ mod tests {
         // Absent fields are not materialized as empty strings.
         assert_eq!(msg.get_meta("auth.user_email"), "");
         assert_eq!(msg.get_meta("auth.user_roles"), "");
+    }
+
+    #[test]
+    fn validate_url_value_blocks_ssrf_and_allows_safe() {
+        assert!(validate_url_value("").is_ok());
+        assert!(validate_url_value("/relative/path").is_ok());
+        assert!(validate_url_value("https://example.com/ok").is_ok());
+        assert!(validate_url_value("http://localhost:8080").is_ok());
+        // SSRF vectors.
+        assert!(validate_url_value("http://example.com").is_err()); // not https
+        assert!(validate_url_value("https://10.0.0.1/admin").is_err());
+        assert!(validate_url_value("https://192.168.1.1").is_err());
+        assert!(validate_url_value("https://127.0.0.1").is_err());
+        assert!(validate_url_value("https://example.com\r\nHost: evil").is_err());
     }
 }


### PR DESCRIPTION
## Two medium findings from the 2026-06-05 review

Both live in the shared `ui::settings_form::save_settings` (used by auth_ui, legalpages, userportal, products, …), so fixing it once covers every block's settings page.

### M16 — `_URL` writes bypassed SSRF validation
The admin variables page funnels `_URL` create/update through an SSRF/HTTPS validator (`admin::ops::validate_url_value`), but the generic settings form wrote `config::set` directly with **no validation** — so an authenticated admin could set a private-IP / non-HTTPS / header-injecting URL through the branding/settings form that the admin variables page would reject (divergent validation for the same key).

**Fix:** every `InputType::Url` value (`var.is_url()` — the declared rule, not a magic `_URL` suffix) is validated before write. To guarantee the two surfaces can't diverge, `validate_url_value` moved to `crate::util` (the shared layer `ui` and `blocks` already depend on) and `admin::ops` re-exports it — one implementation, both callers.

### M24 — save reported success even when the write failed
The loop did `if let Err(e) = config::set(...) { tracing::warn!(...) }` then always returned `{"message":"Settings saved"}` (HTTP 200). A failed write looked successful.

**Fix:** the first `config::set` failure returns a real `err_internal` response (htmx clients branch on status). URL values are validated up front so one bad URL can't leave a half-applied save.

## Tests
- `save_settings_rejects_ssrf_url_for_url_typed_var` — private-IP URL → error, not saved.
- `save_settings_surfaces_config_set_failure` — failed `config::set` → error response (would've been a false "saved" before).
- `validate_url_value` unit test moved alongside the fn in `util`.

```
cargo test -p solobase-core --lib   # 774 passed
```

Part of the 2026-06-05 medium-findings pass (tracked in `workspace/docs/superpowers/REMAINING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)