### PR TITLE
fix(audit): five medium correctness bugs (M01/M04/M07/M18/M22)

### DIFF
--- a/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/local_credentials.rs
@@ -49,7 +49,7 @@ pub async fn insert(
     data.insert("id".into(), json!(id));
     data.insert("user_id".into(), json!(user_id));
     data.insert("password_hash".into(), json!(password_hash));
-    data.insert("must_reset".into(), json!(if must_reset { 1 } else { 0 }));
+    data.insert("must_reset".into(), json!(must_reset));
     data.insert("created_at".into(), json!(now));
 
     db::create(ctx, TABLE, data)

--- a/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
@@ -11,14 +11,18 @@
 //! Request body is `application/x-www-form-urlencoded` (the GET page
 //! submits a plain HTML form — no JS).
 
+use wafer_core::clients::config;
 use wafer_run::{context::Context, InputStream, OutputStream};
 
 use crate::{
-    blocks::auth::{
-        bootstrap,
-        helpers::issue_tokens_and_cookie,
-        repo::{bootstrap_tokens, users},
-        service::hash_token,
+    blocks::{
+        auth::{
+            bootstrap,
+            helpers::issue_tokens_and_cookie,
+            repo::{bootstrap_tokens, users},
+            service::hash_token,
+        },
+        auth_ui::redirect::is_safe_local_redirect,
     },
     http::{
         err_bad_request, err_internal, err_internal_no_cause, err_unauthorized, ResponseBuilder,
@@ -90,13 +94,22 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
             Err(r) => return r,
         };
 
-    // 6. Set the auth cookie + redirect to the dashboard. The form is a
-    //    plain HTML POST (no JS), so a 302 with Set-Cookie is the right
-    //    completion signal.
+    // 6. Set the auth cookie + redirect to a real post-login destination. The
+    //    form is a plain HTML POST (no JS), so a 302 with Set-Cookie is the
+    //    right completion signal. Honor SOLOBASE_SHARED__POST_LOGIN_REDIRECT
+    //    (validated) like login/oauth, defaulting to the admin home — the old
+    //    `/b/auth/dashboard` target is not a registered route (404).
+    let post_login_raw =
+        config::get_default(ctx, "SOLOBASE_SHARED__POST_LOGIN_REDIRECT", "/b/admin/").await;
+    let dest = if is_safe_local_redirect(&post_login_raw) {
+        post_login_raw
+    } else {
+        "/b/admin/".to_string()
+    };
     ResponseBuilder::new()
         .status(302)
         .set_cookie(&issued.cookie)
-        .set_header("Location", "/b/auth/dashboard")
+        .set_header("Location", &dest)
         .empty()
 }
 
@@ -192,5 +205,33 @@ mod tests {
             .unwrap()
             .is_none());
         assert!(bootstrap_tokens::is_valid(&ctx, &hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn redeems_valid_token_redirects_to_a_real_route() {
+        use wafer_run::{MetaGet, META_RESP_STATUS};
+        let ctx = ctx_with_crypto().await;
+        let raw = "redirect-token";
+        let hash = hash_token(raw);
+        let expires = (chrono::Utc::now() + chrono::Duration::hours(24))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        bootstrap_tokens::insert(&ctx, hash, &expires)
+            .await
+            .unwrap();
+
+        let form = format!("token={raw}&email=admin@example.com&password=test1234");
+        let buf = handle(&ctx, InputStream::from_bytes(form.into_bytes()))
+            .await
+            .collect_buffered()
+            .await
+            .expect("redirect response");
+        assert_eq!(MetaGet::get(&buf.meta, META_RESP_STATUS), Some("302"));
+        // Defaults to the admin home (no POST_LOGIN_REDIRECT configured); the
+        // old `/b/auth/dashboard` target was an unregistered route (404).
+        assert_eq!(
+            MetaGet::get(&buf.meta, "resp.header.Location"),
+            Some("/b/admin/")
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -125,9 +125,10 @@ pub async fn delete_context(ctx: &dyn Context, id: &str) -> Result<(), WaferErro
         operator: FilterOp::Equal,
         value: serde_json::Value::String(id.to_string()),
     }];
-    if let Err(e) = db::delete_by_filters(ctx, ENTRIES_TABLE, filters).await {
-        tracing::warn!("Failed to cascade delete entries for context {id}: {e}");
-    }
+    // Propagate a cascade failure instead of swallowing it: returning early
+    // here leaves the context (and its entries) intact, whereas the old
+    // `Ok`-on-warn deleted the parent and orphaned the entries.
+    db::delete_by_filters(ctx, ENTRIES_TABLE, filters).await?;
 
     db::delete(ctx, CONTEXTS_TABLE, id).await
 }

--- a/crates/solobase-core/src/blocks/products/pricing.rs
+++ b/crates/solobase-core/src/blocks/products/pricing.rs
@@ -185,6 +185,11 @@ pub fn evaluate_formula(formula: &str, variables: &HashMap<String, f64>) -> Resu
     let tokens = tokenize(formula)?;
     let mut pos = 0;
     let result = parse_expression(&tokens, &mut pos, variables)?;
+    // Reject input the parser stopped short on (e.g. "2 3", "(1+2))",
+    // "base_price 5") instead of silently returning a partial result.
+    if pos != tokens.len() {
+        return Err("Unexpected trailing tokens in formula".to_string());
+    }
     Ok(result)
 }
 
@@ -354,5 +359,38 @@ fn parse_factor(
             Ok(-val)
         }
         _ => Err(format!("Unexpected token at position {}", pos)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars() -> HashMap<String, f64> {
+        HashMap::from([
+            ("base_price".to_string(), 10.0),
+            ("quantity".to_string(), 3.0),
+        ])
+    }
+
+    #[test]
+    fn evaluate_formula_computes_valid_expression() {
+        assert_eq!(
+            evaluate_formula("base_price * quantity", &vars()).unwrap(),
+            30.0
+        );
+        assert_eq!(evaluate_formula("(1 + 2) * 4", &vars()).unwrap(), 12.0);
+    }
+
+    #[test]
+    fn evaluate_formula_rejects_trailing_tokens() {
+        // Each parses a valid leading sub-expression but leaves tokens behind;
+        // before the fix these silently returned the partial result.
+        for bad in ["2 3", "(1+2))", "base_price 5", "1 + 2 foo"] {
+            assert!(
+                evaluate_formula(bad, &vars()).is_err(),
+                "formula {bad:?} must be rejected, not silently truncated"
+            );
+        }
     }
 }

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -194,11 +194,22 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
 
     let session: serde_json::Value = match serde_json::from_slice(&resp.body) {
         Ok(d) => d,
-        Err(_) => return err_internal_no_cause("Failed to parse Stripe response"),
+        Err(_) => {
+            // Revert so the purchase doesn't stay stuck in checkout_started
+            // (claim_for_checkout only re-claims `pending`).
+            let _ = repo::purchases::revert_checkout_claim(ctx, &body.purchase_id).await;
+            return err_internal_no_cause("Failed to parse Stripe response");
+        }
     };
 
     let session_id = session.get("id").and_then(|v| v.as_str()).unwrap_or("");
     let checkout_url = session.get("url").and_then(|v| v.as_str()).unwrap_or("");
+    if session_id.is_empty() || checkout_url.is_empty() {
+        // No usable checkout session — revert the claim, same as the parse/4xx
+        // paths, rather than returning an empty/broken checkout URL.
+        let _ = repo::purchases::revert_checkout_claim(ctx, &body.purchase_id).await;
+        return err_internal_no_cause("Stripe response missing session id or checkout url");
+    }
 
     // Update purchase with Stripe session ID
     let mut upd = HashMap::new();


### PR DESCRIPTION
Five isolated, verified medium findings from the 2026-06-05 review (each re-confirmed against current code during triage).

| ID | Area | Bug → Fix |
|----|------|-----------|
| **M01** | `auth/repo/local_credentials` | `must_reset` written as int `1/0` while every sibling bool uses a JSON boolean → `json!(must_reset)`. The int form round-trips on SQLite (read path coerces) but breaks on Postgres typed `BOOLEAN`. |
| **M04** | `products/stripe` | Checkout claim wasn't reverted when the Stripe response failed to parse, or had an empty session id / checkout url → purchase stuck in `checkout_started` forever (`claim_for_checkout` only re-claims `pending`). Now reverts on both, like the existing 4xx branch. |
| **M07** | `products/pricing` | `evaluate_formula` silently returned a partial result for input with trailing tokens (`"2 3"`, `"(1+2))"`, `"base_price 5"`). Now errors if the parser didn't consume all tokens. |
| **M18** | `messages/service` | `delete_context` logged a cascade-delete failure then returned `Ok` after deleting the parent — orphaning entries. Now propagates the error (atomic: context stays if its entries can't be removed). |
| **M22** | `auth_ui/api/bootstrap` | Bootstrap redemption redirected to `/b/auth/dashboard` — **a 404** (unregistered route). Now redirects to a real destination: `SOLOBASE_SHARED__POST_LOGIN_REDIRECT` (validated via `is_safe_local_redirect`) or the `/b/admin/` default, matching login/oauth. |

## Tests
- `pricing`: trailing-token rejection + valid-expression eval (new test module).
- `bootstrap`: redirect lands on `/b/admin/` (302), not the old 404 target.

```
cargo test -p solobase-core --lib   # 777 passed
```

Part of the 2026-06-05 medium-findings pass (tracked in `workspace/docs/superpowers/REMAINING.md`). M16/M24 shipped in #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)