### PR TITLE
fix(auth): surface DB errors in get_user_roles instead of silently returning empty roles

### DIFF
--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -62,6 +62,18 @@ crate::solobase_feature_block! {
             ])
             .grants(vec![
                 wafer_run::ResourceGrant::read_write(super::auth::AUTH_BLOCK_ID, USER_ROLES_TABLE),
+                // auth-ui's login/refresh/OAuth-callback handlers call the
+                // shared `ensure_admin_role`/`get_user_roles` helpers
+                // directly (not via the framework `suppers-ai/auth`
+                // service), so WRAP authorizes on their own node_id
+                // ("suppers-ai/auth-ui"). Without this grant, admin login
+                // in the native server hits PermissionDenied reading/
+                // writing user_roles (surfaced as a real error by SB-3;
+                // previously silently swallowed into an empty roles list).
+                wafer_run::ResourceGrant::read_write(
+                    super::auth_ui::AUTH_UI_BLOCK_ID,
+                    USER_ROLES_TABLE,
+                ),
                 wafer_run::ResourceGrant::read(super::auth::AUTH_BLOCK_ID, VARIABLES_TABLE),
                 wafer_run::ResourceGrant::read("suppers-ai/userportal", BLOCK_SETTINGS_TABLE),
                 // Every block may upsert its own migration state into block_settings.
@@ -372,6 +384,34 @@ mod grant_tests {
             "admin block must not declare a typed Storage grant for suppers-ai/files \
              — the files block self-admits its own namespace via WRAP Rule 3 (Wave 26 \
              / c18). Found: {storage_grant_for_files:?}"
+        );
+    }
+
+    #[test]
+    fn admin_block_grants_auth_ui_read_write_on_user_roles() {
+        // auth-ui's login/refresh/OAuth-callback handlers call the shared
+        // `ensure_admin_role`/`get_user_roles` helpers directly, so WRAP
+        // authorizes on their own node_id ("suppers-ai/auth-ui"), not the
+        // framework `suppers-ai/auth` service's. Without this grant, admin
+        // login in the native server hits PermissionDenied reading/writing
+        // user_roles — this was previously masked because `get_user_roles`
+        // swallowed the read error into an empty roles list; SB-3 made it
+        // surface as a real error (500 on login), exposing this
+        // pre-existing missing grant. Pin the grant's presence so it can't
+        // silently regress again.
+        use super::{super::auth_ui::AUTH_UI_BLOCK_ID, USER_ROLES_TABLE};
+
+        let admin = AdminBlock::new();
+        let grants = admin.info().grants;
+
+        let auth_ui_user_roles_grant = grants
+            .iter()
+            .find(|g| g.grantee == AUTH_UI_BLOCK_ID && g.resource == USER_ROLES_TABLE);
+
+        assert!(
+            auth_ui_user_roles_grant.is_some_and(|g| g.write),
+            "admin block must declare a read_write grant for {AUTH_UI_BLOCK_ID} on \
+             {USER_ROLES_TABLE} (login path) — found: {auth_ui_user_roles_grant:?}"
         );
     }
 }

--- a/crates/solobase-core/src/blocks/auth/mod.rs
+++ b/crates/solobase-core/src/blocks/auth/mod.rs
@@ -78,38 +78,59 @@ use crate::blocks::admin::USER_ROLES_TABLE;
 pub(crate) mod helpers {
     use super::*;
 
+    /// Resolve `user_id`'s merged role set: the inline `users.role` (the
+    /// bootstrap path) plus any rows in the legacy `USER_ROLES_TABLE`
+    /// (multi-role history / admin-IAM grants), deduped since both can
+    /// produce `"admin"` for the bootstrapped admin.
+    ///
+    /// Both reads propagate `Err` instead of swallowing it (SB-3): a WRAP
+    /// denial or transient DB error on `USER_ROLES_TABLE` must not look
+    /// identical to "user has no roles" — that would silently 403 every
+    /// admin (`AuthServiceImpl::require_role`), re-insert a duplicate admin
+    /// row on every login (`ensure_admin_role`), and stamp empty roles on
+    /// API keys (`authenticate_api_key`). `NotFound` on the inline-role read
+    /// is the one case that is genuinely "no role from this source", not a
+    /// failure, and stays non-fatal.
     pub(crate) async fn get_user_roles(
         ctx: &dyn wafer_run::context::Context,
         user_id: &str,
-    ) -> Vec<String> {
-        // Plan A2 stores role inline on `users.role`; legacy
-        // USER_ROLES_TABLE carries multi-role-per-user history. Merge
-        // both: the inline role is the bootstrap path, the table is the
-        // legacy path. Dedup since both can produce "admin" for the
-        // bootstrapped admin.
+    ) -> Result<Vec<String>, repo::RepoError> {
+        use wafer_block::ErrorCode;
+
         use crate::util::RecordExt;
+
         let mut roles: Vec<String> = Vec::new();
-        if let Ok(rec) = db::get(ctx, USERS_TABLE, user_id).await {
-            let inline = rec.str_field("role");
-            if !inline.is_empty() {
-                roles.push(inline.to_string());
+        match db::get(ctx, USERS_TABLE, user_id).await {
+            Ok(rec) => {
+                let inline = rec.str_field("role");
+                if !inline.is_empty() {
+                    roles.push(inline.to_string());
+                }
+            }
+            Err(e) if e.code == ErrorCode::NotFound => {}
+            Err(e) => {
+                return Err(repo::RepoError::Db(format!(
+                    "get_user_roles: users lookup: {e}"
+                )))
             }
         }
+
         let filters = vec![Filter {
             field: "user_id".to_string(),
             operator: FilterOp::Equal,
             value: serde_json::Value::String(user_id.to_string()),
         }];
-        if let Ok(records) = db::list_all(ctx, USER_ROLES_TABLE, filters).await {
-            for rec in &records {
-                if let Some(role) = rec.data.get("role").and_then(|v| v.as_str()) {
-                    if !roles.iter().any(|r| r == role) {
-                        roles.push(role.to_string());
-                    }
+        let records = db::list_all(ctx, USER_ROLES_TABLE, filters)
+            .await
+            .map_err(|e| repo::RepoError::Db(format!("get_user_roles: roles table lookup: {e}")))?;
+        for rec in &records {
+            if let Some(role) = rec.data.get("role").and_then(|v| v.as_str()) {
+                if !roles.iter().any(|r| r == role) {
+                    roles.push(role.to_string());
                 }
             }
         }
-        roles
+        Ok(roles)
     }
 
     /// Resolve user roles, idempotently granting `admin` if the user's email
@@ -126,27 +147,30 @@ pub(crate) mod helpers {
     /// to be done explicitly via the admin UI / DB. Removing roles silently
     /// on login would be an availability foot-gun (one typo in env locks
     /// everyone out).
+    ///
+    /// Propagates [`repo::RepoError`] (SB-3) when the underlying roles read
+    /// fails — a WRAP denial or DB error must not be mistaken for "user has
+    /// no admin row yet" and drive a duplicate insert into `USER_ROLES_TABLE`.
     pub(crate) async fn ensure_admin_role(
         ctx: &dyn wafer_run::context::Context,
         user_id: &str,
         email: &str,
-    ) -> Vec<String> {
+    ) -> Result<Vec<String>, repo::RepoError> {
         // Read the bootstrap-admin email *before* the role lookup. The
         // common case in production is "unset" — early-return then,
-        // skipping the role table read and the second `db::create` path
-        // entirely. Authenticated routes mint tokens often enough that the
-        // saved DB reads accumulate.
+        // skipping the second `db::create` path entirely. Authenticated
+        // routes mint tokens often enough that the saved DB reads accumulate.
         let admin_email =
             config_client::get_default(ctx, "SOLOBASE_SHARED__AUTH__BOOTSTRAP_ADMIN_EMAIL", "")
                 .await;
 
-        let mut roles = get_user_roles(ctx, user_id).await;
+        let mut roles = get_user_roles(ctx, user_id).await?;
 
         if admin_email.is_empty()
             || !email.eq_ignore_ascii_case(&admin_email)
             || roles.iter().any(|r| r == "admin")
         {
-            return roles;
+            return Ok(roles);
         }
 
         // Email matches and admin role is missing — grant it.
@@ -171,7 +195,7 @@ pub(crate) mod helpers {
                 );
             }
         }
-        roles
+        Ok(roles)
     }
 
     /// Whether new-account registration is allowed
@@ -558,8 +582,18 @@ pub async fn authenticate_api_key(
         return;
     }
 
-    // Fetch roles from user_roles collection (roles are not stored on the user record)
-    let roles = helpers::get_user_roles(ctx, &key_row.user_id).await;
+    // Fetch roles from user_roles collection (roles are not stored on the
+    // user record). Mirrors the key_row/user lookups above: a real DB error
+    // (WRAP denial, connection blip) must not silently stamp an empty/wrong
+    // roles list on an otherwise-valid key — log it and fall back to
+    // anonymous instead (SB-3).
+    let roles = match helpers::get_user_roles(ctx, &key_row.user_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(user_id = %key_row.user_id, "authenticate_api_key: roles lookup failed: {e}");
+            return;
+        }
+    };
     let roles_str = roles.join(",");
 
     // Set auth meta (same fields as JWT auth)
@@ -620,10 +654,21 @@ mod api_key_lifecycle_tests {
 
     #[tokio::test]
     async fn active_user_key_authenticates() {
+        // SB-3: `get_user_roles` now surfaces (rather than swallows) a
+        // denied read of the admin-owned USER_ROLES_TABLE, so this WRAP
+        // fixture must carry the real grant admin declares for the auth
+        // block (`ResourceGrant::read_write(AUTH_BLOCK_ID, USER_ROLES_TABLE)`
+        // in `blocks/admin/mod.rs`) — sourced from the real block so the
+        // fixture can't drift from production.
+        use wafer_run::Block;
+
+        use crate::blocks::admin::AdminBlock;
+
+        let grants = AdminBlock::new().info().grants;
         let ctx =
             TestContext::with_auth()
                 .await
-                .with_wrap("suppers-ai/auth", vec![], "suppers-ai/admin");
+                .with_wrap("suppers-ai/auth", grants, "suppers-ai/admin");
         let uid = seed_user_and_key(&ctx, "raw-active-key").await;
 
         let mut msg = Message::new("http");
@@ -649,5 +694,58 @@ mod api_key_lifecycle_tests {
         authenticate_api_key(&ctx, "raw-disabled-key", &mut msg).await;
         // No auth meta stamped → request stays anonymous.
         assert_eq!(msg.get_meta(META_AUTH_USER_ID), "");
+    }
+}
+
+// SB-3: `get_user_roles` used to swallow both DB reads with `if let
+// Ok(...)`, so a WRAP-grant regression or transient DB error yielded an
+// empty/partial roles list indistinguishable from "user genuinely has no
+// roles" — silently 403ing every admin (`require_role`), re-inserting a
+// duplicate admin row on every login (`ensure_admin_role`), and stamping
+// empty roles on API keys (`authenticate_api_key`). These tests pin the
+// fix: a denied/failed roles read is now an `Err`, not an empty `Vec`.
+#[cfg(test)]
+mod get_user_roles_error_surfacing_tests {
+    use super::helpers::{ensure_admin_role, get_user_roles};
+    use crate::test_support::TestContext;
+
+    #[tokio::test]
+    async fn denied_roles_table_read_is_an_error_not_empty_roles() {
+        // Auth owns `suppers_ai__auth__users` (Rule 3 own-resource — always
+        // reachable) but not `suppers_ai__admin__user_roles` (admin-owned).
+        // In production, admin's own block-level grant
+        // (`ResourceGrant::read_write(AUTH_BLOCK_ID, USER_ROLES_TABLE)` in
+        // `blocks/admin/mod.rs`) makes that read succeed; passing no grants
+        // here simulates that grant regressing/missing.
+        let ctx = TestContext::with_auth().await.with_wrap(
+            "suppers-ai/auth",
+            Vec::new(),
+            "suppers-ai/admin",
+        );
+
+        let res = get_user_roles(&ctx, "some-user-id").await;
+        assert!(
+            res.is_err(),
+            "a denied/failed roles read must be an Err, not empty roles"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_admin_role_propagates_denied_roles_read_instead_of_inserting() {
+        // If the roles-table read fails, `ensure_admin_role` must not
+        // silently treat that as "no admin row yet" and insert a duplicate
+        // — it must propagate the error and skip the insert entirely.
+        let ctx = TestContext::with_auth().await.with_wrap(
+            "suppers-ai/auth",
+            Vec::new(),
+            "suppers-ai/admin",
+        );
+
+        let res = ensure_admin_role(&ctx, "some-user-id", "admin@example.com").await;
+        assert!(
+            res.is_err(),
+            "ensure_admin_role must propagate a denied roles read instead of \
+             proceeding to (possibly duplicate-)insert the admin grant"
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -361,6 +361,7 @@ impl AuthService for AuthServiceImpl {
         let has = match role {
             Role::Admin => crate::blocks::auth::helpers::get_user_roles(ctx, &uid.0)
                 .await
+                .map_err(|e| AuthError::Internal(e.to_string()))?
                 .iter()
                 .any(|r| r == "admin"),
             Role::User => true, // any authenticated user
@@ -521,7 +522,11 @@ mod tests {
             .await
             .expect("assign admin via roles table");
 
-        let roles = crate::blocks::auth::helpers::get_user_roles(&*ctx, &user.id).await;
+        let roles = crate::blocks::auth::helpers::get_user_roles(&*ctx, &user.id)
+            .await
+            .expect(
+                "get_user_roles must succeed (TestContext::with_admin has no WRAP enforcement)",
+            );
         assert!(
             roles.iter().any(|r| r == "admin"),
             "merged resolver must see the roles-table admin grant: {roles:?}"

--- a/crates/solobase-core/src/blocks/auth_ui/api/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/login.rs
@@ -80,8 +80,14 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
         return error_response(ErrorCode::EmailNotVerified, "Please verify your email before logging in. Check your inbox for the verification link.");
     }
 
-    // Get roles, granting admin role idempotently when ADMIN_EMAIL matches
-    let roles = ensure_admin_role(ctx, &user.id, &email_lower).await;
+    // Get roles, granting admin role idempotently when ADMIN_EMAIL matches.
+    // A WRAP denial or DB error here must not silently resolve to "no
+    // roles" — that would 403 an admin or double-grant on the next login
+    // (SB-3).
+    let roles = match ensure_admin_role(ctx, &user.id, &email_lower).await {
+        Ok(r) => r,
+        Err(e) => return err_internal("Failed to resolve user roles", e),
+    };
 
     // Mint tokens, persist the refresh + session rows, build the cookie.
     let issued =

--- a/crates/solobase-core/src/blocks/auth_ui/api/me.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/me.rs
@@ -20,7 +20,10 @@ pub async fn handle_get(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let Ok(Some(user)) = users::find_by_id(ctx, user_id).await else {
         return err_not_found("User not found");
     };
-    let roles = get_user_roles(ctx, user_id).await;
+    let roles = match get_user_roles(ctx, user_id).await {
+        Ok(r) => r,
+        Err(e) => return err_internal("Failed to resolve user roles", e),
+    };
     ok_json(&serde_json::json!({
         "user": {
             "id": user.id,
@@ -52,7 +55,10 @@ pub async fn handle_update(ctx: &dyn Context, msg: &Message, input: InputStream)
 
     match users::update_profile(ctx, user_id, name, avatar_url).await {
         Ok(user) => {
-            let roles = get_user_roles(ctx, user_id).await;
+            let roles = match get_user_roles(ctx, user_id).await {
+                Ok(r) => r,
+                Err(e) => return err_internal("Failed to resolve user roles", e),
+            };
             ok_json(&serde_json::json!({
                 "id": user.id,
                 "email": user.email,

--- a/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         errors::{error_response, ErrorCode},
     },
-    http::{err_bad_request, ResponseBuilder},
+    http::{err_bad_request, err_internal, ResponseBuilder},
 };
 
 pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
@@ -123,7 +123,13 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     }
 
     let email = user.email.clone();
-    let roles = ensure_admin_role(ctx, &user_id, &email).await;
+    // A WRAP denial or DB error here must not silently resolve to "no
+    // roles" — that would 403 an admin or double-grant on the next login
+    // (SB-3).
+    let roles = match ensure_admin_role(ctx, &user_id, &email).await {
+        Ok(r) => r,
+        Err(e) => return err_internal("Failed to resolve user roles", e),
+    };
 
     // Preserve the original auth method across refresh — a token issued
     // via OAuth must remain "oauth.<provider>" forever, not silently

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -117,7 +117,13 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     let email = info.email;
 
-    let roles = ensure_admin_role(ctx, &user_id, &email).await;
+    // A WRAP denial or DB error here must not silently resolve to "no
+    // roles" — that would 403 an admin or double-grant on the next login
+    // (SB-3).
+    let roles = match ensure_admin_role(ctx, &user_id, &email).await {
+        Ok(r) => r,
+        Err(e) => return err_internal("Failed to resolve user roles", e),
+    };
 
     // Mint tokens, persist the refresh + session rows, build the cookie via
     // the shared issuance tail. Previously this flow hand-rolled token minting


### PR DESCRIPTION
## Summary

`get_user_roles` used `if let Ok(...)` on both of its DB reads with no
logging, so a WRAP-grant regression or transient DB error yielded an
empty/partial roles list that was indistinguishable from "user genuinely
has no roles." That silently 403'd every admin (`require_role`), made
`ensure_admin_role` re-insert a duplicate admin row on every login, and
stamped empty roles onto API-key-authenticated requests.

`get_user_roles` now returns `Result<Vec<String>, RepoError>` — a
WRAP-denied or failed roles-table read is an `Err`, not an empty `Vec`.
`NotFound` on the inline `users.role` read is still treated as "no role
from that source" (not a failure), matching the existing repo-layer
convention (`repo::users::find_by_id`, `repo::api_keys::find_by_key_hash`,
etc).

Threaded through the three callers:
- `require_role` (`service.rs`) maps the error to `AuthError::Internal`.
- `ensure_admin_role` propagates before it ever reaches the `db::create`
  admin-grant path, so a denied read can no longer be mistaken for "no
  admin row yet" and drive a duplicate insert.
- `authenticate_api_key` logs a `tracing::warn!` and falls back to
  anonymous, mirroring the *already-correct* pattern its own
  `key_row`/`user` lookups use a few lines above.

The four HTTP boundaries that call into these (`login`, `refresh`, the
OAuth callback, and `GET`/`PATCH /b/auth/api/me`) now match on the
`Result` and return `err_internal(...)` (which already logs with a
correlation id) instead of silently proceeding with wrong data.

Also fixed the one existing test (`api_key_lifecycle_tests::active_user_key_authenticates`)
that was passing with an under-provisioned WRAP fixture (no grant on the
admin-owned `USER_ROLES_TABLE`) — it "worked" only because the old code
silently swallowed that denial. It now sources the real grant from
`AdminBlock::new().info().grants`, matching the sibling
`wrap_allows_provider_links_list_with_auth_block_grants`-style tests
elsewhere in the crate.

## Test plan

- [x] New failing test (RED, compile error against the old `Vec<String>`
      signature): `get_user_roles_error_surfacing_tests::denied_roles_table_read_is_an_error_not_empty_roles`
- [x] New test: `ensure_admin_role_propagates_denied_roles_read_instead_of_inserting`
      — pins that a denied read short-circuits before the (possibly
      duplicate) admin-row insert.
- [x] `cargo test -p solobase-core auth` — 135 lib tests + all auth
      integration tests pass.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all green (34/34 test-result blocks).
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — 83 warnings before and after (no new warnings; zero warnings in any of the 6 touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)