### PR TITLE
chore(deps): wafer-run pin → de90e03 (host-side WRAP) + TestContext check_resource_access override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#0ccf2b6fa84344343801324abe79f98c620c1750"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#de90e03f42b72ffa963971405a99b3df029a9e78"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -255,6 +255,31 @@ impl TestContext {
 
 #[async_trait::async_trait]
 impl Context for TestContext {
+    /// Host-side WRAP enforcement (only when the test opted in via
+    /// `with_wrap`). Overrides the fail-closed trait default; mirrors
+    /// `RuntimeContext::check_resource_access` — keyed on `caller_id`, same
+    /// `check_access` callsite shape — so tests see identical permission
+    /// behaviour to production. Without a caller the context is permissive,
+    /// matching the pre-WRAP test default.
+    fn check_resource_access(
+        &self,
+        resource: &str,
+        resource_type: wafer_run::ResourceType,
+        is_write: bool,
+    ) -> Result<(), WaferError> {
+        if let Some(ref caller) = self.caller_id {
+            wafer_block::wrap::check_access(
+                Some(caller.as_str()),
+                resource,
+                is_write,
+                Some(&resource_type),
+                &self.wrap_grants,
+                &self.wrap_admin_block,
+            )?;
+        }
+        Ok(())
+    }
+
     async fn call_block(&self, name: &str, msg: Message, input: InputStream) -> OutputStream {
         // WRAP enforcement (only when the test opted in via `with_wrap`).
         // Mirrors `RuntimeContext::call_block` in wafer-run/crates/wafer-run/

--- a/crates/solobase-core/tests/auth/common.rs
+++ b/crates/solobase-core/tests/auth/common.rs
@@ -83,6 +83,21 @@ impl Context for MigrationTestCtx {
         None
     }
 
+    /// This fixture has no caller identity or WRAP grants, so there is
+    /// nothing to enforce — explicitly permissive, overriding the
+    /// fail-closed trait default (which exists so an enforcing runtime
+    /// can never silently fall back to permissive). Mirrors the pre-WRAP
+    /// behaviour of this harness; WRAP-behaviour tests use
+    /// `solobase_core::test_support::TestContext::with_wrap` instead.
+    fn check_resource_access(
+        &self,
+        _resource: &str,
+        _resource_type: wafer_run::ResourceType,
+        _is_write: bool,
+    ) -> Result<(), WaferError> {
+        Ok(())
+    }
+
     fn clone_arc(&self) -> Arc<dyn Context> {
         Arc::new(self.clone())
     }


### PR DESCRIPTION
Consumer follow-up for wafer-run #252/#253 (SP-A host-side WRAP enforcement — the F7 fix):

- **Pin bump** `0ccf2b6` → `de90e03` (includes #251 network-allowlist fix and #254 crossbeam bump). Lockfile regenerated in a clean checkout so the git pins are intact.
- **Own crossbeam-epoch → 0.9.20** (clears the RUSTSEC-2026-0204 Security Audit failure here too).
- **`TestContext::check_resource_access` override** — the new trait method is fail-closed by default; the test context mirrors `RuntimeContext` (keyed on `caller_id`, same `check_access` callsite) so `with_wrap` tests keep production-identical permission behaviour.

Verified locally: 798 solobase-core tests green against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)