### PR TITLE
fix(vector): API degrades gracefully when wafer-run/vector backend is absent (was 500)

### DIFF
--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -64,6 +64,31 @@ use crate::{
 // there (no in-block `route` shim, no `starts_with` ordering guards).
 
 // ---------------------------------------------------------------------------
+// Backend-availability gate
+// ---------------------------------------------------------------------------
+
+/// 503 for every op that needs the `wafer-run/vector` backend when it isn't
+/// registered on this runtime (native solobase ships no native vector
+/// engine — see `pages_ui.rs` module docs).
+///
+/// Every `vclient::*` call below (`create_index`, `list_indexes`, `upsert`,
+/// `query`, …) targets that one block, so its absence surfaces as
+/// `ErrorCode::NotFound: block 'wafer-run/vector' not found` — the *same*
+/// error code the per-op branches below already use for a semantically
+/// different thing ("this index doesn't exist"). Pattern-matching on the
+/// wire error would conflate the two; checking
+/// `service::vector_backend_available` up front (the same check the `/b/vector/`
+/// UI page uses to render its "backend not available" callout) disambiguates
+/// them and lets every handler degrade the same way instead of a handful
+/// misreporting "index not found" and the rest 500ing.
+fn err_vector_backend_unavailable() -> OutputStream {
+    OutputStream::error(WaferError::new(
+        ErrorCode::Unavailable,
+        "vector backend (wafer-run/vector) is not available on this deployment",
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // POST /b/vector/api/indexes — create an index
 // ---------------------------------------------------------------------------
 
@@ -85,6 +110,9 @@ pub(super) async fn create_index(
     msg: &Message,
     input: InputStream,
 ) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let raw = input.collect_to_bytes().await;
     // Accept either JSON (programmatic clients) or URL-encoded form
     // (htmx modal). Parse via the shared helper, then map fields explicitly
@@ -219,6 +247,13 @@ pub(super) async fn create_index(
 // ---------------------------------------------------------------------------
 
 pub(super) async fn list_indexes(ctx: &dyn Context) -> OutputStream {
+    // No backend registered → no indexes to report. Mirrors the `/b/vector/`
+    // UI page's empty state (`pages_ui::index_list_page`): callers that only
+    // ever list should see "nothing here" rather than an error, since an
+    // empty result is already a legitimate response shape for this endpoint.
+    if !service::vector_backend_available(ctx) {
+        return ok_json(&serde_json::json!({ "indexes": Vec::<String>::new() }));
+    }
     match discover_indexes(ctx).await {
         Ok(indexes) => ok_json(&serde_json::json!({ "indexes": indexes })),
         Err(e) => err_internal("list indexes failed", e),
@@ -252,6 +287,9 @@ async fn discover_indexes(ctx: &dyn Context) -> Result<Vec<String>, WaferError> 
 // ---------------------------------------------------------------------------
 
 pub(super) async fn delete_index(ctx: &dyn Context, msg: &Message) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let name = path_param(msg, "name", "/b/vector/api/indexes/");
     if name.is_empty() {
         return err_bad_request("index name is required");
@@ -297,6 +335,9 @@ struct UpsertBody {
 }
 
 pub(super) async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let raw = input.collect_to_bytes().await;
     let body: UpsertBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -326,6 +367,9 @@ pub(super) async fn upsert(ctx: &dyn Context, input: InputStream) -> OutputStrea
 // ---------------------------------------------------------------------------
 
 pub(super) async fn delete_single(ctx: &dyn Context, msg: &Message) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let (index, id) = extract_index_and_id(msg);
     if index.is_empty() {
         return err_bad_request("index is required");
@@ -370,6 +414,12 @@ fn extract_index_and_id(msg: &Message) -> (&str, &str) {
 // ---------------------------------------------------------------------------
 
 pub(super) async fn stats(ctx: &dyn Context) -> OutputStream {
+    // Same "no backend → nothing to report" empty-list shape as
+    // `list_indexes` above — `stats` is a per-index-count listing, not a
+    // write/query op, so an absent backend just means zero indexes to count.
+    if !service::vector_backend_available(ctx) {
+        return ok_json(&serde_json::json!({ "indexes": Vec::<serde_json::Value>::new() }));
+    }
     let indexes = match discover_indexes(ctx).await {
         Ok(v) => v,
         Err(e) => return err_internal("stats failed", e),
@@ -415,6 +465,9 @@ struct QueryBody {
 const DEFAULT_TOP_K: usize = 10;
 
 pub(super) async fn query(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let raw = input.collect_to_bytes().await;
     let mut body: QueryBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -605,6 +658,9 @@ struct IngestResponse {
 /// optionally add context summaries, embed, and upsert. The response tells
 /// the caller how many chunks landed.
 pub(super) async fn ingest(ctx: &dyn Context, input: InputStream) -> OutputStream {
+    if !service::vector_backend_available(ctx) {
+        return err_vector_backend_unavailable();
+    }
     let raw = input.collect_to_bytes().await;
     let body: IngestBody = match serde_json::from_slice(&raw) {
         Ok(b) => b,
@@ -944,6 +1000,138 @@ mod ingest_cleanup_tests {
             200,
             "a genuine NotFound from list_ids must still be tolerated as \
              'no prior chunks', not treated as fatal"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /b/vector/api/indexes degrades gracefully when the
+// `wafer-run/vector` backend block isn't registered (the live-server 500
+// this fix closes), and still lists real indexes when it is.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod backend_availability_tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use wafer_run::{Block as RunBlock, BlockCategory, BlockInfo, LifecycleEvent};
+
+    use super::*;
+    use crate::test_support::{output_is_error, output_json, output_status, TestContext};
+
+    /// Minimal `wafer-run/vector` stand-in that answers `vector.list_indexes`
+    /// with one fixed storage-prefixed stem, mirroring the shape the real
+    /// `wafer-block-sqlite` vector service returns.
+    struct FakeListIndexesBlock;
+
+    #[async_trait]
+    impl RunBlock for FakeListIndexesBlock {
+        fn info(&self) -> BlockInfo {
+            BlockInfo::new("wafer-run/vector", "0.0.1", "vector@v1", "test fake")
+                .category(BlockCategory::Service)
+        }
+
+        async fn handle(
+            &self,
+            _ctx: &dyn Context,
+            msg: Message,
+            _input: InputStream,
+        ) -> OutputStream {
+            match msg.kind.as_str() {
+                wafer_block::common::ServiceOp::VECTOR_LIST_INDEXES => {
+                    let resp = wafer_block::wire::vector::ListIndexesResponse {
+                        indexes: vec!["suppers_ai__vector__docs".to_string()],
+                    };
+                    OutputStream::respond(
+                        wafer_block::codec::encode(&resp).expect("encode list_indexes response"),
+                    )
+                }
+                other => OutputStream::error(WaferError::new(
+                    ErrorCode::Unimplemented,
+                    format!("FakeListIndexesBlock has no handler for '{other}'"),
+                )),
+            }
+        }
+
+        async fn lifecycle(
+            &self,
+            _ctx: &dyn Context,
+            _e: LifecycleEvent,
+        ) -> Result<(), WaferError> {
+            Ok(())
+        }
+    }
+
+    /// `TestContext::with_vector()` on its own — no `wafer-run/vector` block
+    /// registered — is exactly the default native-server configuration
+    /// (`docs/checks/...` bug report: native solobase ships no
+    /// `wafer-run/vector` backend). Before this fix, `list_indexes` blindly
+    /// propagated the backend's `NotFound: block 'wafer-run/vector' not
+    /// found` through `err_internal`, which is what surfaced as the live
+    /// 500 `GET /b/vector/api/indexes` returned.
+    #[tokio::test]
+    async fn list_indexes_returns_200_when_backend_absent() {
+        let ctx = TestContext::with_vector().await;
+
+        let out = list_indexes(&ctx).await;
+
+        assert_eq!(
+            output_status(out).await,
+            200,
+            "list_indexes must not 500 when the wafer-run/vector backend isn't registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_indexes_returns_empty_list_when_backend_absent() {
+        let ctx = TestContext::with_vector().await;
+
+        let out = list_indexes(&ctx).await;
+
+        assert_eq!(
+            output_json(out).await,
+            serde_json::json!({ "indexes": [] }),
+            "backend-absent list must be a clean empty result, matching the \
+             /b/vector/ UI page's existing empty-state behavior"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_indexes_still_lists_real_indexes_when_backend_registered() {
+        let mut ctx = TestContext::with_vector().await;
+        ctx.register_block("wafer-run/vector", Arc::new(FakeListIndexesBlock));
+
+        let out = list_indexes(&ctx).await;
+
+        assert_eq!(
+            output_json(out).await,
+            serde_json::json!({ "indexes": ["docs"] }),
+            "once the backend is registered, list_indexes must go back to \
+             reporting real indexes instead of short-circuiting to empty"
+        );
+    }
+
+    /// Write-shaped ops (as opposed to the list-shaped `list_indexes`) must
+    /// surface a clear, typed `Unavailable` error instead of either a raw
+    /// 500 or a misleading `NotFound: index not found` — the same
+    /// `ErrorCode::NotFound` the backend's "block not found" and an app's
+    /// "index not found" both use, which is exactly the ambiguity the
+    /// up-front `vector_backend_available` check avoids.
+    #[tokio::test]
+    async fn create_index_returns_unavailable_when_backend_absent() {
+        let ctx = TestContext::with_vector().await;
+
+        let body = InputStream::from_bytes(
+            serde_json::to_vec(&serde_json::json!({ "name": "docs" })).unwrap(),
+        );
+        let msg = crate::test_support::admin_msg("create", "/b/vector/api/indexes");
+        let out = create_index(&ctx, &msg, body).await;
+
+        assert!(
+            output_is_error(out, "Unavailable").await,
+            "create_index must report Unavailable (503), not NotFound or Internal, \
+             when the wafer-run/vector backend isn't registered"
         );
     }
 }

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -7,7 +7,7 @@ use maud::{html, Markup};
 use wafer_core::clients::vector as vclient;
 use wafer_run::{context::Context, Message, OutputStream};
 
-use super::service::{display_index_name, IndexRow};
+use super::service::{display_index_name, vector_backend_available, IndexRow};
 use crate::ui::{
     self,
     shell::Crumb,
@@ -170,11 +170,9 @@ pub async fn index_list_page(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // creating/upserting against an index would 500 with "block not found".
     // Detect the missing backend at page render so we can hide the Create
     // button and surface an actionable callout instead of letting the user
-    // hit a generic htmx error.
-    let backend_available = ctx
-        .registered_blocks()
-        .iter()
-        .any(|b| b.name == "wafer-run/vector");
+    // hit a generic htmx error. Single-sourced with the JSON API's own
+    // backend-availability gate (`pages.rs`) via `service::vector_backend_available`.
+    let backend_available = vector_backend_available(ctx);
 
     let body = list_page(
         PageHeader {

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -53,6 +53,26 @@ pub fn display_index_name(stored: &str) -> &str {
     stored.strip_prefix(TABLE_PREFIX).unwrap_or(stored)
 }
 
+/// True when the `wafer-run/vector` backend block is registered on this
+/// runtime.
+///
+/// Native solobase ships no native vector engine (see the module docs on
+/// `pages_ui::index_list_page`) — the `wafer-run/vector` service block is
+/// only present on the browser-WASM build or when a runtime config wires
+/// one in. Without it, every `vclient::*` call in `pages.rs` fails with
+/// `ErrorCode::NotFound: block 'wafer-run/vector' not found`, which is
+/// indistinguishable (same error code) from a genuine "index not found".
+/// Checking `registered_blocks()` up front — instead of pattern-matching on
+/// that ambiguous `NotFound`, which the API's per-index-op error branches
+/// already use for a different meaning — lets both the UI page and every
+/// JSON API handler detect the missing backend unambiguously and degrade
+/// gracefully. Single source of truth so the two call sites can't drift.
+pub fn vector_backend_available(ctx: &dyn Context) -> bool {
+    ctx.registered_blocks()
+        .iter()
+        .any(|b| b.name == "wafer-run/vector")
+}
+
 /// Validate that an index name only contains characters that are safe
 /// to interpolate into SQL identifiers (alphanumeric + underscore).
 ///

--- a/crates/solobase-core/src/test_support.rs
+++ b/crates/solobase-core/src/test_support.rs
@@ -38,6 +38,19 @@ pub struct TestContext {
     config: Arc<HashMap<String, String>>,
     /// Placeholder for dynamically registered blocks — populated by Task 6.
     pub blocks: Arc<Mutex<HashMap<String, Arc<dyn Block>>>>,
+    /// `BlockInfo` for every block registered via [`Self::register_block`],
+    /// keyed by (and kept in sync with) `blocks`. Backs
+    /// `Context::registered_blocks()` so handler code that gates behavior on
+    /// "is block X registered?" (e.g. the vector block's backend-availability
+    /// check, `blocks::vector::service::vector_backend_available`) sees the
+    /// same signal in tests that a real `RuntimeContext` — whose
+    /// `registered_blocks()` reflects its sealed startup snapshot — would
+    /// produce in production. A plain `Vec` (not wrapped in the `blocks`
+    /// mutex) is enough: `register_block` already takes `&mut self`, so no
+    /// interior mutability is needed to update it, and `registered_blocks()`
+    /// can return a borrowed slice directly instead of cloning through a
+    /// lock guard.
+    block_infos: Vec<wafer_run::BlockInfo>,
     /// WRAP-enforcement caller identity. `None` = WRAP checks skipped (the
     /// default — keeps existing tests untouched). Set via [`with_wrap`].
     caller_id: Option<String>,
@@ -62,6 +75,7 @@ impl TestContext {
             database_block,
             config: Arc::new(HashMap::new()),
             blocks: Arc::new(Mutex::new(HashMap::new())),
+            block_infos: Vec::new(),
             caller_id: None,
             wrap_grants: Vec::new(),
             wrap_admin_block: String::new(),
@@ -246,6 +260,17 @@ impl TestContext {
     /// list; tests register a real or fake `UserPortalBlock` so the call
     /// resolves.
     pub fn register_block(&mut self, name: &str, block: Arc<dyn Block>) {
+        // Keep `block_infos` a deduplicated mirror of `blocks`'s keys — a
+        // block re-registered under the same name (e.g. `set_config`
+        // calling `register_block("wafer-run/config", ..)` again) replaces
+        // its old entry rather than appending a duplicate. The registration
+        // name (not whatever `block.info().name` happens to report) is
+        // authoritative, matching how `blocks` itself is keyed.
+        self.block_infos.retain(|b| b.name != name);
+        let mut info = block.info();
+        info.name = name.to_string();
+        self.block_infos.push(info);
+
         self.blocks
             .lock()
             .expect("blocks mutex poisoned")
@@ -330,6 +355,10 @@ impl Context for TestContext {
 
     fn is_cancelled(&self) -> bool {
         false
+    }
+
+    fn registered_blocks(&self) -> &[wafer_run::BlockInfo] {
+        &self.block_infos
     }
 
     fn config_get(&self, key: &str) -> Option<&str> {


### PR DESCRIPTION
## Summary

- `GET /b/vector/api/indexes` (and other vector API endpoints) 500'd on native solobase because it deliberately ships no `wafer-run/vector` backend block — every `vclient::*` call in `pages.rs` fails with an unhandled `NotFound: block 'wafer-run/vector' not found`, which the JSON API propagated straight into a raw 500. The `/b/vector/` UI page already detected this via `registered_blocks()` and rendered a "backend not available" callout; the API had no equivalent.
- Added `service::vector_backend_available(ctx)` — a single source of truth, now used by both the UI page and every backend-dependent API handler (`create_index`, `list_indexes`, `delete_index`, `upsert`, `delete_single`, `query`, `ingest`, `stats`).
- `list_indexes`/`stats` (list-shaped GETs) now return a clean **200 `{"indexes": []}`** when the backend is absent, matching the UI's existing empty state.
- Write/query ops (`create_index`, `delete_index`, `upsert`, `delete_single`, `query`, `ingest`) now return a typed **503 `Unavailable`** (`ErrorCode::Unavailable`, already mapped to HTTP 503 in wafer-block) instead of a raw 500 or a misleading `NotFound`/"index not found" — up-front detection was chosen over pattern-matching the wire error because the same `NotFound` code is already used by those handlers to mean "this index doesn't exist," a different thing than "the backend isn't registered."
- `embed` is untouched — it dispatches to a caller-supplied embedding block (`suppers-ai/fastembed`), never to `wafer-run/vector`, so it was never affected by this bug.
- Fixed a related test-harness gap found along the way: `TestContext::registered_blocks()` silently always returned the `Context` trait's empty default, even after `register_block()` — so the up-front check couldn't be exercised against a registered fake block in tests. `TestContext` now tracks `block_infos` in sync with its `blocks` map.

## Test plan

- [x] New tests in `crates/solobase-core/src/blocks/vector/pages.rs::backend_availability_tests`: `list_indexes` returns 200 + empty list when the backend is absent (reproduces + closes the reported 500 — verified RED before the fix, GREEN after), still lists real indexes once a fake `wafer-run/vector` block is registered, and `create_index` returns `Unavailable` (not `NotFound`/`Internal`) when absent.
- [x] `cargo +nightly fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — no new warnings (verified the two warnings landing in touched files are pre-existing, unmodified code that shifted line numbers).
- [x] `cargo test -p solobase-core vector` — 26 passed.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all green.
- [x] Live smoke test against the native server (`examples/dropship` config, default vector-enabled): confirmed `GET /b/vector/api/indexes` and `/api/stats` now return 200 with an empty list, and `POST /api/indexes`/`/api/upsert` return 503 `Unavailable` instead of 500.
- [x] `Cargo.lock` not touched in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)