### PR TITLE
fix(cf): fail deploys fast on missing/short JWT secret + serve poll detects wrangler death

### DIFF
--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -298,6 +298,37 @@ where
         return worker::Response::error("unauthorized", 401);
     }
 
+    // Deploy-time JWT guard: fail fast with an actionable error when the
+    // JWT secret is missing or too short, rather than letting the funnel
+    // run and every downstream auth op start failing. Read the secret the
+    // same way `build_runtime` does (`env.secret(JWT_SECRET_KEY)`, empty
+    // default on error).
+    //
+    // This is deliberately narrower than the request path: `crypto_service`'s
+    // `jwt()` surfaces a missing/short secret per-operation instead of at
+    // worker boot, because a broken-auth deployment beats a boot-looping
+    // one (see crypto_service.rs:34-38). That adjudication is unchanged
+    // here — this guard only runs inside the operator-driven `/_deploy/init`
+    // funnel (a production deploy or `solobase serve --target cloudflare`),
+    // where the operator is watching and fail-fast is the native-parity
+    // point; it never runs on the request path.
+    let jwt_secret_len = env
+        .secret(solobase_core::blocks::auth::JWT_SECRET_KEY)
+        .map(|s| s.to_string().len())
+        .unwrap_or(0);
+    if jwt_secret_len < wafer_block_crypto::primitives::MIN_JWT_SECRET_LEN {
+        return worker::Response::error(
+            format!(
+                "{} is missing or too short ({jwt_secret_len} bytes, need at least {}); \
+                 set it with: wrangler secret put {}",
+                solobase_core::blocks::auth::JWT_SECRET_KEY,
+                wafer_block_crypto::primitives::MIN_JWT_SECRET_LEN,
+                solobase_core::blocks::auth::JWT_SECRET_KEY,
+            ),
+            500,
+        );
+    }
+
     // Fresh runtime (never the request cache) with run_migrations forced on,
     // so slot-cached pre-migration outcomes can't leak into the funnel.
     let out = async {

--- a/crates/solobase/src/cli/flows/embed_cloudflare.rs
+++ b/crates/solobase/src/cli/flows/embed_cloudflare.rs
@@ -83,12 +83,16 @@ pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result
     let mut child = dev.spawn()?;
 
     let local_url = format!("http://localhost:{local_port}");
-    match wait_and_run_local_init(&local_url, &dev_token).await {
+    match wait_and_run_local_init(&mut child, &local_url, &dev_token).await {
         Ok((ok, report)) => {
             if ok {
                 println!("-> local /_deploy/init ok (migrations + seeds applied)");
             } else {
                 eprintln!("-> local /_deploy/init reported failures:\n{report}");
+                eprintln!(
+                    "-> retry manually: POST {local_url}/_deploy/init with header \
+                     x-deploy-token: {dev_token}"
+                );
             }
         }
         Err(e) => eprintln!(
@@ -106,7 +110,15 @@ pub async fn serve(repo_root: &Path, release: bool, port: Option<u16>) -> Result
 
 /// Poll until the local worker answers, then run the deploy-init funnel
 /// against it. Bounded: ~60s of connect retries.
-async fn wait_and_run_local_init(local_url: &str, token: &str) -> Result<(bool, String)> {
+///
+/// Checks `child` for an early exit before each retry sleep so a wrangler
+/// crash surfaces as "wrangler dev exited" instead of masquerading as 60s
+/// of generic "not reachable" connect failures.
+async fn wait_and_run_local_init(
+    child: &mut tokio::process::Child,
+    local_url: &str,
+    token: &str,
+) -> Result<(bool, String)> {
     const ATTEMPTS: u32 = 120;
     const INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
     let mut last_err = None;
@@ -115,6 +127,12 @@ async fn wait_and_run_local_init(local_url: &str, token: &str) -> Result<(bool, 
             Ok(out) => return Ok(out),
             Err(e) => {
                 last_err = Some(e);
+                if let Some(status) = child.try_wait()? {
+                    return Err(anyhow::anyhow!(
+                        "wrangler dev exited ({status}) before /_deploy/init became \
+                         reachable — see wrangler output above"
+                    ));
+                }
                 tokio::time::sleep(INTERVAL).await;
             }
         }
@@ -214,4 +232,32 @@ pub async fn deploy_secret(repo_root: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A child that exits immediately (no wrangler binary needed) must be
+    /// detected between connect retries: `wait_and_run_local_init` should
+    /// report "wrangler dev exited" rather than exhausting all ~60s of
+    /// retries against a port nothing is listening on.
+    #[tokio::test]
+    async fn wait_and_run_local_init_detects_dead_child() {
+        let mut child = tokio::process::Command::new("true")
+            .spawn()
+            .expect("spawn `true`");
+
+        // Port 1 is unassigned on loopback — connections are refused near-
+        // instantly rather than timing out, so a dead child is what makes
+        // the loop exit quickly instead of the 60s retry budget.
+        let err = wait_and_run_local_init(&mut child, "http://127.0.0.1:1", "token")
+            .await
+            .expect_err("dead child must surface as an error, not a 60s hang");
+
+        assert!(
+            err.to_string().contains("wrangler dev exited"),
+            "expected a wrangler-death error, got: {err}"
+        );
+    }
 }

--- a/crates/solobase/tests/helpers_cloudflare_wrangler.rs
+++ b/crates/solobase/tests/helpers_cloudflare_wrangler.rs
@@ -49,7 +49,7 @@ fn generate_writes_wrangler_toml_with_required_fields() {
     assert!(
         !body.contains("migrations_dir"),
         "deploy toml must not declare a wrangler migrations ledger — \
-         schema funds through /_deploy/init"
+         schema funnels through /_deploy/init"
     );
 }
 


### PR DESCRIPTION
## Summary

Three small CF-path fixes (task T6 of a deferred-work sweep):

1. **Deploy-time JWT guard.** `deploy_init_endpoint` (`crates/solobase-cloudflare/src/lib.rs`) now reads the JWT secret the same way `build_runtime` does (`env.secret(JWT_SECRET_KEY)`, empty default) and returns a 500 naming the missing/short secret plus the `wrangler secret put SUPPERS_AI__AUTH__JWT_SECRET` command when it's under `wafer_block_crypto::primitives::MIN_JWT_SECRET_LEN` (32 bytes). Runs before the funnel's runtime build, so a bad deploy fails fast instead of running migrations/seeds and leaving every downstream auth op broken.

2. **Serve poll UX.** `solobase serve --target cloudflare`'s poll loop (`crates/solobase/src/cli/flows/embed_cloudflare.rs`) now threads `&mut child` into `wait_and_run_local_init` and calls `child.try_wait()` before each retry sleep, so a wrangler crash reports `"wrangler dev exited (...) before /_deploy/init became reachable"` instead of masquerading as ~60s of generic "not reachable" connect failures.

3. **Funnel-failure hint.** The `Ok((false, report))` branch (funnel ran but reported failures) now gets the same manual-retry hint (`POST {local_url}/_deploy/init with header x-deploy-token: {dev_token}`) that the unreachable branch already had — previously only the unreachable branch told the operator how to retry.

4. **Typo fix.** `helpers_cloudflare_wrangler.rs:52`: "schema funds through" -> "schema funnels through".

## Deploy-time vs. request-time adjudication (recorded per task brief)

`build_runtime`/the request path are intentionally **not** touched. `crypto_service.rs`'s `jwt()` (lines 34-38) documents that a missing/short JWT secret surfaces as a per-operation `CryptoError` rather than at worker boot: *"a broken-auth deployment beats a boot-looping one."* That adjudication stands — the request path still degrades gracefully rather than 500-looping the whole worker.

This PR adds a **separate, narrower** guard that only runs inside the operator-driven `/_deploy/init` funnel (a production `deploy` or local `serve --target cloudflare`). Deploy time is where an operator is watching the output; failing fast there is the native-runtime-parity point (native `server.rs` would refuse to boot on a bad secret). The two checks serve different audiences and don't conflict: deploy-time fails loud for the operator, request-time still degrades softly instead of taking the whole worker down.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no new warnings from this diff. Pre-existing failures in `solobase-bundle` (4 lint errors: `needless_borrow`, `uninlined_format_args`, `manual_let_else`, `single_char_add_str`) predate this branch (verified via `git stash` against `bd28046`) and are unrelated to the CF path — out of scope for this task. Note CI's actual clippy step (`cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare`, no `-D warnings`) doesn't fail on these.
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` — all CF-path tests pass, including the new `wait_and_run_local_init_detects_dead_child` unit test and the retyped `helpers_cloudflare_wrangler` test. 4 pre-existing failures (`dry_run_goldens::sealed_web_build_dry_run_with_blocks`, `flow_sealed_web::build_emits_dist_with_wasm_and_index`, `helpers_wasm::wasm_resolution`, `wasm_bundling::bundled_wasm_is_present_and_valid`) also reproduce on baseline `bd28046` — caused by this worktree's empty `solobase-web` wasm/js stub (expected for native-only iteration per project notes), unrelated to this change.
- [x] `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` (matches CI's `Check solobase-cloudflare (wasm32)` step exactly) — clean.

Added a new unit test for the poll-loop change: `wait_and_run_local_init_detects_dead_child` spawns a trivial child that exits immediately and points `wait_and_run_local_init` at an unreachable loopback port, asserting the "wrangler dev exited" error surfaces instead of the loop hanging on retries — no real `wrangler` binary needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLUs2zoynBXtmNFqiMniDj