### PR TITLE
fix(llm): model-picker sends model + provider separately, not a composite (M08)

### DIFF
--- a/crates/solobase-core/src/blocks/llm/pages.rs
+++ b/crates/solobase-core/src/blocks/llm/pages.rs
@@ -535,11 +535,14 @@ async fn load_models(ctx: &dyn Context) -> Vec<ModelInfo> {
 
 /// Render the `<option>` list for the remote-model picker.
 ///
-/// Each option's `value` is `"{backend_id}:{model_id}"` — a single string so
-/// the existing thread-setting shape (single `model` field) stays compatible.
-/// The visible label prefers `display_name`, falling back to `model_id`. The
-/// `backend_id` is appended in parens when non-empty so users can disambiguate
-/// the same model id hosted on different backends.
+/// Each option carries the bare `model_id` as its `value` and the `backend_id`
+/// as a `data-backend-id` attribute — two separate fields, NOT a
+/// `"{backend_id}:{model_id}"` composite. The composite was ambiguous (model
+/// ids such as `llama3:8b` contain colons) and was forwarded to the backend
+/// verbatim as the model id; the JS now sends `model` + `provider` separately.
+/// The visible label prefers `display_name`, falling back to `model_id`, with
+/// `backend_id` appended in parens to disambiguate the same model on different
+/// backends.
 ///
 /// Entries with an empty `model_id` are skipped — the resulting
 /// `<option value="">` would collide with the "Default (remote)" entry and
@@ -550,19 +553,15 @@ fn render_model_picker(models: &[ModelInfo], default_model: &str) -> Markup {
             @let backend_id = m.backend_id.as_str();
             @let model_id = m.model_id.as_str();
             @if !model_id.is_empty() {
-                @let value = if backend_id.is_empty() {
-                    model_id.to_string()
-                } else {
-                    format!("{backend_id}:{model_id}")
-                };
                 @let display = if m.display_name.is_empty() {
                     model_id
                 } else {
                     m.display_name.as_str()
                 };
                 option
-                    value=(value)
-                    selected[value == default_model]
+                    value=(model_id)
+                    data-backend-id=(backend_id)
+                    selected[model_id == default_model]
                 {
                     (display)
                     @if !backend_id.is_empty() {
@@ -601,15 +600,15 @@ mod tests {
     }
 
     /// A typical aggregated `Vec<ModelInfo>` payload renders one option per
-    /// entry with the `"{backend_id}:{model_id}"` value and `display_name`
-    /// label.
+    /// entry with the bare `model_id` value, a `data-backend-id` attribute, and
+    /// the `display_name` label.
     #[test]
     fn render_model_picker_typical_list_emits_one_option_per_model() {
         let models = vec![
             mi("openai", "gpt-4o", "GPT-4o"),
             mi("anthropic", "claude-3-5-sonnet", "Claude 3.5 Sonnet"),
         ];
-        let markup = render_model_picker(&models, "anthropic:claude-3-5-sonnet");
+        let markup = render_model_picker(&models, "claude-3-5-sonnet");
         let html = markup.into_string();
 
         // One <option> per model entry.
@@ -618,14 +617,15 @@ mod tests {
             2,
             "expected 2 <option> tags, got: {html}"
         );
-        // Composite value uses `backend_id:model_id`.
+        // Value is the bare model_id; backend_id rides in data-backend-id —
+        // never a `backend:model` composite.
         assert!(
-            html.contains(r#"value="openai:gpt-4o""#),
-            "missing openai value: {html}"
+            html.contains(r#"value="gpt-4o" data-backend-id="openai""#),
+            "missing openai option shape: {html}"
         );
         assert!(
-            html.contains(r#"value="anthropic:claude-3-5-sonnet""#),
-            "missing anthropic value: {html}"
+            !html.contains(r#"value="openai:gpt-4o""#),
+            "must not emit the ambiguous composite value: {html}"
         );
         // Human label comes from display_name.
         assert!(html.contains("GPT-4o"), "missing GPT-4o label: {html}");
@@ -635,9 +635,9 @@ mod tests {
         );
         // Backend id is appended in parens for disambiguation.
         assert!(html.contains("(openai)"), "missing backend suffix: {html}");
-        // The entry matching the default_model string is pre-selected.
+        // The entry whose model_id matches default_model is pre-selected.
         assert!(
-            html.contains(r#"value="anthropic:claude-3-5-sonnet" selected"#),
+            html.contains(r#"value="claude-3-5-sonnet" data-backend-id="anthropic" selected"#),
             "expected selected attr on matching default_model entry: {html}"
         );
     }
@@ -666,16 +666,18 @@ mod tests {
             2,
             "expected 2 <option> tags, got: {html}"
         );
-        // Empty display_name falls back to model id as the visible label.
+        // Empty display_name falls back to model id as the visible label; the
+        // value is the bare model_id with backend_id in data-backend-id.
         assert!(
-            html.contains(r#"value="openai:gpt-4o-mini""#),
-            "expected openai:gpt-4o-mini value: {html}"
+            html.contains(r#"value="gpt-4o-mini" data-backend-id="openai""#),
+            "expected gpt-4o-mini option shape: {html}"
         );
         assert!(
             html.contains("gpt-4o-mini"),
             "expected gpt-4o-mini label fallback: {html}"
         );
-        // No backend_id — value is the bare model_id, no `(...)` suffix.
+        // No backend_id — value is the bare model_id, empty data-backend-id, no
+        // `(...)` suffix.
         assert!(
             html.contains(r#"value="solo-model""#),
             "expected bare-model value when backend_id is missing: {html}"

--- a/crates/solobase-core/src/ui/assets/llm-chat.js
+++ b/crates/solobase-core/src/ui/assets/llm-chat.js
@@ -204,6 +204,12 @@
 
     var picker = document.getElementById('model-picker');
     var model = picker ? picker.value : '';
+    // The selected option carries the bare model id as its value and the
+    // backend id in data-backend-id, so model + provider go as separate fields
+    // (the old "backend:model" composite was ambiguous and mis-sent the model).
+    var backendId = (picker && picker.selectedOptions[0])
+      ? (picker.selectedOptions[0].dataset.backendId || '')
+      : '';
 
     var chatPromise;
     if (model.startsWith('local:')) {
@@ -215,7 +221,7 @@
         return handleLocalChat(threadId, model.slice(6));
       });
     } else {
-      chatPromise = handleRemoteChat(threadId, userText, model);
+      chatPromise = handleRemoteChat(threadId, userText, model, backendId);
     }
 
     chatPromise.catch(function (err) {
@@ -275,7 +281,7 @@
       });
   }
 
-  function handleRemoteChat(threadId, userText, model) {
+  function handleRemoteChat(threadId, userText, model, backendId) {
     var card = appendMessageCard('assistant', '', { id: 'streaming-msg' });
     var contentDiv = card ? card.querySelector('div:last-child') : null;
     if (contentDiv) contentDiv.innerHTML = '<span class="text-muted" style="animation:pulse 1.5s infinite">Thinking...</span>';
@@ -283,6 +289,7 @@
 
     var body = { thread_id: threadId, message: userText };
     if (model) body.model = model;
+    if (backendId) body.provider = backendId;
 
     return fetch('/b/llm/api/chat', {
       method: 'POST',


### PR DESCRIPTION
## M08 — model-picker composite was never decoded on the remote path

The remote model-picker rendered `<option value="{backend_id}:{model_id}">` and the chat JS sent that composite string as `body.model`. Nothing ever split it:

- `routes::dispatch_chat` → `resolve_provider` returned the composite as `resolved_model`, so the backend received e.g. **`openai:gpt-4o`** as the model id;
- and the **chosen backend was ignored** (the default provider / first-enabled was used instead).

The composite is also fundamentally ambiguous — Ollama model ids like `llama3:8b` contain colons — so blindly splitting on `:` can't work.

## Fix — separate fields (no composite)
- The `<option>` now carries the **bare `model_id`** as its `value` and the **`backend_id`** in a `data-backend-id` attribute.
- `llm-chat.js` reads both from the selected option and sends `model` + `provider` as **separate** fields in the chat body.
- `dispatch_chat` / `resolve_provider` already accept `provider` and `model` separately → the backend gets the bare model id **and** the selected backend. (Local models keep their `local:` value; that path is unchanged.)
- Pre-selection now matches `default_model` against the bare model id.

## Tests
Updated both `render_model_picker` tests to assert `value="gpt-4o" data-backend-id="openai"` (and explicitly that the ambiguous `value="openai:gpt-4o"` composite is **not** emitted).

```
cargo test -p solobase-core --lib   # 779 passed
```

This is the **last** of the 2026-06-05 medium findings worth fixing (tracked in `workspace/docs/superpowers/REMAINING.md`); only M06 (price/base_price — needs your decision on the live-data migration) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)