### PR TITLE
fix(cli): restore SOLOBASE_SKIP_BLOCK_BUILD (never landed on main)

### DIFF
--- a/crates/solobase/src/cli/helpers/blocks.rs
+++ b/crates/solobase/src/cli/helpers/blocks.rs
@@ -28,6 +28,14 @@ pub fn discover_blocks(repo_root: &Path) -> Result<Vec<PathBuf>> {
 /// when possible) so the operator can tell which block of N broke without
 /// having to scroll the streamed `wafer build` output.
 pub async fn build_all(repo_root: &Path) -> Result<()> {
+    if matches!(
+        std::env::var("SOLOBASE_SKIP_BLOCK_BUILD").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES")
+    ) {
+        println!("SOLOBASE_SKIP_BLOCK_BUILD set — using existing blocks/*/target/block.wasm artifacts");
+        return Ok(());
+    }
+
     use anyhow::Context;
     use tokio::process::Command;
     for block in discover_blocks(repo_root)? {

--- a/crates/solobase/src/cli/helpers/blocks.rs
+++ b/crates/solobase/src/cli/helpers/blocks.rs
@@ -32,7 +32,9 @@ pub async fn build_all(repo_root: &Path) -> Result<()> {
         std::env::var("SOLOBASE_SKIP_BLOCK_BUILD").as_deref(),
         Ok("1" | "true" | "TRUE" | "yes" | "YES")
     ) {
-        println!("SOLOBASE_SKIP_BLOCK_BUILD set — using existing blocks/*/target/block.wasm artifacts");
+        println!(
+            "SOLOBASE_SKIP_BLOCK_BUILD set — using existing blocks/*/target/block.wasm artifacts"
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
Cherry-pick of b5df81cc — the commit gizza-ai's solobase pin pointed at since June 30 but which only ever existed on a side branch, never on main.

Without it, gizza's deploy step `SOLOBASE_SKIP_BLOCK_BUILD=1 solobase build --release` silently ignores the flag and rebuilds all ~250 committed block wasms sequentially: gizza deploy run 29011081399 ran 4.5 h and then died with "No space left on device". The July 6–8 green deploys worked only because the old pin carried this commit.

gizza-ai will bump its solobase pin to this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)