### PR TITLE
chore: bump wafer-run pin df23dc1 → 575d5ac (SP-B3, remove raw execute/query)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#df23dc1f1fca1c64cd74b302b928b2be8a840622"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
Lockfile-only bump to wafer-run `575d5ac` — [SP-B3, wafer-run #257](https://github.com/wafer-run/wafer-run/pull/257), which removes the raw `DATABASE_EXECUTE`/`DATABASE_QUERY` ops (wire types, client fns, handler arms, catalog entries). The admin-gated `exec_raw`/`query_raw` escape hatches are unchanged.

**No solobase code changes:** SP-B2 (#304) already migrated all 32 execute/query sites to the typed `db::*` ops; the only remaining reference on main is the (still-accurate) doc comment at `admin/settings.rs:65`.

**Verification (clean clone, new pin):**
- `cargo update -p wafer-run` — all wafer-* crates `df23dc1` → `575d5ac`, nothing else moved
- native `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare --no-fail-fast`: green except `dry_run_goldens`/`flow_sealed_web`/`helpers_wasm`/`wasm_bundling`, which fail **identically on the old pin** in a clone without a built solobase-web pkg (CI's `just build` step provides it) — not pin-related
- `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` ✓
- `cargo check -p solobase-browser -p minimal-browser --target wasm32-unknown-unknown` ✓

This closes the F7 SP-B arc: block code cannot construct SQL, and no generic SQL-bearing op exists on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)