### PR TITLE
fix(auth): resolve require_role admin via merged role resolution (F19)

### DIFF
--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -334,12 +334,16 @@ impl AuthService for AuthServiceImpl {
         }
 
         let uid = self.require_user(msg).await?;
-        let row = users::find_by_id(ctx, &uid.0)
-            .await
-            .map_err(|e| AuthError::Internal(e.to_string()))?
-            .ok_or(AuthError::NotFound)?;
+        // Admin is determined by the SAME merged role resolution the HTTP
+        // `is_admin` path uses — `get_user_roles` merges the inline `users.role`
+        // with `USER_ROLES_TABLE` rows. So a user granted admin via the roles
+        // table (the admin IAM UI) is admin to trait consumers too, not only to
+        // `/b/admin` routes. [F19]
         let has = match role {
-            Role::Admin => row.role == "admin",
+            Role::Admin => crate::blocks::auth::helpers::get_user_roles(ctx, &uid.0)
+                .await
+                .iter()
+                .any(|r| r == "admin"),
             Role::User => true, // any authenticated user
         };
         if has {
@@ -461,5 +465,103 @@ mod tests {
             "expected ≥5 grants, got {}",
             grants.len()
         );
+    }
+
+    #[tokio::test]
+    async fn get_user_roles_reflects_admin_granted_only_via_roles_table() {
+        // The scenario F19 fixes: a user whose inline `users.role` is NOT
+        // "admin" but who has an admin row in USER_ROLES_TABLE must resolve
+        // to admin via the merged resolver that `require_role` now uses.
+        use crate::blocks::admin::USER_ROLES_TABLE;
+
+        let ctx = Arc::new(TestContext::with_admin().await);
+        // Apply auth migrations so the `users` table exists.
+        AuthServiceImpl::new(BlockState::for_test(ctx.clone()))
+            .init(&*ctx)
+            .await
+            .expect("auth init applies user-table migrations");
+
+        // A non-admin user (inline role = "user").
+        let user = users::insert(
+            &*ctx,
+            users::NewUser {
+                email: "roletable@e.co".into(),
+                display_name: "RT".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .expect("insert user");
+
+        // Grant admin ONLY via the roles table.
+        let mut row = std::collections::HashMap::new();
+        row.insert("user_id".to_string(), serde_json::json!(user.id));
+        row.insert("role".to_string(), serde_json::json!("admin"));
+        db::create(&*ctx, USER_ROLES_TABLE, row)
+            .await
+            .expect("assign admin via roles table");
+
+        let roles = crate::blocks::auth::helpers::get_user_roles(&*ctx, &user.id).await;
+        assert!(
+            roles.iter().any(|r| r == "admin"),
+            "merged resolver must see the roles-table admin grant: {roles:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn require_role_admin_grants_via_roles_table_only() {
+        // End-to-end version of the resolver test above: a real
+        // `wafer_session`-cookied Message for a user whose inline
+        // `users.role` is "user" but who has an admin row in
+        // USER_ROLES_TABLE must satisfy `require_role(Role::Admin)`.
+        use crate::blocks::admin::USER_ROLES_TABLE;
+
+        let ctx = Arc::new(TestContext::with_admin().await);
+        let service = AuthServiceImpl::new(BlockState::for_test(ctx.clone()));
+        service
+            .init(&*ctx)
+            .await
+            .expect("auth init applies user-table migrations");
+
+        let user = users::insert(
+            &*ctx,
+            users::NewUser {
+                email: "roletable-e2e@e.co".into(),
+                display_name: "RT2".into(),
+                avatar_url: None,
+                role: "user".into(),
+            },
+        )
+        .await
+        .expect("insert user");
+
+        let mut row = std::collections::HashMap::new();
+        row.insert("user_id".to_string(), serde_json::json!(user.id));
+        row.insert("role".to_string(), serde_json::json!("admin"));
+        db::create(&*ctx, USER_ROLES_TABLE, row)
+            .await
+            .expect("assign admin via roles table");
+
+        let raw_token = "e2e-session-raw";
+        sessions::insert(
+            &*ctx,
+            sessions::NewSession {
+                token_hash: hash_token(raw_token),
+                user_id: user.id.clone(),
+                expires_at: "9999-01-01T00:00:00Z".into(),
+            },
+        )
+        .await
+        .expect("seed session");
+
+        let mut msg = Message::new("auth.require_role");
+        msg.set_meta("http.header.cookie", format!("wafer_session={raw_token}"));
+
+        let got = service
+            .require_role(&msg, Role::Admin)
+            .await
+            .expect("roles-table-only admin must satisfy Role::Admin");
+        assert_eq!(got.0, user.id);
     }
 }


### PR DESCRIPTION
Closes the security-relevant half of finding **F19** from the 2026-07-07 architecture audit: two divergent definitions of "admin".

`AuthServiceImpl::require_role` (the `AuthService` trait path, used by wafer-core consumers such as registry publish) determined `Role::Admin` from the inline `users.role` column ONLY, while the HTTP `is_admin` path reflects the *merged* roles — `get_user_roles` = inline `users.role` + `USER_ROLES_TABLE`. So a user granted admin via the roles table (the admin IAM UI) was admin to `/b/admin` routes but **not** to trait consumers.

### Change (one file: `blocks/auth/service.rs`)
Route `require_role`'s `Role::Admin` arm through the same `get_user_roles` merge, removing the now-unused `users::find_by_id` load. `Role::User` behavior is unchanged.

### Why it's safe
- **Fail-closed:** `get_user_roles` is fail-soft (swallows DB read errors), so a DB error yields empty roles → `Forbidden` for the admin check — a denial, never an accidental grant.
- **No admin demoted:** the inline `users.role` is still read (same table as before, pushed first), so an inline-`admin` user stays admin. The only behavioral change is that `USER_ROLES_TABLE`-only admins are now recognized by the trait path too.
- **Dropped `NotFound`:** a missing user now returns `Forbidden` instead of `NotFound` — both deny, and no consumer distinguishes them (route tier maps any `Err` to 403). Arguably better (doesn't leak existence for a dangling credential).

### Tests
`cargo test -p solobase-core blocks::auth::` → 59 unit + 38 integration pass. Adds a resolver unit test and a full end-to-end `require_role(Role::Admin)` test driving a `wafer_session`-cookied `Message` + real session row + roles-table-only admin. The e2e test was empirically confirmed to FAIL against the old inline-only logic — a genuine regression guard. The pre-existing `service_require_role.rs` integration test (inline-admin path) still passes.

### Notes
- **Intended widening:** `USER_ROLES_TABLE`-only admins are now honored by *all* `AuthService` trait consumers, not just `/b/admin` HTTP routes.
- **Deferred (follow-up):** the other half of F19 — `admin/iam.rs::handle_assign_role` writes an arbitrary role string into `USER_ROLES_TABLE` with no allowlist validation against `ROLES_TABLE`. Low risk (admin-only route), data-hygiene only; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
