### PR TITLE
fix(cloudflare): reject oversized body before buffering (M29)

### DIFF
--- a/crates/solobase-cloudflare/src/convert.rs
+++ b/crates/solobase-cloudflare/src/convert.rs
@@ -34,6 +34,22 @@ pub async fn worker_request_to_message(req: &Request) -> Result<(Message, InputS
     // Read body (with size limit). A read error here would otherwise be
     // swallowed and turned into an empty body, silently corrupting POST/PUT.
     const MAX_BODY_SIZE: usize = 10 * 1024 * 1024; // 10 MB
+
+    // Reject oversized bodies on the declared Content-Length *before* buffering
+    // them into the (128 MB) Worker isolate. The post-read check below is the
+    // backstop for chunked / absent-length requests where the header can't be
+    // trusted.
+    if let Some(len) = req
+        .headers()
+        .get("content-length")
+        .ok()
+        .flatten()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        if len > MAX_BODY_SIZE {
+            return Err("request body too large".into());
+        }
+    }
     let mut req_clone = req.clone()?;
     let body = req_clone.bytes().await?;
     if body.len() > MAX_BODY_SIZE {


### PR DESCRIPTION
## M29 — request-body size limit checked only after buffering

`worker_request_to_message` (`solobase-cloudflare/src/convert.rs`) read the **entire** body into memory (`req.bytes().await`) and only then compared `body.len()` to `MAX_BODY_SIZE` (10 MB) — so the cap couldn't actually prevent memory exhaustion in the 128 MB Worker isolate; the bytes were already resident.

**Fix:** reject on the declared `Content-Length` header *before* buffering. The existing post-read check stays as the backstop for chunked / absent-length requests where the header can't be trusted.

## Verification
```
cargo check -p solobase-cloudflare --target wasm32-unknown-unknown   # the CI "Cloudflare wasm32 check" gate — passes
```
The CF adapter crate has no native test target (it depends on `worker` types), so no unit test — consistent with the rest of the adapter.

Part of the 2026-06-05 medium-findings pass. After this, only M08 (model-picker) + M06 (decision) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)