### PR TITLE
feat: exact-match SW bypass (serve / statically via extra_bypass_exact)

### DIFF
--- a/crates/solobase-bundle/assets/sw.js.tmpl
+++ b/crates/solobase-bundle/assets/sw.js.tmpl
@@ -149,7 +149,7 @@ self.addEventListener('fetch', (event) => {
         url.pathname.startsWith('__WASM_JS_PREFIX__') ||
         url.pathname.startsWith('/snippets/') ||
         url.pathname.startsWith('/vendor/') ||
-        url.pathname.startsWith('/sql-')__EXTRA_BYPASS__) {
+        url.pathname.startsWith('/sql-')__EXTRA_BYPASS____EXTRA_BYPASS_EXACT__) {
         return;
     }
     event.respondWith(handleFetch(event.request));

--- a/crates/solobase-bundle/src/bundle/mod.rs
+++ b/crates/solobase-bundle/src/bundle/mod.rs
@@ -28,6 +28,12 @@ pub struct AppConfig {
     /// `url.pathname.startsWith(<prefix>)` clause via the `__EXTRA_BYPASS__`
     /// placeholder.
     pub extra_bypass_prefix: Vec<String>,
+    /// Additional exact URL paths the Service Worker's fetch handler should
+    /// bypass. Unlike `extra_bypass_prefix` (rendered as `startsWith`), each
+    /// entry renders as `url.pathname === <path>` via the
+    /// `__EXTRA_BYPASS_EXACT__` placeholder — needed for `/` and
+    /// `/index.html`, which cannot be expressed as a prefix.
+    pub extra_bypass_exact: Vec<String>,
     /// Whether loader.js's recovery path should wipe OPFS when the Service
     /// Worker self-destructs. **Default: false** — for production apps that
     /// store user data in OPFS (chat history, generated assets, settings),
@@ -295,6 +301,19 @@ fn build_template_vars(
         out
     };
 
+    let extra_bypass_exact = if app.extra_bypass_exact.is_empty() {
+        String::new()
+    } else {
+        let mut out = String::new();
+        for path in &app.extra_bypass_exact {
+            let escaped = path.replace('\\', "\\\\").replace('\'', "\\'");
+            out.push_str(" || url.pathname === '");
+            out.push_str(&escaped);
+            out.push_str("'");
+        }
+        out
+    };
+
     let mut vars: BTreeMap<String, String> = BTreeMap::new();
     vars.insert("BUILD_ID".to_string(), build_id);
     vars.insert("WASM_JS".to_string(), wasm_js);
@@ -304,6 +323,7 @@ fn build_template_vars(
     vars.insert("APP_TITLE".to_string(), app_title);
     vars.insert("BOOT_REDIRECT".to_string(), boot_redirect);
     vars.insert("EXTRA_BYPASS".to_string(), extra_bypass);
+    vars.insert("EXTRA_BYPASS_EXACT".to_string(), extra_bypass_exact);
     vars.insert(
         "OPFS_WIPE_ON_RECOVERY".to_string(),
         if app.opfs_wipe_on_recovery {

--- a/crates/solobase-bundle/tests/bundle_fixtures/pkg-in/sw.js.tmpl
+++ b/crates/solobase-bundle/tests/bundle_fixtures/pkg-in/sw.js.tmpl
@@ -1,2 +1,3 @@
 // @generated build: __BUILD_ID__
 import init, { initialize, handle_request } from '__WASM_JS__';
+// bypass: url.pathname.startsWith('/sql-')__EXTRA_BYPASS____EXTRA_BYPASS_EXACT__

--- a/crates/solobase-bundle/tests/bundle_integration.rs
+++ b/crates/solobase-bundle/tests/bundle_integration.rs
@@ -12,8 +12,36 @@ fn default_app() -> AppConfig {
         app_title: None,
         boot_redirect: None,
         extra_bypass_prefix: Vec::new(),
+        extra_bypass_exact: Vec::new(),
         opfs_wipe_on_recovery: false,
     }
+}
+
+#[test]
+fn exact_bypass_renders_into_sw() {
+    let tmp = tempfile::tempdir().unwrap();
+    copy_dir(&fixture_path(), tmp.path());
+
+    let app = AppConfig {
+        extra_bypass_exact: vec!["/".to_string(), "/index.html".to_string()],
+        ..default_app()
+    };
+    run(tmp.path(), tmp.path(), app).expect("bundler ok");
+
+    let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
+    assert!(sw.contains("url.pathname === '/'"), "sw.js missing exact '/' bypass = {sw}");
+    assert!(sw.contains("url.pathname === '/index.html'"), "sw.js missing exact '/index.html' bypass");
+    assert!(!sw.contains("__EXTRA_BYPASS_EXACT__"), "placeholder not substituted");
+}
+
+#[test]
+fn exact_bypass_empty_leaves_sw_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    copy_dir(&fixture_path(), tmp.path());
+    run(tmp.path(), tmp.path(), default_app()).expect("bundler ok");
+    let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
+    assert!(!sw.contains("__EXTRA_BYPASS_EXACT__"));
+    assert!(!sw.contains("=== '/'"));
 }
 
 #[test]

--- a/crates/solobase-bundle/tests/bundle_integration.rs
+++ b/crates/solobase-bundle/tests/bundle_integration.rs
@@ -29,9 +29,18 @@ fn exact_bypass_renders_into_sw() {
     run(tmp.path(), tmp.path(), app).expect("bundler ok");
 
     let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
-    assert!(sw.contains("url.pathname === '/'"), "sw.js missing exact '/' bypass = {sw}");
-    assert!(sw.contains("url.pathname === '/index.html'"), "sw.js missing exact '/index.html' bypass");
-    assert!(!sw.contains("__EXTRA_BYPASS_EXACT__"), "placeholder not substituted");
+    assert!(
+        sw.contains("url.pathname === '/'"),
+        "sw.js missing exact '/' bypass = {sw}"
+    );
+    assert!(
+        sw.contains("url.pathname === '/index.html'"),
+        "sw.js missing exact '/index.html' bypass"
+    );
+    assert!(
+        !sw.contains("__EXTRA_BYPASS_EXACT__"),
+        "placeholder not substituted"
+    );
 }
 
 #[test]
@@ -109,10 +118,7 @@ fn empty_exact_leaves_production_sw_bypass_unchanged() {
     copy_dir(&fixture_path(), tmp.path());
 
     // Overwrite the fixture stub with the real production template.
-    let prod_tmpl = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/assets/sw.js.tmpl"
-    ));
+    let prod_tmpl = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/sw.js.tmpl"));
     fs::write(tmp.path().join("sw.js.tmpl"), prod_tmpl).unwrap();
 
     // default_app has both extra_bypass_prefix and extra_bypass_exact empty.
@@ -121,8 +127,14 @@ fn empty_exact_leaves_production_sw_bypass_unchanged() {
     let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
 
     // Placeholders must be fully substituted.
-    assert!(!sw.contains("__EXTRA_BYPASS_EXACT__"), "placeholder not substituted in sw.js");
-    assert!(!sw.contains("__EXTRA_BYPASS__"), "placeholder not substituted in sw.js");
+    assert!(
+        !sw.contains("__EXTRA_BYPASS_EXACT__"),
+        "placeholder not substituted in sw.js"
+    );
+    assert!(
+        !sw.contains("__EXTRA_BYPASS__"),
+        "placeholder not substituted in sw.js"
+    );
     // No injected exact-match bypass clause (the bundler emits " || url.pathname === '<path>'"
     // for each entry; the template itself uses "=== '" for its own static pathname checks but
     // never prefixed with "|| url.pathname").

--- a/crates/solobase-bundle/tests/bundle_integration.rs
+++ b/crates/solobase-bundle/tests/bundle_integration.rs
@@ -103,6 +103,40 @@ fn deterministic_across_runs() {
     assert_eq!(v1.get("assets"), v2.get("assets"));
 }
 
+#[test]
+fn empty_exact_leaves_production_sw_bypass_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    copy_dir(&fixture_path(), tmp.path());
+
+    // Overwrite the fixture stub with the real production template.
+    let prod_tmpl = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/sw.js.tmpl"
+    ));
+    fs::write(tmp.path().join("sw.js.tmpl"), prod_tmpl).unwrap();
+
+    // default_app has both extra_bypass_prefix and extra_bypass_exact empty.
+    run(tmp.path(), tmp.path(), default_app()).expect("bundler ok");
+
+    let sw = fs::read_to_string(tmp.path().join("sw.js")).unwrap();
+
+    // Placeholders must be fully substituted.
+    assert!(!sw.contains("__EXTRA_BYPASS_EXACT__"), "placeholder not substituted in sw.js");
+    assert!(!sw.contains("__EXTRA_BYPASS__"), "placeholder not substituted in sw.js");
+    // No injected exact-match bypass clause (the bundler emits " || url.pathname === '<path>'"
+    // for each entry; the template itself uses "=== '" for its own static pathname checks but
+    // never prefixed with "|| url.pathname").
+    assert!(
+        !sw.contains("|| url.pathname === '"),
+        "unexpected exact-match bypass clause injected into sw.js"
+    );
+    // The bypass expression must close exactly as in the pre-change form.
+    assert!(
+        sw.contains("startsWith('/sql-')) {"),
+        "production bypass closing token changed; sw.js = {sw}"
+    );
+}
+
 fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
     for entry in fs::read_dir(src).unwrap() {
         let e = entry.unwrap();

--- a/crates/solobase/src/cli/config.rs
+++ b/crates/solobase/src/cli/config.rs
@@ -44,6 +44,8 @@ pub struct AssetsConfig {
     #[serde(default)]
     pub extra_bypass_prefix: Vec<String>,
     #[serde(default)]
+    pub extra_bypass_exact: Vec<String>,
+    #[serde(default)]
     pub overlay: Vec<OverlayEntry>,
     /// Whether `loader.js`'s recovery path wipes OPFS when the SW
     /// self-destructs. Defaults to **false** — apps that store user data
@@ -234,5 +236,20 @@ boot_redirect = "/"
         let err = find_and_load(tmp.path()).unwrap_err().to_string();
         assert!(err.contains("solobase.toml"));
         assert!(err.contains("no"));
+    }
+
+    #[test]
+    fn parses_extra_bypass_exact() {
+        let toml = r#"
+[app]
+name = "x"
+title = "y"
+boot_redirect = "/"
+
+[assets]
+extra_bypass_exact = ["/", "/index.html"]
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.assets.extra_bypass_exact, vec!["/".to_string(), "/index.html".to_string()]);
     }
 }

--- a/crates/solobase/src/cli/config.rs
+++ b/crates/solobase/src/cli/config.rs
@@ -250,6 +250,9 @@ boot_redirect = "/"
 extra_bypass_exact = ["/", "/index.html"]
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
-        assert_eq!(cfg.assets.extra_bypass_exact, vec!["/".to_string(), "/index.html".to_string()]);
+        assert_eq!(
+            cfg.assets.extra_bypass_exact,
+            vec!["/".to_string(), "/index.html".to_string()]
+        );
     }
 }

--- a/crates/solobase/src/cli/flows/embed_web.rs
+++ b/crates/solobase/src/cli/flows/embed_web.rs
@@ -37,7 +37,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
         app_title: Some(cfg.app.title.clone()),
         boot_redirect: Some(cfg.app.boot_redirect.clone()),
         extra_bypass_prefix: cfg.assets.extra_bypass_prefix.clone(),
-        extra_bypass_exact: vec![],
+        extra_bypass_exact: cfg.assets.extra_bypass_exact.clone(),
         opfs_wipe_on_recovery: cfg.assets.opfs_wipe_on_recovery,
     };
     solobase_bundle::assets::write_to(&dist_dir)?;

--- a/crates/solobase/src/cli/flows/embed_web.rs
+++ b/crates/solobase/src/cli/flows/embed_web.rs
@@ -37,6 +37,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
         app_title: Some(cfg.app.title.clone()),
         boot_redirect: Some(cfg.app.boot_redirect.clone()),
         extra_bypass_prefix: cfg.assets.extra_bypass_prefix.clone(),
+        extra_bypass_exact: vec![],
         opfs_wipe_on_recovery: cfg.assets.opfs_wipe_on_recovery,
     };
     solobase_bundle::assets::write_to(&dist_dir)?;

--- a/crates/solobase/src/cli/flows/sealed_web.rs
+++ b/crates/solobase/src/cli/flows/sealed_web.rs
@@ -40,6 +40,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
             app_title: Some(c.app.title.clone()),
             boot_redirect: Some(c.app.boot_redirect.clone()),
             extra_bypass_prefix: c.assets.extra_bypass_prefix.clone(),
+            extra_bypass_exact: vec![],
             opfs_wipe_on_recovery: c.assets.opfs_wipe_on_recovery,
         },
         None => solobase_bundle::bundle::AppConfig {
@@ -47,6 +48,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
             app_title: None,
             boot_redirect: None,
             extra_bypass_prefix: vec![],
+            extra_bypass_exact: vec![],
             opfs_wipe_on_recovery: false,
         },
     };

--- a/crates/solobase/src/cli/flows/sealed_web.rs
+++ b/crates/solobase/src/cli/flows/sealed_web.rs
@@ -40,7 +40,7 @@ pub async fn build(repo_root: &Path, release: bool) -> Result<()> {
             app_title: Some(c.app.title.clone()),
             boot_redirect: Some(c.app.boot_redirect.clone()),
             extra_bypass_prefix: c.assets.extra_bypass_prefix.clone(),
-            extra_bypass_exact: vec![],
+            extra_bypass_exact: c.assets.extra_bypass_exact.clone(),
             opfs_wipe_on_recovery: c.assets.opfs_wipe_on_recovery,
         },
         None => solobase_bundle::bundle::AppConfig {


### PR DESCRIPTION
## What

Adds `[assets] extra_bypass_exact` to the solobase bundle template so consumers can mark exact URL paths (notably `/` and `/index.html`) as **Service-Worker-bypassed** — served as static assets the SW never intercepts.

Today only `extra_bypass_prefix` exists, rendered as `url.pathname.startsWith('…')`. `/` can't be a prefix (`'/'.startsWith` matches every path). The new field renders as `url.pathname === '<path>'` clauses via a `__EXTRA_BYPASS_EXACT__` placeholder, mirroring the prefix path's rendering and escaping.

## Why

Producer side of gizza.ai's "static two-button landing": gizza serves a static chooser at `/` that must render even when the in-browser WASM runtime fails to boot (the "gizza-ai couldn't start" mobile-data failure). That requires `/` to be SW-bypassed.

Spec: `docs/superpowers/specs/2026-06-25-gizza-mobile-two-button-landing-design.md` (workspace docs), Component 1.

## Changes

- `solobase-bundle`: new `AppConfig.extra_bypass_exact`, rendered into `sw.js.tmpl` via `__EXTRA_BYPASS_EXACT__`.
- `solobase` CLI: parse `[assets] extra_bypass_exact` (`#[serde(default)]`) and forward it at all flow call sites, symmetric with `extra_bypass_prefix`.

## Backward compatibility

Empty/omitted ⇒ placeholder expands to `""` ⇒ generated `sw.js` is byte-identical to before; existing TOMLs (no key) parse unchanged. Guarded by a test that renders the **production** `sw.js.tmpl` with the field empty and pins the unchanged bypass closing token.

## Tests

`solobase-bundle` 27 pass (incl. exact-render, empty-fixture, and production-template backcompat); `solobase` 23 pass (incl. `[assets]` parse). Final whole-branch review: READY TO MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)