### PR TITLE
fix(admin): empty-state CTAs on Storage/Products + products-disabled hint

### DIFF
--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -102,6 +102,25 @@ pub fn render_admin_overview_stats(stats: &AdminStats) -> Markup {
     }
 }
 
+/// Render the "create your first bucket" CTA for the empty admin storage
+/// overview. Renders empty markup once at least one bucket exists — this is
+/// a first-run nudge, not a permanent overview fixture. Links to the
+/// Buckets tab, which owns the actual "+ New bucket" trigger (the modal +
+/// `files-browser.js` bootstrap script) — no duplicate modal wiring here.
+pub fn render_admin_overview_empty_cta(bucket_count: i64) -> Markup {
+    if bucket_count > 0 {
+        return html! {};
+    }
+    components::empty_state(
+        icons::folder(),
+        "Create your first bucket",
+        "Buckets hold the files uploaded through Storage. Create one to get started.",
+        Some(html! {
+            a .btn .btn--primary .btn--md href="/b/storage/admin/buckets" { "+ New bucket" }
+        }),
+    )
+}
+
 /// Render the optional "X user(s) with custom quotas" hint card.
 /// Returns an empty markup when `quotas_count == 0`. Pure helper.
 pub fn render_admin_overview_quotas_hint(quotas_count: i64) -> Markup {
@@ -135,6 +154,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
         Some(admin_tabs("Overview")),
         html! {
             (render_admin_overview_stats(&stats))
+            (render_admin_overview_empty_cta(stats.buckets))
             (render_admin_overview_quotas_hint(stats.quotas_count))
         },
         None,
@@ -575,6 +595,69 @@ mod tests {
         assert!(html.contains(">5<"), "shares count missing: {html}");
         // total_size_bytes 2.5 GB → "2.3 GB" via format_bytes (or close).
         assert!(html.contains("GB"), "size humanization missing: {html}");
+    }
+
+    #[test]
+    fn render_admin_overview_empty_cta_shown_when_zero_buckets() {
+        let html = render_admin_overview_empty_cta(0).into_string();
+        assert!(
+            html.contains("Create your first bucket"),
+            "cta title missing: {html}"
+        );
+        assert!(
+            html.contains(r#"href="/b/storage/admin/buckets""#),
+            "cta should link to the Buckets tab (the real create trigger): {html}"
+        );
+        assert!(html.contains("New bucket"), "cta label missing: {html}");
+    }
+
+    #[test]
+    fn render_admin_overview_empty_cta_hidden_when_buckets_exist() {
+        let html = render_admin_overview_empty_cta(3).into_string();
+        assert!(
+            html.trim().is_empty(),
+            "cta should be hidden once a bucket exists: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn overview_page_shows_create_bucket_cta_when_empty() {
+        use crate::test_support::{admin_msg, output_html, TestContext};
+
+        let ctx = TestContext::with_files().await;
+        let msg = admin_msg("retrieve", "/b/storage/admin/");
+        let html = output_html(overview(&ctx, &msg).await).await;
+
+        assert!(
+            html.contains("Create your first bucket"),
+            "empty-state CTA missing from the live overview render: {html}"
+        );
+        assert!(
+            html.contains(r#"href="/b/storage/admin/buckets""#),
+            "CTA should link to the Buckets tab: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn overview_page_hides_create_bucket_cta_once_a_bucket_exists() {
+        use crate::test_support::{admin_msg, output_html, TestContext};
+
+        let ctx = TestContext::with_files().await;
+        let mut row: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+        row.insert("name".into(), serde_json::json!("photos"));
+        row.insert("created_by".into(), serde_json::json!("admin_1"));
+        db::create(&ctx, BUCKETS_TABLE, row)
+            .await
+            .expect("seed bucket");
+
+        let msg = admin_msg("retrieve", "/b/storage/admin/");
+        let html = output_html(overview(&ctx, &msg).await).await;
+
+        assert!(
+            !html.contains("Create your first bucket"),
+            "CTA should be gone once a bucket exists: {html}"
+        );
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/products/handlers.rs
+++ b/crates/solobase-core/src/blocks/products/handlers.rs
@@ -347,7 +347,11 @@ pub(crate) const GROUP_TEMPLATES_TABLE: &str = "suppers_ai__products__group_temp
 /// Reusable product template definitions (admin-authored).
 pub(crate) const PRODUCT_TEMPLATES_TABLE: &str = "suppers_ai__products__product_templates";
 
-async fn user_products_enabled(ctx: &dyn Context) -> bool {
+/// Whether `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS` is on — gates the
+/// user-facing (non-admin) product/group CRUD routes above. `pub(super)`
+/// so the admin Overview page (`pages::overview`) can render an accurate
+/// notice instead of a silent empty catalog when it's off.
+pub(super) async fn user_products_enabled(ctx: &dyn Context) -> bool {
     config::get_default(ctx, "SOLOBASE_SHARED__ALLOW_USER_PRODUCTS", "false").await == "true"
 }
 

--- a/crates/solobase-core/src/blocks/products/pages.rs
+++ b/crates/solobase-core/src/blocks/products/pages.rs
@@ -21,6 +21,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let groups_count = db::count(ctx, GROUPS_TABLE, &[]).await.unwrap_or(0);
     let purchases_count = repo::purchases::count_all(ctx).await.unwrap_or(0);
     let pricing_count = db::count(ctx, PRICING_TABLE, &[]).await.unwrap_or(0);
+    let user_products_enabled = super::handlers::user_products_enabled(ctx).await;
 
     let content = html! {
         (components::page_header("Products Overview", Some("Product catalog statistics"), None))
@@ -30,6 +31,7 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
             (components::stat_card("Pricing Templates", &pricing_count.to_string(), icons::dollar_sign()))
             (components::stat_card("Purchases", &purchases_count.to_string(), icons::shopping_cart()))
         }
+        (render_overview_empty_state(products_count, user_products_enabled))
     };
 
     ui::shell_page(
@@ -39,6 +41,46 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
         content,
     )
     .await
+}
+
+/// Render the Products Overview empty-state guidance in place of a bare,
+/// actionless stat grid. Renders empty markup once the catalog has at least
+/// one product. Two mutually exclusive states while it's empty:
+///
+///   - `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS` off: a live 403 on
+///     `/b/products/api/products` (the user-owned-product route,
+///     `handlers::UserRoute::requires_user_products`) was previously the
+///     only signal a new admin got that self-serve selling is disabled —
+///     name the var and link to Settings, where it's the first toggle in
+///     the Features section. The admin JSON create route
+///     (`/b/products/api/admin/products`) is NOT gated by this flag, so no
+///     CTA is withheld here — this state is purely informational.
+///   - Otherwise: an "Add your first product" CTA straight to the Manage
+///     Products page, which owns the "+ New Product" create modal (the
+///     real create path, wired to that same admin route).
+fn render_overview_empty_state(products_count: i64, user_products_enabled: bool) -> maud::Markup {
+    if products_count > 0 {
+        return html! {};
+    }
+    if user_products_enabled {
+        components::empty_state(
+            icons::package(),
+            "Add your first product",
+            "Your catalog is empty. Add a product to start selling.",
+            Some(html! {
+                a .btn .btn--primary .btn--md href="/b/products/admin/manage" { "+ Add product" }
+            }),
+        )
+    } else {
+        components::empty_state(
+            icons::info(),
+            "User products are turned off",
+            "SOLOBASE_SHARED__ALLOW_USER_PRODUCTS is disabled, so regular users can't create or manage their own product listings yet — you can still add products yourself from Manage Products. Enable this in Settings to let users sell their own products.",
+            Some(html! {
+                a .btn .btn--secondary .btn--md href="/b/products/admin/settings" { "Go to Settings" }
+            }),
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -72,8 +114,15 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
     )
     .await;
 
+    let new_product_button = components::button(
+        components::BtnVariant::Primary,
+        components::CtrlSize::Sm,
+        "+ New Product",
+        maud::PreEscaped(r#"type="button" onclick="openModal('create-product')""#.to_string()),
+    );
+
     let content = html! {
-        (components::page_header("Products", Some("Manage your product catalog"), None))
+        (components::page_header("Products", Some("Manage your product catalog"), Some(new_product_button)))
 
         div .filter-bar {
             (components::search_input("search", "Search products...", "/b/products/admin/manage", "#products-content"))
@@ -106,6 +155,9 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
                 Err(e) => { div .login-error { "Error: " (e.message) } }
             }
         }
+
+        (render_create_product_modal())
+        script { (maud::PreEscaped(create_product_js())) }
     };
 
     ui::shell_page(
@@ -115,6 +167,80 @@ pub async fn manage_products(ctx: &dyn Context, msg: &Message) -> OutputStream {
         content,
     )
     .await
+}
+
+/// Render the "+ New Product" create modal for the admin Manage Products
+/// page — the real, working create path the Overview empty-state CTA links
+/// to. Submits via `create_product_js` (fetch + JSON) against the existing
+/// admin JSON API (`POST /b/products/api/admin/products`, already
+/// `AuthLevel::Admin`-gated in `mod.rs` and unaffected by
+/// `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS`) rather than an htmx form post —
+/// that endpoint's JSON contract (typed `base_price`, arbitrary optional
+/// fields) is shared with programmatic API clients and shouldn't grow an
+/// implicit urlencoded-vs-JSON coercion path just for this one modal.
+/// Mirrors the bucket-create modal's fetch+JSON+reload pattern
+/// (`pages_user::render_new_bucket_modal` / `files-browser.js`).
+fn render_create_product_modal() -> maud::Markup {
+    components::modal(
+        "create-product",
+        "Add product",
+        html! {
+            form id="create-product-form" onsubmit="return handleCreateProduct(event)" {
+                p .form-error hidden {}
+                div .form-group {
+                    label .form-label .required for="product-name" { "Name" }
+                    input .form-input type="text" id="product-name" name="name" placeholder="e.g. Cloud Hosting" required;
+                }
+                div .form-group {
+                    label .form-label for="product-price" { "Base price" }
+                    input .form-input type="number" id="product-price" name="base_price" step="0.01" min="0" placeholder="0.00";
+                }
+                div .form-group {
+                    label .form-label for="product-currency" { "Currency" }
+                    input .form-input type="text" id="product-currency" name="currency" value="USD" maxlength="3";
+                }
+                div .form-actions {
+                    button .btn .btn-secondary type="button" onclick="closeModal('create-product')" { "Cancel" }
+                    button .btn .btn-primary type="submit" id="create-product-submit" { "Create" }
+                }
+            }
+        },
+    )
+}
+
+/// JS backing [`render_create_product_modal`]. Validates the name
+/// client-side, coerces an optional price to a number (never sends a
+/// stringly-typed `base_price` to the JSON API), posts, and reloads on
+/// success so the new row shows up in the (newest-first) table.
+fn create_product_js() -> &'static str {
+    r#"
+async function handleCreateProduct(ev){
+  ev.preventDefault();
+  var form=document.getElementById('create-product-form');
+  var errEl=form.querySelector('.form-error');
+  var btn=document.getElementById('create-product-submit');
+  var name=document.getElementById('product-name').value.trim();
+  if(!name){errEl.textContent='Name is required.';errEl.hidden=false;return false}
+  var priceRaw=document.getElementById('product-price').value.trim();
+  var currency=document.getElementById('product-currency').value.trim()||'USD';
+  var payload={name:name,currency:currency};
+  if(priceRaw!==''){
+    var price=parseFloat(priceRaw);
+    if(isNaN(price)||price<0){errEl.textContent='Base price must be a positive number.';errEl.hidden=false;return false}
+    payload.base_price=price;
+  }
+  errEl.hidden=true;
+  btn.disabled=true;
+  try{
+    var r=await fetch('/b/products/api/admin/products',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+    if(r.ok){window.location.reload();return false}
+    var msg='Failed to create product.';
+    try{var d=await r.json();if(d&&d.message)msg=d.message}catch(_){}
+    errEl.textContent=msg;errEl.hidden=false;btn.disabled=false;
+  }catch(e){errEl.textContent='Network error. Please try again.';errEl.hidden=false;btn.disabled=false}
+  return false;
+}
+"#
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
@@ -751,6 +751,115 @@ async fn overview_highlights_products_nav_via_request_path() {
     );
 }
 
+/// When `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS` is off and the catalog is
+/// empty, the Overview page used to render a bare, actionless stat grid — a
+/// live 403 on the gated user route (`/b/products/api/products`) was the
+/// only signal that self-serve selling was disabled. It must now name the
+/// config var and point at Settings, and must NOT show the "Add product"
+/// CTA that belongs to the enabled+empty state (that CTA is safe either
+/// way — it targets the *admin* create route, which isn't gated by this
+/// flag — but the two states render distinct copy, so assert only the
+/// disabled-state text appears).
+#[tokio::test]
+async fn overview_shows_disabled_notice_when_user_products_off() {
+    let ctx = ctx().await; // no ALLOW_USER_PRODUCTS config → defaults to false
+    let (msg, _input) = admin_get_msg("/b/products/");
+    let html = output_to_html(super::super::pages::overview(&ctx, &msg).await).await;
+
+    assert!(
+        html.contains("SOLOBASE_SHARED__ALLOW_USER_PRODUCTS"),
+        "disabled notice should name the exact config var: {html}"
+    );
+    assert!(
+        html.contains("Settings"),
+        "disabled notice should point at how to enable it: {html}"
+    );
+    assert!(
+        html.contains(r#"href="/b/products/admin/settings""#),
+        "disabled notice's action should link to the Settings page: {html}"
+    );
+    assert!(
+        !html.contains("Add your first product"),
+        "disabled overview should not show the enabled+empty CTA copy: {html}"
+    );
+    assert!(
+        !html.contains(r#"href="/b/products/admin/manage""#),
+        "disabled overview should not show a create-product CTA: {html}"
+    );
+}
+
+/// Enabled + empty catalog: the Overview page must show a working
+/// "Add your first product" CTA to the real admin create path (Manage
+/// Products, which owns the "+ New Product" modal), and must not show the
+/// disabled-state notice.
+#[tokio::test]
+async fn overview_shows_add_product_cta_when_enabled_and_empty() {
+    let ctx = ctx_with(&[("SOLOBASE_SHARED__ALLOW_USER_PRODUCTS", "true")]).await;
+    let (msg, _input) = admin_get_msg("/b/products/");
+    let html = output_to_html(super::super::pages::overview(&ctx, &msg).await).await;
+
+    assert!(
+        html.contains("Add your first product"),
+        "enabled+empty overview should show the add-product CTA: {html}"
+    );
+    assert!(
+        html.contains(r#"href="/b/products/admin/manage""#),
+        "CTA should link to the real create path (Manage Products): {html}"
+    );
+    assert!(
+        !html.contains("SOLOBASE_SHARED__ALLOW_USER_PRODUCTS"),
+        "enabled overview should not show the disabled-state notice: {html}"
+    );
+}
+
+/// Once the catalog has products, the empty-state block (CTA or notice)
+/// disappears entirely regardless of the enabled flag.
+#[tokio::test]
+async fn overview_hides_empty_state_once_products_exist() {
+    let ctx = ctx_with(&[("SOLOBASE_SHARED__ALLOW_USER_PRODUCTS", "true")]).await;
+    let (c, c_input) = admin_create_msg(
+        "/admin/b/products/products",
+        serde_json::json!({ "name": "Cloud Hosting", "base_price": 29.99 }),
+    );
+    dispatch_admin(&ctx, c, c_input).await;
+
+    let (msg, _input) = admin_get_msg("/b/products/");
+    let html = output_to_html(super::super::pages::overview(&ctx, &msg).await).await;
+
+    assert!(
+        !html.contains("Add your first product"),
+        "CTA should be gone once the catalog has products: {html}"
+    );
+}
+
+/// The Overview CTA's destination (Manage Products) must actually own a
+/// working create flow, not just be a plausible-looking link — assert the
+/// "+ New Product" trigger, the create modal, and its submit handler are
+/// all present.
+#[tokio::test]
+async fn manage_products_page_renders_create_product_modal() {
+    let ctx = ctx().await;
+    let (msg, _input) = admin_get_msg("/b/products/admin/manage");
+    let html = output_to_html(super::super::pages::manage_products(&ctx, &msg).await).await;
+
+    assert!(
+        html.contains("+ New Product"),
+        "manage page should render the create-product trigger: {html}"
+    );
+    assert!(
+        html.contains(r#"id="create-product""#),
+        "manage page should render the create-product modal: {html}"
+    );
+    assert!(
+        html.contains("handleCreateProduct"),
+        "manage page should wire the create-product submit handler: {html}"
+    );
+    assert!(
+        html.contains("/b/products/api/admin/products"),
+        "create-product JS should post to the real admin create endpoint: {html}"
+    );
+}
+
 /// The products list pages adopt `ui::components::data_table`, which carries
 /// the PR #75 mobile card-collapse fix via `td[data-label]`. Assert the manage
 /// page renders the `.data-table` structure with per-cell data labels (so the


### PR DESCRIPTION
## Summary

- **Storage Overview** (`/b/storage/admin/`): when there are 0 buckets, the stat grid now shows a "Create your first bucket" empty-state CTA (reusing `components::empty_state`) that links to the Buckets tab, which owns the real "+ New bucket" trigger/modal.
- **Products Overview** (`/b/products/admin/`): when there are 0 products, the page now renders one of two mutually-exclusive empty states depending on `SOLOBASE_SHARED__ALLOW_USER_PRODUCTS`:
  - **Disabled**: a notice naming the exact config var and linking to Settings (where it's the first toggle in the Features section) — explains that only *user* self-serve product management is gated by this flag; admins can still add products themselves.
  - **Enabled**: an "Add your first product" CTA to the Manage Products page.
- **Manage Products page** (`/b/products/admin/manage`) previously had **no create UI at all** — the admin JSON API (`POST /b/products/api/admin/products`, already `AuthLevel::Admin`-gated, unaffected by `ALLOW_USER_PRODUCTS`) existed but nothing in the SSR admin pages called it. Added a "+ New Product" button + create modal (name/base price/currency), following the same fetch+JSON+reload pattern as the existing bucket-create modal, so the Overview CTA actually goes somewhere that works.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — zero new warnings
- [x] `cargo test -p solobase-core files` — 86 passed (incl. 4 new)
- [x] `cargo test -p solobase-core products` — 126 passed (incl. 5 new)
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all green
- [x] Cargo.lock not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WLLHawRn5HnCn6CfFZxoq