### PR TITLE
fix(products): collapse to base_price, drop vestigial price column (M06)

### DIFF
--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.postgres.sql
@@ -2,7 +2,7 @@
 --
 -- Mirror of 001_products_schema.sqlite.sql. INTEGER (not BOOLEAN) is used
 -- for boolean-like columns to match the JSON-value round-trips used by
--- block code. DOUBLE PRECISION is used for the float price columns.
+-- block code. DOUBLE PRECISION is used for the float `base_price` column.
 -- CREATE TABLE IF NOT EXISTS makes this idempotent across repeated `Init`
 -- lifecycle events.
 --
@@ -16,7 +16,6 @@ CREATE TABLE IF NOT EXISTS suppers_ai__products__products (
     name                  TEXT NOT NULL,
     description           TEXT NOT NULL DEFAULT '',
     slug                  TEXT NOT NULL DEFAULT '',
-    price                 DOUBLE PRECISION NOT NULL DEFAULT 0,
     base_price            DOUBLE PRECISION NOT NULL DEFAULT 0,
     currency              TEXT NOT NULL DEFAULT 'USD',
     status                TEXT NOT NULL DEFAULT 'draft',

--- a/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
+++ b/crates/solobase-core/src/blocks/products/migrations/001_products_schema.sqlite.sql
@@ -19,7 +19,6 @@ CREATE TABLE IF NOT EXISTS suppers_ai__products__products (
     name                  TEXT NOT NULL,
     description           TEXT NOT NULL DEFAULT '',
     slug                  TEXT NOT NULL DEFAULT '',
-    price                 REAL NOT NULL DEFAULT 0,
     base_price            REAL NOT NULL DEFAULT 0,
     currency              TEXT NOT NULL DEFAULT 'USD',
     status                TEXT NOT NULL DEFAULT 'draft',

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -95,7 +95,7 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
                         vec![
                             html! { span .font-medium { (record.str_field("name")) } },
                             components::status_badge(record.str_field("status")),
-                            html! { (record.str_field("price")) " " span .text-muted { (record.str_field("currency")) } },
+                            html! { (record.str_field("base_price")) " " span .text-muted { (record.str_field("currency")) } },
                             html! { span .text-muted .text-sm { @if group_id.is_empty() { "—" } @else { (group_id.get(..8).unwrap_or(group_id)) } } },
                             html! { span .text-muted .text-sm { (created.get(..10).unwrap_or(created)) } },
                         ]
@@ -335,7 +335,7 @@ pub async fn my_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
                     @let rows: Vec<Vec<maud::Markup>> = list.records.iter().map(|r| vec![
                         html! { span .font-medium { (r.str_field("name")) } },
                         components::status_badge(r.str_field("status")),
-                        html! { (r.str_field("price")) " " span .text-muted { (r.str_field("currency")) } },
+                        html! { (r.str_field("base_price")) " " span .text-muted { (r.str_field("currency")) } },
                         html! { span .text-muted .text-sm { (r.str_field("created_at").get(..10).unwrap_or("")) } },
                     ]).collect();
                     (components::data_table(&cols, rows, None::<fn(usize) -> Option<String>>, html! { p .text-muted { "No products yet" } }))


### PR DESCRIPTION
## M06 — two price columns that disagreed

The products table declared both `price` and `base_price`. The two halves of the system read **different** ones:

- **Admin lists displayed `price`** (`pages.rs:98`, `:338`).
- **Pricing/checkout charged `base_price`** (`pricing.rs::base_price` → `resolve_unit_price` → `purchase.rs`).

But **nothing ever wrote `price`** — `crud_create`/`crud_update` are passthroughs and every caller (fixtures, `handler_tests`, purchase/pricing tests, the JS SDK) uses `base_price`. So `price` stayed at its `0` default: the admin product list showed **`0` for every product** while checkout charged the real `base_price`. A display/charge divergence + dead column.

## Fix — `base_price` is the single source of truth
- Dropped the `price` column from migration 001 (sqlite + postgres). Active-dev / wipeable DB, so edited 001 directly per the `cli_exchange` (#281) / `provider_session_id` (#288) precedent rather than a no-op ALTER.
- Both product tables now display `base_price`.
- No writer, test, or SDK referenced the dropped column, so nothing else changed.

```
cargo test -p solobase-core --lib   # 779 passed
```

This was the last open item from the 2026-06-05 review (`workspace/docs/superpowers/REMAINING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)