### PR TITLE
chore(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Unblocks the repo-wide Security Audit gate

A newly-published advisory **RUSTSEC-2026-0185** (GHSA-4w2j-m93h-cj5j) flags `quinn-proto < 0.11.15`. `cargo audit` (the `Security Audit` CI job) now fails on **every** PR in the repo as a result — it was green earlier today and went red with no code change.

`0.11.15` is the patched release (`patched = ">= 0.11.15"`), a semver-compatible patch bump of a transitive dependency. **Lockfile-only** — 2 lines (version + checksum), no source or manifest changes, dependency graph unchanged.

Produced by temporarily disabling the local `.cargo/config.toml` `[patch]` override and running `cargo update -p quinn-proto --precise 0.11.15`, so the committed lock keeps `wafer-*` on the git source (verified: 21 `git+…/wafer-run` entries intact) and only `quinn-proto` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)