### PR TITLE
fix(browser): add catch to bridge externs so JS rejections surface as typed errors, not SW panics

### DIFF
--- a/crates/solobase-browser/src/asset_loader.rs
+++ b/crates/solobase-browser/src/asset_loader.rs
@@ -83,7 +83,15 @@ impl LoadAssetCallback for SwAssetLoader {
             }
         };
 
-        let js_result = bridge::load_asset(asset_id, &manifest_json).await;
+        let js_result = match bridge::load_asset(asset_id, &manifest_json).await {
+            Ok(v) => v,
+            Err(e) => {
+                return AssetLoadStatus::Failed(AssetLoadError::Unknown(format!(
+                    "load_asset rejected for asset_id={asset_id}: {}",
+                    bridge::describe(&e)
+                )));
+            }
+        };
         let reply: LoadAssetReply = match serde_wasm_bindgen::from_value(js_result) {
             Ok(r) => r,
             Err(e) => {

--- a/crates/solobase-browser/src/bridge.rs
+++ b/crates/solobase-browser/src/bridge.rs
@@ -5,8 +5,10 @@ extern "C" {
     // ─── Database (sql.js) ────────────────────────────────────────────────────
 
     /// Load sql.js WASM, try to load existing DB from OPFS, create new if none.
-    /// Sets PRAGMA foreign_keys=ON.
-    pub async fn dbInit() -> JsValue;
+    /// Sets PRAGMA foreign_keys=ON. Rejects if the sql.js WASM fails to load
+    /// or OPFS is unavailable.
+    #[wasm_bindgen(catch)]
+    pub async fn dbInit() -> Result<JsValue, JsValue>;
 
     /// Execute SQL that modifies data (INSERT/UPDATE/DELETE/DDL).
     /// `params_json` is a JSON array of parameters.
@@ -20,41 +22,58 @@ extern "C" {
     #[wasm_bindgen(catch, js_name = dbQueryRaw)]
     pub fn db_query_raw(sql: &str, params_json: &str) -> Result<String, JsValue>;
 
-    /// Export the sql.js DB to OPFS at `solobase.db`.
-    pub async fn dbFlush() -> JsValue;
+    /// Export the sql.js DB to OPFS at `solobase.db`. Rejects on an OPFS
+    /// write failure (e.g. `QuotaExceededError`).
+    #[wasm_bindgen(catch)]
+    pub async fn dbFlush() -> Result<JsValue, JsValue>;
 
     // ─── Storage (OPFS) ───────────────────────────────────────────────────────
 
     /// Write file + metadata to OPFS.
-    #[wasm_bindgen(js_name = storagePut)]
-    pub async fn storage_put(folder: &str, key: &str, data: &[u8], content_type: &str) -> JsValue;
+    #[wasm_bindgen(catch, js_name = storagePut)]
+    pub async fn storage_put(
+        folder: &str,
+        key: &str,
+        data: &[u8],
+        content_type: &str,
+    ) -> Result<JsValue, JsValue>;
 
     /// Read file + metadata from OPFS.
     /// Returns JSON string: `{ data: number[], meta: { content_type, size } }`.
-    #[wasm_bindgen(js_name = storageGet)]
-    pub async fn storage_get(folder: &str, key: &str) -> JsValue;
+    /// Rejects with a `NotFoundError` `DOMException` if the folder or key
+    /// doesn't exist.
+    #[wasm_bindgen(catch, js_name = storageGet)]
+    pub async fn storage_get(folder: &str, key: &str) -> Result<JsValue, JsValue>;
 
-    /// Delete file + metadata from OPFS.
-    #[wasm_bindgen(js_name = storageDelete)]
-    pub async fn storage_delete(folder: &str, key: &str) -> JsValue;
+    /// Delete file + metadata from OPFS. Rejects with a `NotFoundError`
+    /// `DOMException` if the folder or key doesn't exist.
+    #[wasm_bindgen(catch, js_name = storageDelete)]
+    pub async fn storage_delete(folder: &str, key: &str) -> Result<JsValue, JsValue>;
 
     /// List files in a folder matching a prefix, with pagination.
-    /// Returns JSON array of key strings.
-    #[wasm_bindgen(js_name = storageList)]
-    pub async fn storage_list(folder: &str, prefix: &str, limit: u32, offset: u32) -> JsValue;
+    /// Returns JSON array of key strings. Rejects with a `NotFoundError`
+    /// `DOMException` if the folder doesn't exist.
+    #[wasm_bindgen(catch, js_name = storageList)]
+    pub async fn storage_list(
+        folder: &str,
+        prefix: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<JsValue, JsValue>;
 
     /// Create an OPFS directory under the storage root.
-    #[wasm_bindgen(js_name = storageCreateFolder)]
-    pub async fn storage_create_folder(name: &str) -> JsValue;
+    #[wasm_bindgen(catch, js_name = storageCreateFolder)]
+    pub async fn storage_create_folder(name: &str) -> Result<JsValue, JsValue>;
 
-    /// Remove an OPFS directory recursively.
-    #[wasm_bindgen(js_name = storageDeleteFolder)]
-    pub async fn storage_delete_folder(name: &str) -> JsValue;
+    /// Remove an OPFS directory recursively. Rejects with a `NotFoundError`
+    /// `DOMException` if the folder doesn't exist.
+    #[wasm_bindgen(catch, js_name = storageDeleteFolder)]
+    pub async fn storage_delete_folder(name: &str) -> Result<JsValue, JsValue>;
 
     /// List top-level storage directories.
     /// Returns JSON array of folder name strings.
-    #[wasm_bindgen(js_name = storageListFolders)]
-    pub async fn storage_list_folders() -> JsValue;
+    #[wasm_bindgen(catch, js_name = storageListFolders)]
+    pub async fn storage_list_folders() -> Result<JsValue, JsValue>;
 
     // ─── Cookies (read from SW via CookieStore API) ──────────────────────────
 
@@ -74,8 +93,16 @@ extern "C" {
     /// `body` is the request body bytes (pass empty slice for no body).
     /// Returns a plain JS object `{ status, headers, body: Uint8Array }` —
     /// NOT a JSON string. Decode directly with `serde_wasm_bindgen::from_value`.
-    #[wasm_bindgen(js_name = httpFetch)]
-    pub async fn http_fetch(method: &str, url: &str, headers_json: &str, body: &[u8]) -> JsValue;
+    /// Rejects on a transport-level failure (network error, CORS, invalid
+    /// URL, etc.) — the `fetch()` call itself throwing, not an HTTP error
+    /// status (those resolve normally with `status` set).
+    #[wasm_bindgen(catch, js_name = httpFetch)]
+    pub async fn http_fetch(
+        method: &str,
+        url: &str,
+        headers_json: &str,
+        body: &[u8],
+    ) -> Result<JsValue, JsValue>;
 
     // ─── Asset loader bridge (SW → main thread) ───────────────────────────────
 
@@ -89,8 +116,8 @@ extern "C" {
     /// sha256 verification + named-loader init by postMessaging the main
     /// thread (only place where `fetch`, `crypto.subtle`, and JS-level
     /// loaders like ffmpeg.wasm are reachable).
-    #[wasm_bindgen(js_name = loadAsset)]
-    pub async fn load_asset(asset_id: &str, manifest_json: &str) -> JsValue;
+    #[wasm_bindgen(catch, js_name = loadAsset)]
+    pub async fn load_asset(asset_id: &str, manifest_json: &str) -> Result<JsValue, JsValue>;
 
     // ─── LLM bridge ───────────────────────────────────────────────────────────
 
@@ -154,4 +181,94 @@ extern "C" {
     /// Free the page-resident pipeline for `model_id`. Optional.
     #[wasm_bindgen(catch, js_name = embedUnload)]
     pub async fn embed_unload(model_id: &str) -> Result<JsValue, JsValue>;
+}
+
+// ─── Rejection helpers ──────────────────────────────────────────────────────
+//
+// Shared by every call site that awaits one of the `#[wasm_bindgen(catch)]`
+// externs above: turn a rejected `JsValue` (an `Error`, a `DOMException`, or
+// an arbitrary thrown value) into something a typed Rust error can carry,
+// without losing the distinction JS uses to signal specific failure kinds
+// (a `DOMException`'s `.name`, e.g. `"NotFoundError"`, `"QuotaExceededError"`).
+
+/// Human-readable message for a rejected `JsValue`. Prefers `.message`
+/// (present on `Error`/`DOMException`); falls back to the value itself if
+/// it's a bare string, then to its `Debug` representation.
+pub fn describe(err: &JsValue) -> String {
+    if let Ok(msg) = js_sys::Reflect::get(err, &JsValue::from_str("message")) {
+        if let Some(s) = msg.as_string() {
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    if let Some(s) = err.as_string() {
+        return s;
+    }
+    format!("{err:?}")
+}
+
+/// The `.name` property of a rejected `JsValue`, if present. `DOMException`
+/// sets this to a well-known string — callers match on it to map specific
+/// rejection kinds (e.g. `"NotFoundError"`) to typed Rust errors instead of
+/// collapsing every failure into a generic `Internal`/`Other` variant.
+pub fn error_name(err: &JsValue) -> Option<String> {
+    js_sys::Reflect::get(err, &JsValue::from_str("name"))
+        .ok()
+        .and_then(|v| v.as_string())
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::*;
+
+    #[wasm_bindgen_test]
+    fn describe_prefers_message_over_bare_string_fallback() {
+        let obj = Object::new();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("name"),
+            &JsValue::from_str("NotFoundError"),
+        )
+        .unwrap();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("message"),
+            &JsValue::from_str("no such file"),
+        )
+        .unwrap();
+        let val: JsValue = obj.into();
+
+        assert_eq!(describe(&val), "no such file");
+        assert_eq!(error_name(&val).as_deref(), Some("NotFoundError"));
+    }
+
+    #[wasm_bindgen_test]
+    fn describe_falls_back_to_bare_string_when_no_message() {
+        let val = JsValue::from_str("plain rejection reason");
+        assert_eq!(describe(&val), "plain rejection reason");
+        assert_eq!(error_name(&val), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn describe_falls_back_to_debug_repr_for_valueless_object() {
+        // An object with neither `.message` nor being a string itself —
+        // `describe` must not panic, it degrades to the Debug repr.
+        let obj = Object::new();
+        let val: JsValue = obj.into();
+        // Just assert it doesn't panic and returns something non-empty.
+        assert!(!describe(&val).is_empty());
+        assert_eq!(error_name(&val), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn error_name_none_when_name_is_not_a_string() {
+        let obj = Object::new();
+        Reflect::set(&obj, &JsValue::from_str("name"), &JsValue::from_f64(1.0)).unwrap();
+        let val: JsValue = obj.into();
+        assert_eq!(error_name(&val), None);
+    }
 }

--- a/crates/solobase-browser/src/database.rs
+++ b/crates/solobase-browser/src/database.rs
@@ -74,7 +74,9 @@ impl DbExec for BrowserDatabaseService {
             .map_err(|e| DatabaseError::Internal(format!("sql exec: {e:?}")))?;
         // Persist sql.js to OPFS after every mutating statement (INSERT/UPDATE/
         // DELETE and the ALTER TABLE adds from the lazy column-add path).
-        bridge::dbFlush().await;
+        bridge::dbFlush().await.map_err(|e| {
+            DatabaseError::Internal(format!("flush to OPFS: {}", bridge::describe(&e)))
+        })?;
         Ok(parse_rows_modified(&result))
     }
 

--- a/crates/solobase-browser/src/lib.rs
+++ b/crates/solobase-browser/src/lib.rs
@@ -70,7 +70,12 @@ pub use storage::make_storage_service;
 /// `_db` handle inside bridge.js, losing any in-memory state written after
 /// a prior call. Consumers should guard with `is_initialized()` before
 /// calling this on a re-entry path.
+///
+/// Propagates a rejected `dbInit()` promise (sql.js WASM failed to load,
+/// OPFS unavailable, etc.) as `Err` instead of letting it panic the Service
+/// Worker — see `bridge::dbInit`'s `#[wasm_bindgen(catch)]`.
 #[cfg(target_arch = "wasm32")]
-pub async fn db_init() {
-    bridge::dbInit().await;
+pub async fn db_init() -> Result<(), wasm_bindgen::JsValue> {
+    bridge::dbInit().await?;
+    Ok(())
 }

--- a/crates/solobase-browser/src/network.rs
+++ b/crates/solobase-browser/src/network.rs
@@ -35,7 +35,9 @@ impl NetworkService for BrowserNetworkService {
 
         let body_bytes: &[u8] = req.body.as_deref().unwrap_or(&[]);
 
-        let js_val = bridge::http_fetch(&req.method, &req.url, &headers_json, body_bytes).await;
+        let js_val = bridge::http_fetch(&req.method, &req.url, &headers_json, body_bytes)
+            .await
+            .map_err(|e| NetworkError::RequestError(bridge::describe(&e)))?;
 
         // The bridge resolves a JS object `{ status, headers, body:
         // Uint8Array }` — decode it directly. `serde_wasm_bindgen`

--- a/crates/solobase-browser/src/storage.rs
+++ b/crates/solobase-browser/src/storage.rs
@@ -18,30 +18,52 @@ unsafe impl Sync for BrowserStorageService {}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Convert a JsValue returned by a bridge call to a String.
-/// If the value is a JS exception/error, returns Err with the message.
+/// Convert a *resolved* JsValue to a String. Bridge storage calls resolve
+/// either `undefined` (mutating calls with no payload) or a plain/JSON
+/// string. Anything else would mean bridge.js resolved instead of rejected
+/// with something unexpected — surface its message rather than silently
+/// losing it (shares `bridge::describe`'s message extraction with the
+/// rejection path in `await_bridge` below, so both use the same
+/// Error/DOMException `.message` lookup).
 fn jsvalue_to_string(val: wasm_bindgen::JsValue) -> Result<String, StorageError> {
     if val.is_null() || val.is_undefined() {
         return Ok(String::new());
     }
     match val.as_string() {
         Some(s) => Ok(s),
-        None => {
-            // Check if it's an Error object.
-            let msg = js_sys::Reflect::get(&val, &wasm_bindgen::JsValue::from_str("message"))
-                .ok()
-                .and_then(|v| v.as_string())
-                .unwrap_or_else(|| format!("{:?}", val));
-            Err(StorageError::Internal(msg))
-        }
+        None => Err(StorageError::Internal(bridge::describe(&val))),
     }
 }
 
-/// Await a bridge future and convert its JsValue result to a String.
+/// Map a rejected bridge JsValue to a typed `StorageError`. DOMException
+/// `NotFoundError` — thrown by OPFS `getFileHandle`/`getDirectoryHandle`/
+/// `removeEntry` when the requested folder or key doesn't exist — maps to
+/// `StorageError::NotFound`; every other rejection (quota errors,
+/// permission errors, etc.) collapses to `StorageError::Internal` carrying
+/// the JS error's message.
+///
+/// Pulled out as a pure function (rather than inlined in `await_bridge`) so
+/// the DOMException-name mapping can be exercised directly in a
+/// `wasm_bindgen_test` without needing a real OPFS rejection — see the
+/// `tests` module below.
+fn map_rejection(err: wasm_bindgen::JsValue) -> StorageError {
+    if bridge::error_name(&err).as_deref() == Some("NotFoundError") {
+        StorageError::NotFound
+    } else {
+        StorageError::Internal(bridge::describe(&err))
+    }
+}
+
+/// Await a bridge future, mapping a rejected JS promise to a typed
+/// `StorageError` instead of letting wasm-bindgen panic the Service Worker
+/// (the storage externs in `bridge.rs` are `#[wasm_bindgen(catch)]`).
 async fn await_bridge(
-    future: impl std::future::Future<Output = wasm_bindgen::JsValue>,
+    future: impl std::future::Future<Output = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>>,
 ) -> Result<String, StorageError> {
-    jsvalue_to_string(future.await)
+    match future.await {
+        Ok(val) => jsvalue_to_string(val),
+        Err(err) => Err(map_rejection(err)),
+    }
 }
 
 // ─── JSON shapes returned by the bridge ──────────────────────────────────────
@@ -76,11 +98,12 @@ impl StorageService for BrowserStorageService {
     }
 
     async fn get(&self, folder: &str, key: &str) -> Result<(Vec<u8>, ObjectInfo), StorageError> {
+        // `await_bridge` already maps a missing folder/key to
+        // `StorageError::NotFound` via the OPFS `NotFoundError` DOMException
+        // rejection (see its doc comment) — bridge.js's `storageGet` never
+        // resolves an empty string on success, it always resolves a JSON
+        // payload, so there is no separate empty-string case to guard here.
         let json = await_bridge(bridge::storage_get(folder, key)).await?;
-
-        if json.is_empty() {
-            return Err(StorageError::NotFound);
-        }
 
         let resp: GetResponse = serde_json::from_str(&json)
             .map_err(|e| StorageError::Internal(format!("parse error: {e}")))?;
@@ -169,4 +192,87 @@ impl StorageService for BrowserStorageService {
 pub fn make_storage_service(
 ) -> std::sync::Arc<dyn wafer_core::interfaces::storage::service::StorageService> {
     std::sync::Arc::new(BrowserStorageService)
+}
+
+// `bridge::storage_*` are `#[wasm_bindgen(module = "/js/bridge.js")]` externs,
+// so `BrowserStorageService`'s trait methods (which call them through
+// `await_bridge`) can't be exercised outside a real Service Worker/page
+// context — the module path doesn't resolve under `wasm-pack test`. What CAN
+// be verified in isolation — and is exactly what this task's `catch` fix
+// makes reachable for the first time (a rejection used to panic before ever
+// reaching this mapping) — is `map_rejection`: does an OPFS `NotFoundError`
+// DOMException map to `StorageError::NotFound`, and does every other
+// rejection carry its message through as `StorageError::Internal`.
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use js_sys::{Object, Reflect};
+    use wafer_core::interfaces::storage::service::StorageError;
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::{jsvalue_to_string, map_rejection};
+
+    /// Build a JS object shaped like a rejected `DOMException`/`Error`:
+    /// `{ name, message }`. This is exactly what OPFS's
+    /// `getFileHandle`/`getDirectoryHandle`/`removeEntry` reject with when
+    /// the requested folder or key doesn't exist (`name: "NotFoundError"`),
+    /// and what bridge.js's other OPFS calls reject with on any other
+    /// failure (e.g. `name: "QuotaExceededError"`).
+    fn make_dom_exception(name: &str, message: &str) -> JsValue {
+        let obj = Object::new();
+        Reflect::set(&obj, &JsValue::from_str("name"), &JsValue::from_str(name)).unwrap();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("message"),
+            &JsValue::from_str(message),
+        )
+        .unwrap();
+        obj.into()
+    }
+
+    #[wasm_bindgen_test]
+    fn not_found_dom_exception_maps_to_storage_not_found() {
+        let err = make_dom_exception("NotFoundError", "a file or directory could not be found");
+        match map_rejection(err) {
+            StorageError::NotFound => {}
+            other => panic!("expected StorageError::NotFound, got {other:?}"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn other_dom_exception_maps_to_storage_internal_with_message() {
+        let err = make_dom_exception("QuotaExceededError", "the quota has been exceeded");
+        match map_rejection(err) {
+            StorageError::Internal(msg) => {
+                assert_eq!(msg, "the quota has been exceeded");
+            }
+            other => panic!("expected StorageError::Internal, got {other:?}"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn plain_thrown_string_maps_to_storage_internal_via_fallback() {
+        // Not every rejection is an Error/DOMException — a JS caller can
+        // reject/throw a bare string. `describe` falls back to the value
+        // itself when there's no `.message`.
+        let err = JsValue::from_str("boom");
+        match map_rejection(err) {
+            StorageError::Internal(msg) => assert_eq!(msg, "boom"),
+            other => panic!("expected StorageError::Internal, got {other:?}"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn resolved_null_or_undefined_is_empty_string() {
+        assert_eq!(jsvalue_to_string(JsValue::NULL).unwrap(), "");
+        assert_eq!(jsvalue_to_string(JsValue::UNDEFINED).unwrap(), "");
+    }
+
+    #[wasm_bindgen_test]
+    fn resolved_string_passes_through() {
+        assert_eq!(
+            jsvalue_to_string(JsValue::from_str("hello")).unwrap(),
+            "hello"
+        );
+    }
 }

--- a/crates/solobase-browser/src/vector/service.rs
+++ b/crates/solobase-browser/src/vector/service.rs
@@ -87,7 +87,9 @@ impl VectorService for BrowserVectorService {
         for s in stmts {
             bridge::db_exec_raw(&s, "[]").map_err(|e| VectorError::Internal(js_err(e)))?;
         }
-        bridge::dbFlush().await;
+        bridge::dbFlush()
+            .await
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
         self.indexes
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -110,7 +112,9 @@ impl VectorService for BrowserVectorService {
         for s in stmts {
             bridge::db_exec_raw(&s, "[]").map_err(|e| VectorError::Internal(js_err(e)))?;
         }
-        bridge::dbFlush().await;
+        bridge::dbFlush()
+            .await
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
         self.indexes
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -155,7 +159,9 @@ impl VectorService for BrowserVectorService {
             bridge::db_exec_raw(&stmt.sql, &stmt.params_json)
                 .map_err(|e| VectorError::Internal(js_err(e)))?;
         }
-        bridge::dbFlush().await;
+        bridge::dbFlush()
+            .await
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
         Ok(())
     }
 
@@ -295,7 +301,9 @@ impl VectorService for BrowserVectorService {
         for s in stmts {
             bridge::db_exec_raw(&s, &params_json).map_err(|e| VectorError::Internal(js_err(e)))?;
         }
-        bridge::dbFlush().await;
+        bridge::dbFlush()
+            .await
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
         Ok(())
     }
 

--- a/crates/solobase-web/src/lib.rs
+++ b/crates/solobase-web/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn initialize() -> Result<(), JsValue> {
         return Ok(());
     }
 
-    solobase_browser::db_init().await;
+    solobase_browser::db_init().await?;
 
     // ── Phase 1 ─────────────────────────────────────────────────────────────
     // Build the runtime with EMPTY config + EMPTY block_settings + EMPTY

--- a/examples/minimal-browser/src/lib.rs
+++ b/examples/minimal-browser/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn initialize() -> Result<(), JsValue> {
         return Ok(());
     }
 
-    solobase_browser::db_init().await;
+    solobase_browser::db_init().await?;
 
     let cfg_source: std::sync::Arc<dyn wafer_run::ConfigSource> =
         std::sync::Arc::new(wafer_run::StaticConfigSource::default());


### PR DESCRIPTION
## Summary

The async bridge externs in `solobase-browser` (`dbInit`, `dbFlush`,
`storage_put/get/delete/list/create_folder/delete_folder/list_folders`,
`http_fetch`, `load_asset`) were declared `async ... -> JsValue` with no
`#[wasm_bindgen(catch)]`. wasm-bindgen generates `.expect("uncaught
exception")` for non-catch async imports, so any JS promise rejection —
a missing OPFS key (`NotFoundError` DOMException), a fetch network error,
an OPFS quota error on flush — became a Rust **panic** that killed the
in-flight Service-Worker dispatch instead of surfacing as a typed error.

- Added `#[wasm_bindgen(catch)]` + `Result<JsValue, JsValue>` to every
  fallible extern listed above, matching the existing
  `db_exec_raw`/`db_query_raw`/llm/image/embed reference pattern in the
  same file.
- Added two shared rejection-mapping helpers in `bridge.rs`:
  `describe(&JsValue) -> String` (prefers `.message`, falls back to the
  bare string / Debug repr) and `error_name(&JsValue) -> Option<String>`
  (reads `.name`, the property `DOMException` sets to e.g.
  `"NotFoundError"`).
- Mapped rejections at every call site:
  - `storage.rs`: DOMException `NotFoundError` → `StorageError::NotFound`;
    everything else → `StorageError::Internal(message)`. Pulled the
    mapping into a standalone `map_rejection` fn so it's directly
    unit-testable.
  - `network.rs`: `http_fetch` rejection → `NetworkError::RequestError`.
  - `database.rs` / `vector/service.rs`: `dbFlush`/`dbInit` rejection →
    `DatabaseError::Internal` / `VectorError::Internal`.
  - `asset_loader.rs`: `load_asset` rejection → `AssetLoadError::Unknown`.
  - `lib.rs::db_init()` now returns `Result<(), JsValue>`, propagated by
    `solobase-web`'s `initialize()` via `?`.

## SB-11 reconciliation

SB-11 (merged, PR #322) changed `network.rs`'s `do_request` to resolve
`http_fetch` as a JS object and decode it with `serde_wasm_bindgen`. Adding
`catch` makes `http_fetch`'s return type `Result<JsValue, JsValue>`, so
`do_request` now does:

```rust
let js_val = bridge::http_fetch(&req.method, &req.url, &headers_json, body_bytes)
    .await
    .map_err(|e| NetworkError::RequestError(bridge::describe(&e)))?;
```

then decodes the `Ok` value exactly as SB-11 left it — the object-decode
fix is untouched, only the `catch` handling is threaded through it.

## Dead code made live

- `storage.rs`'s old `jsvalue_to_string` had an "Error object" branch that
  extracted `.message` — dead because a rejection used to panic before any
  value (error or otherwise) was ever resolved. That message-extraction is
  now centralized as `bridge::describe`, invoked from the (also newly live)
  rejection path in `map_rejection`.
- The `get()` function's `if json.is_empty() { return Err(StorageError::
  NotFound) }` check turned out to be **unreachable even after the fix**:
  `bridge.js`'s `storageGet` never resolves an empty string on success (it
  always resolves a JSON payload) — it only ever failed by *rejecting*
  with a `NotFoundError` DOMException. I removed that dead check and
  documented why; `NotFound` is now correctly produced by the rejection
  path in `map_rejection`, verified by a `wasm_bindgen_test`.

## Verification

- `cargo build -p solobase-browser --target wasm32-unknown-unknown` — clean.
- `wasm-pack build --target web --release` for `solobase-web` (the CI job) — clean.
- `wasm-pack test --node` (solobase-browser) — 12/12 pass, including 9 new
  tests: `bridge::tests::*` (describe/error_name against constructed
  Error/DOMException-shaped JsValues) and `storage::tests::*`
  (`map_rejection` on a `NotFoundError` DOMException → `StorageError::
  NotFound`, on other DOMExceptions → `Internal(message)`, on a bare thrown
  string → `Internal(message)`; `jsvalue_to_string` on null/undefined/string).
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare`
  (CI's actual clippy invocation, host target, no `--target wasm32`) —
  passes with only pre-existing warnings; solobase-browser's wasm32-gated
  modules (bridge/storage/database/network/asset_loader, all touched here)
  aren't even compiled under a host-target clippy run, so this gate was a
  no-op for the new code either way.
- `cargo clippy -p solobase-browser --target wasm32-unknown-unknown -- -D
  warnings` does fail, but on pre-existing lints in files this PR doesn't
  touch (`convert.rs`, `runtime.rs`, `vector/sql.rs`) — confirmed identical
  on `main` before this change; not a regression.
- `cargo test -p solobase-browser` (host) — 56/56 pass.
- Cargo.lock: touched transiently by local builds (this repo's
  `.cargo/config.toml` local wafer-run patch strips `source = git+...` from
  the lock), reset via `git checkout -- Cargo.lock` before every commit —
  **not part of this PR's diff**.

## Not testable in isolation

`BrowserStorageService`'s trait methods, `do_request`, `db_init`, and
`SwAssetLoader::load` call through `#[wasm_bindgen(module = "/js/bridge.js")]`
externs, so they can't be exercised end-to-end outside a real Service
Worker/page context (the module path doesn't resolve under `wasm-pack
test`) — same limitation SB-11 already documented for `network.rs`. What's
verified instead is the pure rejection-mapping logic each call site
delegates to (`bridge::describe`/`error_name`, `storage::map_rejection`),
which is where the actual typed-error decision lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)