### PR TITLE
fix(auth): add missing rate_limits migration — CF rate limiting was silently broken

### DIFF
--- a/crates/solobase-core/src/blocks/auth/migrations/008_rate_limits.postgres.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/008_rate_limits.postgres.sql
@@ -1,0 +1,15 @@
+-- Sliding-window rate-limit counters, one row per key (user id or IP).
+-- Written only by the wasm32/D1 path in blocks/rate_limit.rs via the atomic
+-- `OnConflict::WindowedCounter` upsert (native builds use the in-memory
+-- UserRateLimiter); `key` is the upsert's ON CONFLICT target, so it must be
+-- UNIQUE. Timestamps are TIMESTAMPTZ (not TEXT as in older tables) because
+-- the windowed upsert stamps them with a SQL `CURRENT_TIMESTAMP` expression,
+-- which PostgreSQL will not assign to a TEXT column.
+CREATE TABLE IF NOT EXISTS suppers_ai__auth__rate_limits (
+    id           TEXT PRIMARY KEY,
+    key          TEXT NOT NULL UNIQUE,
+    count        BIGINT NOT NULL,
+    window_start BIGINT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL
+);

--- a/crates/solobase-core/src/blocks/auth/migrations/008_rate_limits.sqlite.sql
+++ b/crates/solobase-core/src/blocks/auth/migrations/008_rate_limits.sqlite.sql
@@ -1,0 +1,15 @@
+-- Sliding-window rate-limit counters, one row per key (user id or IP).
+-- Written only by the wasm32/D1 path in blocks/rate_limit.rs via the atomic
+-- `OnConflict::WindowedCounter` upsert (native builds use the in-memory
+-- UserRateLimiter); `key` is the upsert's ON CONFLICT target, so it must be
+-- UNIQUE. New table: `CREATE TABLE IF NOT EXISTS` materializes it on both
+-- fresh installs and existing databases (the table never pre-exists — before
+-- this migration the counter path silently failed against a missing table).
+CREATE TABLE IF NOT EXISTS suppers_ai__auth__rate_limits (
+    id           TEXT PRIMARY KEY,
+    key          TEXT NOT NULL UNIQUE,
+    count        INTEGER NOT NULL,
+    window_start INTEGER NOT NULL,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);

--- a/crates/solobase-core/src/blocks/auth/migrations/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/migrations/mod.rs
@@ -21,6 +21,8 @@ const SQL_006_SQLITE: &str = include_str!("006_user_extended_fields.sqlite.sql")
 const SQL_006_POSTGRES: &str = include_str!("006_user_extended_fields.postgres.sql");
 const SQL_007_SQLITE: &str = include_str!("007_api_keys.sqlite.sql");
 const SQL_007_POSTGRES: &str = include_str!("007_api_keys.postgres.sql");
+const SQL_008_SQLITE: &str = include_str!("008_rate_limits.sqlite.sql");
+const SQL_008_POSTGRES: &str = include_str!("008_rate_limits.postgres.sql");
 
 /// Ordered SQLite migration scripts for this block, as `(basename, content)`
 /// pairs. Feeds the runtime `lifecycle(Init)` apply path (auth's `init`).
@@ -33,6 +35,7 @@ pub(crate) const SQLITE_MIGRATIONS: &[(&str, &str)] = &[
     ("005_jwt_blocklist", SQL_005_SQLITE),
     ("006_user_extended_fields", SQL_006_SQLITE),
     ("007_api_keys", SQL_007_SQLITE),
+    ("008_rate_limits", SQL_008_SQLITE),
 ];
 
 /// Ordered PostgreSQL migration scripts, matching [`SQLITE_MIGRATIONS`] one
@@ -45,6 +48,7 @@ pub(crate) const POSTGRES_MIGRATIONS: &[&str] = &[
     SQL_005_POSTGRES,
     SQL_006_POSTGRES,
     SQL_007_POSTGRES,
+    SQL_008_POSTGRES,
 ];
 
 /// Apply the auth schema through the shared migration-state gate.

--- a/crates/solobase-core/tests/auth/main.rs
+++ b/crates/solobase-core/tests/auth/main.rs
@@ -5,6 +5,7 @@ mod common;
 mod login_session_row;
 mod migrations_001;
 mod migrations_002;
+mod migrations_008_rate_limits;
 mod oauth_callback_repo;
 mod repo_orgs;
 mod repo_pats;

--- a/crates/solobase-core/tests/auth/migrations_008_rate_limits.rs
+++ b/crates/solobase-core/tests/auth/migrations_008_rate_limits.rs
@@ -1,0 +1,97 @@
+//! Apply migrations through 008; verify `suppers_ai__auth__rate_limits`
+//! exists and satisfies the `OnConflict::WindowedCounter` upsert contract
+//! that `blocks/rate_limit.rs` relies on for the wasm32 (D1) counter path.
+//!
+//! Before 008 the table had no in-repo migration at all, so on Cloudflare —
+//! the only platform that uses it — the windowed upsert failed against a
+//! missing table, the caller's `let _ =` swallowed the error, and rate
+//! limiting silently never triggered.
+
+use serde_json::json;
+use solobase_core::blocks::auth::migrations;
+use wafer_block::{
+    db::{Filter, FilterOp},
+    wire::database::OnConflict,
+};
+use wafer_core::clients::database as db;
+
+use crate::common::MigrationTestCtx;
+
+/// Mirrors `blocks/rate_limit.rs`: same table, data shape, conflict target,
+/// and counter/window/timestamp field wiring.
+const TABLE: &str = "suppers_ai__auth__rate_limits";
+
+async fn windowed_upsert(ctx: &MigrationTestCtx, key: &str, now: i64, window_cutoff: i64) {
+    let id = format!("rl-test-{key}-{now}");
+    db::upsert(
+        ctx,
+        TABLE,
+        vec![
+            ("id".to_string(), json!(id)),
+            ("key".to_string(), json!(key)),
+        ],
+        vec!["key".to_string()],
+        OnConflict::WindowedCounter {
+            count_field: "count".to_string(),
+            window_field: "window_start".to_string(),
+            now,
+            window_cutoff,
+            created_fields: vec!["created_at".to_string()],
+            updated_fields: vec!["updated_at".to_string()],
+        },
+    )
+    .await
+    .expect("windowed-counter upsert must succeed against the migrated table");
+}
+
+async fn read_counter(ctx: &MigrationTestCtx, key: &str) -> (i64, i64) {
+    let rows = db::list_all(
+        ctx,
+        TABLE,
+        vec![Filter {
+            field: "key".into(),
+            operator: FilterOp::Equal,
+            value: json!(key),
+        }],
+    )
+    .await
+    .expect("read back rate-limit row");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one row per key (UNIQUE conflict target)"
+    );
+    let row = &rows[0];
+    let count = row.data.get("count").and_then(|v| v.as_i64()).unwrap();
+    let window = row
+        .data
+        .get("window_start")
+        .and_then(|v| v.as_i64())
+        .unwrap();
+    (count, window)
+}
+
+#[tokio::test]
+async fn migration_008_rate_limits_supports_windowed_counter_upsert() {
+    let ctx = MigrationTestCtx::new().await;
+    migrations::apply(&ctx).await.expect("migration apply");
+    migrations::apply(&ctx)
+        .await
+        .expect("second apply must succeed (idempotent)");
+
+    // Two hits inside the same window increment the counter and keep the
+    // original window_start.
+    windowed_upsert(&ctx, "user-1", 1_000, 940).await;
+    windowed_upsert(&ctx, "user-1", 1_010, 950).await;
+    assert_eq!(read_counter(&ctx, "user-1").await, (2, 1_000));
+
+    // A hit after the window expired (window_start < cutoff) resets the
+    // counter and starts a new window.
+    windowed_upsert(&ctx, "user-1", 2_000, 1_940).await;
+    assert_eq!(read_counter(&ctx, "user-1").await, (1, 2_000));
+
+    // Independent keys do not interfere.
+    windowed_upsert(&ctx, "user-2", 2_000, 1_940).await;
+    assert_eq!(read_counter(&ctx, "user-1").await, (1, 2_000));
+    assert_eq!(read_counter(&ctx, "user-2").await, (1, 2_000));
+}


### PR DESCRIPTION
## What

SP-B2 follow-up (see the SP-B3 handoff §4): `suppers_ai__auth__rate_limits` had **no in-repo migration**. On wasm32/D1 — the only platform that uses the table — the `OnConflict::WindowedCounter` upsert in `blocks/rate_limit.rs` failed against a missing table, the `let _ =` swallowed the error, the follow-up count read returned 0, and **rate limiting silently never triggered on Cloudflare**. (Native builds are unaffected: they use the in-memory `UserRateLimiter`.)

## Fix

- `008_rate_limits.{sqlite,postgres}.sql`: creates the table matching the exact contract the server-side windowed-counter render produces — `id` PK, `key` **UNIQUE** (the `ON CONFLICT` target), `count`/`window_start` integers, `created_at`/`updated_at` stamped by SQL `CURRENT_TIMESTAMP` (hence `TIMESTAMPTZ` in the postgres dialect; a TEXT column rejects the timestamp expression there).
- Wired into `SQLITE_MIGRATIONS`/`POSTGRES_MIGRATIONS` (hash-gated apply re-runs; all scripts are `IF NOT EXISTS`-idempotent).

## Test (TDD — watched fail first)

`migrations_008_rate_limits` drives the **real** `db::upsert` WindowedCounter op against the migrated in-memory SQLite: two hits in-window → count 2 with original `window_start`; hit after expiry → resets to 1 with new window; key isolation; double `migrations::apply` idempotency. Before the migration this failed exactly like production: upsert error on missing table. This covers the schema⇄op contract the wasm32 path depends on — the wasm32-specific code differs only in *calling* the same op.

Full native suite (`--exclude solobase-web --exclude solobase-cloudflare --no-fail-fast`) matches the main baseline (only the four known pkg-dependent web-bundling failures in a clone without a built web pkg).

## Deploy note ⚠️

Requires `SOLOBASE_RUN_MIGRATIONS=1` on the next wafer.run deploy to materialize the table on D1 — until then CF rate limiting stays inert (as it is today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)