### PR TITLE
vector: typed introspection ops consumer — blocks/vector off query_raw (§8 complete)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#fdefa90edd12ca9be029397a17bfb72a3a86b605"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -24,7 +24,7 @@
 //! correct embedding model when the caller sends text instead of a raw
 //! vector. Rows are written on `create_index` and removed on `delete_index`.
 //! Pre-registry indexes (created before this table existed) fall back to
-//! `DEFAULT_MODEL` + an `_fts` scan on `sqlite_master`.
+//! `DEFAULT_MODEL` + the typed `vector.describe_index` capability probe.
 //!
 //! ### Route ordering note
 //!
@@ -49,7 +49,6 @@ use wafer_core::{
     interfaces::vector::{get_model, DEFAULT_MODEL},
 };
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream, WaferError};
-use wafer_sql_utils::introspect;
 
 use super::{
     ingestion::{self, DEFAULT_CHUNK_TOKENS, DEFAULT_OVERLAP_RATIO},
@@ -228,28 +227,20 @@ pub(super) async fn list_indexes(ctx: &dyn Context) -> OutputStream {
 
 /// Scan sqlite_master for the per-index `_meta` tables created by
 /// `SqliteVecService::create_index` and return the user-facing index
-/// names (prefix + `_meta` suffix stripped).
+/// names (prefix stripped).
 ///
-/// We scan `sqlite_master` rather than the registry so that indexes
-/// created before the registry existed still surface in list/stats.
-/// The registry is the source of truth for *per-index metadata* (model,
-/// keyword_search flag), not for existence.
+/// We ask the vector service's catalog (typed `vector.list_indexes`, which
+/// is WRAP-authorized on the namespace prefix) rather than the registry so
+/// that indexes created before the registry existed still surface in
+/// list/stats. The registry is the source of truth for *per-index metadata*
+/// (model, keyword_search flag), not for existence.
 async fn discover_indexes(ctx: &dyn Context) -> Result<Vec<String>, WaferError> {
-    // The builder pattern is `prefix%`; we want `prefix%_meta`. Filter the
-    // suffix in Rust after the prefix scan rather than adding a new builder
-    // overload — cheap because the table count is tiny (one row per index).
-    let (sql, args) =
-        introspect::build_list_tables_like(TABLE_PREFIX, crate::db_backend(ctx).await);
-    let rows = db::query_raw(ctx, &sql, &args).await?;
-
-    let mut indexes: Vec<String> = Vec::with_capacity(rows.len());
-    for row in rows {
-        let table = row.data.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        if let Some(stored) = table.strip_suffix("_meta") {
-            if let Some(user_name) = stored.strip_prefix(TABLE_PREFIX) {
-                if !user_name.is_empty() {
-                    indexes.push(user_name.to_string());
-                }
+    let stems = vclient::list_indexes(ctx, TABLE_PREFIX).await?;
+    let mut indexes: Vec<String> = Vec::with_capacity(stems.len());
+    for stem in stems {
+        if let Some(user_name) = stem.strip_prefix(TABLE_PREFIX) {
+            if !user_name.is_empty() {
+                indexes.push(user_name.to_string());
             }
         }
     }
@@ -557,18 +548,14 @@ async fn load_index_metadata(
         }
     }
 
-    // Fallback path: infer keyword_search from the FTS table's presence.
+    // Fallback path: infer keyword_search from the typed describe op.
     // `wafer-block-sqlite::SqliteVecService::create_index` creates
     // `{prefixed}_fts` when keyword_search is enabled and nothing when it
-    // isn't, so the row count for that exact name is a reliable signal.
-    let fts_name = format!("{prefixed_index}_fts");
-    // "Table exists" probe via the sql-utils introspect builder (portable
-    // across backends) instead of a hand-written `sqlite_master` query.
-    let (sql, params) = introspect::build_table_exists(&fts_name, crate::db_backend(ctx).await);
-    let fts_rows = db::query_raw(ctx, &sql, &params).await?;
-    let keyword_search = !fts_rows.is_empty();
+    // isn't; `describe_index` reports that as `keyword_search`. Absence of
+    // the whole index is data too (`exists: false` → false), not an error.
+    let desc = vclient::describe_index(ctx, prefixed_index).await?;
 
-    Ok((DEFAULT_MODEL.to_string(), keyword_search))
+    Ok((DEFAULT_MODEL.to_string(), desc.keyword_search))
 }
 
 /// Map a model id to the embedding block that serves it on this runtime.
@@ -646,27 +633,16 @@ pub(super) async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStrea
     };
 
     // Re-ingestion safety: wipe any chunks we previously wrote for this
-    // document_id before we add the new ones. If the metadata table isn't
-    // there yet (first-ever ingest, or fresh index) the query fails and we
-    // take that as "no prior chunks", not as a fatal error.
-    //
-    // `json_extract(metadata, '$.document_id')` is a SQLite-specific JSON
-    // function the metadata column relies on. The vector block is
-    // SQLite-only by design (sqlite-vec extension), so a dialect-portable
-    // builder is neither needed nor possible — the query stays raw.
-    if let Ok(rows) = db::query_raw(
-        ctx,
-        &format!(
-            "SELECT id FROM {prefixed}_meta WHERE json_extract(metadata, '$.document_id') = ?1"
-        ),
-        &[serde_json::Value::String(body.document_id.clone())],
-    )
-    .await
-    {
-        let prior_ids: Vec<String> = rows
-            .into_iter()
-            .filter_map(|r| r.data.get("id").and_then(|v| v.as_str()).map(String::from))
-            .collect();
+    // document_id before we add the new ones, via the typed `vector.list_ids`
+    // metadata-equality op. If the index isn't there yet (first-ever ingest,
+    // or fresh index) the lookup errors with NotFound and we take that as
+    // "no prior chunks", not as a fatal error.
+    let mut prior_filter = MetadataFilter::default();
+    prior_filter.equals.insert(
+        "document_id".into(),
+        serde_json::Value::String(body.document_id.clone()),
+    );
+    if let Ok(prior_ids) = vclient::list_ids(ctx, &prefixed, prior_filter).await {
         if !prior_ids.is_empty() {
             if let Err(e) = vclient::delete(ctx, &prefixed, prior_ids).await {
                 return err_internal("failed to clear prior chunks", e);

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -4,6 +4,7 @@
 //! unit-tested directly without `Context`.
 
 use maud::{html, Markup};
+use wafer_core::clients::vector as vclient;
 use wafer_run::{context::Context, Message, OutputStream};
 
 use super::service::{display_index_name, IndexRow};
@@ -256,9 +257,17 @@ pub async fn index_detail_page(ctx: &dyn Context, msg: &Message, name: &str) -> 
         }
     };
 
-    let meta_table = format!("{storage_name}_meta");
-    let schema_cols = super::service::introspect_columns(ctx, &meta_table)
+    // Real column state of the meta table via the typed `vector.describe_index`
+    // op (WRAP-authorized on the index). Lenient like before: any error — or a
+    // missing index (`exists: false`) — renders an empty schema section.
+    let schema_cols: Vec<(String, String)> = vclient::describe_index(ctx, &storage_name)
         .await
+        .map(|d| {
+            d.columns
+                .into_iter()
+                .map(|c| (c.name, c.sql_type))
+                .collect()
+        })
         .unwrap_or_default();
 
     let display = display_index_name(&row.name);
@@ -393,13 +402,78 @@ mod tests {
 
 #[cfg(test)]
 mod integration_tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
     use serde_json::json;
+    use wafer_block::{
+        core_types::{LifecycleEvent, WaferError},
+        types::BlockInfo,
+        Block,
+    };
     use wafer_core::clients::database as db;
+    use wafer_run::{ErrorCode, InputStream};
 
     use super::*;
     use crate::test_support::{admin_msg, output_html, TestContext};
+
+    /// Minimal `wafer-run/vector` stand-in answering `vector.describe_index`
+    /// with the columns of the `_meta` fixture table. The TestContext's
+    /// database service owns a private in-memory connection, so a real
+    /// `SqliteVecService` can't see fixture tables; the real describe
+    /// behavior is covered upstream by wafer-run's sqlite behavior tests and
+    /// handler authorization suites. This fake keeps the page-rendering
+    /// assertions meaningful.
+    struct FakeVectorBlock;
+
+    #[wafer_block::wafer_async_trait]
+    impl Block for FakeVectorBlock {
+        fn info(&self) -> BlockInfo {
+            BlockInfo::new("wafer-run/vector", "0.0.1", "vector@v1", "test fake")
+        }
+
+        async fn handle(
+            &self,
+            _ctx: &dyn Context,
+            msg: Message,
+            _input: InputStream,
+        ) -> OutputStream {
+            match msg.kind.as_str() {
+                "vector.describe_index" => {
+                    let resp = wafer_block::wire::vector::DescribeIndexResponse {
+                        exists: true,
+                        columns: [
+                            ("id", "TEXT"),
+                            ("vector_id", "TEXT"),
+                            ("created_at", "TEXT"),
+                            ("updated_at", "TEXT"),
+                        ]
+                        .into_iter()
+                        .map(|(name, sql_type)| wafer_block::wire::vector::ColumnInfo {
+                            name: name.into(),
+                            sql_type: sql_type.into(),
+                        })
+                        .collect(),
+                        keyword_search: true,
+                    };
+                    OutputStream::respond(
+                        wafer_block::codec::encode(&resp).expect("encode describe response"),
+                    )
+                }
+                other => OutputStream::error(WaferError::new(
+                    ErrorCode::Unimplemented,
+                    format!("FakeVectorBlock has no handler for '{other}'"),
+                )),
+            }
+        }
+
+        async fn lifecycle(
+            &self,
+            _ctx: &dyn Context,
+            _e: LifecycleEvent,
+        ) -> Result<(), WaferError> {
+            Ok(())
+        }
+    }
 
     /// Seed one row in the vector registry plus the matching `_meta` table
     /// so the listing has both a registry entry and a vector count to show.
@@ -511,7 +585,8 @@ mod integration_tests {
 
     #[tokio::test]
     async fn index_detail_page_happy_path() {
-        let ctx = TestContext::with_vector().await;
+        let mut ctx = TestContext::with_vector().await;
+        ctx.register_block("wafer-run/vector", Arc::new(FakeVectorBlock));
         seed_docs_index(&ctx).await;
 
         let msg = admin_msg("retrieve", "/b/vector/docs/");

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -8,7 +8,6 @@
 use wafer_block::db::SortField;
 use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, WaferError};
-use wafer_sql_utils::introspect;
 
 use crate::util::RecordExt;
 
@@ -183,41 +182,6 @@ pub async fn get_index_row(
         Err(e) => return Err(e),
     };
     Ok(map_index_row(ctx, &rec).await)
-}
-
-/// Introspect the columns of a per-index storage table, returning
-/// `(name, sql_type)` pairs in declaration order.
-///
-/// Schema introspection is intrinsically backend-specific (SQLite
-/// `PRAGMA table_info` vs Postgres `information_schema.columns`) — the
-/// SQL is built via the `wafer_sql_utils::introspect::build_table_info`
-/// portable builder so backends stay swappable, but the actual
-/// projection still has to flow through `query_raw`. This is the same
-/// pattern the admin database explorer uses and is the only path
-/// available short of teaching `wafer-core::clients::database` a typed
-/// `introspect_columns` API. On unknown tables the SQLite service
-/// returns an empty result rather than erroring, so the detail page
-/// renders cleanly even on a fresh DB.
-pub async fn introspect_columns(
-    ctx: &dyn Context,
-    table: &str,
-) -> Result<Vec<(String, String)>, WaferError> {
-    let (sql, args) = introspect::build_table_info(table, crate::db_backend(ctx).await)
-        .map_err(|e| WaferError::new(ErrorCode::InvalidArgument, e.to_string()))?;
-    let rows = db::query_raw(ctx, &sql, &args).await?;
-    Ok(rows
-        .into_iter()
-        .filter_map(|r| {
-            let name = r.data.get("name").and_then(|v| v.as_str())?.to_string();
-            let ty = r
-                .data
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            Some((name, ty))
-        })
-        .collect())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Consumer half of wafer-run #262. Pin bump `fdefa90` → `5604cf5` + the 4 `query_raw` sites in `blocks/vector/` replaced with the new typed, host-authorized ops. Zero raw SQL left in the block (the `pages_ui.rs` test fixture `exec_raw` stays — allowed exception).

Design: workspace `docs/superpowers/specs/2026-07-10-vector-typed-introspection-ops-design.md`. Closes the vector spec §8 deferred item from the F7 handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)