### PR TITLE
fix(browser): decode network fetch response as a JS object (was double-encoded, broke every request)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +2954,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-browser"
 version = "0.1.0"
 dependencies = [
@@ -3240,6 +3256,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -4285,6 +4307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4688,7 @@ dependencies = [
  "wafer-sql-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "wasm-streams 0.4.2",
  "web-sys",
 ]
@@ -5818,7 +5850,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5842,7 +5873,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5854,7 +5884,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5875,7 +5904,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5886,7 +5914,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5901,7 +5928,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5914,7 +5940,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5926,7 +5951,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5937,7 +5961,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "futures",
@@ -5954,7 +5977,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5975,7 +5997,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -5985,7 +6006,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5997,7 +6017,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6013,7 +6032,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6023,7 +6041,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6044,7 +6061,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6056,7 +6072,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6078,7 +6093,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6088,7 +6102,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6118,7 +6131,6 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6128,13 +6140,22 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "sea-query",
  "serde_json",
  "thiserror 2.0.18",
  "wafer-block",
  "wafer-schema",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -6230,6 +6251,45 @@ checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"
@@ -6457,6 +6517,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5850,6 +5850,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5873,6 +5874,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5884,6 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5904,6 +5907,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5914,6 +5918,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5928,6 +5933,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5940,6 +5946,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5951,6 +5958,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5961,6 +5969,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "futures",
@@ -5977,6 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5997,6 +6007,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6006,6 +6017,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6017,6 +6029,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6032,6 +6045,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6041,6 +6055,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6061,6 +6076,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6072,6 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6093,6 +6110,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6102,6 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6131,6 +6150,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6140,6 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#543e7882e359d876272df141520c3a47a1dfeb3d"
 dependencies = [
  "sea-query",
  "serde_json",

--- a/crates/solobase-browser/Cargo.toml
+++ b/crates/solobase-browser/Cargo.toml
@@ -48,6 +48,9 @@ subtle = { version = "2", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 uuid = { version = "1", features = ["v4", "js"] }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [lints]
 workspace = true
 

--- a/crates/solobase-browser/js/bridge.js
+++ b/crates/solobase-browser/js/bridge.js
@@ -714,7 +714,10 @@ export async function readCookieHeader() {
  * @param {string} url
  * @param {string} headersJson - JSON object of header key/value pairs
  * @param {Uint8Array|null} body
- * @returns {string} JSON string: { status, headers, body: number[] }
+ * @returns {{status: number, headers: Object<string, string>, body: Uint8Array}}
+ *   A plain JS object — NOT a JSON string. `network.rs` decodes it directly
+ *   with `serde_wasm_bindgen::from_value`, so `body` is a real `Uint8Array`
+ *   (deserializes straight into `Vec<u8>`) rather than a JSON number array.
  */
 export async function httpFetch(method, url, headersJson, body) {
     const headersObj = JSON.parse(headersJson);
@@ -735,11 +738,10 @@ export async function httpFetch(method, url, headersJson, body) {
     });
 
     const responseBuffer = await response.arrayBuffer();
-    const responseBody = Array.from(new Uint8Array(responseBuffer));
 
-    return JSON.stringify({
+    return {
         status: response.status,
         headers: responseHeaders,
-        body: responseBody,
-    });
+        body: new Uint8Array(responseBuffer),
+    };
 }

--- a/crates/solobase-browser/src/bridge.rs
+++ b/crates/solobase-browser/src/bridge.rs
@@ -72,7 +72,8 @@ extern "C" {
     /// Execute an HTTP fetch request.
     /// `headers_json` is a JSON object of header key/value pairs.
     /// `body` is the request body bytes (pass empty slice for no body).
-    /// Returns JSON string: `{ status, headers, body: number[] }`.
+    /// Returns a plain JS object `{ status, headers, body: Uint8Array }` —
+    /// NOT a JSON string. Decode directly with `serde_wasm_bindgen::from_value`.
     #[wasm_bindgen(js_name = httpFetch)]
     pub async fn http_fetch(method: &str, url: &str, headers_json: &str, body: &[u8]) -> JsValue;
 

--- a/crates/solobase-browser/src/network.rs
+++ b/crates/solobase-browser/src/network.rs
@@ -14,8 +14,10 @@ pub struct BrowserNetworkService;
 unsafe impl Send for BrowserNetworkService {}
 unsafe impl Sync for BrowserNetworkService {}
 
-/// JSON shape returned by bridge.httpFetch:
-/// `{ status: number, headers: { [key: string]: string }, body: number[] }`
+/// JS object shape returned by bridge.httpFetch (NOT a JSON string):
+/// `{ status: number, headers: { [key: string]: string }, body: Uint8Array }`.
+/// Decoded directly via `serde_wasm_bindgen::from_value` — `serde_wasm_bindgen`
+/// deserializes a JS `Uint8Array` straight into `Vec<u8>`.
 #[derive(Deserialize)]
 struct FetchResponse {
     status: u16,
@@ -35,23 +37,16 @@ impl NetworkService for BrowserNetworkService {
 
         let js_val = bridge::http_fetch(&req.method, &req.url, &headers_json, body_bytes).await;
 
-        // The bridge returns a JS object; stringify it so we can deserialize.
-        // Both `JSON::stringify` rejecting and the result not being a
-        // JS string are explicit bridge-contract violations, not benign
-        // empty bodies — surface them as `RequestError` instead of
-        // silently producing an empty string.
-        let json_js = js_sys::JSON::stringify(&js_val).map_err(|e| {
-            NetworkError::RequestError(format!(
-                "JSON.stringify on fetch response failed: {}",
-                e.as_string().unwrap_or_else(|| format!("{e:?}"))
-            ))
-        })?;
-        let json_str = json_js.as_string().ok_or_else(|| {
-            NetworkError::RequestError("JSON.stringify did not return a string".to_string())
-        })?;
-
-        let fetch_resp: FetchResponse = serde_json::from_str(&json_str).map_err(|e| {
-            NetworkError::RequestError(format!("failed to parse fetch response: {e}"))
+        // The bridge resolves a JS object `{ status, headers, body:
+        // Uint8Array }` — decode it directly. `serde_wasm_bindgen`
+        // deserializes the JS object into `FetchResponse` and the
+        // `Uint8Array` body straight into `Vec<u8>` in one step, with no
+        // JSON round-trip (previously this called `JSON::stringify` on the
+        // resolved value and fed the result to `serde_json::from_str`,
+        // which double-encoded every response into a JSON string literal
+        // and failed with "invalid type: string, expected struct").
+        let fetch_resp: FetchResponse = serde_wasm_bindgen::from_value(js_val).map_err(|e| {
+            NetworkError::RequestError(format!("failed to decode fetch response: {e}"))
         })?;
 
         // Collapse single-value headers into Vec<String> as NetworkService::Response expects.
@@ -72,4 +67,109 @@ impl NetworkService for BrowserNetworkService {
 pub fn make_network_service(
 ) -> std::sync::Arc<dyn wafer_core::interfaces::network::service::NetworkService> {
     std::sync::Arc::new(BrowserNetworkService)
+}
+
+// `bridge::http_fetch` is a `#[wasm_bindgen(module = "/js/bridge.js")]` extern
+// import, so `do_request` itself can't be exercised outside a real Service
+// Worker/page context (the module path doesn't resolve under `wasm-pack
+// test`). What CAN be verified in isolation — and is exactly what the
+// double-encode bug broke — is the decode step: does a JS value shaped like
+// what `bridge.js`'s `httpFetch` now resolves deserialize into
+// `FetchResponse` correctly, and does the *old* buggy shape (a JSON string,
+// from the removed `JSON.stringify` round-trip) correctly fail instead of
+// silently coercing?
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use js_sys::{Object, Reflect, Uint8Array};
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::FetchResponse;
+
+    /// Build the JS object shape `bridge.js`'s `httpFetch` resolves post-fix:
+    /// `{ status: number, headers: {[k]: string}, body: Uint8Array }`.
+    fn make_fetch_response_object(status: u16, body: &[u8]) -> JsValue {
+        let obj = Object::new();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("status"),
+            &JsValue::from_f64(status as f64),
+        )
+        .unwrap();
+
+        let headers = Object::new();
+        Reflect::set(
+            &headers,
+            &JsValue::from_str("content-type"),
+            &JsValue::from_str("application/json"),
+        )
+        .unwrap();
+        Reflect::set(&obj, &JsValue::from_str("headers"), &headers).unwrap();
+
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("body"),
+            &Uint8Array::from(body).into(),
+        )
+        .unwrap();
+
+        obj.into()
+    }
+
+    #[wasm_bindgen_test]
+    fn decodes_js_object_response_in_one_step() {
+        let body = b"hello world";
+        let js_val = make_fetch_response_object(200, body);
+
+        let decoded: FetchResponse =
+            serde_wasm_bindgen::from_value(js_val).expect("decode fetch response");
+
+        assert_eq!(decoded.status, 200);
+        assert_eq!(decoded.body, body.to_vec());
+        assert_eq!(
+            decoded.headers.get("content-type").map(String::as_str),
+            Some("application/json")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn decodes_empty_body_and_headers_via_serde_default() {
+        let obj = Object::new();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("status"),
+            &JsValue::from_f64(204.0),
+        )
+        .unwrap();
+        // No `headers` or `body` keys at all — `#[serde(default)]` must
+        // fill both rather than erroring as "missing field".
+        let js_val: JsValue = obj.into();
+
+        let decoded: FetchResponse =
+            serde_wasm_bindgen::from_value(js_val).expect("decode fetch response");
+
+        assert_eq!(decoded.status, 204);
+        assert!(decoded.body.is_empty());
+        assert!(decoded.headers.is_empty());
+    }
+
+    /// Regression guard for the exact bug this task fixes: `bridge.js` used
+    /// to `JSON.stringify` the response envelope into a JS *string*, and
+    /// `network.rs` then called `JSON::stringify` on that string AGAIN
+    /// before `serde_json::from_str::<FetchResponse>` — double-encoding, so
+    /// every response failed with "invalid type: string, expected struct".
+    /// If `httpFetch` ever regresses back to resolving a string instead of
+    /// an object, decoding must fail loudly here rather than silently
+    /// producing a wrong value.
+    #[wasm_bindgen_test]
+    fn old_json_string_shape_fails_to_decode_as_object() {
+        let json_string = JsValue::from_str(r#"{"status":200,"headers":{},"body":[104,105]}"#);
+
+        let result: Result<FetchResponse, _> = serde_wasm_bindgen::from_value(json_string);
+
+        assert!(
+            result.is_err(),
+            "a JSON string must not decode as the FetchResponse object shape"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The browser `NetworkService::do_request` was functionally broken: every fetch response failed with `RequestError`.

**Root cause (double-encode):**
- `bridge.js`'s `httpFetch` resolved a JSON *string* — `JSON.stringify({ status, headers, body: Array.from(new Uint8Array(...)) })` — instead of a JS object (contrary to the in-code comment in `network.rs`, which claimed "the bridge returns a JS object").
- `network.rs`'s `do_request` then called `js_sys::JSON::stringify(&js_val)` on that already-stringified value. `JSON.stringify` of a JS string wraps it in quotes and escapes it, producing a JSON string *literal* containing the original JSON text.
- `serde_json::from_str::<FetchResponse>` on that literal saw a top-level JSON string where a struct was expected, and failed every time with `invalid type: string, expected struct FetchResponse`.

**Fix (root cause, not a shim):**
- `bridge.js` `httpFetch` now resolves a plain JS object `{ status, headers, body: Uint8Array }` (real `Uint8Array`, not a JSON number array).
- `network.rs` decodes it in **one step** with `serde_wasm_bindgen::from_value::<FetchResponse>`, which deserializes the JS object directly into the struct and the `Uint8Array` straight into `Vec<u8>` — no JSON round-trip at all.
- Fixed the misleading doc comments in `network.rs` and `bridge.rs` that described the old (wrong) contract.
- `serde-wasm-bindgen` was already a workspace dependency of `solobase-browser` (used in `asset_loader.rs`); no new runtime dependency added.
- Request-side encoding was checked and is unaffected: `bridge::http_fetch`'s `body: &[u8]` parameter is auto-converted to a real `Uint8Array` by wasm-bindgen at the FFI boundary — it never went through the JSON-number-array path the response side did.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo build -p solobase-browser --target wasm32-unknown-unknown` — compiles
- [x] `cargo check -p solobase-browser -p minimal-browser --target wasm32-unknown-unknown` (mirrors CI's "Cloudflare wasm32 check" job) — clean
- [x] `cargo clippy -p solobase-browser --target wasm32-unknown-unknown` — no new warnings in changed files
- [x] `cd crates/solobase-web && wasm-pack build --target web --release --out-dir pkg` (mirrors CI's "Build solobase-web wasm" job) — succeeds
- [x] Added 3 `wasm-bindgen-test`s in `network.rs` (run via `wasm-pack test --node`, all pass) covering: decoding the new object shape end-to-end including a real `Uint8Array` body, `#[serde(default)]` fallback for missing `headers`/`body`, and a regression guard proving the old JSON-string shape correctly *fails* to decode as the object shape.
- [x] RED evidence: temporarily reconstructed the exact pre-fix chain (`JSON.stringify` in old `bridge.js` → `JSON::stringify` again in old `network.rs` → `serde_json::from_str`) in a throwaway test and confirmed it fails with the reported error verbatim: `invalid type: string "{\"status\":200,...}", expected struct FetchResponse` — then removed that throwaway test before committing (not part of the shipped suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)