### PR TITLE
fix(admin): remove nested <form> in Settings shell so tab Save/Add persists

### DIFF
--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -34,16 +34,18 @@ fn mailgun_vars() -> Vec<ConfigVar> {
         .collect()
 }
 
-/// Render JUST the email settings form body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell — `form_page` supplies the
-/// page's one `<form>` element and its "Save" button, so this renders fields
-/// only via `settings_form::render_sections` (not the full self-contained
-/// `settings_form::settings_form`, which would nest a second `<form>` inside
-/// that one; see `render_sections`' doc comment).
+/// Render the email settings tab body. The parent `settings_page` handler
+/// wraps this in the form-LESS `tabbed_page` shell, so this tab owns its
+/// `<form>` outright: the full self-contained `settings_form` (its own
+/// `<form id="settings-form">` + "Save Settings" button), posting JSON via
+/// fetch to `POST /b/admin/email` — the `SaveEmailSettings` route that
+/// [`handle_save_email_settings`] serves. Same pattern as every other
+/// block's admin settings page (products / userportal / legalpages /
+/// auth_ui).
 pub async fn settings_body(ctx: &dyn Context, _msg: &Message) -> Markup {
     let vars = mailgun_vars();
     let section = SettingsSection::new("Mailgun Configuration", icons::globe(), &vars);
-    settings_form::render_sections(ctx, &[section]).await
+    settings_form::settings_form(ctx, "/b/admin/email", &[section], maud::html! {}).await
 }
 
 pub async fn handle_save_email_settings(

--- a/crates/solobase-core/src/blocks/admin/pages/network.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/network.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 /// Render JUST the network monitoring body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell.
+/// handler wraps this in the form-less `tabbed_page` shell. This tab is
+/// read-only monitoring — it renders no `<form>` and has nothing to save.
 pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
     html! {
         div .filter-bar style="margin-bottom:0.5rem" {

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -8,7 +8,10 @@ use crate::{
 };
 
 /// Render JUST the permissions settings body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell.
+/// handler wraps this in the form-less `tabbed_page` shell — the
+/// "Database & Config" subtab's Add-Grant modal renders its own
+/// `<form hx-post="/b/admin/grants/rules">`, which is only valid because
+/// the shell contributes no outer `<form>` to nest in.
 ///
 /// Internal sub-tabs use `?subtab=database|all` to avoid colliding with
 /// the parent path-segment tab system (`/settings/{tab}`).

--- a/crates/solobase-core/src/blocks/admin/pages/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/settings.rs
@@ -1,4 +1,14 @@
-//! Consolidated settings page — wraps each tab's body in `form_page`.
+//! Consolidated settings page — wraps each tab's body in the form-LESS
+//! `tabbed_page` shell (tab rail + section chrome, no outer `<form>`).
+//!
+//! Each tab owns its submission story: email renders the self-contained
+//! `settings_form` (posts JSON to `POST /b/admin/email`), variables and
+//! permissions render htmx modal forms (`POST /b/admin/variables`,
+//! `POST /b/admin/grants/rules`), and network is read-only. The shell must
+//! never wrap these in an outer `<form>` — HTML forms cannot nest, and the
+//! browser drops a nested form's start tag, silently breaking the tab's
+//! Save/Add (see the `tabbed_page` docs and the tests below).
+//!
 //! Routes:
 //!   /b/admin/settings              → 308 redirect to /b/admin/settings/email
 //!   /b/admin/settings/email        → email::settings_body
@@ -11,7 +21,7 @@ use wafer_run::{context::Context, Message, OutputStream};
 use super::{admin_page, crumb, email, network, permissions, variables};
 use crate::ui::{
     shell::Topbar,
-    templates::{form_page, FormSection, PageHeader},
+    templates::{tabbed_page, FormSection, PageHeader},
     SiteConfig, UserInfo,
 };
 
@@ -60,21 +70,18 @@ pub async fn settings_page(ctx: &dyn Context, msg: &Message, tab: &str) -> Outpu
         _ => email::settings_body(ctx, msg).await,
     };
 
-    let form_body = form_page(
+    let form_body = tabbed_page(
         PageHeader {
             title: "",
             subtitle: None,
             primary_action: None,
         },
-        Some(tabs),
+        tabs,
         vec![FormSection {
             title: tab_title(active),
             description: tab_description(active),
             body: body_markup,
         }],
-        &format!("/b/admin/settings/{}", active),
-        "post",
-        "Save",
     );
 
     admin_page(
@@ -118,6 +125,125 @@ fn tab_description(active: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{admin_msg, output_html, TestContext};
+
+    /// Maximum `<form>` nesting depth in `html`. HTML forms cannot nest —
+    /// a browser drops a nested `<form>` start tag entirely (its
+    /// `action`/`hx-*` attributes vanish and its inputs join the outer
+    /// form), so any depth > 1 means a tab's Save/Add is broken.
+    fn max_form_nesting_depth(html: &str) -> usize {
+        let b = html.as_bytes();
+        let (mut depth, mut max, mut i) = (0usize, 0usize, 0usize);
+        while i < b.len() {
+            if b[i..].starts_with(b"</form>") {
+                depth = depth.saturating_sub(1);
+                i += "</form>".len();
+            } else if b[i..].starts_with(b"<form")
+                && matches!(b.get(i + 5), Some(b' ') | Some(b'>'))
+            {
+                depth += 1;
+                max = max.max(depth);
+                i += "<form".len();
+            } else {
+                i += 1;
+            }
+        }
+        max
+    }
+
+    /// Number of `<form` start tags in `html`.
+    fn count_forms(html: &str) -> usize {
+        html.match_indices("<form").count()
+    }
+
+    /// Every settings page render for a signed-in admin carries exactly one
+    /// page-chrome form — the sidebar profile menu's logout form. Each
+    /// assertion below is relative to it.
+    const CHROME_FORMS: usize = 1;
+
+    async fn render_tab(tab: &str) -> String {
+        let ctx = TestContext::new().await;
+        let msg = admin_msg("retrieve", &format!("/b/admin/settings/{tab}"));
+        output_html(settings_page(&ctx, &msg, tab).await).await
+    }
+
+    #[tokio::test]
+    async fn no_settings_tab_renders_nested_forms() {
+        for tab in ["email", "network", "variables", "permissions"] {
+            let html = render_tab(tab).await;
+            assert_eq!(
+                max_form_nesting_depth(&html),
+                1,
+                "tab {tab} must not nest <form> elements"
+            );
+            assert!(
+                !html.contains("<form class=\"form-page\""),
+                "tab {tab}: the settings shell must not wrap tab bodies in an outer <form>"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn email_tab_owns_its_form_and_posts_to_the_email_save_handler() {
+        let html = render_tab("email").await;
+        assert_eq!(
+            count_forms(&html),
+            CHROME_FORMS + 1,
+            "email tab renders exactly one tab-owned form"
+        );
+        assert!(
+            html.contains("id=\"settings-form\""),
+            "email tab must render the self-contained settings form: {html}"
+        );
+        assert!(
+            html.contains("fetch(\"/b/admin/email\""),
+            "email form must post to the SaveEmailSettings route (/b/admin/email), \
+             which parses the JSON body it sends: {html}"
+        );
+        assert!(
+            html.contains("type=\"submit\""),
+            "email form must have a submit control"
+        );
+    }
+
+    #[tokio::test]
+    async fn variables_tab_add_variable_modal_form_is_present_and_not_nested() {
+        let html = render_tab("variables").await;
+        assert_eq!(max_form_nesting_depth(&html), 1);
+        assert!(
+            html.contains("hx-post=\"/b/admin/variables\""),
+            "Add Variable modal form must target the CreateVariable route: {html}"
+        );
+        assert!(
+            html.contains("type=\"submit\""),
+            "Add Variable modal must have a submit control"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_tab_renders_no_form_of_its_own() {
+        let html = render_tab("network").await;
+        // The network tab is read-only monitoring — nothing to save, so no
+        // tab-owned form (and therefore no dead "Save" button) at all.
+        assert_eq!(
+            count_forms(&html),
+            CHROME_FORMS,
+            "network tab must not render any form: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn permissions_database_subtab_grant_modal_form_is_not_nested() {
+        let ctx = TestContext::new().await;
+        let mut msg = admin_msg("retrieve", "/b/admin/settings/permissions");
+        msg.set_meta("req.query.subtab", "database");
+        let html = output_html(settings_page(&ctx, &msg, "permissions").await).await;
+        assert_eq!(max_form_nesting_depth(&html), 1);
+        assert!(
+            html.contains("hx-post=\"/b/admin/grants/rules\""),
+            "Add Grant modal form must target the CreateWrapGrant route: {html}"
+        );
+    }
 
     #[test]
     fn tab_title_known_tabs() {

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 
 /// Render JUST the variables settings body. The parent `settings_page`
-/// handler wraps this in `form_page` + the shell.
+/// handler wraps this in the form-less `tabbed_page` shell — this body's
+/// Add-Variable modal renders its own `<form hx-post="/b/admin/variables">`
+/// (and the htmx-loaded edit modal its own `<form hx-put=...>`), which is
+/// only valid because the shell contributes no outer `<form>` to nest in.
 pub async fn settings_body(ctx: &dyn Context, msg: &Message) -> Markup {
     let tab = msg.query("tab");
     let active_tab = if tab == "all" { "all" } else { "blocks" };

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -175,15 +175,16 @@ function submitSettings(e) {{
 /// plus its inputs, values loaded from the config client — with NO enclosing
 /// `<form>`, submit button, or submit script.
 ///
-/// Most callers want the full self-contained form ([`settings_form`], which
-/// is a thin wrapper around this). This lower-level entry point is for a
-/// caller that already lives inside another `<form>` element it doesn't own
-/// — e.g. `blocks/admin/pages/email.rs`, embedded in the admin Settings-tab
-/// shell's own `<form>` (`ui::templates::form_page`). HTML forms can't
-/// nest — a second literal `<form>` there would have its start tag silently
-/// dropped by the browser's parser and its close tag would prematurely close
-/// the outer one — so that caller renders fields only and leaves form/submit
-/// ownership to its host.
+/// Callers want the full self-contained form ([`settings_form`], which is a
+/// thin wrapper around this). This lower-level entry point exists for a
+/// caller that already lives inside another `<form>` element it doesn't own:
+/// HTML forms can't nest — a second literal `<form>` there would have its
+/// start tag silently dropped by the browser's parser and its close tag
+/// would prematurely close the outer one — so such a caller renders fields
+/// only and leaves form/submit ownership to its host. (The admin Settings
+/// shell used to be such a host; it's form-less now — `ui::templates::
+/// tabbed_page` — precisely so every tab can render a complete
+/// [`settings_form`] instead.)
 pub async fn render_sections(ctx: &dyn Context, sections: &[SettingsSection<'_>]) -> Markup {
     let values = load_values(ctx, sections).await;
     let empty = String::new();

--- a/crates/solobase-core/src/ui/templates.rs
+++ b/crates/solobase-core/src/ui/templates.rs
@@ -115,10 +115,51 @@ pub struct FormSection<'a> {
     pub body: Markup,
 }
 
+/// Shared tab-rail + sections chrome used by [`form_page`] and
+/// [`tabbed_page`] — the `.form-grid` with an optional `.form-tabs` left
+/// rail and the `.form-sections` column.
+fn form_grid(tabs: Option<Vec<(String, String, bool)>>, sections: Vec<FormSection<'_>>) -> Markup {
+    let has_tabs = tabs.is_some();
+    html! {
+        div .(if has_tabs { "form-grid form-grid--with-tabs" } else { "form-grid" }) {
+            @if let Some(t) = tabs {
+                nav .form-tabs aria-label="Form sections" {
+                    ul {
+                        @for (label, href, active) in t {
+                            li .(if active { "is-active" } else { "" }) {
+                                a href=(href) aria-current=[active.then_some("page")] { (label) }
+                            }
+                        }
+                    }
+                }
+            }
+            div .form-sections {
+                @for sec in sections {
+                    section .form-section {
+                        header .form-section__head {
+                            h2 .form-section__title { (sec.title) }
+                            @if let Some(d) = sec.description {
+                                p .form-section__desc { (d) }
+                            }
+                        }
+                        div .form-section__body { (sec.body) }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// `form_page` template.
 ///
-/// `tabs` is an optional left-rail of section anchors (used by the admin
-/// Settings consolidation in Phase 3). Pass `None` for a single-column form.
+/// The whole page is ONE `<form>` posting to `submit_url`, with a sticky
+/// save bar. Section bodies therefore must not contain `<form>` elements of
+/// their own (HTML forms cannot nest — the browser drops a nested form's
+/// start tag). For a tabbed shell whose tab bodies own their forms, use
+/// [`tabbed_page`] instead.
+///
+/// `tabs` is an optional left-rail of section anchors. Pass `None` for a
+/// single-column form.
 pub fn form_page(
     header: PageHeader<'_>,
     tabs: Option<Vec<(String, String, bool)>>, // (label, href, is_active)
@@ -127,40 +168,40 @@ pub fn form_page(
     method: &str,
     save_label: &str,
 ) -> Markup {
-    let has_tabs = tabs.is_some();
     html! {
         div .page .page--form {
             (render_header(&header))
             form .form-page action=(submit_url) method=(method) {
-                div .(if has_tabs { "form-grid form-grid--with-tabs" } else { "form-grid" }) {
-                    @if let Some(t) = tabs {
-                        nav .form-tabs aria-label="Form sections" {
-                            ul {
-                                @for (label, href, active) in t {
-                                    li .(if active { "is-active" } else { "" }) {
-                                        a href=(href) aria-current=[active.then_some("page")] { (label) }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    div .form-sections {
-                        @for sec in sections {
-                            section .form-section {
-                                header .form-section__head {
-                                    h2 .form-section__title { (sec.title) }
-                                    @if let Some(d) = sec.description {
-                                        p .form-section__desc { (d) }
-                                    }
-                                }
-                                div .form-section__body { (sec.body) }
-                            }
-                        }
-                    }
-                }
+                (form_grid(tabs, sections))
                 footer .form-bar {
                     button type="submit" .btn .btn--primary .btn--md { (save_label) }
                 }
+            }
+        }
+    }
+}
+
+/// `tabbed_page` template — the same tab-rail + section chrome as
+/// [`form_page`], but form-LESS: a `div.form-page` instead of the outer
+/// `<form>`, and no sticky save bar.
+///
+/// For tabbed shells whose tab bodies own their submission story. HTML forms
+/// cannot nest, so a shell that wraps tab bodies in a `<form>` silently
+/// breaks any `<form>` a tab renders — the browser drops the inner form's
+/// start tag, its `action`/`hx-*` attributes vanish, and its inputs (and
+/// submit button) join the outer form. With this shell each tab renders its
+/// own complete `<form>` + submit control (or none, for read-only tabs).
+/// Used by the admin Settings page.
+pub fn tabbed_page(
+    header: PageHeader<'_>,
+    tabs: Vec<(String, String, bool)>, // (label, href, is_active)
+    sections: Vec<FormSection<'_>>,
+) -> Markup {
+    html! {
+        div .page .page--form {
+            (render_header(&header))
+            div .form-page {
+                (form_grid(Some(tabs), sections))
             }
         }
     }


### PR DESCRIPTION
## Problem

The admin Settings shell (`settings_page`) wrapped every tab body in `form_page`'s outer `<form action="/b/admin/settings/{tab}" method="post">` + sticky Save bar. Two compounding defects, one source:

1. **Nested forms.** HTML forms cannot nest — the parser drops a nested `<form>` start tag (in document parsing AND in htmx `innerHTML` fragment parsing when the context element has a form ancestor), so the inner form's `action`/`hx-*` attributes vanish and its submit buttons submit the outer form instead.
2. **The outer Save was a no-op on every tab.** `POST /b/admin/settings/{tab}` routes to `AdminRoute::SettingsPage` — a pure re-render. No save handler exists at that URL; email's real handler is `POST /b/admin/email` and parses JSON, not a urlencoded native POST.

## Per-tab diagnosis (pre-fix)

| Tab | Nested form? | Broken? |
|---|---|---|
| email | no (post-SB-1 fields-only body) | **YES** — Save posted urlencoded to a page-renderer route; values silently discarded |
| network | no | Save button dead weight (read-only tab); htmx Refresh/Load-more buttons (default `type=submit`) also fired native POSTs of the useless outer form |
| variables | **YES** (Add-Variable modal `hx-post="/b/admin/variables"`; rendered nesting depth 2) | **YES** — Create submitted the outer form; variable never created. htmx-loaded Edit modal (`hx-put`) equally broken via fragment parsing |
| permissions | **YES** on `?subtab=database` (Add-Grant modal `hx-post="/b/admin/grants/rules"`; depth 2) | **YES** — Add Grant broken the same way |

## Fix (root cause: the shell must not own a form)

- `ui/templates.rs`: factor the tab/section chrome into private `form_grid()`; add **`tabbed_page()`** — same `.form-page`/`.form-grid--with-tabs` chrome as `form_page` but a `div` instead of `<form>` and no save bar. `form_page` is behaviorally unchanged (grep shows settings was its only runtime caller; its unit tests still pass).
- `settings.rs`: compose `tabbed_page`; each tab owns its submission story.
- `email.rs`: tab body now renders the full self-contained `settings_form` (own `<form id="settings-form">` + Save Settings, fetch-JSON POST to `/b/admin/email` → `SaveEmailSettings` → the existing JSON `save_settings` handler) — the exact pattern products/userportal/legalpages/auth_ui settings pages already use.
- variables/permissions needed no rewiring: un-nesting makes their existing modal forms valid (`hx-post="/b/admin/variables"` → `CreateVariable`, `hx-put="/b/admin/variables/{key}"` → `UpdateVariable`, `hx-post="/b/admin/grants/rules"` → `CreateWrapGrant`). network is read-only and now renders no form (and no dead Save button).

## Verification

- **5 new server-side rendering tests** (real `TestContext`, full `settings_page` render per tab, byte-level `<form>` nesting scanner): no tab nests forms (max depth 1), shell emits no `<form class="form-page">`, email's form posts to the real handler route with a submit control, Variables/Add-Grant modal forms present un-nested, network renders no tab-owned form. **All 5 fail against the pre-fix code** (variables/permissions measured depth 2) **and pass after.**
- Gates: `cargo +nightly fmt --all -- --check` clean; clippy (workspace minus solobase-web/cloudflare) — no new warnings; `cargo test -p solobase-core admin` 99 passed; full workspace suite green. Cargo.lock untouched.
- Playwright E2E skipped: the rendering test deterministically pins the markup contract the browser parser acts on, and the email save path is the identical `settings_form`+`save_settings` code four other blocks already run (persistence covered by existing unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WLLHawRn5HnCn6CfFZxoq