### PR TITLE
fix(openapi): real title (not "127") + schemas for core auth/storage/products endpoints

### DIFF
--- a/crates/solobase-core/src/blocks/auth_ui/mod.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/mod.rs
@@ -204,15 +204,133 @@ crate::solobase_feature_block! {
                 .summary("Claimed organizations")
                 .auth(AuthLevel::Authenticated),
             BlockEndpoint::get("/b/auth/oauth/login").summary("Start OAuth flow"),
-            // JSON API
-            BlockEndpoint::post("/b/auth/api/login").summary("Authenticate with email/password"),
-            BlockEndpoint::post("/b/auth/api/signup").summary("Create account"),
+            // JSON API — schemas below mirror the real request/response
+            // shapes read from the handlers (`api/login.rs`, `api/signup.rs`,
+            // `api/me.rs`, `api/refresh.rs`, `api/logout.rs`), same pattern
+            // as `blocks/messages/mod.rs`. These are the core developer-facing
+            // auth endpoints; full schema coverage of every `/b/auth/*` route
+            // (OAuth, api-keys, password reset, bootstrap) is a follow-up.
+            BlockEndpoint::post("/b/auth/api/login")
+                .summary("Authenticate with email/password")
+                .input_schema(serde_json::json!({
+                    "type": "object",
+                    "required": ["email", "password"],
+                    "properties": {
+                        "email": {"type": "string", "format": "email"},
+                        "password": {"type": "string"}
+                    }
+                }))
+                .output_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                        "token_type": {"type": "string", "const": "Bearer"},
+                        "expires_in": {"type": "integer", "description": "Access token lifetime in seconds"},
+                        "default_redirect": {"type": "string", "description": "Role-aware post-login redirect path"},
+                        "user": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "email": {"type": "string"},
+                                "roles": {"type": "array", "items": {"type": "string"}},
+                                "name": {"type": "string"}
+                            }
+                        }
+                    }
+                }))
+                .tags(&["auth"]),
+            BlockEndpoint::post("/b/auth/api/signup")
+                .summary("Create account")
+                .input_schema(serde_json::json!({
+                    "type": "object",
+                    "required": ["email", "password"],
+                    "properties": {
+                        "email": {"type": "string", "format": "email"},
+                        "password": {"type": "string"},
+                        "name": {"type": "string", "description": "Optional display name"}
+                    }
+                }))
+                .output_schema(serde_json::json!({
+                    "type": "object",
+                    "description": "Auto-logs in (issues tokens) unless email verification is required, in which case only email_verified/message/user are returned.",
+                    "properties": {
+                        "email_verified": {"type": "boolean"},
+                        "message": {"type": "string", "description": "Present when verification is required or the email is already registered"},
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                        "token_type": {"type": "string", "const": "Bearer"},
+                        "expires_in": {"type": "integer"},
+                        "default_redirect": {"type": "string"},
+                        "user": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "email": {"type": "string"},
+                                "roles": {"type": "array", "items": {"type": "string"}},
+                                "name": {"type": "string"}
+                            }
+                        }
+                    }
+                }))
+                .tags(&["auth"]),
             BlockEndpoint::post("/b/auth/api/logout")
                 .summary("Sign out")
-                .auth(AuthLevel::Authenticated),
+                .auth(AuthLevel::Authenticated)
+                .output_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string"}
+                    }
+                }))
+                .tags(&["auth"]),
             BlockEndpoint::get("/b/auth/api/me")
                 .summary("Get current user")
-                .auth(AuthLevel::Authenticated),
+                .auth(AuthLevel::Authenticated)
+                .output_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "email": {"type": "string"},
+                                "name": {"type": "string"},
+                                "roles": {"type": "array", "items": {"type": "string"}},
+                                "created_at": {"type": "string", "format": "date-time"},
+                                "avatar_url": {"type": "string"}
+                            }
+                        }
+                    }
+                }))
+                .tags(&["auth"]),
+            // Was previously undeclared entirely (dispatched in `handle()`
+            // but absent from `.endpoints`), which meant it was excluded
+            // from `/openapi.json` AND from the per-endpoint access-tier
+            // table. Declaring it here (default `AuthLevel::Public`, matching
+            // its actual undeclared-backstop behavior — the `/b/auth/` prefix
+            // route is Public and this endpoint takes no `Authorization`
+            // header, only a `refresh_token` body field) is a documentation
+            // fix only; it does not change effective access.
+            BlockEndpoint::post("/b/auth/api/refresh")
+                .summary("Rotate an access/refresh token pair")
+                .input_schema(serde_json::json!({
+                    "type": "object",
+                    "required": ["refresh_token"],
+                    "properties": {
+                        "refresh_token": {"type": "string"}
+                    }
+                }))
+                .output_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                        "token_type": {"type": "string", "const": "Bearer"},
+                        "expires_in": {"type": "integer", "description": "Access token lifetime in seconds"}
+                    }
+                }))
+                .tags(&["auth"]),
             BlockEndpoint::post("/b/auth/api/change-password")
                 .summary("Change password")
                 .auth(AuthLevel::Authenticated),

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -57,9 +57,71 @@ crate::solobase_feature_block! {
                 BlockEndpoint::get("/b/storage/{bucket}/{prefix...}/").summary("Object list (nested)").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/storage/api/buckets").summary("List buckets").auth(AuthLevel::Authenticated),
                 BlockEndpoint::post("/b/storage/api/buckets").summary("Create bucket").auth(AuthLevel::Authenticated),
-                BlockEndpoint::get("/b/storage/api/buckets/{name}/objects").summary("List objects").auth(AuthLevel::Authenticated),
+                // Schemas below mirror the real shapes read from
+                // `storage.rs` (`handle_list_objects`/`handle_get_object`,
+                // wire types `wafer_block::wire::storage::{ObjectList,
+                // ObjectInfo}`). These are the two highest-value developer
+                // endpoints for browsing a bucket; full coverage of the
+                // remaining storage routes (buckets, shares, quotas) is a
+                // follow-up.
+                BlockEndpoint::get("/b/storage/api/buckets/{name}/objects")
+                    .summary("List objects")
+                    .auth(AuthLevel::Authenticated)
+                    .path_params_schema(serde_json::json!({
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                            "name": {"type": "string", "description": "Bucket name"}
+                        }
+                    }))
+                    .query_params_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "prefix": {"type": "string", "description": "Key prefix filter"},
+                            "page": {"type": "integer", "default": 1},
+                            "page_size": {"type": "integer", "default": 50, "maximum": 100}
+                        }
+                    }))
+                    .output_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "objects": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {"type": "string"},
+                                        "size": {"type": "integer", "description": "Size in bytes"},
+                                        "content_type": {"type": "string"},
+                                        "last_modified": {"type": "string", "format": "date-time"}
+                                    }
+                                }
+                            },
+                            "total_count": {"type": "integer"}
+                        }
+                    }))
+                    .tags(&["storage"]),
                 BlockEndpoint::post("/b/storage/api/buckets/{name}/objects").summary("Upload file").auth(AuthLevel::Authenticated),
-                BlockEndpoint::get("/b/storage/api/buckets/{name}/objects/{key}").summary("Download file").auth(AuthLevel::Authenticated),
+                // No output_schema: the success response is the raw object
+                // body (`Content-Type` set from the stored object's MIME
+                // type), not JSON — see `handle_get_object`'s
+                // `ResponseBuilder::new().body(data, &info.content_type)`.
+                // `path_params_schema` alone is enough to surface this
+                // endpoint's request shape in `/openapi.json` without
+                // mislabeling the response as `application/json`.
+                BlockEndpoint::get("/b/storage/api/buckets/{name}/objects/{key}")
+                    .summary("Download file")
+                    .description("Returns the raw object bytes with the stored Content-Type — not a JSON envelope.")
+                    .auth(AuthLevel::Authenticated)
+                    .path_params_schema(serde_json::json!({
+                        "type": "object",
+                        "required": ["name", "key"],
+                        "properties": {
+                            "name": {"type": "string", "description": "Bucket name"},
+                            "key": {"type": "string", "description": "Object key (may contain '/')"}
+                        }
+                    }))
+                    .tags(&["storage"]),
                 BlockEndpoint::delete("/b/storage/api/buckets/{name}/objects/{key}").summary("Delete file").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/storage/direct/{token}").summary("Access shared file"),
                 BlockEndpoint::get("/b/cloudstorage/").summary("Shares + quota page").auth(AuthLevel::Authenticated),

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -76,6 +76,32 @@ crate::solobase_feature_block! {
     info: |_this| {
         use wafer_run::{AuthLevel, CollectionSchema};
 
+        // Product row shape (see `migrations/001_products_schema.sqlite.sql`),
+        // reused below by the public catalog list/detail response schemas —
+        // `db::get`/`db::paginated_list` return a `Record { id, data }` where
+        // `data` is the full column map (`id` included).
+        let product_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "slug": {"type": "string"},
+                "base_price": {"type": "number"},
+                "currency": {"type": "string"},
+                "status": {"type": "string", "description": "draft | active | archived"},
+                "category": {"type": "string"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "metadata": {"type": "object"},
+                "image_url": {"type": "string"},
+                "stock": {"type": "integer"},
+                "group_id": {"type": "string"},
+                "type_id": {"type": "string"},
+                "created_at": {"type": "string", "format": "date-time"},
+                "updated_at": {"type": "string", "format": "date-time"}
+            }
+        });
+
         BlockInfo::new("suppers-ai/products", "0.0.1", "http-handler@v1", "Products, pricing, purchases, and payment integration")
             .instance_mode(InstanceMode::Singleton)
             .requires(vec!["wafer-run/database".into(), "wafer-run/config".into(), "wafer-run/network".into()])
@@ -158,8 +184,58 @@ crate::solobase_feature_block! {
                 BlockEndpoint::patch("/b/products/api/admin/purchases/{id}/refund").summary("Refund purchase").auth(AuthLevel::Admin),
                 BlockEndpoint::get("/b/products/api/admin/stats").summary("Stats").auth(AuthLevel::Admin),
                 // Public + authenticated user surface
-                BlockEndpoint::get("/b/products/catalog").summary("Browse catalog"),
-                BlockEndpoint::get("/b/products/catalog/{id}").summary("Product detail"),
+                // Public catalog — highest-value developer-facing surface of
+                // this block; accurate shapes read from `handlers.rs`
+                // (`handle_catalog` → `crud::crud_list` → `RecordList`,
+                // `handle_get_product_public` → `db::get` → `Record`). Full
+                // schema coverage of the admin/purchase/checkout API is a
+                // follow-up.
+                BlockEndpoint::get("/b/products/catalog")
+                    .summary("Browse catalog")
+                    .description("Public list of active products, sorted by name.")
+                    .query_params_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "page": {"type": "integer", "default": 1},
+                            "page_size": {"type": "integer", "default": 20, "maximum": 100}
+                        }
+                    }))
+                    .output_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "records": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string"},
+                                        "data": product_schema
+                                    }
+                                }
+                            },
+                            "total_count": {"type": "integer"},
+                            "page": {"type": "integer"},
+                            "page_size": {"type": "integer"}
+                        }
+                    }))
+                    .tags(&["products"]),
+                BlockEndpoint::get("/b/products/catalog/{id}")
+                    .summary("Product detail")
+                    .path_params_schema(serde_json::json!({
+                        "type": "object",
+                        "required": ["id"],
+                        "properties": {
+                            "id": {"type": "string"}
+                        }
+                    }))
+                    .output_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "data": product_schema
+                        }
+                    }))
+                    .tags(&["products"]),
                 BlockEndpoint::post("/b/products/checkout").summary("Stripe checkout").auth(AuthLevel::Authenticated),
                 BlockEndpoint::post("/b/products/purchases").summary("Create purchase").auth(AuthLevel::Authenticated),
                 BlockEndpoint::get("/b/products/purchases").summary("List purchases").auth(AuthLevel::Authenticated),

--- a/crates/solobase-core/src/blocks/products/mod.rs
+++ b/crates/solobase-core/src/blocks/products/mod.rs
@@ -89,7 +89,7 @@ crate::solobase_feature_block! {
                 "slug": {"type": "string"},
                 "base_price": {"type": "number"},
                 "currency": {"type": "string"},
-                "status": {"type": "string", "description": "draft | active | archived"},
+                "status": {"type": "string", "description": "draft | active"},
                 "category": {"type": "string"},
                 "tags": {"type": "array", "items": {"type": "string"}},
                 "metadata": {"type": "object"},
@@ -97,6 +97,12 @@ crate::solobase_feature_block! {
                 "stock": {"type": "integer"},
                 "group_id": {"type": "string"},
                 "type_id": {"type": "string"},
+                "group_template_id": {"type": "string"},
+                "product_template_id": {"type": "string"},
+                "pricing_template_id": {"type": "string"},
+                "requires": {"type": "string"},
+                "created_by": {"type": "string"},
+                "deleted_at": {"type": ["string", "null"], "format": "date-time", "description": "Null unless the product has been soft-deleted."},
                 "created_at": {"type": "string", "format": "date-time"},
                 "updated_at": {"type": "string", "format": "date-time"}
             }

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -106,12 +106,23 @@ pub async fn handle_request(
         let is_openapi = path == "/openapi.json";
         let host = msg.header("host").to_string();
         let server_url = format!("https://{}", host);
-        let project_name = host.split('.').next().unwrap_or("Solobase Project");
+        // The project/display name for the discovery documents (OpenAPI
+        // `info.title` and the agent-card `name`). Previously this was
+        // derived from the `Host` header (`host.split('.').next()`), which
+        // produced garbage for IP-addressed hosts — e.g. `127.0.0.1:8093`
+        // yielded the literal title `"127"`. `SOLOBASE_SHARED__APP_NAME` is
+        // the existing single-sourced display-name config var (already used
+        // for emails, the login page, and the browser `<title>` — see
+        // `blocks/email.rs`, `ui/mod.rs`), so discovery documents reuse it
+        // instead of inventing a second name knob; it falls back to the
+        // constant `"Solobase"`, never to the host.
+        let project_name =
+            config_client::get_default(ctx, "SOLOBASE_SHARED__APP_NAME", "Solobase").await;
 
         let body = if is_openapi {
-            wafer_core::discovery::generate_openapi(block_infos, project_name, "", &server_url)
+            wafer_core::discovery::generate_openapi(block_infos, &project_name, "", &server_url)
         } else {
-            wafer_core::discovery::generate_agent_card(block_infos, project_name, "", &server_url)
+            wafer_core::discovery::generate_agent_card(block_infos, &project_name, "", &server_url)
         };
 
         // [SEC-073] Only emit `Access-Control-Allow-Origin: *` in dev. These
@@ -422,6 +433,213 @@ async fn collect_buffered_with_prelude(
         Some(StreamEvent::Drop) => Err(TerminalNotResponse::Drop),
         Some(StreamEvent::Continue(msg)) => Err(TerminalNotResponse::Continue(msg)),
         None => Err(TerminalNotResponse::Malformed),
+    }
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    //! Covers the two OpenAPI/agent-card fixes:
+    //!  1. `info.title` (and the agent-card `name`) comes from
+    //!     `SOLOBASE_SHARED__APP_NAME` (fallback `"Solobase"`), never from
+    //!     the `Host` header — an IP-addressed host used to yield the
+    //!     literal title `"127"`.
+    //!  2. The core developer-facing auth/storage/products endpoints now
+    //!     declare schemas, so `wafer_core::discovery::generate_openapi`
+    //!     (which skips any endpoint failing `has_schema()`) includes them.
+
+    use wafer_run::{Block, BlockInfo, InputStream};
+
+    use super::handle_request;
+    use crate::{
+        blocks::{auth_ui::AuthUiBlock, files::FilesBlock, products::ProductsBlock},
+        features::AllEnabled,
+        test_support::{anon_msg, collect_or_panic, TestContext},
+    };
+
+    /// `BlockInfo` for the three blocks this PR added schemas to, fetched
+    /// from the real block structs (not hand-rolled fixtures) so the test
+    /// exercises the actual declarations shipped in `blocks/{auth_ui,files,
+    /// products}/mod.rs`.
+    fn real_block_infos() -> Vec<BlockInfo> {
+        vec![
+            AuthUiBlock::new().info(),
+            FilesBlock::new().info(),
+            ProductsBlock::new().info(),
+        ]
+    }
+
+    async fn discovery_json(ctx: &TestContext, path: &str, host: &str) -> serde_json::Value {
+        let mut msg = anon_msg("retrieve", path);
+        msg.set_meta("http.header.host", host);
+        let out = handle_request(
+            ctx,
+            msg,
+            InputStream::from_bytes(Vec::new()),
+            None,
+            "test-jwt-secret",
+            &AllEnabled,
+            &real_block_infos(),
+            &[],
+        )
+        .await;
+        let buf = collect_or_panic(out).await;
+        serde_json::from_slice(&buf.body).expect("discovery response is valid JSON")
+    }
+
+    #[tokio::test]
+    async fn openapi_title_falls_back_to_solobase_not_host_derived_127() {
+        let ctx = TestContext::new().await;
+        // The exact host shape that produced the bug: an IP:port `Host`
+        // header. `host.split('.').next()` on `"127.0.0.1:8093"` yields
+        // the literal string `"127"`.
+        let body = discovery_json(&ctx, "/openapi.json", "127.0.0.1:8093").await;
+
+        assert_eq!(
+            body["info"]["title"], "Solobase",
+            "no SOLOBASE_SHARED__APP_NAME configured — title must fall back to the constant, not derive from the Host header: {body}"
+        );
+        assert_ne!(body["info"]["title"], "127");
+    }
+
+    #[tokio::test]
+    async fn openapi_title_honors_configured_app_name() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SOLOBASE_SHARED__APP_NAME", "Acme Corp");
+        let body = discovery_json(&ctx, "/openapi.json", "127.0.0.1:8093").await;
+
+        assert_eq!(body["info"]["title"], "Acme Corp");
+    }
+
+    #[tokio::test]
+    async fn agent_card_name_uses_the_same_configured_project_name() {
+        let mut ctx = TestContext::new().await;
+        ctx.set_config("SOLOBASE_SHARED__APP_NAME", "Acme Corp");
+        let body = discovery_json(&ctx, "/.well-known/agent.json", "127.0.0.1:8093").await;
+
+        assert_eq!(
+            body["name"], "Acme Corp",
+            "agent-card generation must use the same corrected project_name as openapi: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn openapi_documents_core_auth_endpoints_with_schemas() {
+        let ctx = TestContext::new().await;
+        let body = discovery_json(&ctx, "/openapi.json", "solobase.example.com").await;
+        let paths = &body["paths"];
+
+        let login = &paths["/b/auth/api/login"]["post"];
+        assert!(
+            !login.is_null(),
+            "login must appear in /openapi.json: {body}"
+        );
+        assert_eq!(
+            login["requestBody"]["content"]["application/json"]["schema"]["required"],
+            serde_json::json!(["email", "password"]),
+            "login request schema must match the real handler body: {login}"
+        );
+        assert!(
+            !login["responses"]["200"]["content"]["application/json"]["schema"].is_null(),
+            "login response schema missing: {login}"
+        );
+        assert!(
+            login.get("security").is_none(),
+            "login is AuthLevel::Public — must not carry a security requirement: {login}"
+        );
+
+        let me = &paths["/b/auth/api/me"]["get"];
+        assert!(!me.is_null(), "me must appear in /openapi.json: {body}");
+        assert_eq!(
+            me["responses"]["200"]["content"]["application/json"]["schema"]["properties"]["user"]
+                ["properties"]["roles"]["type"],
+            "array",
+            "me response schema must match api/me.rs's {{user: {{..., roles: [...]}}}} shape: {me}"
+        );
+        assert_eq!(
+            me["security"][0]["bearerAuth"],
+            serde_json::json!([]),
+            "me is AuthLevel::Authenticated — must carry bearerAuth security: {me}"
+        );
+
+        // /b/auth/api/refresh was previously entirely undeclared (dispatched
+        // in handle() but absent from .endpoints) — now documented.
+        let refresh = &paths["/b/auth/api/refresh"]["post"];
+        assert!(
+            !refresh.is_null(),
+            "refresh must appear in /openapi.json now that it's declared: {body}"
+        );
+        assert_eq!(
+            refresh["requestBody"]["content"]["application/json"]["schema"]["required"],
+            serde_json::json!(["refresh_token"]),
+        );
+    }
+
+    #[tokio::test]
+    async fn openapi_documents_core_storage_endpoints_with_schemas() {
+        let ctx = TestContext::new().await;
+        let body = discovery_json(&ctx, "/openapi.json", "solobase.example.com").await;
+        let paths = &body["paths"];
+
+        let list = &paths["/b/storage/api/buckets/{name}/objects"]["get"];
+        assert!(
+            !list.is_null(),
+            "list-objects must appear in /openapi.json: {body}"
+        );
+        assert_eq!(
+            list["parameters"]
+                .as_array()
+                .expect("list-objects has path+query parameters")
+                .iter()
+                .filter(|p| p["in"] == "path" && p["name"] == "name")
+                .count(),
+            1,
+            "list-objects must declare the {{name}} bucket path param: {list}"
+        );
+        assert!(
+            !list["responses"]["200"]["content"]["application/json"]["schema"]["properties"]
+                ["objects"]
+                .is_null(),
+            "list-objects response schema must match ObjectList {{objects, total_count}}: {list}"
+        );
+
+        let get_obj = &paths["/b/storage/api/buckets/{name}/objects/{key}"]["get"];
+        assert!(
+            !get_obj.is_null(),
+            "get-object must appear in /openapi.json: {body}"
+        );
+        assert!(
+            get_obj["responses"]["200"].get("content").is_none(),
+            "get-object returns raw bytes, not JSON — must not claim an application/json response: {get_obj}"
+        );
+    }
+
+    #[tokio::test]
+    async fn openapi_documents_core_products_endpoints_with_schemas() {
+        let ctx = TestContext::new().await;
+        let body = discovery_json(&ctx, "/openapi.json", "solobase.example.com").await;
+        let paths = &body["paths"];
+
+        let catalog = &paths["/b/products/catalog"]["get"];
+        assert!(
+            !catalog.is_null(),
+            "catalog list must appear in /openapi.json: {body}"
+        );
+        assert_eq!(
+            catalog["responses"]["200"]["content"]["application/json"]["schema"]["properties"]
+                ["records"]["items"]["properties"]["data"]["properties"]["base_price"]["type"],
+            "number",
+            "catalog response schema must match the real products row shape: {catalog}"
+        );
+
+        let detail = &paths["/b/products/catalog/{id}"]["get"];
+        assert!(
+            !detail.is_null(),
+            "product detail must appear in /openapi.json: {body}"
+        );
+        assert_eq!(
+            detail["parameters"][0]["name"], "id",
+            "product detail must declare the {{id}} path param: {detail}"
+        );
     }
 }
 

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -572,6 +572,10 @@ mod discovery_tests {
             refresh["requestBody"]["content"]["application/json"]["schema"]["required"],
             serde_json::json!(["refresh_token"]),
         );
+        assert!(
+            refresh.get("security").is_none(),
+            "refresh is AuthLevel::Public — must not carry a security requirement: {refresh}"
+        );
     }
 
     #[tokio::test]
@@ -630,6 +634,27 @@ mod discovery_tests {
             "number",
             "catalog response schema must match the real products row shape: {catalog}"
         );
+        // The product object schema must cover every column the migration
+        // declares (see `001_products_schema.sqlite.sql`), not just a subset
+        // — `SELECT *` means all 22 columns land in the real response.
+        // `created_by`/`deleted_at` were previously missing entirely; pin
+        // them (plus the other four FK/requires columns) so the gap can't
+        // silently reopen.
+        let product_props = &catalog["responses"]["200"]["content"]["application/json"]["schema"]
+            ["properties"]["records"]["items"]["properties"]["data"]["properties"];
+        for field in [
+            "group_template_id",
+            "product_template_id",
+            "pricing_template_id",
+            "requires",
+            "created_by",
+            "deleted_at",
+        ] {
+            assert!(
+                !product_props[field].is_null(),
+                "product schema is missing real column `{field}`: {product_props}"
+            );
+        }
 
         let detail = &paths["/b/products/catalog/{id}"]["get"];
         assert!(


### PR DESCRIPTION
## Summary

Solobase's `/openapi.json` was found nearly-useless by driving the live app:

1. **The spec's title was literally `"127"`.** `pipeline.rs` derived the OpenAPI `info.title` (and the agent-card `name`) from the `Host` header (`host.split('.').next()`). For an IP-addressed host like `127.0.0.1:8093` that yields the literal string `"127"`.
2. **The spec documented only 3 paths, 0 schemas.** `wafer_core::discovery::generate_openapi` skips any endpoint that doesn't declare `input_schema`/`output_schema`/`query_params_schema`/`path_params_schema`. Only the `messages` block declared these — every other block (auth, storage, products, etc.) was entirely undocumented.

## Changes

- **Title fix** (`pipeline.rs`): `project_name` now comes from the existing `SOLOBASE_SHARED__APP_NAME` config var (already the single-sourced display name used for emails/login page/browser `<title>`), falling back to the constant `"Solobase"`. Never derived from the `Host` header. Applies to both the OpenAPI and agent-card documents.
- **Schema coverage** for the highest-value developer-facing endpoints, with shapes read directly from the handlers (not invented):
  - **auth** (`blocks/auth_ui/mod.rs`): `POST /b/auth/api/login`, `POST /b/auth/api/signup`, `POST /b/auth/api/logout`, `GET /b/auth/api/me`, `POST /b/auth/api/refresh` (this one was previously entirely undeclared — dispatched in `handle()` but absent from `.endpoints` — so it was invisible to `/openapi.json` outright; declaring it is documentation-only, default `AuthLevel::Public` matches its existing undeclared-backstop behavior).
  - **storage** (`blocks/files/mod.rs`): `GET /b/storage/api/buckets/{name}/objects` (list), `GET /b/storage/api/buckets/{name}/objects/{key}` (download — path params only, no `output_schema` since the real response is raw bytes, not JSON).
  - **products** (`blocks/products/mod.rs`): `GET /b/products/catalog` (list), `GET /b/products/catalog/{id}` (detail) — the public catalog surface.
- Full OpenAPI coverage of every endpoint across every block is a larger follow-up initiative; this PR fixes the title bug and covers the core auth/storage/products developer surfaces as a correct, representative bump.

## Test plan

- [x] New `pipeline::discovery_tests` module (6 tests): title falls back to `"Solobase"` (never `"127"`) with no config set; title honors `SOLOBASE_SHARED__APP_NAME` when configured; agent-card uses the same corrected name; auth/storage/products paths now appear in `/openapi.json` with accurate request/response schemas.
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` — no new warnings (pre-existing warnings in untouched files/lines only)
- [x] `cargo test -p solobase-core` — all pass (one pre-existing, unrelated `lockfile_e2e` failure was observed under `-p`-scoped feature unification; it passes under the full `--workspace` run, see below)
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all pass, 0 failures
- [x] `Cargo.lock` not touched (verified not in diff/commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WLLHawRn5HnCn6CfFZxoq