### PR TITLE
chore: bump wafer-run pin 5604cf5 -> 543e788 (M3 borrowed Context introspection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#5604cf563c8e9f559775ce450e6533a73127ea56"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -34,7 +34,7 @@ pub async fn blocks_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     };
 
     // `registered_blocks` is already deterministically ordered by the runtime.
-    let mut all_blocks: Vec<wafer_run::BlockInfo> = ctx.registered_blocks();
+    let mut all_blocks: Vec<wafer_run::BlockInfo> = ctx.registered_blocks().to_vec();
 
     // Load block enabled/disabled state from block_settings table. Collect
     // into a `BTreeMap` so the downstream iteration order is stable across
@@ -268,7 +268,7 @@ pub async fn handle_block_detail(
     _msg: &Message,
     block_name: &str,
 ) -> OutputStream {
-    let blocks: Vec<wafer_run::BlockInfo> = ctx.registered_blocks();
+    let blocks = ctx.registered_blocks();
     let block_opt = blocks.iter().find(|b| b.name == block_name);
 
     // Check block enabled state via shared helper (audit finding #12).

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -80,7 +80,7 @@ fn grants_code_tab(ctx: &dyn Context) -> Markup {
                         }
                     }
                     tbody {
-                        @for block in &blocks {
+                        @for block in blocks {
                             @for grant in &block.grants {
                                 tr {
                                     td {
@@ -408,7 +408,7 @@ async fn permissions_all_tab(ctx: &dyn Context, _msg: &Message) -> Markup {
     // 1. Code grants (from block declarations)
     let mut all_rows: Vec<PermRow> = Vec::new();
 
-    for block in &blocks {
+    for block in blocks {
         for grant in &block.grants {
             let type_label = match &grant.resource_type {
                 Some(rt) => human_resource_type(rt.to_string().as_str()).to_string(),

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -305,7 +305,7 @@ async fn config_all_tab(ctx: &dyn Context) -> Markup {
 
 /// "By Block" tab -- groups config variables by owning block with WRAP access info.
 async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
-    let blocks: Vec<wafer_run::BlockInfo> = ctx.registered_blocks();
+    let blocks = ctx.registered_blocks();
     let shared_vars = crate::config_vars::shared_config_vars();
 
     // Load all variables from DB
@@ -334,7 +334,7 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
 
     // Collect all known keys (block-declared + shared) to detect unowned DB vars
     let mut known_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for block in &blocks {
+    for block in blocks {
         for ck in &block.config_keys {
             known_keys.insert(ck.key.clone());
         }
@@ -349,7 +349,7 @@ async fn config_by_block_tab(ctx: &dyn Context) -> Markup {
     // the inner template just does an O(1) lookup per config key.
     let mut grants_by_resource: std::collections::HashMap<String, Vec<(&str, bool)>> =
         std::collections::HashMap::new();
-    for grant_block in &blocks {
+    for grant_block in blocks {
         for grant in &grant_block.grants {
             grants_by_resource
                 .entry(grant.resource.clone())


### PR DESCRIPTION
Consumer half of wafer-run #263 (M3: introspection getters borrow the sealed snapshot). Pin bump + the 7 mechanical caller edits — `.to_vec()` only where the admin blocks page reorders a local copy; everywhere else the borrowed slice is iterated directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)