### PR TITLE
chore: bump wafer-run pin -> fdefa90 (STORAGE_LIST_FOLDERS admin-only, F7 complete)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#ffb63e3c112dcf64ce1dbe57b701293f44eae486"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
Lockfile-only bump to wafer-run `fdefa90` — [STORAGE_LIST_FOLDERS admin-only sentinel, wafer-run #261](https://github.com/wafer-run/wafer-run/pull/261). `storage.list_folders` is now WRAP-authorized admin-only (it previously did no authorization — any caller could enumerate every folder). **This closes the last unenforced service op in the F7 program.**

**No solobase code change** — solobase has zero `list_folders` consumers (its admin bucket browser reads an owner-keyed DB table).

**Verification (clean clone, new pin):** both wasm32 target checks pass; native suite matches the main baseline (only the four known pkg-dependent web-bundling suites fail, identical on the old pin).

With this merged, **every service op across database/storage/config/crypto/network/vector is host-authorized** — the F7 WRAP-enforcement program is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)