### PR TITLE
fix(browser): hydrate vector index cache on SW restart + idempotent index DDL

### DIFF
--- a/crates/solobase-browser/src/vector/service.rs
+++ b/crates/solobase-browser/src/vector/service.rs
@@ -37,9 +37,21 @@ fn matches_filter(metadata: Option<&serde_json::Value>, filter: &MetadataFilter)
     true
 }
 
-/// Per-index config cached in memory after `create_index`. Persisted via the
-/// `wafer_core::interfaces::vector` block's own registry table; this cache
-/// is hydrated on first use by reading that registry.
+/// Per-index config: cached in memory for the lifetime of this
+/// `BrowserVectorService`, and persisted (`dimensions`/`metric`/
+/// `keyword_search`) in the `sql::REGISTRY_TABLE` table inside the same
+/// sql.js OPFS database that holds the index's own
+/// `_vectors`/`_fts`/`_meta` tables.
+///
+/// Browsers kill idle Service Workers within minutes, and
+/// `BrowserVectorService::new()` always starts with an empty `indexes`
+/// map — so on every SW restart the in-memory cache is cold while the
+/// on-disk tables (and this registry row) survive untouched. `lookup`
+/// treats a cache miss as "maybe just cold, not gone": it hydrates from
+/// the registry row before concluding `IndexNotFound`. `create_index`
+/// writes the row (idempotently, mirroring the `IF NOT EXISTS` index-table
+/// DDL); `delete_index` removes it so a deleted index can't hydrate back
+/// from a stale row.
 #[derive(Clone)]
 struct IndexState {
     dimensions: u32,
@@ -71,22 +83,83 @@ impl BrowserVectorService {
         }
     }
 
-    fn lookup(&self, name: &str) -> Option<IndexState> {
-        self.indexes
+    /// Returns the config for `name`, hydrating from the persisted registry
+    /// row on a cache miss before concluding the index is genuinely absent.
+    /// A miss can mean either "no such index" or "cold cache after a
+    /// Service Worker restart" — see the `IndexState` doc comment.
+    fn lookup(&self, name: &str) -> VResult<Option<IndexState>> {
+        if let Some(state) = self
+            .indexes
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .get(name)
             .cloned()
+        {
+            return Ok(Some(state));
+        }
+        self.hydrate(name)
+    }
+
+    /// Reads `name`'s registry row (if any) and rebuilds it into the
+    /// in-memory cache. Returns `Ok(None)` when there is no such row —
+    /// either the index was never created, or it predates this table
+    /// (unrecoverable; falls back to `IndexNotFound` like a genuinely
+    /// missing index).
+    fn hydrate(&self, name: &str) -> VResult<Option<IndexState>> {
+        // Idempotent — guarantees the table exists so the SELECT below
+        // can't fail with "no such table" on a DB that has never had any
+        // index created in it yet.
+        bridge::db_exec_raw(&sql::build_registry_ddl(), "[]")
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
+
+        let (query, params) = sql::build_registry_select_sql(name);
+        let json =
+            bridge::db_query_raw(&query, &params).map_err(|e| VectorError::Internal(js_err(e)))?;
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&json)
+            .map_err(|e| VectorError::Internal(format!("parse registry row: {e}")))?;
+        let Some(row) = rows.first() else {
+            return Ok(None);
+        };
+        let (dimensions, metric, keyword_search) = sql::parse_registry_row(row)
+            .map_err(|e| VectorError::Internal(format!("registry row for {name:?}: {e}")))?;
+
+        let state = IndexState {
+            dimensions,
+            metric,
+            keyword_search,
+        };
+        self.indexes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(name.to_string(), state.clone());
+        Ok(Some(state))
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl VectorService for BrowserVectorService {
     async fn create_index(&self, config: VectorIndexConfig) -> VResult<()> {
+        // Idempotent — ensures the registry table exists before the upsert
+        // below, on the very first index ever created in this DB.
+        bridge::db_exec_raw(&sql::build_registry_ddl(), "[]")
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
+
         let stmts = sql::build_create_index_sql(&config.name, config.keyword_search);
         for s in stmts {
             bridge::db_exec_raw(&s, "[]").map_err(|e| VectorError::Internal(js_err(e)))?;
         }
+
+        // Persist the config so a future cold cache (post-SW-restart) can
+        // hydrate this index instead of returning `IndexNotFound`.
+        let reg = sql::build_registry_upsert_sql(
+            &config.name,
+            config.dimensions,
+            config.metric,
+            config.keyword_search,
+        );
+        bridge::db_exec_raw(&reg.sql, &reg.params_json)
+            .map_err(|e| VectorError::Internal(js_err(e)))?;
+
         bridge::dbFlush()
             .await
             .map_err(|e| VectorError::Internal(js_err(e)))?;
@@ -106,12 +179,20 @@ impl VectorService for BrowserVectorService {
 
     async fn delete_index(&self, name: &str) -> VResult<()> {
         let state = self
-            .lookup(name)
+            .lookup(name)?
             .ok_or_else(|| VectorError::IndexNotFound(name.into()))?;
         let stmts = sql::build_delete_index_sql(name, state.keyword_search);
         for s in stmts {
             bridge::db_exec_raw(&s, "[]").map_err(|e| VectorError::Internal(js_err(e)))?;
         }
+
+        // Clear the registry row too — otherwise a later `lookup` miss
+        // would hydrate a phantom `IndexState` for tables that no longer
+        // exist, turning what should be `IndexNotFound` into an
+        // `Internal` "no such table" error on the next call.
+        let (del_sql, del_params) = sql::build_registry_delete_sql(name);
+        bridge::db_exec_raw(&del_sql, &del_params).map_err(|e| VectorError::Internal(js_err(e)))?;
+
         bridge::dbFlush()
             .await
             .map_err(|e| VectorError::Internal(js_err(e)))?;
@@ -124,7 +205,7 @@ impl VectorService for BrowserVectorService {
 
     async fn upsert(&self, index: &str, entries: Vec<VectorEntry>) -> VResult<()> {
         let state = self
-            .lookup(index)
+            .lookup(index)?
             .ok_or_else(|| VectorError::IndexNotFound(index.into()))?;
 
         use base64ct::{Base64, Encoding};
@@ -175,7 +256,7 @@ impl VectorService for BrowserVectorService {
         keyword_query: Option<String>,
     ) -> VResult<Vec<VectorMatch>> {
         let state = self
-            .lookup(index)
+            .lookup(index)?
             .ok_or_else(|| VectorError::IndexNotFound(index.into()))?;
 
         let needs_keyword = matches!(mode, SearchMode::Keyword | SearchMode::Hybrid);
@@ -291,7 +372,7 @@ impl VectorService for BrowserVectorService {
 
     async fn delete(&self, index: &str, ids: Vec<String>) -> VResult<()> {
         let state = self
-            .lookup(index)
+            .lookup(index)?
             .ok_or_else(|| VectorError::IndexNotFound(index.into()))?;
         if ids.is_empty() {
             return Ok(());
@@ -308,7 +389,7 @@ impl VectorService for BrowserVectorService {
     }
 
     async fn count(&self, index: &str) -> VResult<u64> {
-        if self.lookup(index).is_none() {
+        if self.lookup(index)?.is_none() {
             return Err(VectorError::IndexNotFound(index.into()));
         }
         let row_json = bridge::db_query_raw(&sql::build_count_sql(index), "[]")

--- a/crates/solobase-browser/src/vector/service.rs
+++ b/crates/solobase-browser/src/vector/service.rs
@@ -49,9 +49,14 @@ fn matches_filter(metadata: Option<&serde_json::Value>, filter: &MetadataFilter)
 /// on-disk tables (and this registry row) survive untouched. `lookup`
 /// treats a cache miss as "maybe just cold, not gone": it hydrates from
 /// the registry row before concluding `IndexNotFound`. `create_index`
-/// writes the row (idempotently, mirroring the `IF NOT EXISTS` index-table
-/// DDL); `delete_index` removes it so a deleted index can't hydrate back
-/// from a stale row.
+/// writes the row idempotently ONLY when there is no existing row or the
+/// existing row's config matches exactly (the SW-restart recovery case,
+/// mirroring the `IF NOT EXISTS` index-table DDL) — a re-create with a
+/// DIFFERENT config is rejected with `VectorError::IndexAlreadyExists`
+/// rather than silently overwritten, since the underlying
+/// `_vectors`/`_meta`/`_fts` tables and their stored rows would otherwise
+/// be left on the old config. `delete_index` removes the row so a deleted
+/// index can't hydrate back from a stale one.
 #[derive(Clone)]
 struct IndexState {
     dimensions: u32,
@@ -112,6 +117,21 @@ impl BrowserVectorService {
         bridge::db_exec_raw(&sql::build_registry_ddl(), "[]")
             .map_err(|e| VectorError::Internal(js_err(e)))?;
 
+        let Some(state) = self.read_registry_row(name)? else {
+            return Ok(None);
+        };
+        self.indexes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(name.to_string(), state.clone());
+        Ok(Some(state))
+    }
+
+    /// Reads and parses `name`'s registry row, without touching the
+    /// in-memory cache. Assumes the registry table already exists (callers
+    /// run `sql::build_registry_ddl()` first). Shared by `hydrate` (cache
+    /// rebuild) and `create_index` (re-create guard).
+    fn read_registry_row(&self, name: &str) -> VResult<Option<IndexState>> {
         let (query, params) = sql::build_registry_select_sql(name);
         let json =
             bridge::db_query_raw(&query, &params).map_err(|e| VectorError::Internal(js_err(e)))?;
@@ -122,27 +142,48 @@ impl BrowserVectorService {
         };
         let (dimensions, metric, keyword_search) = sql::parse_registry_row(row)
             .map_err(|e| VectorError::Internal(format!("registry row for {name:?}: {e}")))?;
-
-        let state = IndexState {
+        Ok(Some(IndexState {
             dimensions,
             metric,
             keyword_search,
-        };
-        self.indexes
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(name.to_string(), state.clone());
-        Ok(Some(state))
+        }))
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl VectorService for BrowserVectorService {
     async fn create_index(&self, config: VectorIndexConfig) -> VResult<()> {
-        // Idempotent — ensures the registry table exists before the upsert
-        // below, on the very first index ever created in this DB.
+        // Idempotent — ensures the registry table exists before the select
+        // and upsert below, on the very first index ever created in this DB.
         bridge::db_exec_raw(&sql::build_registry_ddl(), "[]")
             .map_err(|e| VectorError::Internal(js_err(e)))?;
+
+        // Guard against a silent config-mismatched overwrite: the
+        // `_vectors`/`_meta`/`_fts` DDL below is `IF NOT EXISTS` (idempotent,
+        // to support the SW-restart recovery path — see `IndexState`'s doc
+        // comment), so without this check, re-calling `create_index` for an
+        // EXISTING name with different dimensions/metric/keyword_search
+        // would overwrite the registry row and in-memory cache while
+        // leaving the already-created tables (and any stored rows) on the
+        // old config — bricking the index for subsequent `query`/`upsert`.
+        // Only a genuine name collision (mismatched config) is rejected;
+        // an identical re-create is the legitimate recovery case and must
+        // stay a no-op (matches native's `IndexAlreadyExists` contract for
+        // the collision case, see `wafer-block-sqlite`'s
+        // `create_index_duplicate_fails`).
+        if let Some(existing) = self.read_registry_row(&config.name)? {
+            let existing_tuple = (
+                existing.dimensions,
+                existing.metric,
+                existing.keyword_search,
+            );
+            let incoming_tuple = (config.dimensions, config.metric, config.keyword_search);
+            if sql::classify_registry_conflict(Some(existing_tuple), incoming_tuple)
+                == sql::RegistryConflict::Mismatch
+            {
+                return Err(VectorError::IndexAlreadyExists(config.name));
+            }
+        }
 
         let stmts = sql::build_create_index_sql(&config.name, config.keyword_search);
         for s in stmts {

--- a/crates/solobase-browser/src/vector/sql.rs
+++ b/crates/solobase-browser/src/vector/sql.rs
@@ -2,10 +2,19 @@
 //!
 //! Kept dep-free and side-effect-free so they unit-test on native.
 
+use wafer_core::interfaces::vector::service::DistanceMetric;
+
 /// Returns the DDL statements to create a vector index. Tables:
 /// - `{name}_vectors` — id PK, vector BLOB, metadata TEXT, [text TEXT]
 /// - `{name}_fts` — fts5(id UNINDEXED, text) — only when keyword_search=true
 /// - `{name}_meta` — id PK, rowid INTEGER, metadata TEXT, [text TEXT]
+///
+/// Every statement carries `IF NOT EXISTS`: browsers kill idle Service
+/// Workers within minutes, and the SW's in-memory index cache is rebuilt
+/// from scratch on every restart (see `IndexState` in `service.rs`). A
+/// caller recovering from a cold cache re-calls `create_index` for an index
+/// that may already exist on disk — that must succeed idempotently, not
+/// throw "table already exists".
 pub fn build_create_index_sql(prefixed_name: &str, keyword_search: bool) -> Vec<String> {
     let v = format!("{prefixed_name}_vectors");
     let m = format!("{prefixed_name}_meta");
@@ -13,18 +22,140 @@ pub fn build_create_index_sql(prefixed_name: &str, keyword_search: bool) -> Vec<
     let text_col = if keyword_search { ", text TEXT" } else { "" };
 
     let mut out = vec![format!(
-        r#"CREATE TABLE "{v}" (id TEXT PRIMARY KEY, vector BLOB NOT NULL, metadata TEXT{text_col})"#
+        r#"CREATE TABLE IF NOT EXISTS "{v}" (id TEXT PRIMARY KEY, vector BLOB NOT NULL, metadata TEXT{text_col})"#
     )];
     if keyword_search {
         let f = format!("{prefixed_name}_fts");
         out.push(format!(
-            r#"CREATE VIRTUAL TABLE "{f}" USING fts5(id UNINDEXED, text)"#
+            r#"CREATE VIRTUAL TABLE IF NOT EXISTS "{f}" USING fts5(id UNINDEXED, text)"#
         ));
     }
     out.push(format!(
-        r#"CREATE TABLE "{m}" (id TEXT PRIMARY KEY, rowid INTEGER, metadata TEXT{text_col})"#
+        r#"CREATE TABLE IF NOT EXISTS "{m}" (id TEXT PRIMARY KEY, rowid INTEGER, metadata TEXT{text_col})"#
     ));
     out
+}
+
+// ─── Index config registry ──────────────────────────────────────────────
+//
+// `dimensions`/`metric`/`keyword_search` aren't recoverable from the
+// `_vectors`/`_meta`/`_fts` tables' own schema (the `vector` column is a
+// plain BLOB with no length constraint, and nothing on disk records which
+// distance metric an index was created with). This table is the only
+// record of that config, so `BrowserVectorService::lookup` can hydrate its
+// in-memory cache after a Service Worker restart instead of returning
+// `IndexNotFound` for an index that is still physically on disk.
+
+/// Table that persists per-index config across Service Worker restarts,
+/// inside the same sql.js OPFS database that stores each index's own
+/// `_vectors`/`_fts`/`_meta` tables. Named with a leading/trailing `__` so
+/// it can never collide with a `{prefixed_name}_vectors|_fts|_meta` table —
+/// index names are restricted to `[A-Za-z0-9_]` and none of those suffixes
+/// match this literal name.
+pub const REGISTRY_TABLE: &str = "__vector_index_registry__";
+
+/// Idempotent DDL for the registry table. Safe to run before every write or
+/// hydration read — a warm cache that already created it pays only a no-op
+/// statement.
+pub fn build_registry_ddl() -> String {
+    format!(
+        r#"CREATE TABLE IF NOT EXISTS "{REGISTRY_TABLE}" (name TEXT PRIMARY KEY, dimensions INTEGER NOT NULL, metric TEXT NOT NULL, keyword_search INTEGER NOT NULL)"#
+    )
+}
+
+/// `INSERT OR REPLACE` the config row for `name` — idempotent, matching the
+/// idempotent DDL above, so re-registering an existing index just refreshes
+/// its row instead of erroring.
+pub fn build_registry_upsert_sql(
+    name: &str,
+    dimensions: u32,
+    metric: DistanceMetric,
+    keyword_search: bool,
+) -> PreparedStmt {
+    PreparedStmt {
+        sql: format!(
+            r#"INSERT OR REPLACE INTO "{REGISTRY_TABLE}" (name, dimensions, metric, keyword_search) VALUES (?, ?, ?, ?)"#
+        ),
+        params_json: serde_json::json!([
+            name,
+            dimensions,
+            metric_to_storage_str(metric),
+            keyword_search as i64
+        ])
+        .to_string(),
+    }
+}
+
+/// `(sql, params_json)` to look up one index's persisted config row by name.
+pub fn build_registry_select_sql(name: &str) -> (String, String) {
+    (
+        format!(
+            r#"SELECT dimensions, metric, keyword_search FROM "{REGISTRY_TABLE}" WHERE name = ?"#
+        ),
+        serde_json::json!([name]).to_string(),
+    )
+}
+
+/// `(sql, params_json)` to remove an index's persisted config row.
+pub fn build_registry_delete_sql(name: &str) -> (String, String) {
+    (
+        format!(r#"DELETE FROM "{REGISTRY_TABLE}" WHERE name = ?"#),
+        serde_json::json!([name]).to_string(),
+    )
+}
+
+/// Encodes a [`DistanceMetric`] for the registry `metric` column. A storage
+/// encoding of our own (not the wire JSON one) so it stays legible and
+/// stable regardless of how `wafer_block::wire::vector::DistanceMetric`'s
+/// serde attributes evolve — this string never leaves the browser's own
+/// sql.js database.
+fn metric_to_storage_str(metric: DistanceMetric) -> &'static str {
+    match metric {
+        DistanceMetric::Cosine => "cosine",
+        DistanceMetric::Euclidean => "euclidean",
+        DistanceMetric::DotProduct => "dot_product",
+    }
+}
+
+/// Inverse of [`metric_to_storage_str`]. `None` on anything else — a
+/// registry row with an unrecognized metric string is corrupt, not a
+/// silently-defaulted `Cosine`.
+fn metric_from_storage_str(s: &str) -> Option<DistanceMetric> {
+    match s {
+        "cosine" => Some(DistanceMetric::Cosine),
+        "euclidean" => Some(DistanceMetric::Euclidean),
+        "dot_product" => Some(DistanceMetric::DotProduct),
+        _ => None,
+    }
+}
+
+/// Parses one registry row — a JSON object as returned by `db_query_raw`
+/// for the query built by [`build_registry_select_sql`] (see
+/// `bridge::db_query_raw`'s doc comment for the row-object JSON shape) —
+/// into `(dimensions, metric, keyword_search)`.
+///
+/// Pulled out of `service.rs` (which is wasm32-only, since it calls the
+/// `bridge` extern functions) so the row-shape parsing — including its
+/// error paths — is unit-testable on native without a real sql.js/OPFS
+/// backing store.
+pub fn parse_registry_row(row: &serde_json::Value) -> Result<(u32, DistanceMetric, bool), String> {
+    let dimensions = row
+        .get("dimensions")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| "registry row missing/non-numeric dimensions".to_string())?
+        as u32;
+    let metric_str = row
+        .get("metric")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "registry row missing/non-string metric".to_string())?;
+    let metric = metric_from_storage_str(metric_str)
+        .ok_or_else(|| format!("registry row has unknown metric {metric_str:?}"))?;
+    let keyword_search = row
+        .get("keyword_search")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| "registry row missing/non-numeric keyword_search".to_string())?
+        != 0;
+    Ok((dimensions, metric, keyword_search))
 }
 
 pub fn build_delete_index_sql(prefixed_name: &str, keyword_search: bool) -> Vec<String> {
@@ -181,16 +312,33 @@ mod tests {
     fn create_index_with_keyword_emits_three_tables() {
         let sqls = build_create_index_sql("suppers_ai__vector__docs", true);
         assert_eq!(sqls.len(), 3);
-        assert!(sqls[0].contains(r#"CREATE TABLE "suppers_ai__vector__docs_vectors""#));
+        assert!(
+            sqls[0].contains(r#"CREATE TABLE IF NOT EXISTS "suppers_ai__vector__docs_vectors""#)
+        );
         assert!(sqls[0].contains("vector BLOB"));
         assert!(sqls[0].contains("text TEXT"));
-        assert!(sqls[1].contains(r#"CREATE VIRTUAL TABLE "suppers_ai__vector__docs_fts""#));
+        assert!(sqls[1]
+            .contains(r#"CREATE VIRTUAL TABLE IF NOT EXISTS "suppers_ai__vector__docs_fts""#));
         assert!(sqls[1].contains("USING fts5(id UNINDEXED, text)"));
-        assert!(sqls[2].contains(r#"CREATE TABLE "suppers_ai__vector__docs_meta""#));
+        assert!(sqls[2].contains(r#"CREATE TABLE IF NOT EXISTS "suppers_ai__vector__docs_meta""#));
         assert!(
             sqls[2].contains("text TEXT"),
             "expected _meta to include text column when keyword_search=true"
         );
+    }
+
+    #[test]
+    fn create_index_sql_is_idempotent() {
+        // Re-registering an existing index after a Service Worker restart
+        // (the cache-cold recovery path) must not throw "table already
+        // exists" — every DDL statement needs IF NOT EXISTS.
+        for keyword_search in [true, false] {
+            let sqls = build_create_index_sql("idx", keyword_search);
+            assert!(
+                sqls.iter().all(|s| s.contains("IF NOT EXISTS")),
+                "every create-index statement must be idempotent (keyword_search={keyword_search}): {sqls:?}"
+            );
+        }
     }
 
     #[test]
@@ -314,5 +462,126 @@ mod tests {
         let stmts = build_upsert_sql_stmts("suppers_ai__vector__docs", false, &[entry]);
         assert_eq!(stmts.len(), 2);
         assert!(!stmts.iter().any(|s| s.sql.contains("_fts")));
+    }
+
+    // ─── Registry (hydration persistence) ───────────────────────────────
+
+    #[test]
+    fn registry_ddl_is_idempotent_and_targets_registry_table() {
+        let sql = build_registry_ddl();
+        assert!(sql.contains("IF NOT EXISTS"));
+        assert!(sql.contains(REGISTRY_TABLE));
+        assert!(sql.contains("dimensions INTEGER NOT NULL"));
+        assert!(sql.contains("metric TEXT NOT NULL"));
+        assert!(sql.contains("keyword_search INTEGER NOT NULL"));
+    }
+
+    #[test]
+    fn registry_upsert_uses_or_replace_and_binds_all_fields() {
+        let stmt = build_registry_upsert_sql(
+            "suppers_ai__vector__docs",
+            384,
+            DistanceMetric::Cosine,
+            true,
+        );
+        assert!(stmt.sql.contains("INSERT OR REPLACE INTO"));
+        assert!(stmt.sql.contains(REGISTRY_TABLE));
+        let params: serde_json::Value = serde_json::from_str(&stmt.params_json).unwrap();
+        assert_eq!(
+            params,
+            serde_json::json!(["suppers_ai__vector__docs", 384, "cosine", 1])
+        );
+    }
+
+    #[test]
+    fn registry_upsert_encodes_keyword_search_false_as_zero() {
+        let stmt = build_registry_upsert_sql("idx", 3, DistanceMetric::Euclidean, false);
+        let params: serde_json::Value = serde_json::from_str(&stmt.params_json).unwrap();
+        assert_eq!(params, serde_json::json!(["idx", 3, "euclidean", 0]));
+    }
+
+    #[test]
+    fn registry_select_targets_name_and_registry_table() {
+        let (sql, params) = build_registry_select_sql("idx");
+        assert!(sql.contains(REGISTRY_TABLE));
+        assert!(sql.contains("WHERE name = ?"));
+        assert_eq!(params, serde_json::json!(["idx"]).to_string());
+    }
+
+    #[test]
+    fn registry_delete_targets_name_and_registry_table() {
+        let (sql, params) = build_registry_delete_sql("idx");
+        assert!(sql.starts_with("DELETE FROM"));
+        assert!(sql.contains(REGISTRY_TABLE));
+        assert_eq!(params, serde_json::json!(["idx"]).to_string());
+    }
+
+    #[test]
+    fn metric_storage_encoding_roundtrips_for_every_variant() {
+        for metric in [
+            DistanceMetric::Cosine,
+            DistanceMetric::Euclidean,
+            DistanceMetric::DotProduct,
+        ] {
+            let s = metric_to_storage_str(metric);
+            assert_eq!(
+                metric_from_storage_str(s),
+                Some(metric),
+                "storage encoding for {metric:?} must round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn metric_from_storage_str_rejects_unknown_values() {
+        assert_eq!(metric_from_storage_str("manhattan"), None);
+        assert_eq!(metric_from_storage_str(""), None);
+        // Must not silently accept the wire JSON encoding of DotProduct
+        // (serde's `rename_all = "lowercase"` would collapse it to
+        // "dotproduct") — the registry format is deliberately its own.
+        assert_eq!(metric_from_storage_str("dotproduct"), None);
+    }
+
+    #[test]
+    fn parse_registry_row_happy_path() {
+        let row = serde_json::json!({ "dimensions": 384, "metric": "cosine", "keyword_search": 1 });
+        let (dims, metric, kw) = parse_registry_row(&row).expect("valid row parses");
+        assert_eq!(dims, 384);
+        assert_eq!(metric, DistanceMetric::Cosine);
+        assert!(kw);
+    }
+
+    #[test]
+    fn parse_registry_row_keyword_search_zero_is_false() {
+        let row =
+            serde_json::json!({ "dimensions": 3, "metric": "dot_product", "keyword_search": 0 });
+        let (_, metric, kw) = parse_registry_row(&row).expect("valid row parses");
+        assert_eq!(metric, DistanceMetric::DotProduct);
+        assert!(!kw);
+    }
+
+    #[test]
+    fn parse_registry_row_rejects_missing_dimensions() {
+        let row = serde_json::json!({ "metric": "cosine", "keyword_search": 0 });
+        assert!(parse_registry_row(&row).is_err());
+    }
+
+    #[test]
+    fn parse_registry_row_rejects_missing_metric() {
+        let row = serde_json::json!({ "dimensions": 3, "keyword_search": 0 });
+        assert!(parse_registry_row(&row).is_err());
+    }
+
+    #[test]
+    fn parse_registry_row_rejects_unknown_metric() {
+        let row =
+            serde_json::json!({ "dimensions": 3, "metric": "manhattan", "keyword_search": 0 });
+        assert!(parse_registry_row(&row).is_err());
+    }
+
+    #[test]
+    fn parse_registry_row_rejects_missing_keyword_search() {
+        let row = serde_json::json!({ "dimensions": 3, "metric": "cosine" });
+        assert!(parse_registry_row(&row).is_err());
     }
 }

--- a/crates/solobase-browser/src/vector/sql.rs
+++ b/crates/solobase-browser/src/vector/sql.rs
@@ -1,6 +1,8 @@
 //! Pure SQL-string and BLOB-packing helpers for `BrowserVectorService`.
 //!
-//! Kept dep-free and side-effect-free so they unit-test on native.
+//! Side-effect-free and native-testable: no `wasm_bindgen`/browser-bridge
+//! calls here, so these unit-test on native even though the module imports
+//! `wafer_core::interfaces::vector::service::DistanceMetric`.
 
 use wafer_core::interfaces::vector::service::DistanceMetric;
 
@@ -102,6 +104,46 @@ pub fn build_registry_delete_sql(name: &str) -> (String, String) {
         format!(r#"DELETE FROM "{REGISTRY_TABLE}" WHERE name = ?"#),
         serde_json::json!([name]).to_string(),
     )
+}
+
+/// Outcome of comparing an existing registry row's config (if any) against
+/// an incoming `create_index` request's config for the same index name.
+/// `BrowserVectorService::create_index` uses this to decide whether to
+/// proceed (write the registry row + run the idempotent DDL), silently
+/// no-op (the legitimate SW-restart recovery case: the same config was
+/// already registered), or fail with `VectorError::IndexAlreadyExists` —
+/// matching the native `wafer-block-sqlite` backend's contract for a
+/// genuine name collision (`create_index_duplicate_fails`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistryConflict {
+    /// No existing row for this name — a genuine create.
+    New,
+    /// An existing row's config exactly matches the incoming request — the
+    /// SW-restart recovery case. Safe to no-op (re-running the idempotent
+    /// DDL and re-writing the identical row is harmless).
+    IdenticalNoOp,
+    /// An existing row's config differs in dimensions, metric, or
+    /// keyword_search. A real name collision: silently overwriting the
+    /// registry row here would leave the `_vectors`/`_meta` tables (and
+    /// their already-stored rows) out of sync with the new config, so this
+    /// must be rejected rather than applied.
+    Mismatch,
+}
+
+/// Classifies a `create_index(name, incoming)` call against `name`'s
+/// existing registry row, if any. Both config tuples are
+/// `(dimensions, metric, keyword_search)`. `DistanceMetric` is a discrete
+/// enum (`Cosine`/`Euclidean`/`DotProduct`), not a float, so this
+/// comparison is exact equality — no epsilon/rounding ambiguity.
+pub fn classify_registry_conflict(
+    existing: Option<(u32, DistanceMetric, bool)>,
+    incoming: (u32, DistanceMetric, bool),
+) -> RegistryConflict {
+    match existing {
+        None => RegistryConflict::New,
+        Some(e) if e == incoming => RegistryConflict::IdenticalNoOp,
+        Some(_) => RegistryConflict::Mismatch,
+    }
 }
 
 /// Encodes a [`DistanceMetric`] for the registry `metric` column. A storage
@@ -514,6 +556,58 @@ mod tests {
         assert!(sql.starts_with("DELETE FROM"));
         assert!(sql.contains(REGISTRY_TABLE));
         assert_eq!(params, serde_json::json!(["idx"]).to_string());
+    }
+
+    // ─── create_index re-create guard (registry conflict classification) ──
+
+    #[test]
+    fn classify_registry_conflict_no_existing_row_is_new() {
+        let incoming = (384, DistanceMetric::Cosine, false);
+        assert_eq!(
+            classify_registry_conflict(None, incoming),
+            RegistryConflict::New
+        );
+    }
+
+    #[test]
+    fn classify_registry_conflict_identical_config_is_idempotent_noop() {
+        // The SW-restart recovery case: re-registering the exact same
+        // config after a cold cache must not error.
+        let cfg = (384, DistanceMetric::Cosine, true);
+        assert_eq!(
+            classify_registry_conflict(Some(cfg), cfg),
+            RegistryConflict::IdenticalNoOp
+        );
+    }
+
+    #[test]
+    fn classify_registry_conflict_different_dimensions_is_mismatch() {
+        let existing = (384, DistanceMetric::Cosine, false);
+        let incoming = (768, DistanceMetric::Cosine, false);
+        assert_eq!(
+            classify_registry_conflict(Some(existing), incoming),
+            RegistryConflict::Mismatch
+        );
+    }
+
+    #[test]
+    fn classify_registry_conflict_different_metric_is_mismatch() {
+        let existing = (384, DistanceMetric::Cosine, false);
+        let incoming = (384, DistanceMetric::Euclidean, false);
+        assert_eq!(
+            classify_registry_conflict(Some(existing), incoming),
+            RegistryConflict::Mismatch
+        );
+    }
+
+    #[test]
+    fn classify_registry_conflict_different_keyword_search_is_mismatch() {
+        let existing = (384, DistanceMetric::Cosine, false);
+        let incoming = (384, DistanceMetric::Cosine, true);
+        assert_eq!(
+            classify_registry_conflict(Some(existing), incoming),
+            RegistryConflict::Mismatch
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**SB-10 (P2, final task):** `BrowserVectorService`'s in-memory `indexes` map was written only by `create_index` and read only by `lookup`, while solobase-web constructs a fresh (empty) service at every Service Worker boot. Browsers kill idle SWs within minutes — after which every `upsert`/`query`/`delete`/`count` on a pre-existing index returned `IndexNotFound` despite the data being on disk in OPFS. Recovery via re-calling `create_index` also failed because the DDL lacked `IF NOT EXISTS`.

- **Idempotent DDL** (`sql.rs::build_create_index_sql`): every `CREATE TABLE`/`CREATE VIRTUAL TABLE` statement now carries `IF NOT EXISTS`, so re-registering an existing index (the recovery path) succeeds instead of throwing "table already exists".
- **Persisted registry** (`sql.rs`, new): added a `__vector_index_registry__` table (own idempotent DDL) that persists each index's `dimensions`/`metric`/`keyword_search` — none of which are recoverable from the `_vectors`/`_meta`/`_fts` tables' own schema (the `vector` column is a plain `BLOB` with no length constraint, and nothing on disk records the distance metric). Uses its own storage encoding for `DistanceMetric` (not the wire JSON one).
- **Hydrate-on-miss** (`service.rs`): `create_index` now writes the registry row after creating the index tables; `delete_index` removes it (otherwise a later `lookup` would hydrate a phantom `IndexState` for dropped tables). `lookup` treats a cache miss as "maybe just cold, not gone": it hydrates from the registry row before falling back to `IndexNotFound`.
- **Doc fix**: `IndexState`'s doc comment falsely claimed hydration-on-first-use already existed via "the `wafer_core::interfaces::vector` block's own registry table" — no such table/module exists. Rewrote it to describe the actual mechanism.
- New db calls (registry DDL/upsert/select/delete) all go through the SB-9 `catch`-returning bridge externs and are `map_err`'d into `VectorError::Internal`, mirroring every existing call site in the file.

## Test plan

- [x] 14 new native unit tests in `sql.rs` (DDL idempotency, registry SQL builders, `DistanceMetric` storage-encoding round-trip, and registry-row JSON parsing incl. every error path) — `cargo test -p solobase-browser --lib`: 70 passed, 0 failed.
- [x] `cargo +nightly fmt --all -- --check` clean.
- [x] `cargo build -p solobase-browser --target wasm32-unknown-unknown` clean.
- [x] `wasm-pack build --target web --release` (the exact `build-wasm` CI job) clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` (the exact CI clippy job) — no new warnings/errors from the touched files.
- [x] Cargo.lock not in diff.
- [ ] Not tested: a genuine wasm-bindgen-test exercising the real bridge-backed hydration flow. `js/bridge.js`'s `dbInit`/`dbFlush` hard-depend on OPFS (`navigator.storage`, unavailable under Node) and a `/vendor/sql-wasm-esm.js` static import (unavailable without a real dev-server-backed browser context) — this crate has no existing DB-backed `wasm-bindgen-test` to extend (only `bridge.rs`'s pure `JsValue`-manipulation tests currently run under `wasm-pack test --node`). Verified the hydration logic instead via the native unit tests on the pure row-parsing/SQL-building seam plus a manual trace of the full `create_index` → SW-restart → `lookup`/`hydrate` → `upsert` scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)