### PR TITLE
fix(audit): three medium cleanups (M02/M05/M14)

### DIFF
--- a/crates/solobase-core/src/blocks/admin/iam.rs
+++ b/crates/solobase-core/src/blocks/admin/iam.rs
@@ -4,6 +4,7 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
+use super::logs::audit_log;
 use crate::{
     http::{err_bad_request, err_conflict, err_forbidden, err_internal, err_not_found, ok_json},
     util::{json_map, RecordExt},
@@ -266,6 +267,7 @@ async fn handle_assign_role(ctx: &dyn Context, msg: &Message, input: InputStream
         Err(e) => return err_internal("Database error", e),
     }
 
+    let assigned = format!("users/{}/roles/{}", body.user_id, body.role);
     let data = json_map(serde_json::json!({
         "user_id": body.user_id,
         "role": body.role,
@@ -273,7 +275,19 @@ async fn handle_assign_role(ctx: &dyn Context, msg: &Message, input: InputStream
         "assigned_by": msg.user_id()
     }));
     match db::create(ctx, USER_ROLES_TABLE, data).await {
-        Ok(record) => ok_json(&record),
+        Ok(record) => {
+            // Audit-log like every other admin mutation (this JSON path used to
+            // write zero audit rows).
+            audit_log(
+                ctx,
+                msg.user_id(),
+                "user_role.assign",
+                &assigned,
+                msg.remote_addr(),
+            )
+            .await;
+            ok_json(&record)
+        }
         Err(e) => err_internal("Database error", e),
     }
 }
@@ -302,7 +316,17 @@ async fn handle_remove_role(ctx: &dyn Context, msg: &Message, path: &str) -> Out
     }
 
     match db::delete(ctx, USER_ROLES_TABLE, id).await {
-        Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
+        Ok(()) => {
+            audit_log(
+                ctx,
+                msg.user_id(),
+                "user_role.remove",
+                &format!("user_roles/{id}"),
+                msg.remote_addr(),
+            )
+            .await;
+            ok_json(&serde_json::json!({"deleted": true}))
+        }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("User-role assignment not found"),
         Err(e) => err_internal("Database error", e),
     }

--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS suppers_ai__products__purchases (
     metadata                    TEXT NOT NULL DEFAULT '{}',
     stripe_payment_intent_id    TEXT NOT NULL DEFAULT '',
     provider_payment_intent_id  TEXT NOT NULL DEFAULT '',
+    provider_session_id         TEXT NOT NULL DEFAULT '',
     approved_at                 TEXT,
     refunded_at                 TEXT,
     refunded_by                 TEXT NOT NULL DEFAULT '',

--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
@@ -94,6 +94,7 @@ CREATE TABLE IF NOT EXISTS suppers_ai__products__purchases (
     metadata                    TEXT NOT NULL DEFAULT '{}',
     stripe_payment_intent_id    TEXT NOT NULL DEFAULT '',
     provider_payment_intent_id  TEXT NOT NULL DEFAULT '',
+    provider_session_id         TEXT NOT NULL DEFAULT '',
     approved_at                 TEXT,
     refunded_at                 TEXT,
     refunded_by                 TEXT NOT NULL DEFAULT '',

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -557,16 +557,10 @@ async fn load_index_metadata(
     // `{prefixed}_fts` when keyword_search is enabled and nothing when it
     // isn't, so the row count for that exact name is a reliable signal.
     let fts_name = format!("{prefixed_index}_fts");
-    // Direct `sqlite_master` lookup — the vector block is SQLite-only by
-    // design (sqlite-vec extension), so no dialect-portable equivalent is
-    // needed. `wafer-sql-utils::introspect` doesn't expose a "table exists"
-    // single-name probe; adding one is out of scope for this PR.
-    let fts_rows = db::query_raw(
-        ctx,
-        "SELECT name FROM sqlite_master WHERE type='table' AND name = ?1",
-        &[serde_json::Value::String(fts_name)],
-    )
-    .await?;
+    // "Table exists" probe via the sql-utils introspect builder (portable
+    // across backends) instead of a hand-written `sqlite_master` query.
+    let (sql, params) = introspect::build_table_exists(&fts_name, crate::db_backend(ctx).await);
+    let fts_rows = db::query_raw(ctx, &sql, &params).await?;
     let keyword_search = !fts_rows.is_empty();
 
     Ok((DEFAULT_MODEL.to_string(), keyword_search))


### PR DESCRIPTION
Three small, in-repo medium findings from the 2026-06-05 review.

- **M02** `admin/iam.rs` — `handle_assign_role` / `handle_remove_role` wrote **zero audit-log rows**, unlike every other admin mutation (role create/delete already route through `admin/ops.rs` with `audit_log`; these two JSON paths were the stragglers). Added `audit_log` on success (`user_role.assign` / `user_role.remove`).
- **M05** `products` — `stripe.rs` writes `provider_session_id` via `repo::purchases::update`, but the column was declared in **neither** 001 migration → errors on Postgres / dropped off-schema on D1. Added `provider_session_id TEXT NOT NULL DEFAULT ''` to the purchases table (sqlite + postgres), directly in 001 per the active-dev/wipeable-DB precedent (cli_exchange #281). CollectionSchema is name-only (advisory), so no change there. Column is write-only (no query) → no index needed.
- **M14** `vector/pages.rs` — replaced a hand-written `sqlite_master` table-exists `query_raw` with `wafer_sql_utils::introspect::build_table_exists(table, backend)` (the builder exists; the "out of scope" comment was stale). The file already uses `introspect::build_list_tables_like` the same way.

```
cargo test -p solobase-core --lib   # 778 passed
```

Part of the 2026-06-05 medium-findings pass (`workspace/docs/superpowers/REMAINING.md`). Remaining after this: M08, M09, M29 + M06 (decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)