### PR TITLE
chore: bump wafer-run pin 575d5ac → dbd3689 (I-1 decode-depth cap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#575d5acdf2f1c42b8fb9d93a2c426bd39a2f109a"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#dbd3689ba8e790dd5b724ea370c9057b39c4bc59"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
Lockfile-only bump to wafer-run `dbd3689` — [I-1, wafer-run #258](https://github.com/wafer-run/wafer-run/pull/258): `codec::decode` now caps wire-body nesting at `WIRE_MAX_DEPTH = 128` instead of stack-overflowing (uncatchable abort) on hostile deep bodies. This is the fix that matters most on Cloudflare's small wasm32 stacks, so bumping promptly gets it into the production consumer.

No API changes; no solobase code changes. Verification in a clean clone matched the #306 baseline exactly: native suite green except the four known pkg-dependent web-bundling tests (identical on the old pin; CI's `just build` provides the real pkg), and both wasm32 target checks pass.

Part of the F7 WRAP-enforcement program (I-1; independent of the closed SP-B arc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)