### PR TITLE
feat(core): deploy-init primitives — report funnel, queued request logs, config-version key, wrap-grants loader

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -21,7 +21,7 @@ pub use settings::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE};
 pub const ADMIN_BLOCK_ID: &str = "suppers-ai/admin";
 
 /// WRAP grant rows (block-to-resource access tokens).
-pub(crate) const WRAP_GRANTS_TABLE: &str = "suppers_ai__admin__wrap_grants";
+pub const WRAP_GRANTS_TABLE: &str = "suppers_ai__admin__wrap_grants";
 
 use wafer_run::{
     context::Context, BlockEndpoint, BlockInfo, InputStream, InstanceMode, Message, OutputStream,

--- a/crates/solobase-core/src/boot.rs
+++ b/crates/solobase-core/src/boot.rs
@@ -291,3 +291,127 @@ pub async fn load_all_variables(
     }
     Ok(vars)
 }
+
+/// Load admin-created WRAP grants from `suppers_ai__admin__wrap_grants` via
+/// the `DatabaseService`. DB-service twin of the native sqlite-file reader
+/// (`cli/server_config.rs::load_wrap_grants`) so stateless targets
+/// (Cloudflare) can inject dynamic grants at runtime build. Missing table /
+/// read errors degrade to an empty vec — dynamic grants are additive.
+pub async fn load_wrap_grants_from_db(
+    db: &Arc<dyn DatabaseService>,
+) -> Vec<wafer_run::ResourceGrant> {
+    let opts = ListOptions {
+        limit: 10_000,
+        skip_count: true,
+        ..Default::default()
+    };
+    let rows = match db
+        .list(crate::blocks::admin::WRAP_GRANTS_TABLE, &opts)
+        .await
+    {
+        Ok(list) => list.records,
+        Err(e) => {
+            tracing::debug!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
+            return Vec::new();
+        }
+    };
+    rows.into_iter()
+        .filter_map(|r| {
+            let grantee = r.data.get("grantee")?.as_str()?.to_string();
+            let resource = r.data.get("resource")?.as_str()?.to_string();
+            // sqlite stores booleans as 0/1 integers.
+            let write = match r.data.get("write") {
+                Some(v) => v.as_i64().map(|n| n != 0).or_else(|| v.as_bool())?,
+                None => return None,
+            };
+            // Mirrors `cli/server_config.rs::load_wrap_grants`'s
+            // `ResourceType::parse` call: the wire value is the lowercase
+            // `ResourceType` Display string ("db", "config", …); empty or
+            // unrecognized values parse to `None` (wildcard — all types).
+            let resource_type = r
+                .data
+                .get("resource_type")
+                .and_then(|v| v.as_str())
+                .and_then(wafer_run::ResourceType::parse);
+            Some(wafer_run::ResourceGrant {
+                grantee,
+                resource,
+                write,
+                resource_type,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod wrap_grants_tests {
+    use super::*;
+
+    /// Open a fresh in-memory SQLite [`DatabaseService`] with no migrations
+    /// applied — the same construction `features.rs`'s
+    /// `db_with_block_settings_table` and `test_support::TestContext::new`
+    /// use for a real, host-runnable `DatabaseService`.
+    async fn bare_db() -> Arc<dyn DatabaseService> {
+        Arc::new(
+            wafer_block_sqlite::service::SQLiteDatabaseService::open_in_memory()
+                .expect("open in-memory sqlite"),
+        )
+    }
+
+    #[tokio::test]
+    async fn load_wrap_grants_maps_rows_and_tolerates_missing_table() {
+        let db = bare_db().await;
+
+        // Missing table → empty, no error.
+        assert!(load_wrap_grants_from_db(&db).await.is_empty());
+
+        // Apply admin migrations (creates `suppers_ai__admin__wrap_grants`
+        // among the other admin tables) through the same pre-wafer DDL
+        // runner native's `server.rs::run` uses
+        // (`migration_helper::apply_ddl_via_service` +
+        // `blocks::admin::migrations::ddl_files`) — the migration-file-
+        // runner exception to the no-raw-SQL rule (CLAUDE.md), reusing the
+        // real embedded schema rather than a hand-rolled CREATE TABLE.
+        crate::migration_helper::apply_ddl_via_service(
+            &db,
+            crate::blocks::admin::migrations::ddl_files("sqlite"),
+        )
+        .await
+        .expect("apply admin migrations");
+
+        // Create + seed two rows via the service (no raw SQL).
+        let mut r1 = HashMap::new();
+        r1.insert("grantee".into(), serde_json::json!("suppers-ai/files"));
+        r1.insert(
+            "resource".into(),
+            serde_json::json!("suppers_ai__files__objects"),
+        );
+        r1.insert("write".into(), serde_json::json!(1));
+        r1.insert("resource_type".into(), serde_json::json!("db"));
+        let mut r2 = HashMap::new();
+        r2.insert("grantee".into(), serde_json::json!("suppers-ai/auth"));
+        r2.insert("resource".into(), serde_json::json!("bucket/x"));
+        r2.insert("write".into(), serde_json::json!(0));
+        db.create(crate::blocks::admin::WRAP_GRANTS_TABLE, r1)
+            .await
+            .unwrap();
+        db.create(crate::blocks::admin::WRAP_GRANTS_TABLE, r2)
+            .await
+            .unwrap();
+
+        let grants = load_wrap_grants_from_db(&db).await;
+        assert_eq!(grants.len(), 2);
+        let g1 = grants
+            .iter()
+            .find(|g| g.grantee == "suppers-ai/files")
+            .unwrap();
+        assert!(g1.write);
+        assert_eq!(g1.resource_type, Some(wafer_run::ResourceType::Db));
+        let g2 = grants
+            .iter()
+            .find(|g| g.grantee == "suppers-ai/auth")
+            .unwrap();
+        assert!(!g2.write);
+        assert_eq!(g2.resource_type, None);
+    }
+}

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -6,7 +6,7 @@
 //! logic lives here so it's host-testable; `solobase-cloudflare` is
 //! excluded from `cargo test --workspace`.
 
-use crate::blocks::admin::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE};
+use crate::blocks::admin::{BLOCK_SETTINGS_TABLE, VARIABLES_TABLE, WRAP_GRANTS_TABLE};
 
 /// Tables that this wrapper caches in KV.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +24,21 @@ pub fn classify_table(table: &str) -> Option<CachedTable> {
         t if t == BLOCK_SETTINGS_TABLE => Some(CachedTable::BlockSettings),
         _ => None,
     }
+}
+
+/// KV key holding the opaque config-generation stamp. The Cloudflare entry
+/// compares this against the version its cached runtime was built at and
+/// rebuilds on mismatch. Rewritten (not incremented) on every bump.
+pub const CONFIG_VERSION_KEY: &str = "cfg:v1:config_version";
+
+/// True when a write to `table` must bump [`CONFIG_VERSION_KEY`] — i.e. the
+/// table feeds state that a cached runtime bakes in at build/init time:
+/// `variables` (block config consumed at Init), `block_settings` (router
+/// enablement map consumed at build), `wrap_grants` (loaded into runtime
+/// grants at build). Tables read fresh per request (roles, permissions,
+/// user_roles) do NOT bump.
+pub fn bumps_config_version(table: &str) -> bool {
+    table == VARIABLES_TABLE || table == BLOCK_SETTINGS_TABLE || table == WRAP_GRANTS_TABLE
 }
 
 use wafer_block::db::{Filter, FilterOp, ListOptions};
@@ -456,5 +471,30 @@ mod tests {
             invalidate_keys(CachedTable::BlockSettings, &r),
             vec!["cfg:v1:block_settings:__all__".to_string()]
         );
+    }
+
+    #[test]
+    fn bumps_config_version_covers_runtime_affecting_tables() {
+        assert!(bumps_config_version("suppers_ai__admin__variables"));
+        assert!(bumps_config_version("suppers_ai__admin__block_settings"));
+        assert!(bumps_config_version("suppers_ai__admin__wrap_grants"));
+    }
+
+    #[test]
+    fn bumps_config_version_false_for_runtime_read_tables() {
+        // roles/permissions/user_roles are read fresh from D1 per request —
+        // no cached-runtime state depends on them, so no bump.
+        assert!(!bumps_config_version("suppers_ai__admin__roles"));
+        assert!(!bumps_config_version("suppers_ai__admin__permissions"));
+        assert!(!bumps_config_version("suppers_ai__auth__users"));
+        assert!(!bumps_config_version(""));
+    }
+
+    #[test]
+    fn config_version_key_is_distinct_from_row_cache_keys() {
+        // Row cache keys are "cfg:v1:{variables|block_settings}:{value}".
+        assert!(CONFIG_VERSION_KEY.starts_with("cfg:v1:"));
+        assert!(!CONFIG_VERSION_KEY.starts_with("cfg:v1:variables:"));
+        assert!(!CONFIG_VERSION_KEY.starts_with("cfg:v1:block_settings:"));
     }
 }

--- a/crates/solobase-core/src/deploy_init.rs
+++ b/crates/solobase-core/src/deploy_init.rs
@@ -6,8 +6,10 @@
 use serde::Serialize;
 use wafer_run::{RuntimeError, Wafer};
 
-use crate::blocks::storage::SolobaseStorageBlock;
-use crate::builder::{post_start, BootHooks};
+use crate::{
+    blocks::storage::SolobaseStorageBlock,
+    builder::{post_start, BootHooks},
+};
 
 #[derive(Debug, Serialize)]
 pub struct StepOutcome {

--- a/crates/solobase-core/src/deploy_init.rs
+++ b/crates/solobase-core/src/deploy_init.rs
@@ -1,0 +1,108 @@
+//! Deploy-time init funnel: `boot()`'s ordering invariants with per-step
+//! outcome capture, for the `/_deploy/init` endpoint. Runs once per deploy
+//! (invoked by the CLI against the freshly-uploaded worker version), so the
+//! request path never migrates or seeds.
+
+use serde::Serialize;
+use wafer_run::{RuntimeError, Wafer};
+
+use crate::blocks::storage::SolobaseStorageBlock;
+use crate::builder::{post_start, BootHooks};
+
+#[derive(Debug, Serialize)]
+pub struct StepOutcome {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BlockInitOutcome {
+    pub block: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeployInitReport {
+    pub sealed: bool,
+    pub seed: StepOutcome,
+    pub blocks: Vec<BlockInitOutcome>,
+    /// True iff every step and every block init succeeded.
+    pub ok: bool,
+}
+
+/// `seal → init_block(admin) → seed hook → init every block (captured) →
+/// post_start`, returning a per-step report. Ordering matches
+/// [`crate::builder::boot`]: admin first (its migrations create the
+/// variables / block_settings tables everything else stamps into).
+///
+/// `Err` only for pre-init failures (seal); block-level failures are
+/// captured in the report with `ok: false` so the caller can render the
+/// full picture and fail the deploy.
+pub async fn deploy_init(
+    wafer: &mut Wafer,
+    storage_block: &SolobaseStorageBlock,
+    hooks: &dyn BootHooks,
+) -> Result<DeployInitReport, RuntimeError> {
+    wafer.seal().await?;
+
+    let admin_id = crate::blocks::admin::ADMIN_BLOCK_ID;
+    let mut blocks = Vec::new();
+    let admin_outcome = match wafer.init_block(admin_id).await {
+        Ok(_) => BlockInitOutcome {
+            block: admin_id.to_string(),
+            ok: true,
+            error: None,
+        },
+        Err(e) => BlockInitOutcome {
+            block: admin_id.to_string(),
+            ok: false,
+            error: Some(e.to_string()),
+        },
+    };
+    blocks.push(admin_outcome);
+
+    let seed = match hooks.seed_after_admin_init(wafer).await {
+        Ok(()) => StepOutcome {
+            ok: true,
+            error: None,
+        },
+        Err(e) => StepOutcome {
+            ok: false,
+            error: Some(e),
+        },
+    };
+
+    // Init every registered block individually so each outcome is captured.
+    // Admin is a slot-cached no-op on its second pass.
+    let names: Vec<String> = wafer.block_infos().into_iter().map(|i| i.name).collect();
+    for name in names {
+        if name == admin_id {
+            continue;
+        }
+        match wafer.init_block(&name).await {
+            Ok(_) => blocks.push(BlockInitOutcome {
+                block: name,
+                ok: true,
+                error: None,
+            }),
+            Err(e) => blocks.push(BlockInitOutcome {
+                block: name,
+                ok: false,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    post_start(wafer, storage_block);
+
+    let ok = seed.ok && blocks.iter().all(|b| b.ok);
+    Ok(DeployInitReport {
+        sealed: true,
+        seed,
+        blocks,
+        ok,
+    })
+}

--- a/crates/solobase-core/src/deploy_init.rs
+++ b/crates/solobase-core/src/deploy_init.rs
@@ -79,6 +79,11 @@ pub async fn deploy_init(
 
     // Init every registered block individually so each outcome is captured.
     // Admin is a slot-cached no-op on its second pass.
+    //
+    // Keyed on each block's self-reported `info().name` — `init_block` looks
+    // up registration keys. The two coincide for solobase's block set; a
+    // mismatch fails loud via `InitError::Permanent` captured into the report
+    // (`report.ok == false`), never a silent skip.
     let names: Vec<String> = wafer.block_infos().into_iter().map(|i| i.name).collect();
     for name in names {
         if name == admin_id {

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cache_key;
 pub mod config_source;
 pub mod config_vars;
 pub mod crypto;
+pub mod deploy_init;
 pub mod endpoint_match;
 pub mod features;
 pub mod flows;

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -426,11 +426,10 @@ async fn collect_buffered_with_prelude(
 
 #[cfg(test)]
 mod request_log_mode_tests {
-    use crate::blocks::admin;
-
     use super::{
         drain_queued_request_logs, enqueue_request_log, set_request_log_mode, RequestLogMode,
     };
+    use crate::blocks::admin;
 
     #[test]
     fn default_mode_is_inline_and_drain_is_empty() {

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -427,12 +427,14 @@ async fn collect_buffered_with_prelude(
 #[cfg(test)]
 mod request_log_mode_tests {
     use super::{
-        drain_queued_request_logs, enqueue_request_log, set_request_log_mode, RequestLogMode,
+        drain_queued_request_logs, enqueue_request_log, request_log_mode, set_request_log_mode,
+        RequestLogMode,
     };
     use crate::blocks::admin;
 
     #[test]
     fn default_mode_is_inline_and_drain_is_empty() {
+        assert_eq!(request_log_mode(), RequestLogMode::Inline);
         assert!(drain_queued_request_logs().is_empty());
     }
 

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -3,6 +3,8 @@
 //! Both Cloudflare and native adapters call `handle_request()` after
 //! converting their platform-specific HTTP types into a WAFER Message.
 
+use std::cell::{Cell, RefCell};
+
 use futures::StreamExt;
 use wafer_block::{
     http_codec::{self, ResponseMetaPart},
@@ -21,6 +23,54 @@ use crate::{
     http::ResponseBuilder,
     routing::{self, ExtraRoute},
 };
+
+/// How the pipeline persists the per-request audit row.
+///
+/// `Inline` (default; native): `db::create` awaited on the response path —
+/// today's behavior. `Queued` (Cloudflare): the completed row is pushed to a
+/// thread-local queue; the platform entry drains it after dispatch and
+/// attaches the write to `ctx.wait_until`, so responses stop paying one D1
+/// write of latency. Rows are plain data, so it does not matter which
+/// interleaved request's drain flushes them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestLogMode {
+    Inline,
+    Queued,
+}
+
+/// One queued audit row (table + column map), ready for `DatabaseService::create`.
+pub struct QueuedRequestLog {
+    pub table: &'static str,
+    pub data: std::collections::HashMap<String, serde_json::Value>,
+}
+
+thread_local! {
+    static REQUEST_LOG_MODE: Cell<RequestLogMode> = const { Cell::new(RequestLogMode::Inline) };
+    static REQUEST_LOG_QUEUE: RefCell<Vec<QueuedRequestLog>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Select the request-log persistence mode for this thread (isolate).
+/// Called once at platform init; native never calls it.
+pub fn set_request_log_mode(mode: RequestLogMode) {
+    REQUEST_LOG_MODE.with(|m| m.set(mode));
+}
+
+fn request_log_mode() -> RequestLogMode {
+    REQUEST_LOG_MODE.with(Cell::get)
+}
+
+fn enqueue_request_log(
+    table: &'static str,
+    data: std::collections::HashMap<String, serde_json::Value>,
+) {
+    REQUEST_LOG_QUEUE.with(|q| q.borrow_mut().push(QueuedRequestLog { table, data }));
+}
+
+/// Take every queued row, clearing the queue. The platform entry calls this
+/// after each dispatch and persists the rows off the response path.
+pub fn drain_queued_request_logs() -> Vec<QueuedRequestLog> {
+    REQUEST_LOG_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()))
+}
 
 /// Handle a solobase request.
 ///
@@ -200,8 +250,15 @@ pub async fn handle_request(
         data.insert("user_id".to_string(), serde_json::json!(user_id));
         crate::util::stamp_created(&mut data);
 
-        // Best-effort: don't fail the request if logging fails
-        let _ = db::create(ctx, crate::blocks::admin::REQUEST_LOGS_TABLE, data).await;
+        match request_log_mode() {
+            RequestLogMode::Inline => {
+                // Best-effort: don't fail the request if logging fails
+                let _ = db::create(ctx, crate::blocks::admin::REQUEST_LOGS_TABLE, data).await;
+            }
+            RequestLogMode::Queued => {
+                enqueue_request_log(crate::blocks::admin::REQUEST_LOGS_TABLE, data);
+            }
+        }
     }
 
     reply
@@ -364,5 +421,35 @@ async fn collect_buffered_with_prelude(
         Some(StreamEvent::Drop) => Err(TerminalNotResponse::Drop),
         Some(StreamEvent::Continue(msg)) => Err(TerminalNotResponse::Continue(msg)),
         None => Err(TerminalNotResponse::Malformed),
+    }
+}
+
+#[cfg(test)]
+mod request_log_mode_tests {
+    use crate::blocks::admin;
+
+    use super::{
+        drain_queued_request_logs, enqueue_request_log, set_request_log_mode, RequestLogMode,
+    };
+
+    #[test]
+    fn default_mode_is_inline_and_drain_is_empty() {
+        assert!(drain_queued_request_logs().is_empty());
+    }
+
+    #[test]
+    fn queued_mode_accumulates_and_drain_clears() {
+        set_request_log_mode(RequestLogMode::Queued);
+        let mut data = std::collections::HashMap::new();
+        data.insert("path".to_string(), serde_json::json!("/x"));
+        enqueue_request_log(admin::REQUEST_LOGS_TABLE, data.clone());
+        enqueue_request_log(admin::REQUEST_LOGS_TABLE, data);
+
+        let drained = drain_queued_request_logs();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].table, admin::REQUEST_LOGS_TABLE);
+        assert!(drain_queued_request_logs().is_empty(), "drain must clear");
+
+        set_request_log_mode(RequestLogMode::Inline); // restore for other tests
     }
 }

--- a/crates/solobase/tests/deploy_init.rs
+++ b/crates/solobase/tests/deploy_init.rs
@@ -13,8 +13,10 @@
 
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use solobase_core::builder::{BootHooks, SolobaseBuilder};
-use solobase_core::deploy_init::deploy_init;
+use solobase_core::{
+    builder::{BootHooks, SolobaseBuilder},
+    deploy_init::deploy_init,
+};
 use wafer_core::interfaces::{config::service::ConfigService, database::service::DatabaseService};
 use wafer_run::Wafer;
 

--- a/crates/solobase/tests/deploy_init.rs
+++ b/crates/solobase/tests/deploy_init.rs
@@ -197,3 +197,52 @@ async fn deploy_init_first_run_ok_and_second_run_idempotent() {
         report2.blocks
     );
 }
+
+/// `BootHooks` whose seed step always fails, to exercise `deploy_init`'s
+/// capture-and-continue contract: a failing hook must NOT abort the funnel
+/// (still `Ok(report)`), and every other block must still get initialized.
+struct FailingBootHooks;
+
+#[wafer_block::wafer_async_trait]
+impl BootHooks for FailingBootHooks {
+    async fn seed_after_admin_init(&self, _wafer: &Wafer) -> Result<(), String> {
+        Err("boom".to_string())
+    }
+}
+
+#[tokio::test]
+async fn deploy_init_seed_failure_is_captured_not_aborted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("deploy_init_seed_failure_test.sqlite3");
+    let storage_root = tmp.path().join("storage");
+    std::fs::create_dir_all(&storage_root).expect("create storage root");
+
+    let (mut wafer, storage_block, _db) = build_runtime(&db_path, &storage_root).await;
+    let report = deploy_init(&mut wafer, &storage_block, &FailingBootHooks)
+        .await
+        .expect("deploy_init must still return Ok even when the seed hook errors");
+
+    assert!(
+        !report.ok,
+        "overall report must be not-ok when the seed hook fails: {report:?}"
+    );
+    assert!(
+        !report.seed.ok,
+        "seed step outcome must be not-ok: {:?}",
+        report.seed
+    );
+    assert_eq!(report.seed.error.as_deref(), Some("boom"));
+
+    // Seed failure must not prevent the rest of the funnel: blocks still
+    // get initialized.
+    assert!(
+        !report.blocks.is_empty(),
+        "blocks must still be initialized after a seed failure: {:?}",
+        report.blocks
+    );
+    assert!(
+        report.blocks.iter().all(|b| b.ok),
+        "every block must still init ok despite the seed failure: {:?}",
+        report.blocks
+    );
+}

--- a/crates/solobase/tests/deploy_init.rs
+++ b/crates/solobase/tests/deploy_init.rs
@@ -1,0 +1,197 @@
+//! Integration test for `solobase_core::deploy_init::deploy_init` over a
+//! real, file-backed SQLite `DatabaseService` — mirroring the native boot
+//! path in `crates/solobase/src/cli/server.rs::run` (steps 5-11), but
+//! calling `deploy_init` instead of `builder::boot` so per-block outcomes
+//! are captured into a report.
+//!
+//! Exercises the full ordering invariant end to end: seal → init_block
+//! (admin) → seed hook (no-op on native, which seeds pre-wafer) → init
+//! every other registered block → post_start. Then rebuilds a second
+//! runtime over the *same* sqlite file (matching a redeploy) and asserts
+//! the block-settings hash-gate makes the second `deploy_init` call an
+//! all-ok no-op.
+
+use std::{collections::HashMap, path::Path, sync::Arc};
+
+use solobase_core::builder::{BootHooks, SolobaseBuilder};
+use solobase_core::deploy_init::deploy_init;
+use wafer_core::interfaces::{config::service::ConfigService, database::service::DatabaseService};
+use wafer_run::Wafer;
+
+/// Native's `BootHooks`: native seeds the variables / block_settings tables
+/// pre-wafer (see `build_runtime` below), so there is nothing left to seed
+/// once admin's `Init` has run. Mirrors `solobase::cli::server::NativeBootHooks`,
+/// which is private to that module.
+struct NoopBootHooks;
+
+#[wafer_block::wafer_async_trait]
+impl BootHooks for NoopBootHooks {
+    async fn seed_after_admin_init(&self, _wafer: &Wafer) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// Build one WAFER runtime over the sqlite file at `db_path`, mirroring
+/// `solobase::cli::server::run`'s steps 5-11 (database construction, the
+/// pre-wafer admin-table DDL, variable seeding, block-settings hash-gate
+/// load, and `SolobaseBuilder::build()`), minus the native-only http-listener
+/// bind / observability hooks / shutdown loop that `deploy_init` doesn't need.
+///
+/// Returns the sealed-but-not-yet-inited `Wafer`, its `SolobaseStorageBlock`,
+/// and the `DatabaseService` handle (so the test can inspect
+/// `block_settings` rows directly afterwards).
+async fn build_runtime(
+    db_path: &Path,
+    storage_root: &Path,
+) -> (
+    Wafer,
+    Arc<solobase_core::blocks::storage::SolobaseStorageBlock>,
+    Arc<dyn DatabaseService>,
+) {
+    let db_path_str = db_path.to_str().expect("db path is valid utf-8");
+
+    let database = solobase_native::make_database_service("sqlite", db_path_str, None)
+        .await
+        .expect("construct sqlite database service");
+
+    // Pre-wafer admin DDL — same migration-file-runner exception `server.rs`
+    // uses, so the variables / block_settings tables exist before
+    // `seed_and_load_variables` and `load_and_seed_block_settings` read them.
+    solobase_core::migration_helper::apply_ddl_via_service(
+        &database,
+        solobase_core::blocks::admin::migrations::ddl_files("sqlite"),
+    )
+    .await
+    .expect("apply admin tables pre-wafer");
+
+    // No process-env vars to seed in this harness; auto-generated secrets
+    // (incl. the JWT secret) are still seeded by `seed_and_load_variables`.
+    let vars = solobase_core::boot::seed_and_load_variables(&database, &[])
+        .await
+        .expect("seed and load variables");
+
+    let jwt_secret = vars
+        .get(solobase_core::blocks::auth::JWT_SECRET_KEY)
+        .cloned()
+        .expect("JWT secret auto-seeded");
+
+    let features = solobase_core::features::load_and_seed_block_settings(&database).await;
+
+    let config_service = wafer_core::service_blocks::config::EnvConfigService::new();
+    for (key, value) in &vars {
+        config_service.set(key, value);
+    }
+    config_service.set(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY,
+        &features.to_config_json(),
+    );
+
+    let mut snapshot: HashMap<String, String> = vars.clone();
+    snapshot.insert(
+        solobase_core::features::BLOCK_SETTINGS_CONFIG_KEY.to_string(),
+        features.to_config_json(),
+    );
+
+    let storage_root_str = storage_root.to_str().expect("storage root is valid utf-8");
+    let storage = solobase_native::make_storage_service("local", storage_root_str)
+        .await
+        .expect("construct local storage service");
+
+    let (mut wafer, storage_block) = SolobaseBuilder::new()
+        .database(database.clone())
+        .storage(storage)
+        .config(Arc::new(config_service))
+        .config_source(Arc::new(wafer_run::StaticConfigSource::new(vars.clone())))
+        .crypto(solobase_native::make_jwt_crypto_service(jwt_secret).expect("jwt crypto service"))
+        .network(solobase_native::make_fetch_network_service())
+        .logger(solobase_native::make_tracing_logger())
+        .block_settings(features)
+        .sqlite_db_path(db_path_str)
+        .build()
+        .expect("build solobase runtime");
+
+    wafer.set_config_snapshot(snapshot);
+
+    (wafer, storage_block, database)
+}
+
+#[tokio::test]
+async fn deploy_init_first_run_ok_and_second_run_idempotent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("deploy_init_test.sqlite3");
+    let storage_root = tmp.path().join("storage");
+    std::fs::create_dir_all(&storage_root).expect("create storage root");
+
+    // --- First run: fresh DB, everything must init ok. ---
+    let (mut wafer, storage_block, db) = build_runtime(&db_path, &storage_root).await;
+    let report = deploy_init(&mut wafer, &storage_block, &NoopBootHooks)
+        .await
+        .expect("seal");
+
+    assert!(report.ok, "first deploy_init must succeed: {report:?}");
+    assert!(report.sealed);
+    assert!(
+        report
+            .blocks
+            .iter()
+            .any(|b| b.block == solobase_core::blocks::admin::ADMIN_BLOCK_ID && b.ok),
+        "admin block must be present and ok: {:?}",
+        report.blocks
+    );
+    // More than just admin got initialized (the default feature set
+    // registers several other feature blocks).
+    assert!(
+        report.blocks.len() > 1,
+        "expected more than admin to be initialized: {:?}",
+        report.blocks
+    );
+
+    // --- Stamp format: block_settings rows carry 64-hex current_hash == blessed_hash. ---
+    let opts = wafer_block::db::ListOptions {
+        limit: 10_000,
+        skip_count: true,
+        ..Default::default()
+    };
+    let rows = db
+        .list(solobase_core::admin_schema::BLOCK_SETTINGS_TABLE, &opts)
+        .await
+        .expect("list block_settings")
+        .records;
+    let admin_row = rows
+        .iter()
+        .find(|r| {
+            r.data["block_name"] == serde_json::json!(solobase_core::blocks::admin::ADMIN_BLOCK_ID)
+        })
+        .expect("admin row stamped");
+    let cur = admin_row.data["current_hash"]
+        .as_str()
+        .expect("current_hash is a string");
+    assert_eq!(cur.len(), 64, "raw sha256 hex, got: {cur}");
+    assert!(
+        cur.chars().all(|c| c.is_ascii_hexdigit()),
+        "current_hash must be hex: {cur}"
+    );
+    assert_eq!(
+        admin_row.data["current_hash"],
+        admin_row.data["blessed_hash"]
+    );
+
+    // --- Idempotency: second run over the same DB, via a REBUILT runtime, is all-ok. ---
+    let (mut wafer2, storage_block2, _db2) = build_runtime(&db_path, &storage_root).await;
+    let report2 = deploy_init(&mut wafer2, &storage_block2, &NoopBootHooks)
+        .await
+        .expect("seal 2");
+
+    assert!(
+        report2.ok,
+        "second deploy_init must be a clean no-op: {report2:?}"
+    );
+    assert!(
+        report2
+            .blocks
+            .iter()
+            .any(|b| b.block == solobase_core::blocks::admin::ADMIN_BLOCK_ID && b.ok),
+        "admin block must be ok on second run too: {:?}",
+        report2.blocks
+    );
+}


### PR DESCRIPTION
PR 1 of 3 for the Cloudflare deploy-init + lazy-runtime program (spec/plan: Jsuppers/workspace#29). These are inert solobase-core primitives — nothing consumes them until PR 2 wires them into solobase-cloudflare + the deploy CLI.

## What's in here

- **`cache_key`**: `CONFIG_VERSION_KEY` + `bumps_config_version(table)` — classifies which admin tables invalidate the per-isolate config cache (consumed by PR 2's KV-cached DB + entry version check).
- **`pipeline`**: `RequestLogMode::{Inline,Queued}` + queue drain — lets the worker defer request-log D1 writes to `ctx.wait_until` instead of blocking the response path.
- **`boot::load_wrap_grants_from_db`**: DatabaseService-backed WRAP-grants loader for stateless targets (mirrors the native reader; `ResourceGrant.resource_type` parsed via `ResourceType::parse`).
- **`deploy_init`**: the deploy-time init funnel — seal → admin init → seed hook → remaining blocks → post_start (ordering parity with `builder::boot()`), returning a per-step/per-block `DeployInitReport` instead of fire-and-forget. Deliberate divergence: a seed failure is captured and remaining blocks still init, so the deploy report carries the full failure picture; `report.ok` gates the deploy.

## Verification

- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` green (per-task, CI-exact)
- `cargo clippy` (same excludes): exit 0, 81 warnings = branch-baseline, none added
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` green
- `cargo +nightly fmt --all --check` clean
- New integration test: `solobase/tests/deploy_init.rs` (first-run report all-ok + hash assertions, second-run idempotency over the same DB file)

Every task was implemented and reviewed via subagent-driven development (4 tasks, 4 approved reviews); a whole-branch review will run on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrWWzPqjNXUMcqsMzSBnUw