### PR TITLE
fix(vector): complete the block's requires allowlist (db + embed calls were denied)

### DIFF
--- a/crates/solobase-core/src/blocks/vector/mod.rs
+++ b/crates/solobase-core/src/blocks/vector/mod.rs
@@ -72,7 +72,19 @@ crate::solobase_feature_block! {
             "Vector search, RAG ingestion, and embedding generation",
         )
         .instance_mode(InstanceMode::Singleton)
-        .requires(vec!["wafer-run/vector".into()])
+        .requires(vec![
+            // The runtime vector service (typed index/query/introspection ops).
+            "wafer-run/vector".into(),
+            // Registry table reads/writes + per-index counts go through the
+            // database service; without this entry caller_requires denies
+            // every db::* call and the admin list silently renders empty.
+            "wafer-run/database".into(),
+            // Embedding for ingest / query-by-text. Allowlist entries are
+            // call-time only, so listing both targets is safe on either
+            // target (the unused one is simply never called).
+            "suppers-ai/fastembed".into(),
+            "suppers-ai/transformers-embed".into(),
+        ])
         .category(wafer_run::BlockCategory::Feature)
         .endpoints(vec![
             BlockEndpoint::get("/b/vector/")


### PR DESCRIPTION
Found by walking the live pages on a local native server: the vector block's `requires` listed only `wafer-run/vector`, but `caller_requires` enforcement denies any `call_block` target not in the list. Every registry read/write and per-index count through `db::*` was `PermissionDenied` — the admin list silently rendered empty (the page maps failures to the empty state) — and ingest/query-by-text embedding calls were denied the same way.

Server log signature: `PermissionDenied: block 'wafer-run/database' not in requires list — call_block denied` (WARN, vector index list failed).

Adds `wafer-run/database` + both embedding targets (`suppers-ai/fastembed` native, `suppers-ai/transformers-embed` wasm). Requires entries are call-time allowlist strings only, so the unused target is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)