### PR TITLE
fix(cloudflare): R2 delete_folder actually deletes objects (was a silent no-op)

### DIFF
--- a/crates/solobase-cloudflare/src/storage.rs
+++ b/crates/solobase-cloudflare/src/storage.rs
@@ -162,8 +162,48 @@ impl StorageService for R2StorageService {
         Ok(())
     }
 
-    async fn delete_folder(&self, _name: &str) -> Result<(), StorageError> {
-        // Would need to list + batch delete; no-op for now
+    async fn delete_folder(&self, name: &str) -> Result<(), StorageError> {
+        // R2 has no native folder/directory concept — deleting a "folder"
+        // means listing every object under its prefix and deleting each one.
+        // `list()` returns at most 1000 objects per page (R2's own cap), so
+        // we page through with the cursor until `truncated` is false,
+        // batch-deleting each page via `delete_multiple` (also capped at
+        // 1000 keys per call — same limit, so one `delete_multiple` per
+        // page is always within bounds).
+        let prefix = self.folder_prefix(name);
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let mut list_builder = self.bucket.list().prefix(&prefix).limit(1000);
+            if let Some(c) = cursor.take() {
+                list_builder = list_builder.cursor(c);
+            }
+
+            let listed = list_builder
+                .execute()
+                .await
+                .map_err(|e| StorageError::Internal(e.to_string()))?;
+
+            let keys: Vec<String> = listed.objects().iter().map(|obj| obj.key()).collect();
+            if !keys.is_empty() {
+                self.bucket
+                    .delete_multiple(keys)
+                    .await
+                    .map_err(|e| StorageError::Internal(e.to_string()))?;
+            }
+
+            if !listed.truncated() {
+                break;
+            }
+            cursor = listed.cursor();
+            if cursor.is_none() {
+                // `truncated() == true` is documented to always come with a
+                // cursor; bail rather than loop forever if that contract
+                // is ever violated.
+                break;
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/solobase-cloudflare/src/storage.rs
+++ b/crates/solobase-cloudflare/src/storage.rs
@@ -198,9 +198,13 @@ impl StorageService for R2StorageService {
             cursor = listed.cursor();
             if cursor.is_none() {
                 // `truncated() == true` is documented to always come with a
-                // cursor; bail rather than loop forever if that contract
-                // is ever violated.
-                break;
+                // cursor. If that contract is ever violated, we cannot tell
+                // whether more objects remain under this prefix — falling
+                // through to `Ok(())` would silently report success on a
+                // partial delete. Fail loudly instead.
+                return Err(StorageError::Internal(
+                    "R2 reported truncated results with no cursor".into(),
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

`R2StorageService::delete_folder` returned `Ok(())` with a `// no-op for now` comment — every caller (the files block's bucket-delete path, `blocks/files/storage.rs:352` and `:377`) got a success response while every object under the folder persisted in R2. On the live wafer.run Cloudflare deployment this meant a user deleting a bucket was told it succeeded while their data silently remained (privacy + billing implications).

## Approach: implement (root cause), not fail-loud

The R2 `Bucket` handle this service already holds supports `list()` (with `prefix`/`limit`/`cursor`) and `delete_multiple()`, so listing + batch-deleting is feasible — no need for the fail-loud fallback.

`delete_folder` now:
1. Builds the folder prefix the same way `list()`/`get`/`put` already do (`self.folder_prefix(name)`).
2. Pages through `bucket.list().prefix(..).limit(1000)`, following `cursor()`/`truncated()` until exhausted (R2 caps each list page at 1000 objects).
3. Batch-deletes each page's keys via `bucket.delete_multiple()` (also capped at 1000 keys/call, so one call per page is always within bounds).
4. Propagates any R2 error via `StorageError::Internal` instead of swallowing it — a real failure now surfaces to callers instead of a fabricated success.

`create_folder`/`list_folders` no-ops are unrelated and correct — R2 has no folder objects, so nothing to create, and there's no folder listing API. `delete_folder` was the only case where the no-op was a false success signal for a destructive operation.

## Testing

- `solobase-cloudflare` is wasm32-only (depends on `worker`) and is excluded from host `cargo test`/`clippy`/`build` entirely — it cannot even compile on the host target, so no host unit test of this logic is possible in this crate.
- Verified `cargo build -p solobase-cloudflare --target wasm32-unknown-unknown` succeeds.
- Verified `cargo +nightly fmt --all -- --check` is clean.
- Logic review against the file's existing `list()`/`get`/`put`/`delete` R2 usage patterns (prefix construction, error mapping) to keep this consistent with the rest of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)