### PR TITLE
fix(cf): runtime hardening — persistent version stamp, funnel bump collapse, rebuild cache bypass, isolate init, fail-closed grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,20 +5875,22 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "fastembed",
+ "tokio",
  "wafer-core",
 ]
 
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
+ "http-body-util",
  "parking_lot",
  "tokio",
  "tracing",
@@ -5899,11 +5901,10 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "percent-encoding",
- "serde",
  "serde_json",
  "tracing",
  "wafer-block",
@@ -5913,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5925,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5936,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "futures",
@@ -5953,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5974,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5984,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5996,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6012,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6022,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6043,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6055,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6077,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "serde",
  "serde_json",
@@ -6087,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6117,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "serde",
  "serde_json",
@@ -6127,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#4906202d7d743324666caf55f93a6878bfd631cb"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -306,39 +306,42 @@ impl DatabaseService for KvCachedD1DatabaseService {
             return self.inner.list(collection, opts).await;
         };
 
-        // Try cache hit.
-        match self.kv.get(&key).await {
-            Ok(Some(body)) => match serde_json::from_str::<Vec<Record>>(&body) {
-                Ok(records) => {
-                    let page_size = opts.limit;
-                    let total_count = records.len() as i64;
-                    tracing::debug!(table = %collection, key = %key, "cache_hit");
-                    return Ok(RecordList {
-                        records,
-                        total_count,
-                        page: 1,
-                        page_size,
-                    });
+        // Try cache hit (skipped in read-through mode; the fall-through
+        // below still repopulates KV with the fresh D1 rows).
+        if !self.mode.read_through {
+            match self.kv.get(&key).await {
+                Ok(Some(body)) => match serde_json::from_str::<Vec<Record>>(&body) {
+                    Ok(records) => {
+                        let page_size = opts.limit;
+                        let total_count = records.len() as i64;
+                        tracing::debug!(table = %collection, key = %key, "cache_hit");
+                        return Ok(RecordList {
+                            records,
+                            total_count,
+                            page: 1,
+                            page_size,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            table = %collection,
+                            key = %key,
+                            error = %e,
+                            "cache value deserialize failed; falling through"
+                        );
+                    }
+                },
+                Ok(None) => {
+                    tracing::debug!(table = %collection, key = %key, "cache_miss");
                 }
                 Err(e) => {
                     tracing::warn!(
                         table = %collection,
                         key = %key,
                         error = %e,
-                        "cache value deserialize failed; falling through"
+                        "kv get failed; falling through"
                     );
                 }
-            },
-            Ok(None) => {
-                tracing::debug!(table = %collection, key = %key, "cache_miss");
-            }
-            Err(e) => {
-                tracing::warn!(
-                    table = %collection,
-                    key = %key,
-                    error = %e,
-                    "kv get failed; falling through"
-                );
             }
         }
 

--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -24,6 +24,10 @@ pub trait KvBackend: MaybeSend + MaybeSync {
     /// Writes `value` under `key` with the given TTL (seconds).
     async fn put_with_ttl(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), String>;
 
+    /// Writes `value` under `key` with no expiration. Reserved for the
+    /// config-version stamp — row-cache entries always carry a TTL.
+    async fn put(&self, key: &str, value: &str) -> Result<(), String>;
+
     /// Deletes `key`. Deleting a non-existent key is not an error.
     async fn delete(&self, key: &str) -> Result<(), String>;
 }
@@ -43,6 +47,15 @@ impl KvBackend for WorkerKvBackend {
             .put(key, value)
             .map_err(|e| e.to_string())?
             .expiration_ttl(ttl_secs)
+            .execute()
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn put(&self, key: &str, value: &str) -> Result<(), String> {
+        self.0
+            .put(key, value)
+            .map_err(|e| e.to_string())?
             .execute()
             .await
             .map_err(|e| e.to_string())
@@ -78,17 +91,52 @@ pub fn new_version_stamp() -> String {
     wafer_run::hex_encode(&buf)
 }
 
+/// Behavior switches for [`KvCachedD1DatabaseService`], chosen per
+/// runtime-build context.
+#[derive(Debug, Clone, Copy)]
+pub struct CacheMode {
+    /// Skip the KV row-cache read in `list()` (still repopulating it from
+    /// the fresh D1 result). Used by version-mismatch rebuilds and the
+    /// deploy-init funnel, where a stale row cache must not be baked into
+    /// a runtime tagged with the new version stamp.
+    pub read_through: bool,
+    /// Bump the config-version stamp on writes to classified tables.
+    /// The deploy-init funnel disables this (~19 sequential same-key puts
+    /// under KV per-key throttling) and issues one explicit bump after.
+    pub bump_on_write: bool,
+}
+
+impl Default for CacheMode {
+    fn default() -> Self {
+        Self {
+            read_through: false,
+            bump_on_write: true,
+        }
+    }
+}
+
 /// Wraps a [`DatabaseService`] with a write-through-invalidated KV cache
 /// for the `variables` and `block_settings` per-block read paths.
 pub struct KvCachedD1DatabaseService {
     inner: Arc<dyn DatabaseService>,
     kv: Arc<dyn KvBackend>,
+    mode: CacheMode,
 }
 
 impl KvCachedD1DatabaseService {
-    /// Wrap `inner` with a KV-backed cache using `kv`.
+    /// Wrap `inner` with a KV-backed cache using `kv` and default
+    /// [`CacheMode`].
     pub fn new(inner: Arc<dyn DatabaseService>, kv: Arc<dyn KvBackend>) -> Self {
-        Self { inner, kv }
+        Self::with_mode(inner, kv, CacheMode::default())
+    }
+
+    /// Wrap `inner` with explicit [`CacheMode`] switches.
+    pub fn with_mode(
+        inner: Arc<dyn DatabaseService>,
+        kv: Arc<dyn KvBackend>,
+        mode: CacheMode,
+    ) -> Self {
+        Self { inner, kv, mode }
     }
 
     /// Delete every cache key in `keys`, logging (but never failing on) KV
@@ -113,23 +161,42 @@ impl KvCachedD1DatabaseService {
 
     /// Rewrite the config-version stamp after a write to a table whose
     /// contents a cached runtime bakes in (variables / block_settings /
-    /// wrap_grants). Best-effort like row invalidation: a failed put leaves
-    /// live isolates on the old runtime until the next successful bump.
+    /// wrap_grants). Best-effort with one retry: a failed put leaves live
+    /// isolates on the old runtime until the next successful bump.
     async fn bump_config_version(&self, collection: &str, op: &str) {
-        if !cache_key::bumps_config_version(collection) {
+        if !self.mode.bump_on_write || !cache_key::bumps_config_version(collection) {
             return;
         }
         let stamp = new_version_stamp();
-        if let Err(e) = self
-            .kv
-            .put_with_ttl(cache_key::CONFIG_VERSION_KEY, &stamp, CACHE_TTL_SECS)
-            .await
-        {
+        if let Err(e) = put_version_stamp_with_retry(self.kv.as_ref(), &stamp).await {
             tracing::warn!(table = %collection, error = %e, op, "config-version bump failed");
         } else {
             tracing::debug!(table = %collection, version = %stamp, op, "config_version_bump");
         }
     }
+}
+
+/// PUT `stamp` under [`cache_key::CONFIG_VERSION_KEY`] persistently (no
+/// TTL — a quiet day must not expire the stamp and trigger a fleet-wide
+/// restamp), retrying once on KV transport error.
+pub(crate) async fn put_version_stamp_with_retry(
+    kv: &dyn KvBackend,
+    stamp: &str,
+) -> Result<(), String> {
+    match kv.put(cache_key::CONFIG_VERSION_KEY, stamp).await {
+        Ok(()) => Ok(()),
+        Err(first) => kv
+            .put(cache_key::CONFIG_VERSION_KEY, stamp)
+            .await
+            .map_err(|second| format!("first attempt: {first}; retry: {second}")),
+    }
+}
+
+/// Mint and persist a fresh config-version stamp unconditionally.
+/// Deploy-init calls this once after the funnel (per-write bumps are
+/// suppressed during it — see [`CacheMode::bump_on_write`]).
+pub(crate) async fn force_bump_config_version(kv: &dyn KvBackend) -> Result<(), String> {
+    put_version_stamp_with_retry(kv, &new_version_stamp()).await
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -153,6 +153,29 @@ pub fn make_config_service(vars: HashMap<String, String>) -> Arc<dyn ConfigServi
     Arc::new(config_service::HashMapConfigService::new(vars))
 }
 
+thread_local! {
+    static ISOLATE_INITIALIZED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// One-time isolate initialization: selects [`RequestLogMode::Queued`]
+/// (audit rows drain into `ctx.wait_until` off the response path — see
+/// `run`). Consumers should call this from their worker's
+/// `#[event(start)]` handler; `run()` also invokes it behind a
+/// once-per-isolate guard, so isolates stay correct either way and repeat
+/// calls are no-ops.
+///
+/// [`RequestLogMode::Queued`]: solobase_core::pipeline::RequestLogMode
+pub fn init_isolate() {
+    ISOLATE_INITIALIZED.with(|done| {
+        if !done.get() {
+            solobase_core::pipeline::set_request_log_mode(
+                solobase_core::pipeline::RequestLogMode::Queued,
+            );
+            done.set(true);
+        }
+    });
+}
+
 use solobase_core::builder::SolobaseBuilder;
 
 /// Worker entry shim: load D1 vars, wire services, run the consumer's
@@ -212,9 +235,9 @@ where
         return worker::Response::error("not found", 404);
     }
 
-    // Audit rows are queued during dispatch and flushed off the response path
-    // below, so the D1 write never adds latency to the request.
-    solobase_core::pipeline::set_request_log_mode(solobase_core::pipeline::RequestLogMode::Queued);
+    // Isolate-scoped init (request-log mode) — no-op after the first call;
+    // consumers with an #[event(start)] handler have already run it.
+    init_isolate();
     let result = run_inner(req, env, register_blocks, register_post_build).await;
 
     // Persist any audit rows queued during this dispatch off the response

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -64,7 +64,12 @@ pub fn make_kv_cached_database_service(
     d1_binding: &str,
     kv_binding: &str,
 ) -> Result<Arc<dyn DatabaseService>, worker::Error> {
-    let (db, _backend) = make_kv_cached_database_service_with_backend(env, d1_binding, kv_binding)?;
+    let (db, _backend) = make_kv_cached_database_service_with_backend(
+        env,
+        d1_binding,
+        kv_binding,
+        kv_cached_db::CacheMode::default(),
+    )?;
     Ok(db)
 }
 
@@ -78,12 +83,14 @@ fn make_kv_cached_database_service_with_backend(
     env: &worker::Env,
     d1_binding: &str,
     kv_binding: &str,
+    mode: kv_cached_db::CacheMode,
 ) -> Result<(Arc<dyn DatabaseService>, Arc<dyn kv_cached_db::KvBackend>), worker::Error> {
     let inner = make_d1_database_service(env, d1_binding)?;
     let backend = make_kv_backend(env, kv_binding)?;
-    let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::new(
+    let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::with_mode(
         inner,
         backend.clone(),
+        mode,
     ));
     Ok((db, backend))
 }
@@ -270,7 +277,17 @@ where
     // Fresh runtime (never the request cache) with run_migrations forced on,
     // so slot-cached pre-migration outcomes can't leak into the funnel.
     let out = async {
-        let mut built = build_runtime(&env, register_blocks, register_post_build, true).await?;
+        let mut built = build_runtime(
+            &env,
+            register_blocks,
+            register_post_build,
+            true,
+            kv_cached_db::CacheMode {
+                read_through: true,
+                bump_on_write: false,
+            },
+        )
+        .await?;
         apply_db_wrap_grants(&mut built).await;
         let report = solobase_core::deploy_init::deploy_init(
             &mut built.wafer,
@@ -284,6 +301,19 @@ where
         Ok::<_, Box<dyn std::error::Error>>(report)
     }
     .await;
+
+    // One explicit config-version bump for the whole funnel (per-write bumps
+    // are suppressed via CacheMode). Runs on failure too: a partial funnel
+    // may already have written rows, and a spurious bump only costs each
+    // live isolate one rebuild.
+    match make_kv_backend(&env, runner::KV_BINDING) {
+        Ok(kv) => {
+            if let Err(e) = kv_cached_db::force_bump_config_version(kv.as_ref()).await {
+                worker::console_log!("post-funnel config-version bump failed: {e}");
+            }
+        }
+        Err(e) => worker::console_log!("post-funnel bump skipped (KV binding): {e}"),
+    }
 
     match out {
         Ok(report) => {
@@ -333,6 +363,9 @@ pub(crate) async fn apply_db_wrap_grants(built: &mut BuiltRuntime) {
 /// endpoint (Task 8) to force a migration pass on demand. The normal request
 /// path passes `false` and keeps honoring the env var exactly as before.
 ///
+/// `cache_mode` selects KV row-cache read-through and write-bump behavior for
+/// this runtime's DB handle.
+///
 /// Missing-table tolerance is an invariant here: on a first-ever deploy
 /// `/_deploy/init` builds this runtime BEFORE any migration has run, so every
 /// eager D1 read in this function MUST tolerate a not-yet-created table
@@ -345,6 +378,7 @@ async fn build_runtime<F, G>(
     register_blocks: F,
     register_post_build: G,
     force_run_migrations: bool,
+    cache_mode: kv_cached_db::CacheMode,
 ) -> Result<BuiltRuntime, Box<dyn std::error::Error>>
 where
     F: FnOnce(SolobaseBuilder) -> Result<SolobaseBuilder, Box<dyn std::error::Error>>,
@@ -354,15 +388,19 @@ where
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
     // 1. Construct D1 service (with KV cache) first — env vars live in D1.
-    let (db, kv) =
-        make_kv_cached_database_service_with_backend(env, runner::D1_BINDING, runner::KV_BINDING)
-            .map_err(|e| {
-            format!(
-                "DB/KV bindings (D1={:?}, KV={:?}): {e}",
-                runner::D1_BINDING,
-                runner::KV_BINDING
-            )
-        })?;
+    let (db, kv) = make_kv_cached_database_service_with_backend(
+        env,
+        runner::D1_BINDING,
+        runner::KV_BINDING,
+        cache_mode,
+    )
+    .map_err(|e| {
+        format!(
+            "DB/KV bindings (D1={:?}, KV={:?}): {e}",
+            runner::D1_BINDING,
+            runner::KV_BINDING
+        )
+    })?;
 
     // 2. Load block settings (enablement + migration state) eagerly —
     //    this is the only D1 read at cold start now. The per-block

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -91,13 +91,19 @@ where
     //
     // Hit / mismatch path: probe through the CACHED runtime's own KV
     // backend — no fresh `KvStore` construction on the request hot path.
-    let probed_version = if let Some(rt) = cached() {
+    //
+    // The flag threaded alongside the version is `read_through`: version-
+    // mismatch rebuilds bypass the KV row cache (the rebuild exists BECAUSE
+    // config just changed, which is exactly when cross-PoP KV lag or a
+    // failed row-invalidate would bake stale rows under the new stamp).
+    // Cold builds keep the cache (cold-start latency is its remaining value).
+    let (probed_version, read_through) = if let Some(rt) = cached() {
         let version = current_version(&rt.kv).await;
         if rt.version == version {
             return Ok(rt);
         }
         tracing::info!(old = %rt.version, new = %version, "config version moved; rebuilding runtime");
-        version
+        (version, true)
     } else {
         // Cold isolate: nothing cached to probe through. Construct a
         // standalone KV backend (cold path only — the hit/mismatch branch
@@ -108,10 +114,20 @@ where
         // the whole point is to probe before the build starts. Either way
         // this is exactly one KV `get` for the version stamp.
         let kv = crate::make_kv_backend(env, crate::runner::KV_BINDING)?;
-        current_version(&kv).await
+        (current_version(&kv).await, false)
     };
 
-    let mut built = crate::build_runtime(env, register_blocks, register_post_build, false).await?;
+    let mut built = crate::build_runtime(
+        env,
+        register_blocks,
+        register_post_build,
+        false,
+        crate::kv_cached_db::CacheMode {
+            read_through,
+            bump_on_write: true,
+        },
+    )
+    .await?;
 
     // Dynamic WRAP grants must be registered before seal.
     crate::apply_db_wrap_grants(&mut built).await;

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -54,9 +54,10 @@ async fn current_version(kv: &Arc<dyn crate::kv_cached_db::KvBackend>) -> String
         Ok(Some(v)) => v,
         _ => {
             let v = crate::kv_cached_db::new_version_stamp();
-            let _ = kv
-                .put_with_ttl(CONFIG_VERSION_KEY, &v, crate::kv_cached_db::CACHE_TTL_SECS)
-                .await;
+            if let Err(e) = crate::kv_cached_db::put_version_stamp_with_retry(kv.as_ref(), &v).await
+            {
+                tracing::warn!(error = %e, "config-version cold mint failed; proceeding unstamped");
+            }
             v
         }
     }

--- a/crates/solobase-core/src/boot.rs
+++ b/crates/solobase-core/src/boot.rs
@@ -300,6 +300,27 @@ pub async fn load_all_variables(
 pub async fn load_wrap_grants_from_db(
     db: &Arc<dyn DatabaseService>,
 ) -> Vec<wafer_run::ResourceGrant> {
+    // Structured fresh-boot signal: on a first-ever deploy the table does
+    // not exist yet (deploy-init builds the runtime BEFORE migrations run)
+    // — that's expected and quiet. Any error after the existence check is a
+    // real read failure and yields a grant-less, WRAP-denying runtime on
+    // the Cloudflare path, so it warns.
+    match db
+        .schema_table_exists(crate::blocks::admin::WRAP_GRANTS_TABLE)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                "wrap_grants table absent (fresh boot before migrations); no dynamic grants"
+            );
+            return Vec::new();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "wrap_grants existence check failed; dynamic grants skipped");
+            return Vec::new();
+        }
+    }
     let opts = ListOptions {
         limit: 10_000,
         skip_count: true,
@@ -311,20 +332,7 @@ pub async fn load_wrap_grants_from_db(
     {
         Ok(list) => list.records,
         Err(e) => {
-            // Missing table is expected on a fresh boot before migrations
-            // have run — stays `debug!`. Any other failure (e.g. a
-            // transient D1 error) silently yields a grant-less,
-            // WRAP-denying runtime on the Cloudflare path, so it's surfaced
-            // as `warn!` instead. Backends surface a missing table as a
-            // driver message containing "no such table" (see
-            // `solobase-cloudflare::database::is_no_such_table`); there's
-            // no structured `DatabaseError` variant for it, hence the
-            // string match.
-            if e.to_string().contains("no such table") {
-                tracing::debug!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
-            } else {
-                tracing::warn!(error = %e, "wrap_grants read skipped (table missing or unreadable)");
-            }
+            tracing::warn!(error = %e, "wrap_grants read failed; dynamic grants skipped");
             return Vec::new();
         }
     };
@@ -358,17 +366,20 @@ pub async fn load_wrap_grants_from_db(
                     return None;
                 }
             };
-            // Mirrors `cli/server_config.rs::load_wrap_grants`'s
-            // `ResourceType::parse` call: the wire value is the lowercase
-            // `ResourceType` Display string ("db", "config", …); empty or
-            // unrecognized values parse to `None` (wildcard — all types).
-            // Absent/unrecognized `resource_type` is a legitimate wildcard
-            // grant, not malformed data, so it does not warn.
-            let resource_type = r
-                .data
-                .get("resource_type")
-                .and_then(|v| v.as_str())
-                .and_then(wafer_run::ResourceType::parse);
+            // Stored wire value is the lowercase `ResourceType` Display
+            // string ("db", "config", …). Absent/empty = intentional
+            // all-types wildcard; a non-empty unrecognized value is a
+            // typo'd grant and is dropped (fail-closed) rather than
+            // widened to the wildcard.
+            let resource_type = match wafer_run::ResourceType::parse_stored(
+                r.data.get("resource_type").and_then(|v| v.as_str()),
+            ) {
+                Ok(rt) => rt,
+                Err(e) => {
+                    tracing::warn!(id = %r.id, grantee = %grantee, resource = %resource, error = %e, "wrap_grants row dropped");
+                    return None;
+                }
+            };
             Some(wafer_run::ResourceGrant {
                 grantee,
                 resource,
@@ -449,5 +460,37 @@ mod wrap_grants_tests {
             .unwrap();
         assert!(!g2.write);
         assert_eq!(g2.resource_type, None);
+
+        // Unrecognized resource_type → the ROW is dropped (fail-closed),
+        // never widened to the all-types wildcard.
+        let mut r3 = HashMap::new();
+        r3.insert("grantee".into(), serde_json::json!("suppers-ai/products"));
+        r3.insert(
+            "resource".into(),
+            serde_json::json!("suppers_ai__products__items"),
+        );
+        r3.insert("write".into(), serde_json::json!(1));
+        r3.insert("resource_type".into(), serde_json::json!("databsae"));
+        db.create(crate::blocks::admin::WRAP_GRANTS_TABLE, r3)
+            .await
+            .unwrap();
+        // Empty-string resource_type → kept as an intentional wildcard.
+        let mut r4 = HashMap::new();
+        r4.insert("grantee".into(), serde_json::json!("suppers-ai/files"));
+        r4.insert("resource".into(), serde_json::json!("bucket/y"));
+        r4.insert("write".into(), serde_json::json!(0));
+        r4.insert("resource_type".into(), serde_json::json!(""));
+        db.create(crate::blocks::admin::WRAP_GRANTS_TABLE, r4)
+            .await
+            .unwrap();
+
+        let grants = load_wrap_grants_from_db(&db).await;
+        assert_eq!(grants.len(), 3, "typo'd resource_type row must be dropped");
+        assert!(grants.iter().all(|g| g.grantee != "suppers-ai/products"));
+        let g4 = grants
+            .iter()
+            .find(|g| g.resource == "bucket/y")
+            .expect("empty resource_type row kept");
+        assert_eq!(g4.resource_type, None);
     }
 }

--- a/crates/solobase-core/src/deploy_init.rs
+++ b/crates/solobase-core/src/deploy_init.rs
@@ -78,14 +78,10 @@ pub async fn deploy_init(
     };
 
     // Init every registered block individually so each outcome is captured.
-    // Admin is a slot-cached no-op on its second pass.
-    //
-    // Keyed on each block's self-reported `info().name` — `init_block` looks
-    // up registration keys. The two coincide for solobase's block set; a
-    // mismatch fails loud via `InitError::Permanent` captured into the report
-    // (`report.ok == false`), never a silent skip.
-    let names: Vec<String> = wafer.block_infos().into_iter().map(|i| i.name).collect();
-    for name in names {
+    // Admin is a slot-cached no-op on its second pass. Iterates the
+    // registration keys (`block_names`) — the exact set `init_block`
+    // resolves — rather than each block's self-reported `info().name`.
+    for name in wafer.block_names() {
         if name == admin_id {
             continue;
         }

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -265,11 +265,12 @@ impl Context for TestContext {
             if !resource.is_empty() {
                 let is_write = msg.get_meta(wafer_block::meta::META_WRAP_ACCESS) == "write";
                 let rt_str = msg.get_meta(wafer_block::meta::META_WRAP_RESOURCE_TYPE);
-                let rt = if rt_str.is_empty() {
+                let rt = wafer_run::ResourceType::parse_stored(if rt_str.is_empty() {
                     None
                 } else {
-                    wafer_run::ResourceType::parse(rt_str)
-                };
+                    Some(rt_str)
+                })
+                .unwrap_or_else(|e| panic!("test WRAP resource_type meta {rt_str:?}: {e}"));
                 if let Err(e) = wafer_block::wrap::check_access(
                     Some(caller.as_str()),
                     resource,

--- a/crates/solobase/src/cli/server_config.rs
+++ b/crates/solobase/src/cli/server_config.rs
@@ -84,11 +84,18 @@ pub fn load_wrap_grants(db_path: &str) -> Vec<wafer_run::ResourceGrant> {
     if let Ok(rows) = rows {
         for row in rows.flatten() {
             let (grantee, resource, write, rt) = row;
+            let resource_type = match wafer_run::ResourceType::parse_stored(rt.as_deref()) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(grantee = %grantee, resource = %resource, error = %e, "wrap_grants row dropped");
+                    continue;
+                }
+            };
             grants.push(wafer_run::ResourceGrant {
                 grantee,
                 resource,
                 write: write != 0,
-                resource_type: rt.and_then(|s| wafer_run::ResourceType::parse(&s)),
+                resource_type,
             });
         }
     }


### PR DESCRIPTION
Deferred-hardening batch from the shipped deploy-init + lazy-runtime program (#294/#295). Consumes wafer-run#250 (`Wafer::block_names()`, `ResourceType::parse_stored`) — Cargo.lock moves all 21 wafer git crates to that rev.

**Persistent config-version stamp + retry-once bumps** — `cfg:v1:config_version` no longer carries the 24h TTL (a quiet day expired it → pointless fleet-wide restamp + one rebuild per isolate); `KvBackend` gains a persistent `put`, and every stamp write retries once before the warn-only give-up.

**`CacheMode` (deploy-funnel bump suppression + rebuild row-cache bypass)** — the `/_deploy/init` funnel used to issue ~19 sequential same-key version PUTs (KV per-key throttling could drop the tail bump); per-write bumps are now suppressed during the funnel and ONE explicit bump runs after it (failure paths included — a partial funnel may have written rows). Version-mismatch rebuilds and the funnel build now read config rows through D1 directly (`read_through`, still repopulating KV) so cross-PoP KV lag or a failed row-invalidate can't bake stale rows into a runtime tagged with the new stamp. Cold isolate builds keep the row cache (cold-start latency is its remaining value).

**`init_isolate()`** — request-log mode (`Queued`) is now set once per isolate behind a thread-local guard instead of re-asserted on every request; consumers can call it from `#[event(start)]` (site follow-up PR), and `run()` guards it either way.

**Fail-closed grant loading** — `load_wrap_grants_from_db` pre-checks `schema_table_exists` (structured fresh-boot signal; the unreachable `"no such table"` string-match is gone), and all three grant readers use `parse_stored`: absent/empty `resource_type` stays the documented wildcard, but a typo'd value now drops that row with a warn instead of silently widening it to the all-types wildcard.

**`deploy_init` iterates `Wafer::block_names()`** — the registration keys `init_block` resolves, not each block's self-reported `info().name`.

Verification: nightly fmt ✓; host clippy 0 errors / exactly the 81-warning baseline ✓; host tests all green (786 core + suites) ✓; `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` ✓ (crate is wasm-only; no host tests by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)