### PR TITLE
fix(auth): single source of truth for password policy

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/bootstrap.rs
@@ -23,6 +23,7 @@ use crate::{
             service::hash_token,
         },
         auth_ui::redirect::is_safe_local_redirect,
+        errors::error_response,
     },
     http::{
         err_bad_request, err_internal, err_internal_no_cause, err_unauthorized, ResponseBuilder,
@@ -45,8 +46,8 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         Some(p) if !p.is_empty() => p.clone(),
         _ => return err_bad_request("missing password"),
     };
-    if password.len() < 8 {
-        return err_bad_request("password must be at least 8 characters");
+    if let Err((code, msg)) = super::password_policy::validate_new_password(ctx, &password).await {
+        return error_response(code, &msg);
     }
 
     let token_hash = hash_token(&token);
@@ -196,6 +197,33 @@ mod tests {
             .unwrap();
 
         let form = format!("token={raw}&email=admin@example.com&password=short");
+        let input = InputStream::from_bytes(form.into_bytes());
+        let _ = handle(&ctx, input).await;
+
+        // No admin user, token row still valid (not consumed on rejection).
+        assert!(users::find_by_email(&ctx, "admin@example.com")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(bootstrap_tokens::is_valid(&ctx, &hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn rejects_common_password() {
+        let ctx = ctx_with_crypto().await;
+        // "admin123" is 8 chars — the old `password.len() < 8` check let it
+        // through. It must now be rejected via the shared blocklist
+        // (`validate_new_password`) routed through in Task 5.
+        let raw = "common-pw-token";
+        let hash = hash_token(raw);
+        let expires = (chrono::Utc::now() + chrono::Duration::hours(24))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        bootstrap_tokens::insert(&ctx, hash.clone(), &expires)
+            .await
+            .unwrap();
+
+        let form = format!("token={raw}&email=admin@example.com&password=admin123");
         let input = InputStream::from_bytes(form.into_bytes());
         let _ = handle(&ctx, input).await;
 

--- a/crates/solobase-core/src/blocks/auth_ui/api/change_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/change_password.rs
@@ -31,17 +31,10 @@ pub async fn handle(ctx: &dyn Context, msg: &Message, input: InputStream) -> Out
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    if body.new_password.len() < 8 {
-        return error_response(
-            ErrorCode::PasswordTooShort,
-            "New password must be at least 8 characters",
-        );
-    }
-    if body.new_password.len() > 1024 {
-        return error_response(
-            ErrorCode::PasswordTooLong,
-            "Password must not exceed 1024 characters",
-        );
+    if let Err((code, msg)) =
+        super::password_policy::validate_new_password(ctx, &body.new_password).await
+    {
+        return error_response(code, &msg);
     }
 
     // Verify user exists

--- a/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/mod.rs
@@ -10,6 +10,7 @@ pub mod forgot_password;
 pub mod login;
 pub mod logout;
 pub mod me;
+mod password_policy;
 pub mod refresh;
 pub mod reset_password;
 pub mod signup;

--- a/crates/solobase-core/src/blocks/auth_ui/api/password_policy.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/password_policy.rs
@@ -1,0 +1,116 @@
+//! Single source of truth for new-password validation, shared by signup,
+//! password-reset, password-change, and bootstrap-redeem. Consolidates the
+//! per-path checks that had drifted (three paths hardcoded `len() < 8` and
+//! skipped the common-password blocklist — audit F21).
+
+use wafer_run::context::Context;
+
+use crate::blocks::{auth::helpers::password_min_length, errors::ErrorCode};
+
+/// Validate a caller-supplied new password against the account policy:
+/// configurable minimum length, a 1024-char maximum, no control characters,
+/// and a small common-password blocklist. Returns the error code + message a
+/// handler should surface, or `Ok(())` when the password is acceptable.
+pub(crate) async fn validate_new_password(
+    ctx: &dyn Context,
+    pw: &str,
+) -> Result<(), (ErrorCode, String)> {
+    let min_len = password_min_length(ctx).await;
+    if pw.len() < min_len {
+        return Err((
+            ErrorCode::PasswordTooShort,
+            format!("Password must be at least {min_len} characters"),
+        ));
+    }
+    if pw.len() > 1024 {
+        return Err((
+            ErrorCode::PasswordTooLong,
+            "Password must not exceed 1024 characters".to_string(),
+        ));
+    }
+    if pw.chars().any(|c| c.is_control()) {
+        return Err((
+            ErrorCode::InvalidInput,
+            "Password must not contain control characters".to_string(),
+        ));
+    }
+    if is_common_password(pw) {
+        return Err((
+            ErrorCode::InvalidInput,
+            "Password is too common. Please choose a less predictable password.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// [SEC-041] Top-25 most common passwords from the NordPass 2023 list.
+/// Comparison is case-insensitive — `Password1` and `password1` are both
+/// rejected. Embedded rather than pulled from a crate to keep dependencies
+/// minimal; the list rarely drifts year-over-year and a refresh is cheap.
+const COMMON_PASSWORDS: &[&str] = &[
+    "123456",
+    "admin",
+    "12345678",
+    "123456789",
+    "1234",
+    "12345",
+    "password",
+    "123",
+    "aa123456",
+    "1234567890",
+    "user",
+    "unknown",
+    "1234567",
+    "tmp",
+    "test",
+    "111111",
+    "qwerty123",
+    "abc123",
+    "1q2w3e4r5t",
+    "qwertyuiop",
+    "654321",
+    "iloveyou",
+    "dragon",
+    "monkey",
+    "qwerty",
+    // Common Solobase-flavored additions that always show up in password lists
+    // for new self-hosted apps. Cheap to include here.
+    "password1",
+    "admin123",
+    "solobase",
+];
+
+pub(crate) fn is_common_password(pw: &str) -> bool {
+    COMMON_PASSWORDS.iter().any(|p| p.eq_ignore_ascii_case(pw))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{blocks::errors::ErrorCode, test_support::TestContext};
+
+    use super::validate_new_password;
+
+    #[tokio::test]
+    async fn rejects_short_common_and_control_but_accepts_strong() {
+        let ctx = TestContext::with_auth().await; // password_min_length defaults to 8
+
+        // Too short.
+        let e = validate_new_password(&ctx, "short").await.unwrap_err();
+        assert_eq!(e.0, ErrorCode::PasswordTooShort);
+
+        // Common password (in the blocklist) even though length is fine.
+        let e = validate_new_password(&ctx, "password").await.unwrap_err();
+        assert_eq!(e.0, ErrorCode::InvalidInput);
+
+        // Control character.
+        let e = validate_new_password(&ctx, "abcdefg\u{0007}h")
+            .await
+            .unwrap_err();
+        assert_eq!(e.0, ErrorCode::InvalidInput);
+
+        // Strong, uncommon passphrase → Ok.
+        assert!(validate_new_password(&ctx, "correct-horse-battery-staple-9")
+            .await
+            .is_ok());
+    }
+}

--- a/crates/solobase-core/src/blocks/auth_ui/api/password_policy.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/password_policy.rs
@@ -86,9 +86,8 @@ pub(crate) fn is_common_password(pw: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{blocks::errors::ErrorCode, test_support::TestContext};
-
     use super::validate_new_password;
+    use crate::{blocks::errors::ErrorCode, test_support::TestContext};
 
     #[tokio::test]
     async fn rejects_short_common_and_control_but_accepts_strong() {
@@ -109,8 +108,10 @@ mod tests {
         assert_eq!(e.0, ErrorCode::InvalidInput);
 
         // Strong, uncommon passphrase → Ok.
-        assert!(validate_new_password(&ctx, "correct-horse-battery-staple-9")
-            .await
-            .is_ok());
+        assert!(
+            validate_new_password(&ctx, "correct-horse-battery-staple-9")
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/reset_password.rs
@@ -24,17 +24,10 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
     };
 
-    if body.new_password.len() < 8 {
-        return error_response(
-            ErrorCode::PasswordTooShort,
-            "Password must be at least 8 characters",
-        );
-    }
-    if body.new_password.len() > 1024 {
-        return error_response(
-            ErrorCode::PasswordTooLong,
-            "Password must not exceed 1024 characters",
-        );
+    if let Err((code, msg)) =
+        super::password_policy::validate_new_password(ctx, &body.new_password).await
+    {
+        return error_response(code, &msg);
     }
 
     // Find user by reset token. The DB column stores `sha256_hex(raw)`;

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -101,7 +101,7 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // attacker hits these first. The list is intentionally tiny (NordPass
     // 2023 top 25) so the check stays cheap and doesn't drift into HIBP
     // territory in this PR.
-    if is_common_password(&body.password) {
+    if super::password_policy::is_common_password(&body.password) {
         return error_response(
             ErrorCode::InvalidInput,
             "Password is too common. Please choose a less predictable password.",
@@ -242,45 +242,4 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
                 "name": user.display_name
             }
         }))
-}
-
-/// [SEC-041] Top-25 most common passwords from the NordPass 2023 list.
-/// Comparison is case-insensitive — `Password1` and `password1` are both
-/// rejected. Embedded rather than pulled from a crate to keep dependencies
-/// minimal; the list rarely drifts year-over-year and a refresh is cheap.
-const COMMON_PASSWORDS: &[&str] = &[
-    "123456",
-    "admin",
-    "12345678",
-    "123456789",
-    "1234",
-    "12345",
-    "password",
-    "123",
-    "aa123456",
-    "1234567890",
-    "user",
-    "unknown",
-    "1234567",
-    "tmp",
-    "test",
-    "111111",
-    "qwerty123",
-    "abc123",
-    "1q2w3e4r5t",
-    "qwertyuiop",
-    "654321",
-    "iloveyou",
-    "dragon",
-    "monkey",
-    "qwerty",
-    // Common Solobase-flavored additions that always show up in password lists
-    // for new self-hosted apps. Cheap to include here.
-    "password1",
-    "admin123",
-    "solobase",
-];
-
-fn is_common_password(pw: &str) -> bool {
-    COMMON_PASSWORDS.iter().any(|p| p.eq_ignore_ascii_case(pw))
 }

--- a/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/signup.rs
@@ -7,8 +7,7 @@ use crate::{
     blocks::{
         auth::{
             helpers::{
-                email_domain_allowed, initial_role_for, issue_tokens_and_cookie,
-                password_min_length, signup_allowed,
+                email_domain_allowed, initial_role_for, issue_tokens_and_cookie, signup_allowed,
             },
             repo::{local_credentials, users},
             USERS_TABLE,
@@ -62,24 +61,10 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         );
     }
 
-    let min_len = password_min_length(ctx).await;
-    if body.password.len() < min_len {
-        return error_response(
-            ErrorCode::PasswordTooShort,
-            &format!("Password must be at least {min_len} characters"),
-        );
-    }
-    if body.password.len() > 1024 {
-        return error_response(
-            ErrorCode::PasswordTooLong,
-            "Password must not exceed 1024 characters",
-        );
-    }
-    if body.password.chars().any(|c| c.is_control()) {
-        return error_response(
-            ErrorCode::InvalidInput,
-            "Password must not contain control characters",
-        );
+    if let Err((code, msg)) =
+        super::password_policy::validate_new_password(ctx, &body.password).await
+    {
+        return error_response(code, &msg);
     }
     if email_lower.len() > 255 {
         return error_response(
@@ -94,18 +79,6 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
                 "Name must not exceed 200 characters",
             );
         }
-    }
-
-    // Reject top-25 common passwords. [SEC-041] A length minimum alone lets
-    // `password1`, `12345678`, `qwerty12`, etc. through — a credential-stuffing
-    // attacker hits these first. The list is intentionally tiny (NordPass
-    // 2023 top 25) so the check stays cheap and doesn't drift into HIBP
-    // territory in this PR.
-    if super::password_policy::is_common_password(&body.password) {
-        return error_response(
-            ErrorCode::InvalidInput,
-            "Password is too common. Please choose a less predictable password.",
-        );
     }
 
     // [SEC-035] If the email is already registered, do NOT confirm that to


### PR DESCRIPTION
Closes finding **F21** from the 2026-07-07 architecture audit: password policy was enforced on only one of four write paths.

`signup` enforced a configurable minimum length, a 1024-char max, control-char rejection, and a common-password blocklist — while `reset_password`, `change_password`, and `bootstrap` each hardcoded a weaker `len() < 8` that skipped the blocklist and ignored `SOLOBASE_SHARED__AUTH__PASSWORD_MIN_LENGTH`. So a user could reset to `password` or `admin123` even though signup forbids them.

### Change
- Extract one `validate_new_password(ctx, pw) -> Result<(), (ErrorCode, String)>` into a new `blocks/auth_ui/api/password_policy.rs` (the single source of truth; `COMMON_PASSWORDS` + `is_common_password` moved here from `signup.rs`).
- Route all four handlers — `signup`, `reset_password`, `change_password`, `bootstrap` — through it. No handler retains an independent length or blocklist check.

### Intended behavior changes (the point of the fix)
- `reset_password` / `change_password` / `bootstrap` now honor the configurable `PASSWORD_MIN_LENGTH` (were hardcoded to 8) and now **reject common passwords** they previously accepted (e.g. `admin123`).
- `change_password`'s too-short message wording is unified to `Password must be at least {min_len} characters`.
- Minor edge: in signup, the common-password check now runs before the email/name-length checks, so the rare "common password + over-length email" case returns `InvalidInput` instead of `InvalidEmail`. Not a security change; a side effect of grouping all password rules.

### Tests
New handler-level `bootstrap::tests::rejects_common_password` proves `admin123` (exactly 8 chars — the old boundary) is now rejected end-to-end. `validate_new_password` has unit coverage (short / common / control-char / strong). `reset_password` and `change_password` have **no dedicated handler-level regression test** — no test harness exists for those handlers; their wiring is covered by compilation + the full `blocks::auth_ui::` suite (43/43) + being byte-for-byte identical to the tested `bootstrap` call site.

Note: the crate has ~63 pre-existing, unrelated clippy errors, so `cargo clippy -p solobase-core -- -D warnings` fails independent of this change — this branch introduces none and removes one (the transient `dead_code` on the new validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
