### PR TITLE
refactor(admin): migrate email settings to shared save_settings helper

### DIFF
--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -1,112 +1,49 @@
-use maud::{html, Markup, PreEscaped};
-use wafer_core::clients::config;
-use wafer_run::{context::Context, InputStream, Message, OutputStream};
+use maud::Markup;
+use wafer_run::{context::Context, ConfigVar, InputStream, Message, OutputStream};
 
 use crate::{
-    blocks::email::DEFAULT_MAILGUN_BASE_URL,
-    http::{err_bad_request, err_internal, ok_json},
-    ui::icons,
+    blocks::email,
+    config_vars,
+    ui::{
+        icons,
+        settings_form::{self, SettingsSection},
+    },
 };
 
-/// One row in the Mailgun settings form. Was a positional 5-tuple
-/// `(key, label, help, default, sensitive)` — names make the call site
-/// readable and let future fields land without re-counting tuple positions.
-struct EmailSettingField {
-    key: &'static str,
-    label: &'static str,
-    help: &'static str,
-    default: &'static str,
-    sensitive: bool,
-}
-
-const EMAIL_SETTINGS_KEYS: &[EmailSettingField] = &[
-    EmailSettingField {
-        key: "SUPPERS_AI__EMAIL__MAILGUN_API_KEY",
-        label: "Mailgun API Key",
-        help: "API key from your Mailgun account.",
-        default: "",
-        sensitive: true,
-    },
-    EmailSettingField {
-        key: "SUPPERS_AI__EMAIL__MAILGUN_DOMAIN",
-        label: "Mailgun Domain",
-        help: "Sending domain configured in Mailgun (e.g. mg.example.com).",
-        default: "",
-        sensitive: false,
-    },
-    EmailSettingField {
-        key: "SUPPERS_AI__EMAIL__MAILGUN_FROM",
-        label: "From Address",
-        help: "Sender address for emails. Leave empty for default (noreply@domain).",
-        default: "",
-        sensitive: false,
-    },
-    EmailSettingField {
-        key: "SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO",
-        label: "Reply-To Address",
-        help: "Reply-to address for emails. Leave empty to omit.",
-        default: "",
-        sensitive: false,
-    },
-    EmailSettingField {
-        key: "SUPPERS_AI__EMAIL__MAILGUN_BASE_URL",
-        label: "Mailgun Base URL",
-        help: "API base URL. Leave empty for US (https://api.mailgun.net); use https://api.eu.mailgun.net for EU accounts.",
-        default: DEFAULT_MAILGUN_BASE_URL,
-        sensitive: false,
-    },
+/// The Mailgun settings surfaced on the admin Email settings tab — a named
+/// subset of `email::config_vars()` (the block's canonical declarations; the
+/// block also declares rate-limit + allowed-recipient vars that aren't
+/// editable from this page). Selected by key via `config_vars::var_in` so
+/// this page never re-declares label/default/input_type/sensitivity in a
+/// parallel table — the `ConfigVar` in `blocks/email.rs` is the single
+/// source of truth, shared with `BlockInfo::config_keys` and the admin
+/// Variables page.
+const MAILGUN_KEYS: &[&str] = &[
+    "SUPPERS_AI__EMAIL__MAILGUN_API_KEY",
+    "SUPPERS_AI__EMAIL__MAILGUN_DOMAIN",
+    "SUPPERS_AI__EMAIL__MAILGUN_FROM",
+    "SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO",
+    "SUPPERS_AI__EMAIL__MAILGUN_BASE_URL",
 ];
 
-/// Render JUST the email settings form body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell.
-pub async fn settings_body(ctx: &dyn Context, _msg: &Message) -> Markup {
-    let mut values: Vec<(&EmailSettingField, String)> = Vec::new();
-    for field in EMAIL_SETTINGS_KEYS {
-        let value = config::get_default(ctx, field.key, field.default).await;
-        values.push((field, value));
-    }
-
-    html! {
-        h3 style="font-size:1rem;font-weight:600;margin:0 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)" {
-            (icons::globe()) " Mailgun Configuration"
-        }
-
-        @for (field, value) in &values {
-            div .form-group style="margin-bottom:1.25rem" {
-                label .form-label for=(field.key) { (field.label) }
-                @if field.sensitive {
-                    div style="display:flex;align-items:center;gap:0.5rem" {
-                        input .form-input #(field.key) name=(field.key) type="password" value=(value)
-                            placeholder=(if value.is_empty() { "Not configured" } else { "******** (set)" })
-                            style="flex:1";
-                        button type="button" .btn .btn-ghost .btn-sm
-                            onclick={"var i=document.getElementById('" (field.key) "');i.type=i.type==='password'?'text':'password'"}
-                        { (icons::eye()) }
-                    }
-                } @else {
-                    input .form-input #(field.key) name=(field.key) type="text" value=(value) placeholder=(field.default);
-                }
-                p .text-muted style="font-size:0.8rem;margin-top:0.25rem" { (field.help) }
-            }
-        }
-
-        script { (PreEscaped(r#"
-function submitEmailSettings(e) {
-    e.preventDefault();
-    var form = document.getElementById('settings-form');
-    var data = {};
-    form.querySelectorAll('input[name]').forEach(function(el) { data[el.name] = el.value; });
-    var btn = form.querySelector('button[type="submit"]');
-    btn.disabled = true; btn.textContent = 'Saving...';
-    fetch('/b/admin/email', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
-    .then(function(r) { return r.json(); })
-    .then(function(d) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: d.message || 'Saved', type: d.error ? 'error' : 'success' } })); })
-    .catch(function(err) { document.body.dispatchEvent(new CustomEvent('showToast', { detail: { message: 'Error: ' + err.message, type: 'error' } })); })
-    .finally(function() { btn.disabled = false; btn.textContent = 'Save'; });
-    return false;
+fn mailgun_vars() -> Vec<ConfigVar> {
+    let own = email::config_vars();
+    MAILGUN_KEYS
+        .iter()
+        .map(|key| config_vars::var_in(&own, key))
+        .collect()
 }
-"#)) }
-    }
+
+/// Render JUST the email settings form body. The parent `settings_page`
+/// handler wraps this in `form_page` + the shell — `form_page` supplies the
+/// page's one `<form>` element and its "Save" button, so this renders fields
+/// only via `settings_form::render_sections` (not the full self-contained
+/// `settings_form::settings_form`, which would nest a second `<form>` inside
+/// that one; see `render_sections`' doc comment).
+pub async fn settings_body(ctx: &dyn Context, _msg: &Message) -> Markup {
+    let vars = mailgun_vars();
+    let section = SettingsSection::new("Mailgun Configuration", icons::globe(), &vars);
+    settings_form::render_sections(ctx, &[section]).await
 }
 
 pub async fn handle_save_email_settings(
@@ -114,27 +51,12 @@ pub async fn handle_save_email_settings(
     _msg: &Message,
     input: InputStream,
 ) -> OutputStream {
-    let bytes = input.collect_to_bytes().await;
-    let body: std::collections::HashMap<String, String> = match serde_json::from_slice(&bytes) {
-        Ok(b) => b,
-        Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
-    };
-    for field in EMAIL_SETTINGS_KEYS {
-        if let Some(value) = body.get(field.key) {
-            // Surface the first write failure instead of reporting a false
-            // "saved" — the page JS renders a success toast unless the
-            // response is an error (see `submitEmailSettings` above), so a
-            // swallowed error here silently drops Mailgun config changes.
-            if let Err(e) = config::set(ctx, field.key, value).await {
-                return err_internal("Failed to save email settings", e);
-            }
-        }
-    }
-    ok_json(&serde_json::json!({"message": "Email settings saved"}))
+    settings_form::save_settings(ctx, input, &mailgun_vars(), "email").await
 }
 
 #[cfg(test)]
 mod tests {
+    use wafer_core::clients::config;
     use wafer_run::{streams::output::TerminalNotResponse, InputStream};
 
     use super::*;
@@ -153,8 +75,10 @@ mod tests {
         // `config::set` call fails with NotFound (mirrors
         // `save_settings_surfaces_config_set_failure` in `ui/settings_form.rs`,
         // the established way this test infra exercises a config::set
-        // failure). Before the fix, the save loop swallowed the error via
-        // `let _ = config::set(...)` and returned success anyway.
+        // failure). Before the SB-1 fix, the save loop swallowed the error via
+        // `let _ = config::set(...)` and returned success anyway; the shared
+        // `settings_form::save_settings` helper this now delegates to carries
+        // the same fix.
         let ctx = TestContext::new().await;
         let msg = anon_msg("create", "/b/admin/email");
         let input = InputStream::from_bytes(serde_json::to_vec(&email_body()).unwrap());
@@ -182,10 +106,71 @@ mod tests {
         let out = handle_save_email_settings(&ctx, &msg, input).await;
         let body = output_json(out).await;
 
-        assert_eq!(body["message"], "Email settings saved");
+        // Generic message from the shared `settings_form::save_settings` —
+        // every block using the shared helper reports the same wording (see
+        // `ui/settings_form.rs`'s own `save_settings_*` tests); no block-name
+        // string to preserve here since the old hand-rolled handler's
+        // "Email settings saved" was itself just a hardcoded literal, not
+        // something the page JS branches on (it only checks `d.error`).
+        assert_eq!(body["message"], "Settings saved");
 
         // The value was actually persisted, not just reported as saved.
         let stored = config::get_default(&ctx, "SUPPERS_AI__EMAIL__MAILGUN_API_KEY", "").await;
         assert_eq!(stored, "key-123");
+    }
+
+    #[tokio::test]
+    async fn settings_body_masks_a_stored_mailgun_api_key() {
+        // SEC-060: the Mailgun API key is a `ConfigVar` with
+        // `InputType::Password` (declared once in `blocks::email::config_vars`
+        // and picked up here via `config_vars::var_in`) — `render_sections`
+        // must render it exactly like every other shared-helper password
+        // field: `type="password"` (visually masked, not plaintext), the eye
+        // toggle to reveal/edit it, and the "(set)" placeholder rather than
+        // "Not configured" once a value exists. This matches the old
+        // hand-rolled field's behavior byte-for-byte (both it and the shared
+        // `render_field` populate the input's `value=` attribute so the
+        // existing key can be edited in place — masking is visual/toggle-based,
+        // not source-redaction; see `settings_form.rs`'s own
+        // `password_field_is_masked_with_eye_toggle_...` test for the same
+        // contract).
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SUPPERS_AI__EMAIL__MAILGUN_API_KEY", "super-secret-value");
+        let msg = anon_msg("retrieve", "/b/admin/settings/email");
+
+        let html = settings_body(&ctx, &msg).await.into_string();
+
+        assert!(
+            html.contains(r#"type="password""#),
+            "the API key field must render as a masked password input: {html}"
+        );
+        assert!(
+            html.contains("i.type=i.type==='password'?'text':'password'"),
+            "the reveal/edit eye toggle must be present: {html}"
+        );
+        assert!(
+            html.contains("(set)"),
+            "a configured secret shows the '(set)' placeholder: {html}"
+        );
+        assert!(
+            !html.contains("Not configured"),
+            "a configured secret must not show the empty-state placeholder: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn settings_body_renders_mailgun_base_url_default_placeholder() {
+        // The base-URL field keeps its documented default-as-placeholder
+        // behavior (was `field.default` in the old hand-rolled render; now
+        // sourced from the same `ConfigVar.default` the block declares).
+        let ctx = TestContext::new().await;
+        let msg = anon_msg("retrieve", "/b/admin/settings/email");
+
+        let html = settings_body(&ctx, &msg).await.into_string();
+
+        assert!(
+            html.contains(email::DEFAULT_MAILGUN_BASE_URL),
+            "unset base URL should show the default as a placeholder: {html}"
+        );
     }
 }

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -44,6 +44,79 @@ pub(crate) fn resolve_base_url(configured: &str) -> &str {
     }
 }
 
+/// The email block's own declared config vars. Single source of truth for
+/// both `BlockInfo::config_keys` and the admin Email settings page (rendered
+/// via `ui::settings_form`, not a parallel `EmailSettingField` tuple table —
+/// see `blocks/admin/pages/email.rs`, which selects the Mailgun subset by key
+/// via `config_vars::var_in` rather than re-declaring these).
+pub(crate) fn config_vars() -> Vec<ConfigVar> {
+    vec![
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__MAILGUN_API_KEY",
+            "API key from your Mailgun account.",
+            "",
+        )
+        .name("Mailgun API Key")
+        .input_type(InputType::Password)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__MAILGUN_DOMAIN",
+            "Sending domain configured in Mailgun (e.g. mg.example.com).",
+            "",
+        )
+        .name("Mailgun Domain")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__MAILGUN_FROM",
+            "Sender address for emails. Leave empty for default (noreply@domain).",
+            "",
+        )
+        .name("From Address")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO",
+            "Reply-to address for emails. Leave empty to omit.",
+            "",
+        )
+        .name("Reply-To Address")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__MAILGUN_BASE_URL",
+            "Mailgun API base URL (US: https://api.mailgun.net, EU: https://api.eu.mailgun.net)",
+            DEFAULT_MAILGUN_BASE_URL,
+        )
+        .name("Mailgun Base URL")
+        // A real URL field (unlike the shared helper's other optional/blank
+        // text fields) — SEC/SSRF: mark it `Url` so `settings_form::save_settings`
+        // runs it through `validate_url_value` on write. The old hand-rolled
+        // admin save loop never validated this field at all.
+        .input_type(InputType::Url)
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__RATE_LIMIT_MAX",
+            "Maximum emails per caller per window (0 disables rate limiting)",
+            &DEFAULT_RATE_LIMIT_MAX.to_string(),
+        )
+        .name("Rate Limit (max emails)")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__RATE_LIMIT_WINDOW_SECS",
+            "Rate limit window in seconds",
+            &DEFAULT_RATE_LIMIT_WINDOW_SECS.to_string(),
+        )
+        .name("Rate Limit Window (seconds)")
+        .optional(),
+        ConfigVar::new(
+            "SUPPERS_AI__EMAIL__ALLOWED_RECIPIENT_PATTERNS",
+            "Comma-separated allow-list of recipient glob patterns (e.g. \
+             `*@example.com,admin@*`). Empty = allow all (with startup warning).",
+            "",
+        )
+        .name("Allowed Recipient Patterns")
+        .optional(),
+    ]
+}
+
 crate::solobase_feature_block! {
     /// Email sending via the Mailgun HTTP API (`suppers-ai/email`).
     pub struct EmailBlock;
@@ -55,50 +128,7 @@ crate::solobase_feature_block! {
             .requires(vec!["wafer-run/network".into(), "wafer-run/config".into()])
             .category(wafer_run::BlockCategory::Service)
             .description("Email sending service via Mailgun HTTP API. Supports raw email sending and templated emails for verification, password reset, welcome messages, and payment notifications. Used internally by the auth block for email verification and password reset flows.")
-            .config_keys(vec![
-                ConfigVar::new("SUPPERS_AI__EMAIL__MAILGUN_API_KEY", "Mailgun API key", "")
-                    .name("Mailgun API Key")
-                    .input_type(InputType::Password)
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__EMAIL__MAILGUN_DOMAIN", "Mailgun sending domain", "")
-                    .name("Mailgun Domain")
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__EMAIL__MAILGUN_FROM", "From address for emails", "")
-                    .name("From Address")
-                    .optional(),
-                ConfigVar::new("SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO", "Reply-to address", "")
-                    .name("Reply-To Address")
-                    .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__EMAIL__MAILGUN_BASE_URL",
-                    "Mailgun API base URL (US: https://api.mailgun.net, EU: https://api.eu.mailgun.net)",
-                    DEFAULT_MAILGUN_BASE_URL,
-                )
-                .name("Mailgun Base URL")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__EMAIL__RATE_LIMIT_MAX",
-                    "Maximum emails per caller per window (0 disables rate limiting)",
-                    &DEFAULT_RATE_LIMIT_MAX.to_string(),
-                )
-                .name("Rate Limit (max emails)")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__EMAIL__RATE_LIMIT_WINDOW_SECS",
-                    "Rate limit window in seconds",
-                    &DEFAULT_RATE_LIMIT_WINDOW_SECS.to_string(),
-                )
-                .name("Rate Limit Window (seconds)")
-                .optional(),
-                ConfigVar::new(
-                    "SUPPERS_AI__EMAIL__ALLOWED_RECIPIENT_PATTERNS",
-                    "Comma-separated allow-list of recipient glob patterns (e.g. \
-                     `*@example.com,admin@*`). Empty = allow all (with startup warning).",
-                    "",
-                )
-                .name("Allowed Recipient Patterns")
-                .optional(),
-            ])
+            .config_keys(config_vars())
     },
     handle: |this, ctx, msg, input| {
         match msg.kind.as_str() {

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -171,6 +171,37 @@ function submitSettings(e) {{
     )
 }
 
+/// Render just the field groups for each [`SettingsSection`] — a heading
+/// plus its inputs, values loaded from the config client — with NO enclosing
+/// `<form>`, submit button, or submit script.
+///
+/// Most callers want the full self-contained form ([`settings_form`], which
+/// is a thin wrapper around this). This lower-level entry point is for a
+/// caller that already lives inside another `<form>` element it doesn't own
+/// — e.g. `blocks/admin/pages/email.rs`, embedded in the admin Settings-tab
+/// shell's own `<form>` (`ui::templates::form_page`). HTML forms can't
+/// nest — a second literal `<form>` there would have its start tag silently
+/// dropped by the browser's parser and its close tag would prematurely close
+/// the outer one — so that caller renders fields only and leaves form/submit
+/// ownership to its host.
+pub async fn render_sections(ctx: &dyn Context, sections: &[SettingsSection<'_>]) -> Markup {
+    let values = load_values(ctx, sections).await;
+    let empty = String::new();
+    html! {
+        @for (i, section) in sections.iter().enumerate() {
+            h3 style=(format!(
+                "font-size:1rem;font-weight:600;margin:{} 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)",
+                if i == 0 { "0" } else { "1.5rem" }
+            )) {
+                (section.icon) " " (section.title)
+            }
+            @for var in section.vars {
+                (render_field(var, values.get(&var.key).unwrap_or(&empty)))
+            }
+        }
+    }
+}
+
 /// Render the full ConfigVar-driven settings form: a `#settings-form` posting
 /// JSON to `post_url`, with one titled section per [`SettingsSection`], a
 /// "Save Settings" button, and the shared submit snippet. Current values are
@@ -185,21 +216,10 @@ pub async fn settings_form(
     sections: &[SettingsSection<'_>],
     extra: Markup,
 ) -> Markup {
-    let values = load_values(ctx, sections).await;
-    let empty = String::new();
+    let fields = render_sections(ctx, sections).await;
     html! {
         form #settings-form onsubmit="return submitSettings(event)" {
-            @for (i, section) in sections.iter().enumerate() {
-                h3 style=(format!(
-                    "font-size:1rem;font-weight:600;margin:{} 0 1rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border-color)",
-                    if i == 0 { "0" } else { "1.5rem" }
-                )) {
-                    (section.icon) " " (section.title)
-                }
-                @for var in section.vars {
-                    (render_field(var, values.get(&var.key).unwrap_or(&empty)))
-                }
-            }
+            (fields)
             (extra)
             button .btn .btn-primary type="submit" style="margin-top:1rem" { "Save Settings" }
         }


### PR DESCRIPTION
## Summary
- Migrates `blocks/admin/pages/email.rs` off its hand-rolled `EmailSettingField` tuple table + bespoke save loop/render path onto the shared, `ConfigVar`-driven `ui::settings_form::save_settings` (plus a new `render_sections` — see below).
- Extracts the email block's Mailgun `ConfigVar`s into `blocks::email::config_vars()` (matching the existing `products`/`legalpages` pattern), so the admin page selects the same declarations via `config_vars::var_in` instead of re-declaring them in a parallel table.
- Preserves the SB-1 error-propagation fix (a failed `config::set` still surfaces as an error, not a false "saved") and sensitive-field masking (Password input type, eye toggle, `(set)` placeholder) byte-for-byte.
- Closes a latent gap as a side effect: `MAILGUN_BASE_URL` is now declared `InputType::Url`, so it gets the same SSRF/HTTPS validation every other URL `ConfigVar` already gets via `save_settings` — the old hand-rolled loop never validated it.

## What the shared helper covered vs. what email.rs needed
Investigated both files fully before touching anything (per the task brief). The shared helper (`ui/settings_form.rs`) already expresses everything email.rs needed:
- **Fields**: all 5 Mailgun keys were already declared as `ConfigVar`s on the block (just inline in the macro, not extracted) — extracted them the same way `products`/`legalpages` already do.
- **Sensitive masking (SEC-060)**: `render_field`'s `Password` arm produces the exact same masked-input + eye-toggle + `(set)`-placeholder markup the old hand-rolled field had.
- **Default-URL placeholders**: identical mechanic (`placeholder=(var.default)`), same default value.
- **Error propagation**: `save_settings` already had the SB-1 fix (first `config::set` failure returns an error, doesn't swallow).

One genuine pre-existing, **out-of-scope** issue surfaced during investigation: the admin Settings-tab shell (`admin/pages/settings.rs` + `ui/templates::form_page`) wraps every tab body (email/network/variables/permissions) in one shared outer `<form>`. Calling the shared helper's full `settings_form()` (which renders its own `<form id="settings-form">`) there would nest a second literal `<form>` inside that outer one — invalid HTML that browsers silently mangle (verified empirically: the inner form's start tag is dropped, and its end tag prematurely closes the *outer* form, orphaning whatever follows). This turns out to be a pre-existing bug affecting more than email (the Variables tab's "Add Variable" modal has the same issue) — the browser "Save" button on the admin Email settings tab doesn't currently persist anything either way. Rather than fix that shared, cross-tab shell here (out of scope, bigger blast radius) or make it worse (a second broken nested form + duplicate button), I factored a new `settings_form::render_sections()` out of `settings_form()` — same `ConfigVar`-driven field rendering, no enclosing `<form>`/button/script — and had `email.rs` use that. `settings_form()` itself is now a thin wrapper around `render_sections()`, so legalpages/products (which own their own top-level page, not nested in another form) are unaffected. Full writeup in the task report.

## Test plan
- [x] `cargo test -p solobase-core admin` — 76 unit tests + all admin/extra-route integration tests pass, incl. the SB-1 `save_email_settings_reports_failure_when_a_write_fails`-equivalent and the happy-path test (message assertion updated to the shared helper's generic `"Settings saved"`), plus 2 new tests: sensitive-field masking on render, and default-URL placeholder rendering.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — 34 test binaries, 0 failures.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — no new warnings (verified none point at the 3 changed files).
- [x] `Cargo.lock` not touched in the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)