### PR TITLE
fix(auth): enforce disabled/deleted account state on all credential paths

### DIFF
--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -584,10 +584,11 @@ pub(crate) fn brand_panel(config: &SiteConfig) -> BrandPanel<'_> {
 mod api_key_lifecycle_tests {
     use wafer_run::{Message, META_AUTH_USER_ID};
 
-    use super::repo::{api_keys, users};
-    use super::authenticate_api_key;
-    use crate::test_support::TestContext;
-    use crate::util::sha256_hex;
+    use super::{
+        authenticate_api_key,
+        repo::{api_keys, users},
+    };
+    use crate::{test_support::TestContext, util::sha256_hex};
 
     async fn seed_user_and_key(ctx: &TestContext, raw_key: &str) -> String {
         let user = users::insert(
@@ -619,9 +620,10 @@ mod api_key_lifecycle_tests {
 
     #[tokio::test]
     async fn active_user_key_authenticates() {
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         let uid = seed_user_and_key(&ctx, "raw-active-key").await;
 
         let mut msg = Message::new("http");
@@ -633,9 +635,10 @@ mod api_key_lifecycle_tests {
     async fn disabled_user_key_is_rejected() {
         use wafer_core::clients::database as db;
 
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         let uid = seed_user_and_key(&ctx, "raw-disabled-key").await;
 
         let mut patch = std::collections::HashMap::new();

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -551,6 +551,13 @@ pub async fn authenticate_api_key(
         }
     };
 
+    // Deleted or disabled accounts must not authenticate, even with a
+    // still-valid API key. Login/refresh/OAuth already enforce this on their
+    // own row loads; this is the same gate for the key path.
+    if !user.is_active() {
+        return;
+    }
+
     // Fetch roles from user_roles collection (roles are not stored on the user record)
     let roles = helpers::get_user_roles(ctx, &key_row.user_id).await;
     let roles_str = roles.join(",");
@@ -570,5 +577,74 @@ pub(crate) fn brand_panel(config: &SiteConfig) -> BrandPanel<'_> {
         logo_html: None,
         headline: &config.app_name,
         tagline: Some("Sign in to continue."),
+    }
+}
+
+#[cfg(test)]
+mod api_key_lifecycle_tests {
+    use wafer_run::{Message, META_AUTH_USER_ID};
+
+    use super::repo::{api_keys, users};
+    use super::authenticate_api_key;
+    use crate::test_support::TestContext;
+    use crate::util::sha256_hex;
+
+    async fn seed_user_and_key(ctx: &TestContext, raw_key: &str) -> String {
+        let user = users::insert(
+            ctx,
+            users::NewUser {
+                email: "key@e.co".into(),
+                display_name: "Key".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let key_hash = sha256_hex(raw_key.as_bytes());
+        api_keys::insert(
+            ctx,
+            api_keys::NewApiKey {
+                user_id: &user.id,
+                name: "test-key",
+                key_hash: &key_hash,
+                key_prefix: "sb_test",
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        user.id
+    }
+
+    #[tokio::test]
+    async fn active_user_key_authenticates() {
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let uid = seed_user_and_key(&ctx, "raw-active-key").await;
+
+        let mut msg = Message::new("http");
+        authenticate_api_key(&ctx, "raw-active-key", &mut msg).await;
+        assert_eq!(msg.get_meta(META_AUTH_USER_ID), uid);
+    }
+
+    #[tokio::test]
+    async fn disabled_user_key_is_rejected() {
+        use wafer_core::clients::database as db;
+
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let uid = seed_user_and_key(&ctx, "raw-disabled-key").await;
+
+        let mut patch = std::collections::HashMap::new();
+        patch.insert("disabled".to_string(), serde_json::json!(true));
+        db::update(&ctx, users::TABLE, &uid, patch).await.unwrap();
+
+        let mut msg = Message::new("http");
+        authenticate_api_key(&ctx, "raw-disabled-key", &mut msg).await;
+        // No auth meta stamped → request stays anonymous.
+        assert_eq!(msg.get_meta(META_AUTH_USER_ID), "");
     }
 }

--- a/crates/solobase-core/src/blocks/auth/repo/users.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/users.rs
@@ -549,9 +549,10 @@ mod typed_client_tests {
 
     #[tokio::test]
     async fn fresh_user_is_active() {
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         let id = seed_active(&ctx).await;
         let row = find_by_id(&ctx, &id).await.unwrap().unwrap();
         assert!(row.is_active());
@@ -561,9 +562,10 @@ mod typed_client_tests {
 
     #[tokio::test]
     async fn disabled_user_is_not_active() {
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         let id = seed_active(&ctx).await;
         let mut patch = std::collections::HashMap::new();
         patch.insert("disabled".to_string(), serde_json::json!(true));
@@ -576,9 +578,10 @@ mod typed_client_tests {
 
     #[tokio::test]
     async fn soft_deleted_user_is_not_active() {
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
         let id = seed_active(&ctx).await;
         let mut patch = std::collections::HashMap::new();
         patch.insert(

--- a/crates/solobase-core/src/blocks/auth/repo/users.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/users.rs
@@ -19,9 +19,28 @@ pub struct UserRow {
     pub avatar_url: Option<String>,
     pub role: String,
     pub disabled: bool,
+    /// Soft-delete timestamp (ISO-8601). `None`/empty when the account is live.
+    /// Column exists since migration 006; a soft-deleted account keeps its row
+    /// but must not authenticate.
+    pub deleted_at: Option<String>,
     pub email_verified: bool,
     pub created_at: String,
     pub updated_at: String,
+}
+
+impl UserRow {
+    /// True when the account has been soft-deleted (a non-empty `deleted_at`).
+    /// Treats both SQL `NULL`/absent and an empty string as "not deleted".
+    pub fn is_deleted(&self) -> bool {
+        self.deleted_at.as_deref().is_some_and(|s| !s.is_empty())
+    }
+
+    /// True when the account may authenticate: neither disabled nor
+    /// soft-deleted. The single lifecycle-state predicate shared by every
+    /// credential-verification path.
+    pub fn is_active(&self) -> bool {
+        !self.disabled && !self.is_deleted()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -40,6 +59,7 @@ fn row_from_map(m: &HashMap<String, Value>) -> Result<UserRow, RepoError> {
         avatar_url: map_opt_str(m, "avatar_url"),
         role: map_opt_str(m, "role").unwrap_or_else(|| "user".into()),
         disabled: map_bool(m, "disabled"),
+        deleted_at: map_opt_str(m, "deleted_at"),
         email_verified: map_bool(m, "email_verified"),
         created_at: map_str(m, "created_at"),
         updated_at: map_str(m, "updated_at"),
@@ -510,5 +530,65 @@ mod typed_client_tests {
         use crate::util::RecordExt;
         assert_eq!(raw.str_field("name"), "New Name");
         assert_eq!(raw.str_field("display_name"), "New Name");
+    }
+
+    async fn seed_active(ctx: &TestContext) -> String {
+        insert(
+            ctx,
+            NewUser {
+                email: "life@example.com".into(),
+                display_name: "Life".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn fresh_user_is_active() {
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let id = seed_active(&ctx).await;
+        let row = find_by_id(&ctx, &id).await.unwrap().unwrap();
+        assert!(row.is_active());
+        assert!(!row.is_deleted());
+        assert_eq!(row.deleted_at, None);
+    }
+
+    #[tokio::test]
+    async fn disabled_user_is_not_active() {
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let id = seed_active(&ctx).await;
+        let mut patch = std::collections::HashMap::new();
+        patch.insert("disabled".to_string(), serde_json::json!(true));
+        db::update(&ctx, TABLE, &id, patch).await.unwrap();
+
+        let row = find_by_id(&ctx, &id).await.unwrap().unwrap();
+        assert!(row.disabled);
+        assert!(!row.is_active());
+    }
+
+    #[tokio::test]
+    async fn soft_deleted_user_is_not_active() {
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let id = seed_active(&ctx).await;
+        let mut patch = std::collections::HashMap::new();
+        patch.insert(
+            "deleted_at".to_string(),
+            serde_json::json!("2026-01-01T00:00:00Z"),
+        );
+        db::update(&ctx, TABLE, &id, patch).await.unwrap();
+
+        let row = find_by_id(&ctx, &id).await.unwrap().unwrap();
+        assert!(row.is_deleted());
+        assert!(!row.is_active());
     }
 }

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -488,9 +488,10 @@ mod tests {
 
         use crate::test_support::TestContext;
 
-        let ctx = TestContext::with_auth()
-            .await
-            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+        let ctx =
+            TestContext::with_auth()
+                .await
+                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
 
         let live = users::insert(
             &ctx,

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -195,6 +195,22 @@ pub fn auth_grants() -> Vec<wafer_block::types::ResourceGrant> {
     ]
 }
 
+/// Reject a resolved user id whose account is disabled or soft-deleted.
+/// The single lifecycle-state gate shared by every `require_*` credential
+/// path — session cookies and PATs resolve a user id without otherwise
+/// loading the user row, so without this they would authenticate a
+/// deactivated account.
+async fn ensure_active(ctx: &dyn Context, user_id: &str) -> Result<(), AuthError> {
+    let user = users::find_by_id(ctx, user_id)
+        .await
+        .map_err(|e| AuthError::Internal(e.to_string()))?
+        .ok_or(AuthError::Unauthorized)?;
+    if !user.is_active() {
+        return Err(AuthError::Unauthorized);
+    }
+    Ok(())
+}
+
 #[wafer_block::wafer_async_trait]
 impl AuthService for AuthServiceImpl {
     /// Apply auth migrations and run the bootstrap admin step. Invoked by the
@@ -261,6 +277,7 @@ impl AuthService for AuthServiceImpl {
                 sessions::touch_last_used(ctx, &h)
                     .await
                     .map_err(|e| AuthError::Internal(e.to_string()))?;
+                ensure_active(ctx, &row.user_id).await?;
                 Ok(UserId(row.user_id))
             }
             Creds::Pat(h) => {
@@ -276,6 +293,7 @@ impl AuthService for AuthServiceImpl {
                 pats::touch_last_used(ctx, &h)
                     .await
                     .map_err(|e| AuthError::Internal(e.to_string()))?;
+                ensure_active(ctx, &row.user_id).await?;
                 Ok(UserId(row.user_id))
             }
         }
@@ -309,6 +327,7 @@ impl AuthService for AuthServiceImpl {
         pats::touch_last_used(ctx, &h)
             .await
             .map_err(|e| AuthError::Internal(e.to_string()))?;
+        ensure_active(ctx, &row.user_id).await?;
         Ok(UserId(row.user_id))
     }
 
@@ -461,5 +480,47 @@ mod tests {
             "expected ≥5 grants, got {}",
             grants.len()
         );
+    }
+
+    #[tokio::test]
+    async fn ensure_active_rejects_disabled_and_deleted() {
+        use wafer_core::clients::database as db;
+
+        use crate::test_support::TestContext;
+
+        let ctx = TestContext::with_auth()
+            .await
+            .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+
+        let live = users::insert(
+            &ctx,
+            users::NewUser {
+                email: "live@e.co".into(),
+                display_name: "Live".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .unwrap();
+        // Active user → Ok.
+        assert!(ensure_active(&ctx, &live.id).await.is_ok());
+
+        // Disabled → Unauthorized.
+        let mut patch = std::collections::HashMap::new();
+        patch.insert("disabled".to_string(), serde_json::json!(true));
+        db::update(&ctx, users::TABLE, &live.id, patch)
+            .await
+            .unwrap();
+        assert!(matches!(
+            ensure_active(&ctx, &live.id).await,
+            Err(AuthError::Unauthorized)
+        ));
+
+        // Missing user → Unauthorized (not a 500).
+        assert!(matches!(
+            ensure_active(&ctx, "does-not-exist").await,
+            Err(AuthError::Unauthorized)
+        ));
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/login.rs
@@ -69,7 +69,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // confirms to an attacker that the email exists, gives them a target for
     // a re-enable social-engineering attack, and signals when an admin has
     // taken action on a compromised account.
-    if user.disabled {
+    if !user.is_active() {
         return error_response(ErrorCode::InvalidCredentials, "Invalid email or password");
     }
 

--- a/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
@@ -112,7 +112,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         Err(_) => return error_response(ErrorCode::NotAuthenticated, "User not found"),
     };
 
-    if user.disabled {
+    if !user.is_active() {
         return error_response(ErrorCode::AccountDisabled, "Account is disabled");
     }
 

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -857,10 +857,7 @@ mod security_regression_tests {
         .await
         .expect("soft-delete user");
         // Sanity: the typed row now reports deleted/inactive but NOT disabled.
-        let row = users::find_by_id(&ctx, &user.id)
-            .await
-            .unwrap()
-            .unwrap();
+        let row = users::find_by_id(&ctx, &user.id).await.unwrap().unwrap();
         assert!(row.is_deleted(), "fixture user must be soft-deleted");
         assert!(!row.disabled, "fixture user must not be `disabled`");
         assert!(!row.is_active(), "soft-deleted user must not be active");

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -412,7 +412,7 @@ async fn resolve_user(
                 // `role == "disabled"` check tested a value nothing ever
                 // writes, so disabled accounts could still authenticate via
                 // OAuth.
-                if existing_user.disabled {
+                if !existing_user.is_active() {
                     return Err(err_forbidden("Account is disabled"));
                 }
                 // Reuse this account; the upsert below will create the new link.
@@ -814,6 +814,74 @@ mod security_regression_tests {
         assert!(
             session_rows.is_empty(),
             "no session may be created for a disabled OAuth login"
+        );
+    }
+
+    /// Regression test for the whole-branch review finding: credential
+    /// *issuance* paths (login / refresh / OAuth) gated on `user.disabled`
+    /// only, not on soft-delete. `db::soft_delete` leaves `local_credentials`
+    /// and refresh tokens intact, so a soft-deleted user could still
+    /// authenticate via OAuth email-matching and mint fresh tokens. The fix
+    /// replaces `existing_user.disabled` with `!existing_user.is_active()`,
+    /// which also covers `is_deleted()`.
+    #[tokio::test]
+    async fn soft_deleted_user_cannot_oauth_in() {
+        // Seed a SOFT-DELETED (but not `disabled`) user with the email the
+        // provider will return.
+        let email = "softdeleted@example.com";
+        let ctx = ctx_for_oauth(email).await;
+
+        let user = users::insert(
+            &ctx,
+            users::NewUser {
+                email: email.to_string(),
+                display_name: "Soft Deleted User".to_string(),
+                avatar_url: None,
+                role: "user".to_string(),
+            },
+        )
+        .await
+        .expect("seed user");
+        // Set `deleted_at` (soft-delete marker) — NOT `disabled`. Mirrors the
+        // Task-1/2 lifecycle tests in `auth/repo/users.rs`.
+        let mut upd = crate::util::json_map(serde_json::json!({
+            "deleted_at": "2026-01-01T00:00:00Z"
+        }));
+        crate::util::stamp_updated(&mut upd);
+        wafer_core::clients::database::update(
+            &ctx,
+            crate::blocks::auth::USERS_TABLE,
+            &user.id,
+            upd,
+        )
+        .await
+        .expect("soft-delete user");
+        // Sanity: the typed row now reports deleted/inactive but NOT disabled.
+        let row = users::find_by_id(&ctx, &user.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.is_deleted(), "fixture user must be soft-deleted");
+        assert!(!row.disabled, "fixture user must not be `disabled`");
+        assert!(!row.is_active(), "soft-deleted user must not be active");
+
+        // The callback must reject with a PermissionDenied error stream (mapped
+        // to HTTP 403 at the boundary), the same as a disabled account. Before
+        // the fix this only checked `existing_user.disabled` and returned a
+        // 302 login for a soft-deleted user.
+        let out = handle(&ctx, &callback_msg()).await;
+        assert!(
+            crate::test_support::output_is_error(out, "PermissionDenied").await,
+            "soft-deleted account must be rejected at the OAuth callback (regression: it logged in)"
+        );
+
+        // And no session row was minted for the soft-deleted user.
+        let session_rows = sessions::list_for_user(&ctx, &user.id)
+            .await
+            .expect("list sessions ok");
+        assert!(
+            session_rows.is_empty(),
+            "no session may be created for a soft-deleted OAuth login"
         );
     }
 }


### PR DESCRIPTION
Closes two findings from the 2026-07-07 architecture audit:

- **F1 — soft-deleted users could still authenticate.** Admin "delete" only sets `deleted_at`; the auth user-readers had no `deleted_at` filter and `UserRow` didn't even map the column.
- **F2 — disabling a user didn't stop API-key / PAT / session-cookie auth.** Only the issuance paths (login/refresh/OAuth) checked `disabled`; the long-lived DB-backed credentials skipped it.

### Approach
Introduce one lifecycle predicate — `UserRow::is_active()` = `!disabled && !is_deleted()` (reads the existing `deleted_at` column; migration 006 already added it, no schema change) — and enforce it at **every** credential-verification surface:

| Surface | Where | Kind |
|---|---|---|
| API key | `authenticate_api_key` (`auth/mod.rs`) | resolution |
| Session cookie | `require_user` session arm (`auth/service.rs`) | resolution |
| PAT | `require_user` PAT arm + `require_token` (`auth/service.rs`) | resolution |
| Login / Refresh / OAuth | `login.rs` / `refresh.rs` / `oauth/callback.rs` | issuance |

A missing or soft-deleted user resolves to `AuthError::Unauthorized` (no "deleted vs disabled" info leak). `require_role` inherits the gate via `require_user`.

### Scope boundary (intentional)
Normal request auth is a **stateless JWT**: a token issued *before* the account was disabled/deleted keeps working until it expires. This PR gates the DB-backed credential paths (checked on every request) and the issuance paths (so no *new* tokens are minted for a deactivated account). Immediate revocation of already-issued JWTs remains bounded by TTL + the jti-blocklist, out of scope here.

### Tests
TDD throughout: `UserRow::is_active` unit cases (active / disabled / soft-deleted), `ensure_active` (active→Ok, disabled→Unauthorized, missing→Unauthorized), an API-key end-to-end pair (active stamps auth meta; disabled stamps none), and an OAuth soft-delete rejection (red→green). Full auth suite green (`cargo test -p solobase-core blocks::auth::` + `blocks::auth_ui::`).

Minor, accepted: `ensure_active` adds one `find_by_id` per session/PAT verification (not on the JWT hot path; API-key path adds zero reads); `require_role` double-reads the user row — tracked as a follow-up optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
