### PR TITLE
fix(config): close SSRF/HTTPS bypasses in validate_url_value via url crate

### DIFF
--- a/crates/solobase-core/src/util.rs
+++ b/crates/solobase-core/src/util.rs
@@ -238,17 +238,21 @@ pub(crate) fn validate_url_value(value: &str) -> Result<(), String> {
 
     let parsed = url::Url::parse(value).map_err(|e| format!("invalid URL: {e}"))?;
 
-    // Must be https:// or http://localhost for dev. `host_str()` is the
+    // Must be https:// or http://localhost for dev. `host()` is the
     // canonical, userinfo-stripped host (e.g. `https://user@localhost/`
-    // still yields `Some("localhost")` here), so there is no separate
-    // prefix test that a crafted authority can dodge.
-    let is_localhost = matches!(
-        parsed.host_str(),
-        Some("localhost") | Some("127.0.0.1") | Some("::1")
-    );
+    // still yields `Host::Domain("localhost")` here), so there is no
+    // separate prefix test that a crafted authority can dodge. The dev
+    // exception is scoped to the `localhost` *domain* specifically:
+    // loopback IPs (`127.0.0.1`, `::1`) are intentionally NOT granted it —
+    // they're rejected below by the private/loopback-IP block regardless,
+    // so exempting them here would be misleading. `Host::Ipv6` also never
+    // matches the bare string `"::1"` (it serializes bracketed, `"[::1]"`),
+    // so a string-based check would silently never apply anyway.
+    let is_dev_localhost =
+        matches!(parsed.host(), Some(url::Host::Domain(h)) if h.eq_ignore_ascii_case("localhost"));
     match parsed.scheme() {
         "https" => {}
-        "http" if is_localhost => {}
+        "http" if is_dev_localhost => {}
         _ => {
             return Err("URL must use HTTPS (or http://localhost for development)".to_string());
         }
@@ -679,5 +683,24 @@ mod tests {
     fn still_allows_plain_https_and_real_localhost() {
         assert!(validate_url_value("https://api.example.com/x").is_ok());
         assert!(validate_url_value("http://localhost:8080/x").is_ok());
+    }
+
+    /// The http-localhost dev exception is scoped to the `localhost` domain
+    /// only. Loopback IPs are NOT granted it — they fall through to (and are
+    /// rejected by) the private/loopback-IP block below regardless. IPv6
+    /// loopback in particular would never have matched a bare `"::1"` string
+    /// check anyway, since `Url::host_str()` serializes it bracketed.
+    #[test]
+    fn rejects_loopback_ips_over_http() {
+        assert!(validate_url_value("http://[::1]/x").is_err());
+        assert!(validate_url_value("http://127.0.0.1:8080/x").is_err());
+    }
+
+    /// Userinfo-stripped host must still be `localhost` the domain, not
+    /// merely contain the substring — `http://localhost@evil.com` has host
+    /// `evil.com`, so it must be rejected (not confused with the userinfo).
+    #[test]
+    fn rejects_userinfo_localhost_with_external_host() {
+        assert!(validate_url_value("http://localhost@evil.com").is_err());
     }
 }

--- a/crates/solobase-core/src/util.rs
+++ b/crates/solobase-core/src/util.rs
@@ -211,6 +211,11 @@ pub fn url_path_encode(s: &str) -> String {
 /// `http://localhost` for local development), must not contain newlines (header
 /// injection), and must not resolve to a private/internal/loopback IP.
 ///
+/// Parses with [`url::Url`] rather than hand-rolled string splitting: `Url`
+/// canonicalizes the scheme/host and `Url::host()` strips userinfo and port
+/// and unwraps IPv6 brackets, so there is no separate "is this really
+/// localhost" string check to go stale relative to the parse.
+///
 /// Single source of truth for the `InputType::Url` write rule, shared by every
 /// config-value write surface — the admin variables page (`blocks::admin::ops`)
 /// and the generic settings form (`ui::settings_form::save_settings`) — so a
@@ -219,59 +224,61 @@ pub(crate) fn validate_url_value(value: &str) -> Result<(), String> {
     if value.is_empty() {
         return Ok(());
     }
-    // Allow relative paths.
+    // Allow relative paths. Checked before `Url::parse`, which errors on a
+    // bare relative path (no scheme) rather than accepting it.
     if value.starts_with('/') && !value.starts_with("//") {
         return Ok(());
     }
-    // Block newlines (header injection).
+    // Block newlines (header injection). `Url::parse` also rejects ASCII
+    // control characters, but keep this as an explicit, readable check with
+    // its own error message rather than relying on parse-error wording.
     if value.contains('\n') || value.contains('\r') {
         return Err("URL must not contain newlines".to_string());
     }
-    // Must be https:// or http://localhost for dev.
-    let is_localhost = value.starts_with("http://localhost");
-    if !value.starts_with("https://") && !is_localhost {
-        return Err("URL must use HTTPS (or http://localhost for development)".to_string());
-    }
-    // Extract hostname and check for private/internal IPs.
-    let host = value
-        .split("://")
-        .nth(1)
-        .and_then(|rest| rest.split('/').next())
-        .and_then(|authority| {
-            // Handle [IPv6]:port
-            if authority.starts_with('[') {
-                authority.strip_prefix('[')?.split(']').next()
-            } else {
-                authority.split(':').next()
-            }
-        })
-        .unwrap_or("");
 
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        match ip {
-            std::net::IpAddr::V4(v4) => {
-                let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
-                    || v4.is_loopback()                // 127.x
-                    || v4.is_link_local()              // 169.254.x
-                    || v4.octets()[0] == 0; // 0.0.0.0/8
-                if is_blocked && !is_localhost {
+    let parsed = url::Url::parse(value).map_err(|e| format!("invalid URL: {e}"))?;
+
+    // Must be https:// or http://localhost for dev. `host_str()` is the
+    // canonical, userinfo-stripped host (e.g. `https://user@localhost/`
+    // still yields `Some("localhost")` here), so there is no separate
+    // prefix test that a crafted authority can dodge.
+    let is_localhost = matches!(
+        parsed.host_str(),
+        Some("localhost") | Some("127.0.0.1") | Some("::1")
+    );
+    match parsed.scheme() {
+        "https" => {}
+        "http" if is_localhost => {}
+        _ => {
+            return Err("URL must use HTTPS (or http://localhost for development)".to_string());
+        }
+    }
+
+    // Check for private/internal IPs using the parsed host, which is
+    // guaranteed to have userinfo and port stripped and IPv6 brackets
+    // removed — unlike the old string-split extraction.
+    match parsed.host() {
+        Some(url::Host::Ipv4(v4)) => {
+            let is_blocked = v4.is_private()       // 10.x, 172.16-31.x, 192.168.x
+                || v4.is_loopback()                // 127.x
+                || v4.is_link_local()              // 169.254.x
+                || v4.octets()[0] == 0; // 0.0.0.0/8
+            if is_blocked {
+                return Err("URL must not point to private/internal IP addresses".to_string());
+            }
+        }
+        Some(url::Host::Ipv6(v6)) => {
+            if v6.is_loopback() {
+                return Err("URL must not point to loopback address".to_string());
+            }
+            // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
                     return Err("URL must not point to private/internal IP addresses".to_string());
                 }
             }
-            std::net::IpAddr::V6(v6) => {
-                if v6.is_loopback() {
-                    return Err("URL must not point to loopback address".to_string());
-                }
-                // Block IPv4-mapped IPv6 addresses (::ffff:10.x.x.x etc.)
-                if let Some(v4) = v6.to_ipv4_mapped() {
-                    if v4.is_private() || v4.is_loopback() || v4.is_link_local() {
-                        return Err(
-                            "URL must not point to private/internal IP addresses".to_string()
-                        );
-                    }
-                }
-            }
         }
+        Some(url::Host::Domain(_)) | None => {}
     }
     Ok(())
 }
@@ -647,5 +654,30 @@ mod tests {
         assert!(validate_url_value("https://192.168.1.1").is_err());
         assert!(validate_url_value("https://127.0.0.1").is_err());
         assert!(validate_url_value("https://example.com\r\nHost: evil").is_err());
+    }
+
+    /// Bypass #1: a raw `starts_with("http://localhost")` prefix test treats
+    /// any host merely beginning with the string "localhost" as exempt from
+    /// the HTTPS requirement, letting external plain-HTTP hosts through.
+    #[test]
+    fn rejects_localhost_prefixed_external_host_over_http() {
+        assert!(validate_url_value("http://localhost.evil.com/").is_err());
+        assert!(validate_url_value("http://localhostfoo/").is_err());
+    }
+
+    /// Bypass #2: hand-rolled host extraction never stripped userinfo, so
+    /// `user@10.0.0.1` failed to parse as an `IpAddr` and the private-IP
+    /// block was skipped entirely. Combined with bypass #1, a userinfo of
+    /// literally "localhost" also smuggled a private IP in over plain HTTP.
+    #[test]
+    fn rejects_userinfo_masked_private_ip() {
+        assert!(validate_url_value("https://user@10.0.0.1/").is_err());
+        assert!(validate_url_value("http://localhost@10.0.0.1/").is_err());
+    }
+
+    #[test]
+    fn still_allows_plain_https_and_real_localhost() {
+        assert!(validate_url_value("https://api.example.com/x").is_ok());
+        assert!(validate_url_value("http://localhost:8080/x").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

`validate_url_value` — the single write-gate for `InputType::Url` config values (SSRF/HTTPS guard), reachable from admin `ops.rs` and `ui/settings_form.rs` — used a hand-rolled scheme/host parser with three bypasses:

1. **Prefix test, not host match.** `is_localhost = value.starts_with("http://localhost")` treats `http://localhost.evil.com/` and `http://localhostfoo/` as "localhost", letting external hosts through the HTTPS requirement over plain HTTP.
2. **Userinfo never stripped.** Host extraction split on `://`, `/`, `[..]`, `:` but never dropped a `user@` prefix, so `https://user@10.0.0.1/` extracted `user@10.0.0.1` as the "host", which fails `IpAddr::parse`, silently skipping the private-IP block.
3. **Dead code.** `if is_blocked && !is_localhost` — a host that begins with `"localhost"` can never also parse as an IPv4 literal, so `!is_localhost` never actually excluded anything.

Combined (1)+(2): `http://localhost@10.0.0.1/` reached a private IP over plain HTTP.

## Fix

Rewrote the function on `url::Url` (already a `solobase-core` dependency, `url = "2"`):
- `url::Url::parse(value)` replaces the hand-rolled `://`/`/`/`:` splitting.
- The HTTPS/localhost gate now matches on `parsed.scheme()` + `parsed.host_str()` (userinfo-stripped, so a crafted authority can't spoof the localhost carve-out).
- The private/loopback/link-local IP checks now run on `parsed.host()` (`url::Host::Ipv4`/`Ipv6`/`Domain`), which strips userinfo and port and unwraps IPv6 brackets — reusing the same `is_private()`/`is_loopback()`/`is_link_local()`/IPv4-mapped-IPv6 predicates as before.
- Dropped the dead `&& !is_localhost` clause.
- Preserved: empty value → `Ok`, relative path (`/x`, not `//x`) → `Ok` (checked before `Url::parse`, which errors on a bare relative path), newline/CR → `Err`.

## Test plan

- [x] TDD: added 3 new tests for all three bypasses, confirmed RED against the old implementation (`http://localhost.evil.com/`, `http://localhostfoo/`, `https://user@10.0.0.1/`, `http://localhost@10.0.0.1/` all wrongly passed before the fix).
- [x] Positive cases preserved: `https://api.example.com/x` → Ok, `http://localhost:8080/x` → Ok, empty → Ok, `/relative` → Ok, `\r\n` → Err (all covered by existing + new tests).
- [x] `cargo test -p solobase-core util` — 31 passed, 0 failed.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — 802+ passed across all crates, 0 failed.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — no new warnings (pre-existing warnings in unrelated files only; verified none touch `util.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)