### PR TITLE
feat(cf,cli): per-isolate cached runtime, /_deploy/init, atomic versioned deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,6 +4683,7 @@ dependencies = [
  "maud",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "solobase-core",
  "tracing",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,6 @@ dependencies = [
  "maud",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "solobase-core",
  "tracing",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4612,6 +4612,7 @@ dependencies = [
  "clap",
  "getrandom 0.2.17",
  "glob",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/solobase-cloudflare/Cargo.toml
+++ b/crates/solobase-cloudflare/Cargo.toml
@@ -70,9 +70,6 @@ serde_json = { workspace = true }
 # Crypto (wasm-compatible). JWT + argon2 policy delegates to
 # wafer-block-crypto's pure-Rust primitives — same engine as native.
 wafer-block-crypto = { workspace = true }
-# sha256 hash-then-compare for the `/_deploy/init` `X-Deploy-Token` check
-# (sidesteps timing comparisons on raw secret bytes).
-sha2 = { workspace = true }
 getrandom = { workspace = true, features = ["js"] }
 # uuid needs the "js" feature for wasm (uses js_sys random); inherit v4+v7 from workspace
 uuid = { workspace = true, features = ["js"] }

--- a/crates/solobase-cloudflare/Cargo.toml
+++ b/crates/solobase-cloudflare/Cargo.toml
@@ -70,6 +70,9 @@ serde_json = { workspace = true }
 # Crypto (wasm-compatible). JWT + argon2 policy delegates to
 # wafer-block-crypto's pure-Rust primitives — same engine as native.
 wafer-block-crypto = { workspace = true }
+# sha256 hash-then-compare for the `/_deploy/init` `X-Deploy-Token` check
+# (sidesteps timing comparisons on raw secret bytes).
+sha2 = { workspace = true }
 getrandom = { workspace = true, features = ["js"] }
 # uuid needs the "js" feature for wasm (uses js_sys random); inherit v4+v7 from workspace
 uuid = { workspace = true, features = ["js"] }

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -68,6 +68,14 @@ use wafer_core::interfaces::database::service::{
 /// KV TTL applied to every cache PUT (24 h).
 const CACHE_TTL_SECS: u64 = 86_400;
 
+/// Fresh opaque config-version stamp (16 random bytes, lowercase hex).
+pub fn new_version_stamp() -> String {
+    let mut buf = [0u8; 16];
+    // getrandom's js feature routes to crypto.getRandomValues on wasm.
+    getrandom::getrandom(&mut buf).expect("getrandom");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 /// Wraps a [`DatabaseService`] with a write-through-invalidated KV cache
 /// for the `variables` and `block_settings` per-block read paths.
 pub struct KvCachedD1DatabaseService {
@@ -98,6 +106,26 @@ impl KvCachedD1DatabaseService {
             } else {
                 tracing::debug!(table = %collection, key = %key, op, "cache_invalidate");
             }
+        }
+    }
+
+    /// Rewrite the config-version stamp after a write to a table whose
+    /// contents a cached runtime bakes in (variables / block_settings /
+    /// wrap_grants). Best-effort like row invalidation: a failed put leaves
+    /// live isolates on the old runtime until the next successful bump.
+    async fn bump_config_version(&self, collection: &str, op: &str) {
+        if !cache_key::bumps_config_version(collection) {
+            return;
+        }
+        let stamp = new_version_stamp();
+        if let Err(e) = self
+            .kv
+            .put_with_ttl(cache_key::CONFIG_VERSION_KEY, &stamp, CACHE_TTL_SECS)
+            .await
+        {
+            tracing::warn!(table = %collection, error = %e, op, "config-version bump failed");
+        } else {
+            tracing::debug!(table = %collection, version = %stamp, op, "config_version_bump");
         }
     }
 }
@@ -284,6 +312,7 @@ impl DatabaseService for KvCachedD1DatabaseService {
             );
         }
         self.invalidate_all(collection, &invalidate, "create").await;
+        self.bump_config_version(collection, "create").await;
 
         Ok(record)
     }
@@ -315,6 +344,7 @@ impl DatabaseService for KvCachedD1DatabaseService {
         let record = self.inner.update(collection, id, data).await?;
 
         self.invalidate_all(collection, &invalidate, "update").await;
+        self.bump_config_version(collection, "update").await;
 
         Ok(record)
     }
@@ -341,6 +371,7 @@ impl DatabaseService for KvCachedD1DatabaseService {
         self.inner.delete(collection, id).await?;
 
         self.invalidate_all(collection, &invalidate, "delete").await;
+        self.bump_config_version(collection, "delete").await;
 
         Ok(())
     }

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -75,7 +75,7 @@ pub fn new_version_stamp() -> String {
     let mut buf = [0u8; 16];
     // getrandom's js feature routes to crypto.getRandomValues on wasm.
     getrandom::getrandom(&mut buf).expect("getrandom");
-    buf.iter().map(|b| format!("{b:02x}")).collect()
+    wafer_run::hex_encode(&buf)
 }
 
 /// Wraps a [`DatabaseService`] with a write-through-invalidated KV cache

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -65,8 +65,10 @@ use wafer_core::interfaces::database::service::{
     Column, DatabaseError, DatabaseService, Record, RecordList, Table,
 };
 
-/// KV TTL applied to every cache PUT (24 h).
-const CACHE_TTL_SECS: u64 = 86_400;
+/// KV TTL applied to every cache PUT (24 h). Also the TTL the per-isolate
+/// runtime cache stamps a freshly-minted config-version with (see
+/// `runtime_cache::current_version`).
+pub(crate) const CACHE_TTL_SECS: u64 = 86_400;
 
 /// Fresh opaque config-version stamp (16 random bytes, lowercase hex).
 pub fn new_version_stamp() -> String {

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -181,6 +181,10 @@ where
         Arc<dyn StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
+    if req.path() == "/_deploy/init" {
+        return deploy_init_endpoint(req, env, register_blocks, register_post_build).await;
+    }
+
     // Audit rows are queued during dispatch and flushed off the response path
     // below, so the D1 write never adds latency to the request.
     solobase_core::pipeline::set_request_log_mode(solobase_core::pipeline::RequestLogMode::Queued);
@@ -208,6 +212,77 @@ where
             worker::Response::error(format!("solobase: {e}"), 500)
         }
     }
+}
+
+/// Deploy-time init: runs the full migrate+seed funnel once, invoked by
+/// `solobase deploy` against the freshly-uploaded version (pre-promote).
+/// Auth: sha256-compare of `X-Deploy-Token` against the `DEPLOY_TOKEN`
+/// wrangler secret (hash-then-compare sidesteps timing on raw bytes).
+async fn deploy_init_endpoint<F, G>(
+    req: worker::Request,
+    env: worker::Env,
+    register_blocks: F,
+    register_post_build: G,
+) -> worker::Result<worker::Response>
+where
+    F: FnOnce(SolobaseBuilder) -> Result<SolobaseBuilder, Box<dyn std::error::Error>>,
+    G: FnOnce(
+        &mut wafer_run::Wafer,
+        Arc<dyn StorageService>,
+    ) -> Result<(), Box<dyn std::error::Error>>,
+{
+    if req.method() != worker::Method::Post {
+        return worker::Response::error("method not allowed", 405);
+    }
+    let Ok(secret) = env.secret("DEPLOY_TOKEN") else {
+        // Secret unset ⇒ endpoint disabled entirely.
+        return worker::Response::error("not found", 404);
+    };
+    let presented = req.headers().get("x-deploy-token")?.unwrap_or_default();
+    if presented.is_empty() || sha256_hex(&presented) != sha256_hex(&secret.to_string()) {
+        return worker::Response::error("unauthorized", 401);
+    }
+
+    // Fresh runtime (never the request cache) with run_migrations forced on,
+    // so slot-cached pre-migration outcomes can't leak into the funnel.
+    let out = async {
+        let mut built = build_runtime(&env, register_blocks, register_post_build, true).await?;
+        let db_grants = solobase_core::boot::load_wrap_grants_from_db(&built.db).await;
+        if !db_grants.is_empty() {
+            built.wafer.add_wrap_grants(db_grants);
+        }
+        let report = solobase_core::deploy_init::deploy_init(
+            &mut built.wafer,
+            &built.storage_block,
+            &CfBootHooks {
+                db: built.db.clone(),
+            },
+        )
+        .await
+        .map_err(|e| format!("deploy_init: {e}"))?;
+        Ok::<_, Box<dyn std::error::Error>>(report)
+    }
+    .await;
+
+    match out {
+        Ok(report) => {
+            let status = if report.ok { 200 } else { 500 };
+            let body = serde_json::to_string_pretty(&report)
+                .unwrap_or_else(|e| format!("{{\"serialize_error\":\"{e}\"}}"));
+            Ok(worker::Response::ok(body)?.with_status(status))
+        }
+        Err(e) => {
+            worker::console_log!("deploy_init failed: {e}");
+            worker::Response::error(format!("deploy_init: {e}"), 500)
+        }
+    }
+}
+
+fn sha256_hex(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    h.finalize().iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Everything [`build_runtime`] produces: a sealed-but-not-yet-booted runtime
@@ -426,9 +501,8 @@ const PROTECTED_ENV_KEYS: &[&str] = &[solobase_core::blocks::auth::JWT_SECRET_KE
 /// has added the `variables.block` column.
 ///
 /// Not constructed on the request path — the per-isolate cache seals without a
-/// boot funnel. Held for Task 8's `/_deploy/init`, which runs the full boot
-/// (migrations + seeds) on demand at deploy time.
-#[allow(dead_code)]
+/// boot funnel. Constructed by `deploy_init_endpoint` (`/_deploy/init`), which
+/// runs the full boot (migrations + seeds) on demand at deploy time.
 struct CfBootHooks {
     db: Arc<dyn DatabaseService>,
 }

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -239,7 +239,10 @@ where
         return worker::Response::error("not found", 404);
     };
     let presented = req.headers().get("x-deploy-token")?.unwrap_or_default();
-    if presented.is_empty() || sha256_hex(&presented) != sha256_hex(&secret.to_string()) {
+    if presented.is_empty()
+        || wafer_run::sha256_hex(presented.as_bytes())
+            != wafer_run::sha256_hex(secret.to_string().as_bytes())
+    {
         return worker::Response::error("unauthorized", 401);
     }
 
@@ -247,10 +250,7 @@ where
     // so slot-cached pre-migration outcomes can't leak into the funnel.
     let out = async {
         let mut built = build_runtime(&env, register_blocks, register_post_build, true).await?;
-        let db_grants = solobase_core::boot::load_wrap_grants_from_db(&built.db).await;
-        if !db_grants.is_empty() {
-            built.wafer.add_wrap_grants(db_grants);
-        }
+        apply_db_wrap_grants(&mut built).await;
         let report = solobase_core::deploy_init::deploy_init(
             &mut built.wafer,
             &built.storage_block,
@@ -278,13 +278,6 @@ where
     }
 }
 
-fn sha256_hex(s: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut h = Sha256::new();
-    h.update(s.as_bytes());
-    h.finalize().iter().map(|b| format!("{b:02x}")).collect()
-}
-
 /// Everything [`build_runtime`] produces: a built-but-not-sealed-or-booted
 /// runtime plus the service handles Tasks 7-8 need (per-isolate build
 /// caching, the `/_deploy/init` endpoint) that would otherwise be locked
@@ -292,13 +285,22 @@ fn sha256_hex(s: &str) -> String {
 struct BuiltRuntime {
     wafer: wafer_run::Wafer,
     storage_block: Arc<solobase_core::blocks::storage::SolobaseStorageBlock>,
-    // Not read by this task's `run_inner` — held for Task 7 (per-isolate
-    // build cache) and Task 8 (`/_deploy/init`) to consume.
-    #[allow(dead_code)]
-    bucket: Arc<dyn StorageService>,
     db: Arc<dyn DatabaseService>,
-    #[allow(dead_code)]
+    /// KV backend the DB service is cached through — reused by the per-isolate
+    /// runtime cache (`runtime_cache`) to probe the config-version stamp
+    /// without re-deriving a second `KvStore` handle from `env`.
     kv: Arc<dyn kv_cached_db::KvBackend>,
+}
+
+/// Register any admin-created WRAP grants loaded from D1 onto the built
+/// runtime. MUST run BEFORE `wafer.seal()` — grants added after seal are
+/// ignored. Shared by the request-path per-isolate cache
+/// (`runtime_cache::get_or_build`) and the `/_deploy/init` boot funnel.
+pub(crate) async fn apply_db_wrap_grants(built: &mut BuiltRuntime) {
+    let db_grants = solobase_core::boot::load_wrap_grants_from_db(&built.db).await;
+    if !db_grants.is_empty() {
+        built.wafer.add_wrap_grants(db_grants);
+    }
 }
 
 /// Build (but do not seal or boot) the WAFER runtime for a request: wire the
@@ -309,6 +311,14 @@ struct BuiltRuntime {
 /// snapshot regardless of the worker env var — used by the `/_deploy/init`
 /// endpoint (Task 8) to force a migration pass on demand. The normal request
 /// path passes `false` and keeps honoring the env var exactly as before.
+///
+/// Missing-table tolerance is an invariant here: on a first-ever deploy
+/// `/_deploy/init` builds this runtime BEFORE any migration has run, so every
+/// eager D1 read in this function MUST tolerate a not-yet-created table
+/// (`block_settings` → default map; `wrap_grants` → empty vec, applied in the
+/// callers via [`apply_db_wrap_grants`]). A non-tolerant eager read would
+/// error out and deadlock first deploys before migrations can create the
+/// tables.
 async fn build_runtime<F, G>(
     env: &worker::Env,
     register_blocks: F,
@@ -434,18 +444,14 @@ where
     wafer.set_config_snapshot(snapshot);
 
     // 6b. Consumer post-build hook (override flows / configs before start).
-    //     Receives the R2-backed StorageService so consumers can register
-    //     blocks that need direct un-namespaced bucket access. Cloned so the
-    //     bucket handle also survives into the returned `BuiltRuntime` — the
-    //     hook only borrows it to register additional blocks, it doesn't need
-    //     exclusive ownership.
-    register_post_build(&mut wafer, bucket.clone())
-        .map_err(|e| format!("register_post_build: {e}"))?;
+    //     Receives the R2-backed StorageService (moved in — the builder above
+    //     already holds its own clone) so consumers can register blocks that
+    //     need direct un-namespaced bucket access.
+    register_post_build(&mut wafer, bucket).map_err(|e| format!("register_post_build: {e}"))?;
 
     Ok(BuiltRuntime {
         wafer,
         storage_block,
-        bucket,
         db,
         kv,
     })

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -63,12 +63,30 @@ pub fn make_kv_cached_database_service(
     d1_binding: &str,
     kv_binding: &str,
 ) -> Result<Arc<dyn DatabaseService>, worker::Error> {
+    let (db, _backend) = make_kv_cached_database_service_with_backend(env, d1_binding, kv_binding)?;
+    Ok(db)
+}
+
+/// Internals of [`make_kv_cached_database_service`], additionally returning
+/// the `KvBackend` handle it constructs — `build_runtime` needs the backend
+/// itself (not just the `DatabaseService` it's wrapped into) so Task 7's
+/// per-isolate cache and Task 8's `/_deploy/init` endpoint can drive KV
+/// directly (e.g. bumping the config-version stamp) without re-deriving a
+/// second `KvStore` handle from `env`.
+fn make_kv_cached_database_service_with_backend(
+    env: &worker::Env,
+    d1_binding: &str,
+    kv_binding: &str,
+) -> Result<(Arc<dyn DatabaseService>, Arc<dyn kv_cached_db::KvBackend>), worker::Error> {
     let inner = make_d1_database_service(env, d1_binding)?;
     let kv_store = env.kv(kv_binding)?;
-    let backend = Arc::new(kv_cached_db::WorkerKvBackend(kv_store));
-    Ok(Arc::new(kv_cached_db::KvCachedD1DatabaseService::new(
-        inner, backend,
-    )))
+    let backend: Arc<dyn kv_cached_db::KvBackend> =
+        Arc::new(kv_cached_db::WorkerKvBackend(kv_store));
+    let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::new(
+        inner,
+        backend.clone(),
+    ));
+    Ok((db, backend))
 }
 
 /// Construct an R2-backed [`StorageService`] from a worker `Env` and the R2
@@ -160,12 +178,36 @@ where
     }
 }
 
-async fn run_inner<F, G>(
-    req: worker::Request,
-    env: worker::Env,
+/// Everything [`build_runtime`] produces: a sealed-but-not-yet-booted runtime
+/// plus the service handles Tasks 7-8 need (per-isolate build caching, the
+/// `/_deploy/init` endpoint) that would otherwise be locked inside its
+/// function-local scope.
+struct BuiltRuntime {
+    wafer: wafer_run::Wafer,
+    storage_block: Arc<solobase_core::blocks::storage::SolobaseStorageBlock>,
+    // Not read by this task's `run_inner` — held for Task 7 (per-isolate
+    // build cache) and Task 8 (`/_deploy/init`) to consume.
+    #[allow(dead_code)]
+    bucket: Arc<dyn StorageService>,
+    db: Arc<dyn DatabaseService>,
+    #[allow(dead_code)]
+    kv: Arc<dyn kv_cached_db::KvBackend>,
+}
+
+/// Build (but do not seal or boot) the WAFER runtime for a request: wire the
+/// D1/KV/R2/crypto/network/logger services, run the consumer's block
+/// registrations, and build + config-snapshot the runtime.
+///
+/// `force_run_migrations` inserts `SOLOBASE_RUN_MIGRATIONS=1` into the config
+/// snapshot regardless of the worker env var — used by the `/_deploy/init`
+/// endpoint (Task 8) to force a migration pass on demand. The normal request
+/// path passes `false` and keeps honoring the env var exactly as before.
+async fn build_runtime<F, G>(
+    env: &worker::Env,
     register_blocks: F,
     register_post_build: G,
-) -> Result<worker::Response, Box<dyn std::error::Error>>
+    force_run_migrations: bool,
+) -> Result<BuiltRuntime, Box<dyn std::error::Error>>
 where
     F: FnOnce(SolobaseBuilder) -> Result<SolobaseBuilder, Box<dyn std::error::Error>>,
     G: FnOnce(
@@ -174,8 +216,9 @@ where
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
     // 1. Construct D1 service (with KV cache) first — env vars live in D1.
-    let db = make_kv_cached_database_service(&env, runner::D1_BINDING, runner::KV_BINDING)
-        .map_err(|e| {
+    let (db, kv) =
+        make_kv_cached_database_service_with_backend(env, runner::D1_BINDING, runner::KV_BINDING)
+            .map_err(|e| {
             format!(
                 "DB/KV bindings (D1={:?}, KV={:?}): {e}",
                 runner::D1_BINDING,
@@ -221,12 +264,13 @@ where
     // gate on it via `ctx.config_get`. Without this, `run_requested` is
     // always `false` on CF and a `--run-migrations` deploy against an
     // existing (non-wiped) D1 silently no-ops.
-    if env
-        .var(solobase_core::migration_helper::RUN_MIGRATIONS_KEY)
-        .ok()
-        .map(|v| v.to_string())
-        .as_deref()
-        == Some("1")
+    if force_run_migrations
+        || env
+            .var(solobase_core::migration_helper::RUN_MIGRATIONS_KEY)
+            .ok()
+            .map(|v| v.to_string())
+            .as_deref()
+            == Some("1")
     {
         cfg_svc_map.insert(
             solobase_core::migration_helper::RUN_MIGRATIONS_KEY.to_string(),
@@ -235,7 +279,7 @@ where
     }
 
     // 4. Construct remaining services.
-    let bucket: Arc<dyn StorageService> = make_r2_storage_service(&env, runner::R2_BINDING)
+    let bucket: Arc<dyn StorageService> = make_r2_storage_service(env, runner::R2_BINDING)
         .map_err(|e| format!("R2 binding {:?}: {e}", runner::R2_BINDING))?;
     let jwt_secret = cfg_svc_map
         .get(solobase_core::blocks::auth::JWT_SECRET_KEY)
@@ -284,18 +328,28 @@ where
 
     // 6b. Consumer post-build hook (override flows / configs before start).
     //     Receives the R2-backed StorageService so consumers can register
-    //     blocks that need direct un-namespaced bucket access.
-    register_post_build(&mut wafer, bucket).map_err(|e| format!("register_post_build: {e}"))?;
+    //     blocks that need direct un-namespaced bucket access. Cloned so the
+    //     bucket handle also survives into the returned `BuiltRuntime` — the
+    //     hook only borrows it to register additional blocks, it doesn't need
+    //     exclusive ownership.
+    register_post_build(&mut wafer, bucket.clone())
+        .map_err(|e| format!("register_post_build: {e}"))?;
 
-    // 6c. Run the shared boot funnel: seal → init_block(admin) →
-    //     seed_after_admin_init → init_all_blocks → post_start. The hook seeds
-    //     `auto_generate` ConfigVars once admin's migration 002 has added the
-    //     `variables.block` column. block_settings was already loaded eagerly
-    //     above (the router consumes its enablement map at build time).
-    solobase_core::builder::boot(&mut wafer, &storage_block, &CfBootHooks { db: db.clone() })
-        .await
-        .map_err(|e| format!("boot: {e}"))?;
+    Ok(BuiltRuntime {
+        wafer,
+        storage_block,
+        bucket,
+        db,
+        kv,
+    })
+}
 
+/// Convert a worker request into a WAFER message (preserving the auth header)
+/// and dispatch it through the `"site-main"` flow.
+async fn dispatch(
+    wafer: &wafer_run::Wafer,
+    req: worker::Request,
+) -> Result<worker::Response, Box<dyn std::error::Error>> {
     // 7. Convert request → message; preserve auth header in meta.
     let auth_header = req.headers().get("authorization")?;
     let (mut msg, input) = convert::worker_request_to_message(&req).await?;
@@ -306,6 +360,39 @@ where
     // 8. Dispatch and convert response.
     let output = wafer.run("site-main", msg, input).await;
     Ok(convert::output_to_response(output).await?)
+}
+
+async fn run_inner<F, G>(
+    req: worker::Request,
+    env: worker::Env,
+    register_blocks: F,
+    register_post_build: G,
+) -> Result<worker::Response, Box<dyn std::error::Error>>
+where
+    F: FnOnce(SolobaseBuilder) -> Result<SolobaseBuilder, Box<dyn std::error::Error>>,
+    G: FnOnce(
+        &mut wafer_run::Wafer,
+        Arc<dyn StorageService>,
+    ) -> Result<(), Box<dyn std::error::Error>>,
+{
+    let mut built = build_runtime(&env, register_blocks, register_post_build, false).await?;
+
+    // Run the shared boot funnel: seal → init_block(admin) →
+    // seed_after_admin_init → init_all_blocks → post_start. The hook seeds
+    // `auto_generate` ConfigVars once admin's migration 002 has added the
+    // `variables.block` column. block_settings was already loaded eagerly in
+    // `build_runtime` (the router consumes its enablement map at build time).
+    solobase_core::builder::boot(
+        &mut built.wafer,
+        &built.storage_block,
+        &CfBootHooks {
+            db: built.db.clone(),
+        },
+    )
+    .await
+    .map_err(|e| format!("boot: {e}"))?;
+
+    dispatch(&built.wafer, req).await
 }
 
 /// Worker `Env` bindings that override D1 variables (set via

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -285,10 +285,10 @@ fn sha256_hex(s: &str) -> String {
     h.finalize().iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Everything [`build_runtime`] produces: a sealed-but-not-yet-booted runtime
-/// plus the service handles Tasks 7-8 need (per-isolate build caching, the
-/// `/_deploy/init` endpoint) that would otherwise be locked inside its
-/// function-local scope.
+/// Everything [`build_runtime`] produces: a built-but-not-sealed-or-booted
+/// runtime plus the service handles Tasks 7-8 need (per-isolate build
+/// caching, the `/_deploy/init` endpoint) that would otherwise be locked
+/// inside its function-local scope.
 struct BuiltRuntime {
     wafer: wafer_run::Wafer,
     storage_block: Arc<solobase_core::blocks::storage::SolobaseStorageBlock>,

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -18,6 +18,7 @@ pub mod kv_cached_db;
 pub mod logger_service;
 pub mod network_service;
 mod runner;
+mod runtime_cache;
 pub mod storage;
 
 // ---------------------------------------------------------------------------
@@ -79,14 +80,25 @@ fn make_kv_cached_database_service_with_backend(
     kv_binding: &str,
 ) -> Result<(Arc<dyn DatabaseService>, Arc<dyn kv_cached_db::KvBackend>), worker::Error> {
     let inner = make_d1_database_service(env, d1_binding)?;
-    let kv_store = env.kv(kv_binding)?;
-    let backend: Arc<dyn kv_cached_db::KvBackend> =
-        Arc::new(kv_cached_db::WorkerKvBackend(kv_store));
+    let backend = make_kv_backend(env, kv_binding)?;
     let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::new(
         inner,
         backend.clone(),
     ));
     Ok((db, backend))
+}
+
+/// Construct a raw [`KvBackend`](kv_cached_db::KvBackend) from a worker `Env`
+/// and a KV binding name. Single construction path shared by the KV-cached DB
+/// factory above and the per-isolate runtime cache's config-version probe
+/// (`runtime_cache::get_or_build`), so both derive the `KvStore` handle the
+/// same way.
+pub(crate) fn make_kv_backend(
+    env: &worker::Env,
+    binding: &str,
+) -> Result<Arc<dyn kv_cached_db::KvBackend>, worker::Error> {
+    let kv_store = env.kv(binding)?;
+    Ok(Arc::new(kv_cached_db::WorkerKvBackend(kv_store)))
 }
 
 /// Construct an R2-backed [`StorageService`] from a worker `Env` and the R2
@@ -158,7 +170,7 @@ use solobase_core::builder::SolobaseBuilder;
 pub async fn run<F, G>(
     req: worker::Request,
     env: worker::Env,
-    _ctx: worker::Context,
+    ctx: worker::Context,
     register_blocks: F,
     register_post_build: G,
 ) -> worker::Result<worker::Response>
@@ -169,7 +181,27 @@ where
         Arc<dyn StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
-    match run_inner(req, env, register_blocks, register_post_build).await {
+    // Audit rows are queued during dispatch and flushed off the response path
+    // below, so the D1 write never adds latency to the request.
+    solobase_core::pipeline::set_request_log_mode(solobase_core::pipeline::RequestLogMode::Queued);
+    let result = run_inner(req, env, register_blocks, register_post_build).await;
+
+    // Persist any audit rows queued during this dispatch off the response
+    // path. Rows are self-contained data; attaching them to *this* request's
+    // waitUntil is correct even if they were queued by an interleaved one.
+    if let Some(rt) = runtime_cache::peek() {
+        let rows = solobase_core::pipeline::drain_queued_request_logs();
+        if !rows.is_empty() {
+            let db = rt.db.clone();
+            ctx.wait_until(async move {
+                for row in rows {
+                    let _ = db.create(row.table, row.data).await;
+                }
+            });
+        }
+    }
+
+    match result {
         Ok(response) => Ok(response),
         Err(e) => {
             worker::console_log!("solobase-cloudflare run error: {e}");
@@ -375,24 +407,11 @@ where
         Arc<dyn StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
-    let mut built = build_runtime(&env, register_blocks, register_post_build, false).await?;
-
-    // Run the shared boot funnel: seal → init_block(admin) →
-    // seed_after_admin_init → init_all_blocks → post_start. The hook seeds
-    // `auto_generate` ConfigVars once admin's migration 002 has added the
-    // `variables.block` column. block_settings was already loaded eagerly in
-    // `build_runtime` (the router consumes its enablement map at build time).
-    solobase_core::builder::boot(
-        &mut built.wafer,
-        &built.storage_block,
-        &CfBootHooks {
-            db: built.db.clone(),
-        },
-    )
-    .await
-    .map_err(|e| format!("boot: {e}"))?;
-
-    dispatch(&built.wafer, req).await
+    // Reuse the per-isolate runtime; rebuild only when the KV config-version
+    // stamp has moved. No boot funnel here — migrations/seeds run at deploy
+    // time via `/_deploy/init`, not on the request path.
+    let rt = runtime_cache::get_or_build(&env, register_blocks, register_post_build).await?;
+    dispatch(&rt.wafer, req).await
 }
 
 /// Worker `Env` bindings that override D1 variables (set via
@@ -405,6 +424,11 @@ const PROTECTED_ENV_KEYS: &[&str] = &[solobase_core::blocks::auth::JWT_SECRET_KE
 /// enablement map at build time); the only post-admin-init seed step is the
 /// shared auto-generated-secret pass, which must run after admin migration 002
 /// has added the `variables.block` column.
+///
+/// Not constructed on the request path — the per-isolate cache seals without a
+/// boot funnel. Held for Task 8's `/_deploy/init`, which runs the full boot
+/// (migrations + seeds) on demand at deploy time.
+#[allow(dead_code)]
 struct CfBootHooks {
     db: Arc<dyn DatabaseService>,
 }

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -527,9 +527,11 @@ const PROTECTED_ENV_KEYS: &[&str] = &[solobase_core::blocks::auth::JWT_SECRET_KE
 const ALLOW_WORKERS_DEV_KEY: &str = "SOLOBASE_ALLOW_WORKERS_DEV";
 
 /// True when the request's host is a `*.workers.dev` host (ASCII
-/// case-insensitive). Drives the preview-host lockdown in [`run`]; a request
-/// with no parseable host is treated as not-workers.dev (fail open to normal
-/// handling — a hostless request can't be a public preview URL).
+/// case-insensitive). Drives the preview-host lockdown in [`run`]. Two
+/// distinct failure modes: a malformed request URL fails via `?` and
+/// propagates as an error (the caller turns it into a 500); a well-formed
+/// URL with no host (`host_str()` returns `None`) fails open to normal
+/// handling — a hostless request can't be a public preview URL.
 fn host_is_workers_dev(req: &worker::Request) -> worker::Result<bool> {
     Ok(req
         .url()?

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -185,6 +185,26 @@ where
         return deploy_init_endpoint(req, env, register_blocks, register_post_build).await;
     }
 
+    // Lock down `*.workers.dev` preview hosts. Version preview URLs
+    // (`https://<hash>-<worker>.<subdomain>.workers.dev`) expose the full app
+    // on a public workers.dev host during the atomic deploy window; this guard
+    // returns a plain 404 there so only the deploy endpoint is reachable.
+    // Runs AFTER the `/_deploy/init` intercept above, so `solobase deploy`'s
+    // init gate still works on the preview host — that's the whole deploy flow.
+    // Consumers that legitimately serve on workers.dev opt out with the
+    // `SOLOBASE_ALLOW_WORKERS_DEV=1` worker var. `wrangler dev` (localhost) is
+    // unaffected.
+    if host_is_workers_dev(&req)?
+        && env
+            .var(ALLOW_WORKERS_DEV_KEY)
+            .ok()
+            .map(|v| v.to_string())
+            .as_deref()
+            != Some("1")
+    {
+        return worker::Response::error("not found", 404);
+    }
+
     // Audit rows are queued during dispatch and flushed off the response path
     // below, so the D1 write never adds latency to the request.
     solobase_core::pipeline::set_request_log_mode(solobase_core::pipeline::RequestLogMode::Queued);
@@ -216,7 +236,8 @@ where
 
 /// Deploy-time init: runs the full migrate+seed funnel once, invoked by
 /// `solobase deploy` against the freshly-uploaded version (pre-promote).
-/// Auth: sha256-compare of `X-Deploy-Token` against the `DEPLOY_TOKEN`
+/// Auth: sha256-compare of `X-Deploy-Token` against the
+/// [`DEPLOY_TOKEN_KEY`](solobase_core::config_vars::DEPLOY_TOKEN_KEY)
 /// wrangler secret (hash-then-compare sidesteps timing on raw bytes).
 async fn deploy_init_endpoint<F, G>(
     req: worker::Request,
@@ -234,7 +255,7 @@ where
     if req.method() != worker::Method::Post {
         return worker::Response::error("method not allowed", 405);
     }
-    let Ok(secret) = env.secret("DEPLOY_TOKEN") else {
+    let Ok(secret) = env.secret(solobase_core::config_vars::DEPLOY_TOKEN_KEY) else {
         // Secret unset ⇒ endpoint disabled entirely.
         return worker::Response::error("not found", 404);
     };
@@ -499,6 +520,23 @@ where
 /// `wrangler secret put`). Most config belongs in D1 so admins can
 /// manage it through the dashboard — this list stays short.
 const PROTECTED_ENV_KEYS: &[&str] = &[solobase_core::blocks::auth::JWT_SECRET_KEY];
+
+/// Worker var (`env.var`) that opts a consumer out of the `*.workers.dev`
+/// preview-host lockdown in [`run`]. Set to `"1"` to serve the full app on a
+/// `workers.dev` host (e.g. consumers with no custom domain).
+const ALLOW_WORKERS_DEV_KEY: &str = "SOLOBASE_ALLOW_WORKERS_DEV";
+
+/// True when the request's host is a `*.workers.dev` host (ASCII
+/// case-insensitive). Drives the preview-host lockdown in [`run`]; a request
+/// with no parseable host is treated as not-workers.dev (fail open to normal
+/// handling — a hostless request can't be a public preview URL).
+fn host_is_workers_dev(req: &worker::Request) -> worker::Result<bool> {
+    Ok(req
+        .url()?
+        .host_str()
+        .map(|h| h.to_ascii_lowercase().ends_with(".workers.dev"))
+        .unwrap_or(false))
+}
 
 /// [`BootHooks`](solobase_core::builder::BootHooks) impl for the Cloudflare
 /// target. block_settings is loaded eagerly before build (the router needs its

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -1,0 +1,108 @@
+//! Per-isolate runtime cache. Builds the Wafer once per isolate (sealed, no
+//! boot funnel — migrations/seeds happen at deploy via `/_deploy/init`),
+//! stores it in a thread_local, and rebuilds when the KV config-version
+//! stamp moves. Mirrors solobase-browser/src/runtime.rs's thread_local
+//! pattern; `Rc` handles (not raw pointers) keep an in-flight request's
+//! runtime alive across a swap. wasm32 is single-threaded, so the RefCell
+//! borrows are never contended — but they are still never held across an
+//! `.await` (interleaved fetch events resume at await points).
+//!
+//! Concurrent first requests may race to build; last store wins. A build
+//! is pure CPU plus one KV-cached block_settings read, so a duplicate
+//! build is wasteful-but-correct and only possible in the first instants
+//! of an isolate's life. (YAGNI: no async build-guard until measurement
+//! says otherwise.)
+
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use solobase_core::cache_key::CONFIG_VERSION_KEY;
+use wafer_core::interfaces::database::service::DatabaseService;
+
+pub(crate) struct ReadyRuntime {
+    pub wafer: wafer_run::Wafer,
+    pub db: Arc<dyn DatabaseService>,
+    pub version: String,
+}
+
+thread_local! {
+    static RUNTIME: RefCell<Option<Rc<ReadyRuntime>>> = const { RefCell::new(None) };
+}
+
+fn cached() -> Option<Rc<ReadyRuntime>> {
+    RUNTIME.with(|r| r.borrow().clone())
+}
+
+fn store(rt: Rc<ReadyRuntime>) {
+    RUNTIME.with(|r| *r.borrow_mut() = Some(rt));
+}
+
+/// Read-only peek at the currently-cached runtime, if any. Used by `run` to
+/// drain queued request-log rows through the cached runtime's DB handle in a
+/// `waitUntil` without forcing a build.
+pub(crate) fn peek() -> Option<Rc<ReadyRuntime>> {
+    cached()
+}
+
+/// Current KV config-version stamp. Missing key ⇒ stamp a fresh one so all
+/// isolates converge on the same generation.
+async fn current_version(kv: &Arc<dyn crate::kv_cached_db::KvBackend>) -> String {
+    match kv.get(CONFIG_VERSION_KEY).await {
+        Ok(Some(v)) => v,
+        _ => {
+            let v = crate::kv_cached_db::new_version_stamp();
+            let _ = kv
+                .put_with_ttl(CONFIG_VERSION_KEY, &v, crate::kv_cached_db::CACHE_TTL_SECS)
+                .await;
+            v
+        }
+    }
+}
+
+/// Return the per-isolate cached runtime, rebuilding it if the KV
+/// config-version stamp has moved (or if nothing is cached yet).
+///
+/// The `register_blocks` / `register_post_build` hooks are `FnOnce` and are
+/// consumed only on the build path; on a cache hit they are dropped unused.
+pub(crate) async fn get_or_build<F, G>(
+    env: &worker::Env,
+    register_blocks: F,
+    register_post_build: G,
+) -> Result<Rc<ReadyRuntime>, Box<dyn std::error::Error>>
+where
+    F: FnOnce(crate::SolobaseBuilder) -> Result<crate::SolobaseBuilder, Box<dyn std::error::Error>>,
+    G: FnOnce(
+        &mut wafer_run::Wafer,
+        Arc<dyn wafer_core::interfaces::storage::service::StorageService>,
+    ) -> Result<(), Box<dyn std::error::Error>>,
+{
+    // Cheap probe first: one KV read per request.
+    // (Build a KV backend from env to read the version even on the hit path.)
+    let kv = crate::make_kv_backend(env, crate::runner::KV_BINDING)?;
+    let version = current_version(&kv).await;
+
+    if let Some(rt) = cached() {
+        if rt.version == version {
+            return Ok(rt);
+        }
+        tracing::info!(old = %rt.version, new = %version, "config version moved; rebuilding runtime");
+    }
+
+    let mut built = crate::build_runtime(env, register_blocks, register_post_build, false).await?;
+
+    // Dynamic WRAP grants must be registered before seal.
+    let db_grants = solobase_core::boot::load_wrap_grants_from_db(&built.db).await;
+    if !db_grants.is_empty() {
+        built.wafer.add_wrap_grants(db_grants);
+    }
+
+    built.wafer.seal().await.map_err(|e| format!("seal: {e}"))?;
+    solobase_core::builder::post_start(&built.wafer, &built.storage_block);
+
+    let rt = Rc::new(ReadyRuntime {
+        wafer: built.wafer,
+        db: built.db,
+        version,
+    });
+    store(rt.clone());
+    Ok(rt)
+}

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -79,29 +79,38 @@ where
         Arc<dyn wafer_core::interfaces::storage::service::StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
-    // Hit path: probe the config-version through the CACHED runtime's own KV
-    // backend — no fresh `KvStore` construction on the request hot path. One
-    // KV `get` per request. On a version move we reuse this probed value to
-    // tag the rebuild, so the mismatch path still costs a single KV `get`.
+    // Every path probes the config-version BEFORE building, so the stored
+    // ReadyRuntime is always tagged with a version no newer than the config
+    // generation it was actually built from. Version stamps are monotonic,
+    // so a pre-build probe is safe: worst case the stamp moves again between
+    // the probe and the build, and the next request pays one harmless extra
+    // rebuild. Probing AFTER the build would risk the opposite — stamping a
+    // runtime built from stale config with a fresh version, which would
+    // never self-heal until the next bump.
+    //
+    // Hit / mismatch path: probe through the CACHED runtime's own KV
+    // backend — no fresh `KvStore` construction on the request hot path.
     let probed_version = if let Some(rt) = cached() {
         let version = current_version(&rt.kv).await;
         if rt.version == version {
             return Ok(rt);
         }
         tracing::info!(old = %rt.version, new = %version, "config version moved; rebuilding runtime");
-        Some(version)
+        version
     } else {
-        None
+        // Cold isolate: nothing cached to probe through. Construct a
+        // standalone KV backend (cold path only — the hit/mismatch branch
+        // above never constructs one) and probe it now, before
+        // `build_runtime` runs. `build_runtime` constructs its own KV
+        // backend internally (`built.kv`, used for the D1 read-cache), but
+        // that handle isn't available yet and isn't reused for this probe —
+        // the whole point is to probe before the build starts. Either way
+        // this is exactly one KV `get` for the version stamp.
+        let kv = crate::make_kv_backend(env, crate::runner::KV_BINDING)?;
+        current_version(&kv).await
     };
 
     let mut built = crate::build_runtime(env, register_blocks, register_post_build, false).await?;
-
-    // Cold isolate: nothing was cached to probe through, so read the version
-    // now via the freshly-built runtime's own backend (still one KV `get`).
-    let version = match probed_version {
-        Some(v) => v,
-        None => current_version(&built.kv).await,
-    };
 
     // Dynamic WRAP grants must be registered before seal.
     crate::apply_db_wrap_grants(&mut built).await;
@@ -113,7 +122,7 @@ where
         wafer: built.wafer,
         db: built.db,
         kv: built.kv,
-        version,
+        version: probed_version,
     });
     store(rt.clone());
     Ok(rt)

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -21,6 +21,10 @@ use wafer_core::interfaces::database::service::DatabaseService;
 pub(crate) struct ReadyRuntime {
     pub wafer: wafer_run::Wafer,
     pub db: Arc<dyn DatabaseService>,
+    /// KV backend this runtime was built with. Held so the config-version
+    /// probe on the request hot path reuses it instead of constructing a fresh
+    /// `KvStore` handle from `env` on every request.
+    pub kv: Arc<dyn crate::kv_cached_db::KvBackend>,
     pub version: String,
 }
 
@@ -75,25 +79,32 @@ where
         Arc<dyn wafer_core::interfaces::storage::service::StorageService>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
-    // Cheap probe first: one KV read per request.
-    // (Build a KV backend from env to read the version even on the hit path.)
-    let kv = crate::make_kv_backend(env, crate::runner::KV_BINDING)?;
-    let version = current_version(&kv).await;
-
-    if let Some(rt) = cached() {
+    // Hit path: probe the config-version through the CACHED runtime's own KV
+    // backend — no fresh `KvStore` construction on the request hot path. One
+    // KV `get` per request. On a version move we reuse this probed value to
+    // tag the rebuild, so the mismatch path still costs a single KV `get`.
+    let probed_version = if let Some(rt) = cached() {
+        let version = current_version(&rt.kv).await;
         if rt.version == version {
             return Ok(rt);
         }
         tracing::info!(old = %rt.version, new = %version, "config version moved; rebuilding runtime");
-    }
+        Some(version)
+    } else {
+        None
+    };
 
     let mut built = crate::build_runtime(env, register_blocks, register_post_build, false).await?;
 
+    // Cold isolate: nothing was cached to probe through, so read the version
+    // now via the freshly-built runtime's own backend (still one KV `get`).
+    let version = match probed_version {
+        Some(v) => v,
+        None => current_version(&built.kv).await,
+    };
+
     // Dynamic WRAP grants must be registered before seal.
-    let db_grants = solobase_core::boot::load_wrap_grants_from_db(&built.db).await;
-    if !db_grants.is_empty() {
-        built.wafer.add_wrap_grants(db_grants);
-    }
+    crate::apply_db_wrap_grants(&mut built).await;
 
     built.wafer.seal().await.map_err(|e| format!("seal: {e}"))?;
     solobase_core::builder::post_start(&built.wafer, &built.storage_block);
@@ -101,6 +112,7 @@ where
     let rt = Rc::new(ReadyRuntime {
         wafer: built.wafer,
         db: built.db,
+        kv: built.kv,
         version,
     });
     store(rt.clone());

--- a/crates/solobase-core/src/boot.rs
+++ b/crates/solobase-core/src/boot.rs
@@ -311,23 +311,59 @@ pub async fn load_wrap_grants_from_db(
     {
         Ok(list) => list.records,
         Err(e) => {
-            tracing::debug!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
+            // Missing table is expected on a fresh boot before migrations
+            // have run — stays `debug!`. Any other failure (e.g. a
+            // transient D1 error) silently yields a grant-less,
+            // WRAP-denying runtime on the Cloudflare path, so it's surfaced
+            // as `warn!` instead. Backends surface a missing table as a
+            // driver message containing "no such table" (see
+            // `solobase-cloudflare::database::is_no_such_table`); there's
+            // no structured `DatabaseError` variant for it, hence the
+            // string match.
+            if e.to_string().contains("no such table") {
+                tracing::debug!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
+            } else {
+                tracing::warn!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
+            }
             return Vec::new();
         }
     };
     rows.into_iter()
         .filter_map(|r| {
-            let grantee = r.data.get("grantee")?.as_str()?.to_string();
-            let resource = r.data.get("resource")?.as_str()?.to_string();
+            let grantee = match r.data.get("grantee").and_then(|v| v.as_str()) {
+                Some(g) => g.to_string(),
+                None => {
+                    tracing::warn!(id = %r.id, "wrap_grants row missing/non-string `grantee`; dropped");
+                    return None;
+                }
+            };
+            let resource = match r.data.get("resource").and_then(|v| v.as_str()) {
+                Some(s) => s.to_string(),
+                None => {
+                    tracing::warn!(id = %r.id, grantee = %grantee, "wrap_grants row missing/non-string `resource`; dropped");
+                    return None;
+                }
+            };
             // sqlite stores booleans as 0/1 integers.
             let write = match r.data.get("write") {
-                Some(v) => v.as_i64().map(|n| n != 0).or_else(|| v.as_bool())?,
-                None => return None,
+                Some(v) => match v.as_i64().map(|n| n != 0).or_else(|| v.as_bool()) {
+                    Some(w) => w,
+                    None => {
+                        tracing::warn!(id = %r.id, grantee = %grantee, resource = %resource, "wrap_grants row has non-bool/non-int `write`; dropped");
+                        return None;
+                    }
+                },
+                None => {
+                    tracing::warn!(id = %r.id, grantee = %grantee, resource = %resource, "wrap_grants row missing `write`; dropped");
+                    return None;
+                }
             };
             // Mirrors `cli/server_config.rs::load_wrap_grants`'s
             // `ResourceType::parse` call: the wire value is the lowercase
             // `ResourceType` Display string ("db", "config", …); empty or
             // unrecognized values parse to `None` (wildcard — all types).
+            // Absent/unrecognized `resource_type` is a legitimate wildcard
+            // grant, not malformed data, so it does not warn.
             let resource_type = r
                 .data
                 .get("resource_type")

--- a/crates/solobase-core/src/cache_key.rs
+++ b/crates/solobase-core/src/cache_key.rs
@@ -497,4 +497,37 @@ mod tests {
         assert!(!CONFIG_VERSION_KEY.starts_with("cfg:v1:variables:"));
         assert!(!CONFIG_VERSION_KEY.starts_with("cfg:v1:block_settings:"));
     }
+
+    /// Pins the invariant: every table `classify_table` recognizes as
+    /// KV-row-cached must also bump the config version, or a cached runtime
+    /// could keep serving stale rows forever after a write to that table.
+    ///
+    /// `classify_table` matches individual table constants rather than
+    /// iterating a shared list, so this test can't literally replay its
+    /// match arms. Instead it exhaustively matches every `CachedTable`
+    /// variant with NO wildcard arm: adding a new variant (i.e. a new
+    /// cached table) without updating this test is a compile error here,
+    /// not a silent gap. If you just added a table to `classify_table`,
+    /// add its variant + constant below and confirm `bumps_config_version`
+    /// covers it too.
+    #[test]
+    fn every_classified_table_bumps_config_version() {
+        for table in [CachedTable::Variables, CachedTable::BlockSettings] {
+            let table_name = match table {
+                CachedTable::Variables => VARIABLES_TABLE,
+                CachedTable::BlockSettings => BLOCK_SETTINGS_TABLE,
+            };
+            assert_eq!(
+                classify_table(table_name),
+                Some(table),
+                "{table_name} no longer classifies as {table:?} — test is stale"
+            );
+            assert!(
+                bumps_config_version(table_name),
+                "{table_name} is KV-row-cached ({table:?} via classify_table) but \
+                 bumps_config_version() is false — every cached table must bump \
+                 the config version so cached runtimes don't serve stale state"
+            );
+        }
+    }
 }

--- a/crates/solobase-core/src/config_vars.rs
+++ b/crates/solobase-core/src/config_vars.rs
@@ -8,6 +8,17 @@
 
 use wafer_run::{ConfigVar, InputType};
 
+/// Worker-secret name for the deploy-time `/_deploy/init` bearer token.
+///
+/// One canonical name shared by both sides of the deploy handshake: the CLI
+/// (`solobase deploy` / `solobase deploy secret`) reads it from the
+/// same-named env var and provisions it via `wrangler secret put`, and the
+/// Cloudflare worker reads it via `env.secret(DEPLOY_TOKEN_KEY)` to gate the
+/// endpoint. Not a `ConfigVar` (never lives in D1 or the admin UI) — it is a
+/// deploy-time worker secret, so it is a plain const rather than a
+/// `SOLOBASE_SHARED__*` entry.
+pub const DEPLOY_TOKEN_KEY: &str = "SOLOBASE_DEPLOY_TOKEN";
+
 /// Shared config variables readable by all blocks, writable only by admin.
 ///
 /// These are NOT owned by any block — they're platform-level settings.

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -50,7 +50,8 @@ thread_local! {
 }
 
 /// Select the request-log persistence mode for this thread (isolate).
-/// Called once at platform init; native never calls it.
+/// The Cloudflare target sets it (idempotently) at the top of every request;
+/// native never calls it.
 pub fn set_request_log_mode(mode: RequestLogMode) {
     REQUEST_LOG_MODE.with(|m| m.set(mode));
 }

--- a/crates/solobase/Cargo.toml
+++ b/crates/solobase/Cargo.toml
@@ -80,6 +80,9 @@ async-trait = { workspace = true }
 # Async runtime
 tokio = { workspace = true, features = ["full"] }
 
+# HTTP client for `solobase deploy`'s post-upload `/_deploy/init` gate call.
+reqwest = { workspace = true }
+
 # Observability
 tracing = { workspace = true }
 

--- a/crates/solobase/src/cli/cli_args.rs
+++ b/crates/solobase/src/cli/cli_args.rs
@@ -57,7 +57,24 @@ pub enum Command {
 
         #[arg(long)]
         release: bool,
+
+        /// Optional subaction. Bare `solobase deploy` runs the full deploy;
+        /// `solobase deploy secret` provisions worker secrets instead.
+        #[command(subcommand)]
+        action: Option<DeployAction>,
     },
+}
+
+/// Subactions of `solobase deploy`.
+#[derive(Subcommand, Debug)]
+pub enum DeployAction {
+    /// Provision the one-time-per-environment worker secrets
+    /// (`SOLOBASE_DEPLOY_TOKEN` + the auth JWT secret) via
+    /// `wrangler secret put`. Each value is taken from the same-named env var
+    /// if set, otherwise a fresh 32-byte hex token is generated. Requires a
+    /// generated `wrangler.toml` (run `solobase build --target cloudflare`
+    /// first).
+    Secret,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/solobase/src/cli/cli_args.rs
+++ b/crates/solobase/src/cli/cli_args.rs
@@ -45,20 +45,18 @@ pub enum Command {
     },
     /// Build the app and deploy it to the target's hosting environment.
     /// (v1: only `--target cloudflare` is supported.)
+    ///
+    /// Cloudflare deploys are atomic: an unpromoted version is uploaded,
+    /// migrations + seeds run against it via an authenticated
+    /// `/_deploy/init` call, and only on success is the version promoted
+    /// to 100% traffic. There is no `--run-migrations` flag here (unlike
+    /// `serve`) — every deploy always runs the init funnel.
     Deploy {
         #[arg(long)]
         target: Option<Target>,
 
         #[arg(long)]
         release: bool,
-
-        /// Apply pending block migrations on deploy.
-        /// Required after adding or modifying migration SQL in any block.
-        /// The first deploy after upgrading solobase must pass this flag.
-        /// For --target cloudflare, threads `SOLOBASE_RUN_MIGRATIONS=1` to
-        /// the deployed Worker via `wrangler deploy --var`.
-        #[arg(long)]
-        run_migrations: bool,
     },
 }
 

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -126,10 +126,11 @@ pub async fn serve(
 pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
     let cfg = env::load(repo_root)?;
     let _ = env::require_api_token()?; // account_id already validated by load()
-    let deploy_token = std::env::var("SOLOBASE_DEPLOY_TOKEN").map_err(|_| {
+    let token_key = solobase_core::config_vars::DEPLOY_TOKEN_KEY;
+    let deploy_token = std::env::var(token_key).map_err(|_| {
         anyhow::anyhow!(
-            "SOLOBASE_DEPLOY_TOKEN is not set. Generate one, store it as a worker \
-             secret (`wrangler secret put DEPLOY_TOKEN`), and export it for deploys."
+            "{token_key} is not set. Provision it with `solobase deploy secret` \
+             (or `wrangler secret put {token_key}`) and export it for deploys."
         )
     })?;
 
@@ -170,5 +171,48 @@ pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
 
     println!();
     println!("deploy complete");
+    Ok(())
+}
+
+/// `solobase deploy secret`: provision the one-time-per-environment worker
+/// secrets (`SOLOBASE_DEPLOY_TOKEN` + the auth JWT secret) via
+/// `wrangler secret put`. Each value is taken from the same-named env var when
+/// set, otherwise a fresh 32-byte hex token is generated. Requires the
+/// generated `wrangler.toml` (run `solobase build --target cloudflare` first).
+pub async fn deploy_secret(repo_root: &Path) -> Result<()> {
+    let out_dir = repo_root.join("target/solobase-cloudflare");
+    let wrangler_toml = out_dir.join("wrangler.toml");
+    if !wrangler_toml.exists() {
+        bail!(
+            "wrangler.toml not found at {}. Run `solobase build --target cloudflare` first.",
+            wrangler_toml.display()
+        );
+    }
+
+    let deploy_token_key = solobase_core::config_vars::DEPLOY_TOKEN_KEY;
+    for name in [
+        deploy_token_key,
+        solobase_core::blocks::auth::JWT_SECRET_KEY,
+    ] {
+        // 32 random bytes → 64 hex chars. getrandom is already a dependency
+        // (used for variable seeding); no new crate for randomness.
+        let mut buf = [0u8; 32];
+        getrandom::getrandom(&mut buf).map_err(|e| anyhow::anyhow!("getrandom: {e}"))?;
+        let (value, generated) = cf_deploy::resolve_secret(std::env::var(name).ok(), &buf);
+
+        cf_deploy::wrangler_secret_put(&wrangler_toml, name, &value)?;
+
+        if generated {
+            println!("-> generated and set worker secret {name}");
+            if name == deploy_token_key {
+                println!(
+                    "   IMPORTANT: export this for future `solobase deploy` runs:\n     \
+                     export {name}={value}"
+                );
+            }
+        } else {
+            println!("-> set worker secret {name} (from env {name})");
+        }
+    }
     Ok(())
 }

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -123,36 +123,43 @@ pub async fn serve(
     Ok(())
 }
 
-pub async fn deploy(repo_root: &Path, release: bool, run_migrations: bool) -> Result<()> {
+pub async fn deploy(repo_root: &Path, release: bool) -> Result<()> {
     let cfg = env::load(repo_root)?;
     let _ = env::require_api_token()?; // account_id already validated by load()
+    let deploy_token = std::env::var("SOLOBASE_DEPLOY_TOKEN").map_err(|_| {
+        anyhow::anyhow!(
+            "SOLOBASE_DEPLOY_TOKEN is not set. Generate one, store it as a worker \
+             secret (`wrangler secret put DEPLOY_TOKEN`), and export it for deploys."
+        )
+    })?;
 
     build(repo_root, release).await?;
 
     let out_dir = repo_root.join("target/solobase-cloudflare");
     let wrangler_toml = out_dir.join("wrangler.toml");
 
-    // Apply D1 migrations BEFORE pushing the worker bundle. The new code
-    // expects tables to exist (no more lazy ensure_table()), so migrations
-    // must land first.
-    let migrations_dir = out_dir.join("migrations");
-    if migrations_dir.is_dir() {
-        cf_deploy::d1_migrate_remote(&cfg.d1.database_name, &wrangler_toml)?;
-        println!("-> D1 migrations applied to {}", cfg.d1.database_name);
+    // 1. Upload an unpromoted version (no traffic routed yet).
+    let upload = cf_deploy::wrangler_versions_upload(&wrangler_toml)?;
+    println!(
+        "-> uploaded version {} (preview {})",
+        upload.version_id, upload.preview_url
+    );
+
+    // 2. Run migrations + seeds through the new version's own code, against
+    //    the shared production D1 (additive migrations keep the still-live
+    //    old version safe). Abort pre-promote on failure.
+    let (ok, report) = cf_deploy::call_deploy_init(&upload.preview_url, &deploy_token).await?;
+    println!("{report}");
+    if !ok {
+        bail!(
+            "deploy init failed — version {} NOT promoted",
+            upload.version_id
+        );
     }
 
-    // Block-SQL migrations (the in-Worker hash-gated `apply_if_blessed`
-    // sweep) gate on `SOLOBASE_RUN_MIGRATIONS=1` in the Worker env. The
-    // D1-side schema migrations above run during `wrangler d1 migrations
-    // apply` and are independent of this flag.
-    cf_deploy::wrangler_deploy_with_vars(
-        &wrangler_toml,
-        if run_migrations {
-            &[("SOLOBASE_RUN_MIGRATIONS", "1")]
-        } else {
-            &[]
-        },
-    )?;
+    // 3. Promote.
+    cf_deploy::wrangler_versions_promote(&upload.version_id, &wrangler_toml)?;
+    println!("-> promoted {}", upload.version_id);
 
     let assets_root = out_dir.join("assets");
     let n = cf_deploy::r2_upload_dir(&cfg.r2.bucket_name, &assets_root)?;

--- a/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
@@ -4,7 +4,11 @@
 //! stdio for interactive progress except `wrangler_versions_upload`,
 //! which captures stdout to parse the version id and preview URL.
 
-use std::{path::Path, process::Command};
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use anyhow::{bail, Context, Result};
 
@@ -88,6 +92,46 @@ pub async fn call_deploy_init(preview_url: &str, token: &str) -> Result<(bool, S
     Ok((ok, body))
 }
 
+/// Set a worker secret via `wrangler secret put <NAME> --config <toml>`,
+/// piping the value on stdin (never as an argv arg, which would leak it into
+/// the process table). Stdout/stderr inherit so wrangler's own confirmation
+/// shows through. One-time provisioning helper behind `solobase deploy secret`.
+pub fn wrangler_secret_put(wrangler_toml: &Path, name: &str, value: &str) -> Result<()> {
+    let mut child = Command::new("wrangler")
+        .args(["secret", "put", name, "--config"])
+        .arg(wrangler_toml)
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("spawn wrangler secret put")?;
+    child
+        .stdin
+        .take()
+        .context("wrangler secret put stdin unavailable")?
+        .write_all(value.as_bytes())
+        .context("write secret value to wrangler stdin")?;
+    let status = child.wait().context("wait for wrangler secret put")?;
+    if !status.success() {
+        bail!(
+            "wrangler secret put {name} failed (exit {:?})",
+            status.code()
+        );
+    }
+    Ok(())
+}
+
+/// Resolve a secret value for `solobase deploy secret`: reuse a caller-provided
+/// value (from the same-named env var) when present and non-empty, otherwise
+/// generate one by hex-encoding `random_bytes`. Returns `(value, generated)`
+/// where `generated` is `true` when the value was freshly minted (so the CLI
+/// can print an export reminder for the deploy token). Pure — the impure env
+/// lookup and randomness are supplied by the caller so this stays host-testable.
+pub fn resolve_secret(from_env: Option<String>, random_bytes: &[u8]) -> (String, bool) {
+    match from_env {
+        Some(v) if !v.is_empty() => (v, false),
+        _ => (solobase_core::util::hex_encode(random_bytes), true),
+    }
+}
+
 pub fn r2_upload_dir(bucket: &str, assets_root: &Path) -> Result<usize> {
     if !assets_root.is_dir() {
         return Ok(0);
@@ -131,7 +175,30 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::parse_labeled_line;
+    use super::{parse_labeled_line, resolve_secret};
+
+    #[test]
+    fn resolve_secret_prefers_non_empty_env() {
+        let (value, generated) = resolve_secret(Some("from-env".to_string()), &[0xab, 0xcd]);
+        assert_eq!(value, "from-env");
+        assert!(!generated);
+    }
+
+    #[test]
+    fn resolve_secret_generates_when_env_absent() {
+        let (value, generated) = resolve_secret(None, &[0x00, 0xff, 0x0a, 0xbc]);
+        // Hex-encoded random bytes, lowercase zero-padded.
+        assert_eq!(value, "00ff0abc");
+        assert!(generated);
+    }
+
+    #[test]
+    fn resolve_secret_generates_when_env_empty() {
+        // An empty env var is treated as unset — generate instead.
+        let (value, generated) = resolve_secret(Some(String::new()), &[0x01, 0x02]);
+        assert_eq!(value, "0102");
+        assert!(generated);
+    }
 
     #[test]
     fn parses_wrangler_version_lines() {

--- a/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/deploy.rs
@@ -1,6 +1,8 @@
-//! Deploy subprocess orchestration: `wrangler deploy`, R2 asset upload,
-//! D1 migrations. All commands inherit stdout/stderr; errors propagate
-//! verbatim.
+//! Deploy subprocess orchestration: atomic versioned `wrangler` deploys
+//! (`versions upload` → `/_deploy/init` gate → `versions deploy` promote),
+//! plus R2 asset upload. The version-upload/promote helpers inherit
+//! stdio for interactive progress except `wrangler_versions_upload`,
+//! which captures stdout to parse the version id and preview URL.
 
 use std::{path::Path, process::Command};
 
@@ -8,25 +10,82 @@ use anyhow::{bail, Context, Result};
 
 use super::assets::mime_for_path;
 
-pub fn wrangler_deploy(wrangler_toml: &Path) -> Result<()> {
-    wrangler_deploy_with_vars(wrangler_toml, &[])
+/// Output of `wrangler versions upload` (unpromoted deployment).
+pub struct VersionUpload {
+    pub version_id: String,
+    pub preview_url: String,
 }
 
-/// `wrangler deploy` plus zero or more `--var KEY:VALUE` flags injected
-/// into the Worker's runtime env. Used by the Solobase CLI to plumb
-/// `solobase deploy --run-migrations` through to the Worker's
-/// `apply_if_blessed` hash-gated migration sweep.
-pub fn wrangler_deploy_with_vars(wrangler_toml: &Path, vars: &[(&str, &str)]) -> Result<()> {
-    let mut cmd = Command::new("wrangler");
-    cmd.args(["deploy", "--config"]).arg(wrangler_toml);
-    for (k, v) in vars {
-        cmd.args(["--var", &format!("{k}:{v}")]);
+/// Upload a new worker version WITHOUT routing traffic to it. Captures
+/// stdout (unlike the inherit-stdio helpers) to parse the version id and
+/// preview URL.
+pub fn wrangler_versions_upload(wrangler_toml: &Path) -> Result<VersionUpload> {
+    let output = Command::new("wrangler")
+        .args(["versions", "upload", "--config"])
+        .arg(wrangler_toml)
+        .output()
+        .context("run wrangler versions upload")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    print!("{stdout}");
+    eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    if !output.status.success() {
+        bail!(
+            "wrangler versions upload failed (exit {:?})",
+            output.status.code()
+        );
     }
-    let status = cmd.status().context("run wrangler deploy")?;
+    // wrangler prints lines like:
+    //   Worker Version ID: 8e3c...-....
+    //   Version Preview URL: https://<hash>-<worker>.<subdomain>.workers.dev
+    let version_id = parse_labeled_line(&stdout, "Version ID:")
+        .context("parse Version ID from wrangler versions upload output")?;
+    let preview_url = parse_labeled_line(&stdout, "Preview URL:")
+        .context("parse Preview URL (enable preview_urls in wrangler.toml)")?;
+    Ok(VersionUpload {
+        version_id,
+        preview_url,
+    })
+}
+
+fn parse_labeled_line(stdout: &str, label: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find_map(|l| l.split(label).nth(1))
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Promote an uploaded version to 100% of traffic.
+pub fn wrangler_versions_promote(version_id: &str, wrangler_toml: &Path) -> Result<()> {
+    let status = Command::new("wrangler")
+        .args([
+            "versions",
+            "deploy",
+            &format!("{version_id}@100%"),
+            "--yes",
+            "--config",
+        ])
+        .arg(wrangler_toml)
+        .status()
+        .context("run wrangler versions deploy")?;
     if !status.success() {
-        bail!("wrangler deploy failed (exit {:?})", status.code());
+        bail!("wrangler versions deploy failed (exit {:?})", status.code());
     }
     Ok(())
+}
+
+/// POST /_deploy/init on the preview URL. Returns (ok, report_body).
+pub async fn call_deploy_init(preview_url: &str, token: &str) -> Result<(bool, String)> {
+    let url = format!("{}/_deploy/init", preview_url.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("x-deploy-token", token)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let ok = resp.status().is_success();
+    let body = resp.text().await.unwrap_or_default();
+    Ok((ok, body))
 }
 
 pub fn r2_upload_dir(bucket: &str, assets_root: &Path) -> Result<usize> {
@@ -53,25 +112,6 @@ pub fn r2_upload_dir(bucket: &str, assets_root: &Path) -> Result<usize> {
     Ok(uploaded)
 }
 
-pub fn d1_migrate_remote(database_name: &str, wrangler_toml: &Path) -> Result<()> {
-    let status = Command::new("wrangler")
-        .args([
-            "d1",
-            "migrations",
-            "apply",
-            database_name,
-            "--remote",
-            "--config",
-        ])
-        .arg(wrangler_toml)
-        .status()
-        .context("run wrangler d1 migrations apply --remote")?;
-    if !status.success() {
-        bail!("wrangler d1 migrations apply --remote failed");
-    }
-    Ok(())
-}
-
 fn walk_files<F>(root: &Path, f: &mut F) -> Result<()>
 where
     F: FnMut(&Path) -> Result<()>,
@@ -87,4 +127,27 @@ where
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_labeled_line;
+
+    #[test]
+    fn parses_wrangler_version_lines() {
+        let out = "Total Upload: 4210 KiB\nWorker Version ID: abc-123\nVersion Preview URL: https://x-y.z.workers.dev\n";
+        assert_eq!(
+            parse_labeled_line(out, "Version ID:").as_deref(),
+            Some("abc-123")
+        );
+        assert_eq!(
+            parse_labeled_line(out, "Preview URL:").as_deref(),
+            Some("https://x-y.z.workers.dev")
+        );
+    }
+
+    #[test]
+    fn missing_label_returns_none() {
+        assert_eq!(parse_labeled_line("no labels here", "Version ID:"), None);
+    }
 }

--- a/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/wrangler.rs
@@ -67,6 +67,10 @@ fn base_toml(cfg: &CloudflareConfig) -> toml::Value {
         "compatibility_date".into(),
         Value::String(cfg.compatibility_date.clone()),
     );
+    // Required so `wrangler versions upload` prints a "Version Preview
+    // URL" line — `solobase deploy` parses that URL to call the new
+    // version's own `/_deploy/init` before promoting it.
+    root.insert("preview_urls".into(), Value::Boolean(true));
 
     let mut build = toml::map::Map::new();
     // Pin to ^0.7 — worker-build 0.8.x rejects consumers using

--- a/crates/solobase/src/main.rs
+++ b/crates/solobase/src/main.rs
@@ -11,7 +11,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use solobase::cli::{
-    cli_args::{Cli, Command, Target},
+    cli_args::{Cli, Command, DeployAction, Target},
     flows::{embed_cloudflare, embed_native, embed_web, sealed_native, sealed_web},
     mode::{default_target, detect_mode, Mode, ModeContext},
 };
@@ -62,9 +62,16 @@ async fn run() -> anyhow::Result<()> {
             let target = default_target(&ctx, target)?;
             dispatch_serve(&ctx, target, release, port, run_migrations).await
         }
-        Command::Deploy { target, release } => {
+        Command::Deploy {
+            target,
+            release,
+            action,
+        } => {
             let target = default_target(&ctx, target)?;
-            dispatch_deploy(&ctx, target, release).await
+            match action {
+                Some(DeployAction::Secret) => dispatch_deploy_secret(&ctx, target).await,
+                None => dispatch_deploy(&ctx, target, release).await,
+            }
         }
     }
 }
@@ -121,5 +128,20 @@ async fn dispatch_deploy(ctx: &ModeContext, target: Target, release: bool) -> an
             "--target cloudflare requires a Cargo package; sealed mode not yet implemented"
         ),
         _ => anyhow::bail!("solobase deploy is only implemented for --target cloudflare in v1"),
+    }
+}
+
+async fn dispatch_deploy_secret(ctx: &ModeContext, target: Target) -> anyhow::Result<()> {
+    let repo_root = &ctx.cwd;
+    match (detect_mode(ctx), target) {
+        (Mode::Embed, Target::Cloudflare) => embed_cloudflare::deploy_secret(repo_root).await,
+        (Mode::Sealed, Target::Cloudflare) => anyhow::bail!(
+            "--target cloudflare requires a Cargo package; sealed mode not yet implemented"
+        ),
+        _ => {
+            anyhow::bail!(
+                "solobase deploy secret is only implemented for --target cloudflare in v1"
+            )
+        }
     }
 }

--- a/crates/solobase/src/main.rs
+++ b/crates/solobase/src/main.rs
@@ -62,13 +62,9 @@ async fn run() -> anyhow::Result<()> {
             let target = default_target(&ctx, target)?;
             dispatch_serve(&ctx, target, release, port, run_migrations).await
         }
-        Command::Deploy {
-            target,
-            release,
-            run_migrations,
-        } => {
+        Command::Deploy { target, release } => {
             let target = default_target(&ctx, target)?;
-            dispatch_deploy(&ctx, target, release, run_migrations).await
+            dispatch_deploy(&ctx, target, release).await
         }
     }
 }
@@ -117,17 +113,10 @@ async fn dispatch_serve(
     }
 }
 
-async fn dispatch_deploy(
-    ctx: &ModeContext,
-    target: Target,
-    release: bool,
-    run_migrations: bool,
-) -> anyhow::Result<()> {
+async fn dispatch_deploy(ctx: &ModeContext, target: Target, release: bool) -> anyhow::Result<()> {
     let repo_root = &ctx.cwd;
     match (detect_mode(ctx), target) {
-        (Mode::Embed, Target::Cloudflare) => {
-            embed_cloudflare::deploy(repo_root, release, run_migrations).await
-        }
+        (Mode::Embed, Target::Cloudflare) => embed_cloudflare::deploy(repo_root, release).await,
         (Mode::Sealed, Target::Cloudflare) => anyhow::bail!(
             "--target cloudflare requires a Cargo package; sealed mode not yet implemented"
         ),

--- a/crates/solobase/tests/cli_args.rs
+++ b/crates/solobase/tests/cli_args.rs
@@ -2,7 +2,7 @@
 //! design (build/serve, --target native|web, --release, --port).
 
 use clap::Parser;
-use solobase::cli::cli_args::{Cli, Command, Target};
+use solobase::cli::cli_args::{Cli, Command, DeployAction, Target};
 
 #[test]
 fn parses_build_with_target_native() {
@@ -32,6 +32,35 @@ fn parses_serve_with_port() {
         assert_eq!(port, Some(9090));
     } else {
         panic!("expected Serve");
+    }
+}
+
+#[test]
+fn parses_deploy_without_action() {
+    // Bare `solobase deploy` (optionally with flags) leaves `action` None so
+    // the full deploy flow runs — the `secret` subaction is opt-in.
+    let cli = Cli::parse_from(["solobase", "deploy", "--target", "cloudflare"]);
+    if let Command::Deploy {
+        target,
+        release,
+        action,
+    } = cli.command
+    {
+        assert_eq!(target, Some(Target::Cloudflare));
+        assert!(!release);
+        assert!(action.is_none());
+    } else {
+        panic!("expected Deploy");
+    }
+}
+
+#[test]
+fn parses_deploy_secret_action() {
+    let cli = Cli::parse_from(["solobase", "deploy", "secret"]);
+    if let Command::Deploy { action, .. } = cli.command {
+        assert!(matches!(action, Some(DeployAction::Secret)));
+    } else {
+        panic!("expected Deploy");
     }
 }
 

--- a/crates/solobase/tests/helpers_cloudflare_wrangler.rs
+++ b/crates/solobase/tests/helpers_cloudflare_wrangler.rs
@@ -41,6 +41,11 @@ fn generate_writes_wrangler_toml_with_required_fields() {
     assert!(body.contains(r#"binding = "STORAGE""#));
     assert!(body.contains(r#"bucket_name = "wafer-site-assets""#));
     assert!(body.contains(r#"main = "../../build/worker/shim.mjs""#));
+    assert!(
+        body.contains("preview_urls = true"),
+        "preview_urls must be enabled so `wrangler versions upload` prints a \
+         Version Preview URL for `solobase deploy` to parse:\n{body}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
PR 2 of 3 for the Cloudflare deploy-init + lazy-runtime program (spec/plan/follow-ups: Jsuppers/workspace#29). Wires the PR 1 (#294) primitives into the worker and deploy CLI. Kills the per-request full runtime rebuild+boot, the `SOLOBASE_RUN_MIGRATIONS` deploy footgun, and the non-atomic deploy.

## What's in here (plan Tasks 5–9 + review waves)

**Worker (`solobase-cloudflare`):**
- Config-affecting KV-cached D1 writes (`variables`/`block_settings`/`wrap_grants`) rewrite a KV `config_version` stamp (Task 5).
- `run_inner` split into `BuiltRuntime`/`build_runtime`/`dispatch` (Task 6, pure refactor).
- Per-isolate thread_local runtime cache with version-gated rebuild — one KV read per request, WRAP grants loaded pre-seal, request-log D1 writes deferred to `ctx.wait_until` (Task 7). The per-request boot funnel is gone; migrations/seeds run once per deploy.
- Authenticated `POST /_deploy/init` (secret `SOLOBASE_DEPLOY_TOKEN`; 404 fail-closed when unset) running PR 1's `deploy_init` funnel on a fresh migrations-forced runtime, returning the per-block JSON report (Task 8).
- **workers.dev host guard**: preview/workers.dev hosts serve only `/_deploy/init` (generic 404 otherwise); opt-out `SOLOBASE_ALLOW_WORKERS_DEV=1` for consumers that serve on workers.dev deliberately. Added because `preview_urls = true` (required by the deploy flow) would otherwise expose the full app on public preview URLs.

**CLI (`solobase`):**
- Atomic deploy: `wrangler versions upload` → `POST /_deploy/init` on the version's preview URL → promote only on `report.ok` → R2 assets (Task 9). Every failure mode aborts pre-promote; `run_migrations` removed from `deploy` (kept on `serve`); orphaned `wrangler_deploy`/`d1_migrate_remote` helpers deleted.
- **`solobase deploy secret`** (spec §4.2): provisions `SOLOBASE_DEPLOY_TOKEN` + `SUPPERS_AI__AUTH__JWT_SECRET` via `wrangler secret put` (stdin-piped, never argv; values from same-named env vars or CSPRNG-generated).
- Deploy-token name unified to `SOLOBASE_DEPLOY_TOKEN` on both sides via a shared const (nothing was provisioned under the old name).

## Review pipeline

Each task: fresh implementer + independent spec/quality review (all 5 approved). Whole-branch review (cross-task: invalidation loop, deploy atomicity per failure stage, funnel↔stamp interaction, serve/native untouched) → fix bundle. Then an 8-angle/8-verifier `/code-review` pass: 10 verified findings — 7 fixed here (canonical `sha256_hex`/`hex_encode` + dropped `sha2` dep, `ReadyRuntime` carries the KV backend (no per-request `env.kv()`), dead `bucket` field removed, shared pre-seal grant helper, doc fixes, token unification, host guard, deploy-secret cmd, cold-path probe-before-build ordering) — 3 recorded with sketches in `workspace docs/superpowers/REMAINING.md` (wrangler D1 ledger divergence, KV bump-burst tail drop, local-dev auto_generate seed gap).

## Verification (CI-exact, at head)

- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` green (known `bundle_integration` ENOENT flake isolated-green)
- clippy (same excludes): exit 0, 81 warnings = baseline, none added
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` clean
- nightly fmt clean; Cargo.lock delta: +reqwest (CLI), −sha2

## Operator notes

- Before the next deploy to an existing worker: `solobase deploy secret` (or `wrangler secret put SOLOBASE_DEPLOY_TOKEN`), and export `SOLOBASE_DEPLOY_TOKEN` locally. First-ever deploy of a brand-new worker: upload once (init 404s, aborts) → `deploy secret` → deploy again.
- Consumers serving primarily on `*.workers.dev` must set `SOLOBASE_ALLOW_WORKERS_DEV=1` or all routes 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrWWzPqjNXUMcqsMzSBnUw