### PR TITLE
fix(admin): server-redact secrets in shared settings form (SEC-060) + unchanged-secret guard

### DIFF
--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -27,30 +27,26 @@ use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 
 use super::{logs::audit_log, settings::VARIABLES_TABLE, ROLES_TABLE, USER_ROLES_TABLE};
-use crate::{
-    blocks::auth::USERS_TABLE,
-    http::{err_bad_request, err_forbidden, err_internal, err_not_found},
-    util::RecordExt,
-};
-
-/// Masked placeholder shown in place of a sensitive value.
-pub(super) const MASKED_VALUE: &str = "********";
-
-/// SEC-060: a config value is sensitive when the row's `sensitive` flag is set
-/// **or** the key follows the `_SECRET` / `_KEY` suffix convention. Both
-/// surfaces (JSON `handle_list*` and the SSR variable tables) must agree on
-/// this — masking on the flag alone leaked a `*_SECRET` value whenever an admin
-/// forgot to flip the flag. This is the single source of truth for that rule.
-pub(super) fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
-    sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
-}
-
 /// SSRF URL validator for `InputType::Url` writes. The single implementation
 /// lives in [`crate::util::validate_url_value`]; re-exported here so the admin
 /// variable create/update paths and the generic settings form
 /// (`ui::settings_form::save_settings`) validate through the exact same impl and
 /// can't diverge on what a URL value is allowed to be.
 pub(super) use crate::util::validate_url_value;
+/// `MASKED_VALUE` / `is_sensitive_key`: the single source of truth lives in
+/// [`crate::util`] so the generic ConfigVar-driven settings form
+/// (`ui::settings_form`) can share it too — masking on a DB `sensitive` flag
+/// (or `InputType::Password`) alone leaked a `*_SECRET`/`*_KEY` value
+/// whenever a var/row wasn't explicitly marked. Both surfaces (JSON
+/// `handle_list*`, the SSR variable tables, and the shared settings form)
+/// must agree on this rule; re-exported here so existing `ops::`-qualified
+/// call sites in this module tree keep working.
+pub(super) use crate::util::{is_sensitive_key, MASKED_VALUE};
+use crate::{
+    blocks::auth::USERS_TABLE,
+    http::{err_bad_request, err_forbidden, err_internal, err_not_found},
+    util::RecordExt,
+};
 
 /// Bulk-fetch the roles assigned to each of `user_ids` in a single `In`-filter
 /// query, bucketed back into a `user_id -> [role]` map.
@@ -431,22 +427,14 @@ pub(super) async fn update_variable(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn is_sensitive_key_honors_flag_and_suffix() {
-        // Flag set → sensitive regardless of name.
-        assert!(is_sensitive_key("PLAIN", 1));
-        // SEC-060: suffix makes it sensitive even when the flag is clear.
-        assert!(is_sensitive_key("STRIPE_SECRET", 0));
-        assert!(is_sensitive_key("JWT_KEY", 0));
-        // Neither flag nor suffix → not sensitive.
-        assert!(!is_sensitive_key("SITE_NAME", 0));
-    }
+    // `is_sensitive_key_honors_flag_and_suffix` lives in `crate::util`'s test
+    // module now, alongside the function it tests (moved when
+    // `is_sensitive_key`/`MASKED_VALUE` were promoted to the shared
+    // single-source location — see the doc comment on the re-export above).
 
     // --- End-to-end regression tests for the security drifts this module
     // closes. They run the ops functions against the real DatabaseBlock (via
     // TestContext) so they exercise the same statements both surfaces now share.
-
     use crate::test_support::{admin_msg, TestContext};
 
     /// Assert an ops call succeeded. `OutputStream` (the `Err` arm) isn't

--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -129,19 +129,22 @@ mod tests {
         // must render it exactly like every other shared-helper password
         // field: `type="password"` (visually masked, not plaintext), the eye
         // toggle to reveal/edit it, and the "(set)" placeholder rather than
-        // "Not configured" once a value exists. This matches the old
-        // hand-rolled field's behavior byte-for-byte (both it and the shared
-        // `render_field` populate the input's `value=` attribute so the
-        // existing key can be edited in place — masking is visual/toggle-based,
-        // not source-redaction; see `settings_form.rs`'s own
-        // `password_field_is_masked_with_eye_toggle_...` test for the same
-        // contract).
+        // "Not configured" once a value exists. Masking is now
+        // source-redaction, not just visual: the raw value must never appear
+        // in the rendered HTML at all (previously it sat in the `value=`
+        // attribute in plaintext, readable via page source / devtools — see
+        // `settings_form.rs`'s own `password_field_is_masked_with_eye_toggle_
+        // and_never_echoes_the_raw_value` test for the same contract).
         let mut ctx = TestContext::new().await;
         ctx.set_config("SUPPERS_AI__EMAIL__MAILGUN_API_KEY", "super-secret-value");
         let msg = anon_msg("retrieve", "/b/admin/settings/email");
 
         let html = settings_body(&ctx, &msg).await.into_string();
 
+        assert!(
+            !html.contains("super-secret-value"),
+            "the raw API key must never reach the rendered HTML: {html}"
+        );
         assert!(
             html.contains(r#"type="password""#),
             "the API key field must render as a masked password input: {html}"

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -26,7 +26,7 @@ pub use wafer_run::{ConfigVar, InputType};
 
 use crate::{
     http::{err_bad_request, err_internal, ok_json},
-    util::validate_url_value,
+    util::{is_sensitive_key, validate_url_value, MASKED_VALUE},
 };
 
 /// One titled group of settings within a form (e.g. "Stripe", "OAuth Providers").
@@ -71,6 +71,20 @@ fn render_field(var: &ConfigVar, value: &str) -> Markup {
     } else {
         var.name.as_str()
     };
+    // SEC-060: a sensitive field's raw value must never reach the rendered
+    // HTML — masking it only via `type="password"` still leaves the secret
+    // readable in page source / devtools. `is_sensitive_key` is the single
+    // source of truth shared with the admin Variables page
+    // (`blocks::admin::ops::is_sensitive_key`, re-exported from
+    // `crate::util`): sensitive when the var declares `InputType::Password`
+    // *or* its key follows the `_SECRET`/`_KEY` suffix convention, so a var
+    // left on the default `Text` widget by mistake still gets redacted.
+    // `has_value` is captured from the real value (presence only, never its
+    // content) so the placeholder can still distinguish "configured" from
+    // "not configured" without ever exposing the secret itself.
+    let is_sensitive = is_sensitive_key(&var.key, var.is_sensitive() as i64);
+    let has_value = !value.is_empty();
+    let value = if is_sensitive { "" } else { value };
     match var.input_type {
         InputType::Toggle => html! {
             div .form-group style="margin-bottom:1.25rem" {
@@ -86,7 +100,6 @@ fn render_field(var: &ConfigVar, value: &str) -> Markup {
             }
         },
         InputType::Password => {
-            let has_value = !value.is_empty();
             html! {
                 div .form-group style="margin-bottom:1.25rem" {
                     label .form-label for=(var.key) { (label) }
@@ -259,12 +272,27 @@ pub async fn save_settings(
         }
     }
     for var in allowed {
-        if let Some(value) = body.get(&var.key) {
-            // Surface the first write failure instead of reporting a false
-            // "saved" — htmx clients branch on the status, not a 200 body.
-            if let Err(e) = config::set(ctx, &var.key, value).await {
-                return err_internal(&format!("Failed to save {block_label} settings"), e);
-            }
+        let Some(value) = body.get(&var.key) else {
+            continue;
+        };
+        // SEC-060: `render_field` never echoes a sensitive var's real value
+        // back into the DOM (it renders empty + a placeholder instead), so
+        // when the admin re-submits the form without retyping the secret the
+        // browser posts back either an empty string or — if some client
+        // literally round-trips the placeholder — the `MASKED_VALUE` mask
+        // itself. Neither is a real value; treat both as "leave the stored
+        // secret alone" instead of overwriting it with blank/mask bytes.
+        // Only a genuinely retyped value reaches `config::set`. Uses the
+        // same single-sourced `is_sensitive_key` rule as the render path so
+        // the two can't disagree on which fields this guard applies to.
+        let is_sensitive = is_sensitive_key(&var.key, var.is_sensitive() as i64);
+        if is_sensitive && (value.is_empty() || value == MASKED_VALUE) {
+            continue;
+        }
+        // Surface the first write failure instead of reporting a false
+        // "saved" — htmx clients branch on the status, not a 200 body.
+        if let Err(e) = config::set(ctx, &var.key, value).await {
+            return err_internal(&format!("Failed to save {block_label} settings"), e);
         }
     }
     ok_json(&serde_json::json!({"message": "Settings saved"}))
@@ -292,16 +320,47 @@ mod tests {
     }
 
     #[test]
-    fn password_field_is_masked_with_eye_toggle_and_no_value_echoed_when_empty() {
+    fn password_field_is_masked_with_eye_toggle_and_never_echoes_the_raw_value() {
+        // SEC-060: only masking a secret via `type="password"` still leaves
+        // the raw bytes sitting in the HTML `value=` attribute — readable in
+        // page source / devtools. The rendered markup must never contain the
+        // secret at all, regardless of the visual widget.
         let v = var("X__PW", "Secret", InputType::Password);
         let set = render_field(&v, "hunter2").into_string();
+        assert!(
+            !set.contains("hunter2"),
+            "the raw secret must never reach the rendered HTML: {set}"
+        );
         assert!(set.contains(r#"type="password""#));
+        assert!(
+            set.contains(r#"value="""#),
+            "value must render empty: {set}"
+        );
         assert!(set.contains("(set)"));
         // eye toggle present
         assert!(set.contains("i.type=i.type==='password'?'text':'password'"));
 
         let empty = render_field(&v, "").into_string();
         assert!(empty.contains("Not configured"));
+    }
+
+    #[test]
+    fn key_with_secret_suffix_is_redacted_even_without_password_input_type() {
+        // Defense-in-depth: a var accidentally left on the default `Text`
+        // widget whose key still ends `_SECRET`/`_KEY` must not leak either
+        // — the single-sourced `is_sensitive_key` suffix rule catches it
+        // exactly like `blocks::admin::ops::is_sensitive_key` does for the
+        // Variables table, independent of which widget `input_type` picked.
+        let v = var(
+            "LEGACY_APP__WEBHOOK_SECRET",
+            "Webhook Secret",
+            InputType::Text,
+        );
+        let s = render_field(&v, "shh-dont-tell").into_string();
+        assert!(
+            !s.contains("shh-dont-tell"),
+            "a `_SECRET`-suffixed key must be redacted regardless of input_type: {s}"
+        );
     }
 
     #[test]
@@ -357,7 +416,7 @@ mod tests {
     // --- save_settings: URL validation (M16) + error surfacing (M24) ---
     use wafer_run::{streams::output::TerminalNotResponse, InputStream};
 
-    use crate::test_support::TestContext;
+    use crate::test_support::{output_json, TestContext};
 
     async fn run_save(
         ctx: &TestContext,
@@ -409,6 +468,112 @@ mod tests {
                 Err(TerminalNotResponse::Error(_))
             ),
             "a failed config::set must surface as an error, not a 'saved' success"
+        );
+    }
+
+    // --- SEC-060: render_sections never leaks a raw secret into the DOM ---
+
+    #[tokio::test]
+    async fn render_sections_never_leaks_a_stored_secret_into_the_html() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SUPPERS_AI__EMAIL__MAILGUN_API_KEY", "key-abcdef0123456789");
+        let v = var(
+            "SUPPERS_AI__EMAIL__MAILGUN_API_KEY",
+            "Mailgun API Key",
+            InputType::Password,
+        );
+        let sections = [SettingsSection::new(
+            "Email",
+            html! {},
+            std::slice::from_ref(&v),
+        )];
+        let out = render_sections(&ctx, &sections).await.into_string();
+
+        assert!(
+            !out.contains("key-abcdef0123456789"),
+            "raw secret must never reach the rendered HTML: {out}"
+        );
+        assert!(out.contains("(set)"));
+        assert!(out.contains(r#"type="password""#));
+    }
+
+    // --- SEC-060: save_settings' unchanged-secret guard ---
+
+    #[tokio::test]
+    async fn save_settings_leaves_a_sensitive_field_unchanged_on_empty_or_masked_submit() {
+        let mut ctx = TestContext::new().await;
+        // Registers a real `wafer-run/config` service block (TestContext::set_config)
+        // and seeds the current stored secret.
+        ctx.set_config("X__API_SECRET", "original-secret");
+        let allowed = [var("X__API_SECRET", "API Secret", InputType::Password)];
+
+        // Empty submit (what `render_field` actually emits for a set secret,
+        // per the render-side fix) must not touch the stored value.
+        let out = run_save(&ctx, &allowed, serde_json::json!({"X__API_SECRET": ""})).await;
+        let body = output_json(out).await;
+        assert_eq!(body["message"], "Settings saved");
+        assert_eq!(
+            config::get_default(&ctx, "X__API_SECRET", "").await,
+            "original-secret",
+            "an empty submit for a sensitive field must not clear/overwrite the stored secret"
+        );
+
+        // A literal round-trip of the mask placeholder must also be treated
+        // as "unchanged", not stored as the literal mask string.
+        let out = run_save(
+            &ctx,
+            &allowed,
+            serde_json::json!({"X__API_SECRET": MASKED_VALUE}),
+        )
+        .await;
+        let body = output_json(out).await;
+        assert_eq!(body["message"], "Settings saved");
+        assert_eq!(
+            config::get_default(&ctx, "X__API_SECRET", "").await,
+            "original-secret",
+            "submitting the mask placeholder must not overwrite the stored secret with it"
+        );
+
+        // A genuinely new value must still be written.
+        let out = run_save(
+            &ctx,
+            &allowed,
+            serde_json::json!({"X__API_SECRET": "brand-new-secret"}),
+        )
+        .await;
+        let body = output_json(out).await;
+        assert_eq!(body["message"], "Settings saved");
+        assert_eq!(
+            config::get_default(&ctx, "X__API_SECRET", "").await,
+            "brand-new-secret",
+            "a genuinely retyped secret must be saved"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_settings_still_clears_a_non_sensitive_field_on_empty_submit() {
+        // Non-sensitive fields keep the pre-existing behavior: an empty
+        // submit is a real write (clears the stored value), not "unchanged".
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SOLOBASE_SHARED__APP_NAME", "MyApp");
+        let allowed = [var(
+            "SOLOBASE_SHARED__APP_NAME",
+            "App Name",
+            InputType::Text,
+        )];
+
+        let out = run_save(
+            &ctx,
+            &allowed,
+            serde_json::json!({"SOLOBASE_SHARED__APP_NAME": ""}),
+        )
+        .await;
+        let body = output_json(out).await;
+        assert_eq!(body["message"], "Settings saved");
+        assert_eq!(
+            config::get_default(&ctx, "SOLOBASE_SHARED__APP_NAME", "").await,
+            "",
+            "a non-sensitive field's empty submit is a real write, unlike a sensitive field's"
         );
     }
 }

--- a/crates/solobase-core/src/util.rs
+++ b/crates/solobase-core/src/util.rs
@@ -287,6 +287,27 @@ pub(crate) fn validate_url_value(value: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Masked placeholder shown in place of a sensitive value.
+pub(crate) const MASKED_VALUE: &str = "********";
+
+/// SEC-060: a config value is sensitive when it's explicitly flagged
+/// sensitive **or** the key follows the `_SECRET` / `_KEY` suffix
+/// convention. "Explicitly flagged" means different things on each caller's
+/// substrate — the admin Variables table's DB `sensitive` column for ad hoc
+/// rows, or a declared [`ConfigVar`](wafer_run::ConfigVar)'s
+/// `InputType::Password` for the generic settings form — so callers pass
+/// their own flag in as `1`/`0`. The suffix half of the rule is what both
+/// sides share: masking on the flag alone leaked a `*_SECRET` value whenever
+/// a var/row wasn't explicitly marked.
+///
+/// Single source of truth for "is this key sensitive", used by both the
+/// admin Variables page (`blocks::admin::ops`, re-exported from here) and
+/// the generic ConfigVar-driven settings form (`ui::settings_form`) so the
+/// two admin surfaces can't disagree on what gets redacted.
+pub(crate) fn is_sensitive_key(key: &str, sensitive_flag: i64) -> bool {
+    sensitive_flag == 1 || key.ends_with("_SECRET") || key.ends_with("_KEY")
+}
+
 /// Percent-encode a string for use as an OAuth / `application/x-www-form-urlencoded`
 /// query parameter or form-body value. Delegates to
 /// [`url::form_urlencoded::byte_serialize`] which encodes spaces as `+` and
@@ -702,5 +723,16 @@ mod tests {
     #[test]
     fn rejects_userinfo_localhost_with_external_host() {
         assert!(validate_url_value("http://localhost@evil.com").is_err());
+    }
+
+    #[test]
+    fn is_sensitive_key_honors_flag_and_suffix() {
+        // Flag set → sensitive regardless of name.
+        assert!(is_sensitive_key("PLAIN", 1));
+        // SEC-060: suffix makes it sensitive even when the flag is clear.
+        assert!(is_sensitive_key("STRIPE_SECRET", 0));
+        assert!(is_sensitive_key("JWT_KEY", 0));
+        // Neither flag nor suffix → not sensitive.
+        assert!(!is_sensitive_key("SITE_NAME", 0));
     }
 }


### PR DESCRIPTION
## Summary

The shared ConfigVar-driven admin settings form (`ui/settings_form.rs`) — now used by every block's admin settings page (email, products, auth, auth_ui, userportal, legalpages) — rendered sensitive config values (Mailgun API key, any `_SECRET`/`_KEY`) straight into the HTML `value=` attribute. Masking was purely visual (`type="password"`), so the raw secret was readable in page source / devtools. The admin Variables tab already server-redacts correctly via `blocks::admin::ops::is_sensitive_key`; this brings the shared settings-form path (which the Variables tab does *not* go through) up to the same standard, closing the SEC-060 gap for every caller of `settings_form`/`render_field` in one place.

- **Render (`render_field`)**: sensitive fields now render an empty `value=` with the existing "(set)"/"Not configured" placeholder — the secret bytes never reach the DOM. Defense-in-depth: this is computed once, ahead of the widget-type match, so a var accidentally left on the default `Text` widget whose key still ends `_SECRET`/`_KEY` is redacted too, not just `InputType::Password` fields.
- **Save (`save_settings`)**: an empty or literal-mask (`"********"`) submit for a sensitive field is now treated as "unchanged" — `config::set` is skipped and the stored secret survives — instead of wiping it or persisting the mask string. A genuinely retyped value still saves normally. The existing SB-1 error-propagation behavior (a `config::set` failure surfaces as a real error, not a false "saved") is unchanged for keys that do get written.
- **Single-sourced `is_sensitive_key`/`MASKED_VALUE`**: promoted from `blocks::admin::ops` (`pub(super)`) to `crate::util` (`pub(crate)`), with `ops.rs` re-exporting them so its existing call sites (Variables page, JSON settings API) are untouched. `ui::settings_form` now imports the same function directly. Both paths call it with their own "explicitly sensitive" signal — the DB `sensitive` column for ad hoc Variables rows, `ConfigVar::is_sensitive()` (`InputType::Password`) for the settings form — OR'd with the shared `_SECRET`/`_KEY` suffix rule. One function, two callers, can't drift again.

## Test plan

- [x] `password_field_is_masked_with_eye_toggle_and_never_echoes_the_raw_value` — asserts the rendered HTML does **not** contain the raw secret, `value=""`, `type="password"`, and the eye toggle/placeholder are still present. RED against pre-fix code (which echoed `value="hunter2"`), GREEN after.
- [x] `key_with_secret_suffix_is_redacted_even_without_password_input_type` — defense-in-depth: a `Text`-typed var with a `_SECRET` key is still redacted.
- [x] `render_sections_never_leaks_a_stored_secret_into_the_html` — section-level integration test with a real stored Mailgun-key-shaped secret.
- [x] `settings_body_masks_a_stored_mailgun_api_key` (existing test, extended) — now also asserts the raw value is absent from the real email settings page render.
- [x] `save_settings_leaves_a_sensitive_field_unchanged_on_empty_or_masked_submit` — empty submit and mask-literal submit both leave the stored secret unchanged; a genuinely new value is written.
- [x] `save_settings_still_clears_a_non_sensitive_field_on_empty_submit` — non-sensitive fields keep the pre-existing empty-submit-clears behavior.
- [x] `is_sensitive_key_honors_flag_and_suffix` (moved to `util.rs`, unchanged assertions) — single-source regression coverage co-located with the function.
- [x] `cargo +nightly fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — 82 warnings before and after (no new warnings; verified via stash-diff).
- [x] `cargo test -p solobase-core admin` — 80 passed.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — 832 passed in solobase-core lib + all integration binaries green.
- [x] `Cargo.lock` not touched (checked out before commit; confirmed absent from the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)