### PR TITLE
fix(auth): associate field labels + label the password-reveal button (a11y)

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/login.rs
@@ -212,4 +212,56 @@ mod tests {
         let html = output_html(handle(&ctx, &msg).await).await;
         assert!(!html.contains(&long_email));
     }
+
+    /// A11y: the visible "Email"/"Password" labels must be programmatically
+    /// associated with their inputs via `<label for>` + matching `id`, not
+    /// bare `<div>`s a screen reader can't tie to the field.
+    #[tokio::test]
+    async fn email_and_password_labels_are_associated_with_their_inputs() {
+        let ctx = TestContext::new().await;
+        let msg = login_msg(&[]);
+        let html = output_html(handle(&ctx, &msg).await).await;
+
+        assert!(
+            html.contains(r#"<label class="form-label" for="email">Email</label>"#),
+            "email label must be a <label for=\"email\"> tied to the #email input: {html}"
+        );
+        assert!(
+            html.contains(r#"id="email""#),
+            "input must carry the id the label's for= references: {html}"
+        );
+
+        assert!(
+            html.contains(r#"<label class="form-label" for="password">Password</label>"#),
+            "password label must be a <label for=\"password\"> tied to the #password input: {html}"
+        );
+        assert!(
+            html.contains(r#"id="password""#),
+            "input must carry the id the label's for= references: {html}"
+        );
+    }
+
+    /// A11y: the icon-only password-reveal toggle must have an accessible
+    /// name (aria-label), since it renders no visible text.
+    #[tokio::test]
+    async fn password_toggle_button_has_non_empty_aria_label() {
+        let ctx = TestContext::new().await;
+        let msg = login_msg(&[]);
+        let html = output_html(handle(&ctx, &msg).await).await;
+
+        let marker = "class=\"pw-toggle\"";
+        let idx = html
+            .find(marker)
+            .expect("password toggle button must be present");
+        let tag_end = html[idx..]
+            .find('>')
+            .map(|end| idx + end)
+            .unwrap_or(html.len());
+        let button_tag = &html[idx..tag_end];
+
+        assert!(
+            button_tag.contains("aria-label=\"") && !button_tag.contains("aria-label=\"\""),
+            "password toggle button must have a non-empty aria-label: {button_tag}"
+        );
+    }
 }

--- a/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/mod.rs
@@ -144,7 +144,7 @@ pub(super) fn pw_field(id: &str, placeholder: &str, minlength: Option<&str>) -> 
                 placeholder=(placeholder)
                 required
                 minlength=[minlength];
-            button type="button" class="pw-toggle" onclick={"togglePw(this)"} {
+            button type="button" class="pw-toggle" aria-label="Toggle password visibility" onclick={"togglePw(this)"} {
                 (ui::icons::eye_off())
             }
         }

--- a/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/pages/signup.rs
@@ -92,3 +92,83 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
     ui::html_response(markup)
 }
+
+#[cfg(test)]
+mod tests {
+    use wafer_run::Message;
+
+    use super::handle;
+    use crate::test_support::{output_html, TestContext};
+
+    /// A11y: the visible "Email"/"Password" labels must be programmatically
+    /// associated with their inputs via `<label for>` + matching `id`, not
+    /// bare `<div>`s a screen reader can't tie to the field.
+    #[tokio::test]
+    async fn email_and_password_labels_are_associated_with_their_inputs() {
+        let ctx = TestContext::new().await;
+        let msg = Message::new("http.request");
+        let html = output_html(handle(&ctx, &msg).await).await;
+
+        assert!(
+            html.contains(r#"<label class="form-label" for="email">Email</label>"#),
+            "email label must be a <label for=\"email\"> tied to the #email input: {html}"
+        );
+        assert!(
+            html.contains(r#"id="email""#),
+            "input must carry the id the label's for= references: {html}"
+        );
+
+        assert!(
+            html.contains(r#"<label class="form-label" for="password">Password</label>"#),
+            "password label must be a <label for=\"password\"> tied to the #password input: {html}"
+        );
+        assert!(
+            html.contains(r#"id="password""#),
+            "input must carry the id the label's for= references: {html}"
+        );
+    }
+
+    /// A11y: the icon-only password-reveal toggle must have an accessible
+    /// name (aria-label), since it renders no visible text.
+    #[tokio::test]
+    async fn password_toggle_button_has_non_empty_aria_label() {
+        let ctx = TestContext::new().await;
+        let msg = Message::new("http.request");
+        let html = output_html(handle(&ctx, &msg).await).await;
+
+        let marker = "class=\"pw-toggle\"";
+        let idx = html
+            .find(marker)
+            .expect("password toggle button must be present");
+        let tag_end = html[idx..]
+            .find('>')
+            .map(|end| idx + end)
+            .unwrap_or(html.len());
+        let button_tag = &html[idx..tag_end];
+
+        assert!(
+            button_tag.contains("aria-label=\"") && !button_tag.contains("aria-label=\"\""),
+            "password toggle button must have a non-empty aria-label: {button_tag}"
+        );
+    }
+
+    /// A11y (regression guard): the signup page's brand-panel tagline must
+    /// be signup-appropriate, not a copy-paste of the login copy. Fixed
+    /// upstream in 5a47de0 ("fixed the brand panel tagline being hardcoded
+    /// to login copy on every auth page"); this locks that fix in place.
+    #[tokio::test]
+    async fn brand_panel_tagline_is_signup_appropriate() {
+        let ctx = TestContext::new().await;
+        let msg = Message::new("http.request");
+        let html = output_html(handle(&ctx, &msg).await).await;
+
+        assert!(
+            html.contains("Create your account."),
+            "signup brand panel must use signup-appropriate copy: {html}"
+        );
+        assert!(
+            !html.contains("Sign in to continue."),
+            "signup page must not carry over the login page's brand-panel tagline: {html}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `aria-label="Toggle password visibility"` to the icon-only password-reveal toggle button, rendered via the shared `pw_field()` helper in `auth_ui/pages/mod.rs` (used by login, signup, and change-password). Previously it was a bare `<button>` with an SVG icon and no accessible name — screen readers announced nothing for it.
- **Verified but did not change**: the Email/Password `<label for="...">` associations on login, signup, reset-password, change-password, and bootstrap pages were already correctly wired (matching input `id`s), mirroring the pattern used in `ui/settings_form.rs`. Added regression tests locking this in rather than a no-op fix.
- **Verified but did not change**: the signup page's left-panel tagline was already fixed to "Create your account." (not the login page's "Sign in to continue.") in `5a47de0`, the immediately-preceding commit on main. Added a regression test locking this in.

## Test plan

- [x] New tests in `login.rs`/`signup.rs`: `email_and_password_labels_are_associated_with_their_inputs`, `password_toggle_button_has_non_empty_aria_label` (RED against the pre-fix button markup, GREEN after adding the `aria-label`)
- [x] New test in `signup.rs`: `brand_panel_tagline_is_signup_appropriate` (regression guard for the already-fixed copy)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — no new warnings vs. base
- [x] `cargo test -p solobase-core auth` — 156 passed, 0 failed
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all 34 test binaries green
- [x] `Cargo.lock` not touched in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)