### PR TITLE
fix(routing): anonymous/stale-session HTML requests 302 to login with return path (was bare 403)

### DIFF
--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -255,10 +255,20 @@ fn declared_access(block_infos: &[BlockInfo], block_name: &str, msg: &Message) -
 fn check_access(access: RouteAccess, msg: &Message) -> Option<OutputStream> {
     match access {
         RouteAccess::Public => None,
+        // Missing identity (anonymous OR stale session — crypto.rs leaves
+        // `user_id` empty on any invalid token) → send browsers to login with a
+        // return path; keep the JSON 403 for API callers. Both protected tiers
+        // share this: an `Admin` route hit with no identity is a login problem,
+        // not a role problem.
         RouteAccess::Authenticated if msg.user_id().is_empty() => {
-            Some(crate::ui::forbidden_response(msg))
+            Some(crate::ui::unauthenticated_response(msg))
         }
         RouteAccess::Authenticated => None,
+        RouteAccess::Admin if msg.user_id().is_empty() => {
+            Some(crate::ui::unauthenticated_response(msg))
+        }
+        // Authenticated but lacking the admin role is a genuine 403, not a
+        // "log in" — keep the styled/JSON forbidden response (no redirect).
         RouteAccess::Admin if !crate::util::is_admin(msg) => {
             Some(crate::ui::forbidden_response(msg))
         }

--- a/crates/solobase-core/src/ui/mod.rs
+++ b/crates/solobase-core/src/ui/mod.rs
@@ -334,6 +334,28 @@ pub fn forbidden_response(msg: &wafer_run::Message) -> wafer_run::OutputStream {
     }
 }
 
+/// Anonymous (or stale-session — identical by the time enforcement runs)
+/// browser request on a protected route: send the user to login with a return
+/// path so they land back where they started after signing in. API callers
+/// (non-HTML `Accept`) keep the JSON 403 contract instead of a redirect.
+///
+/// The return path is form-encoded via [`crate::util::urlencode`] into a
+/// `?redirect=` query param — the exact param name and encoding the login page
+/// consumes (`is_safe_local_redirect` on the consumer side); the producer only
+/// needs to encode.
+pub fn unauthenticated_response(msg: &wafer_run::Message) -> wafer_run::OutputStream {
+    let accept = msg.get_meta("http.header.accept");
+    if accept.contains("text/html") && !accept.contains("application/json") {
+        let target = format!(
+            "/b/auth/login?redirect={}",
+            crate::util::urlencode(msg.path())
+        );
+        crate::http::redirect(302, &target)
+    } else {
+        crate::http::err_forbidden("authentication required")
+    }
+}
+
 /// Return styled 404 for browser requests, JSON for API requests.
 pub fn not_found_response(msg: &wafer_run::Message) -> wafer_run::OutputStream {
     let accept = msg.get_meta("http.header.accept");
@@ -513,6 +535,51 @@ mod tests {
             body.contains("Sign in"),
             "body should contain Sign in action"
         );
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_response_redirects_html_to_login() {
+        // Browser (HTML) request with an empty identity → 302 to the login page
+        // carrying a form-encoded `?redirect=` return path the login page
+        // consumes via `is_safe_local_redirect`.
+        let mut msg = Message::new("http.request");
+        msg.set_meta("req.resource", "/b/chat/hello");
+        msg.set_meta("http.header.accept", "text/html,application/xhtml+xml");
+        let buf = unauthenticated_response(&msg)
+            .collect_buffered()
+            .await
+            .expect("redirect is a Response terminal");
+        let status = buf
+            .meta
+            .iter()
+            .find(|e| e.key == "resp.status")
+            .map(|e| e.value.as_str());
+        let location = buf
+            .meta
+            .iter()
+            .find(|e| e.key == "resp.header.Location")
+            .map(|e| e.value.as_str());
+        assert_eq!(status, Some("302"));
+        assert_eq!(location, Some("/b/auth/login?redirect=%2Fb%2Fchat%2Fhello"));
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_response_json_accept_stays_403() {
+        // API caller (non-HTML Accept) keeps the JSON 403 contract — status
+        // stays 403 (not 401) so existing API clients/tests don't break.
+        use wafer_block::http_codec;
+        use wafer_run::streams::output::TerminalNotResponse;
+        let mut msg = Message::new("http.request");
+        msg.set_meta("req.resource", "/b/chat/hello");
+        msg.set_meta("http.header.accept", "application/json");
+        let status = match unauthenticated_response(&msg).collect_buffered().await {
+            Ok(buf) => i64::from(http_codec::resolve_status(&buf.meta, 200)),
+            Err(TerminalNotResponse::Error(err)) => {
+                i64::from(http_codec::resolve_error_status(&err))
+            }
+            Err(other) => panic!("unexpected terminal: {other:?}"),
+        };
+        assert_eq!(status, 403);
     }
 
     #[tokio::test]

--- a/crates/solobase-core/tests/extra_routes_test.rs
+++ b/crates/solobase-core/tests/extra_routes_test.rs
@@ -130,6 +130,28 @@ async fn response_status(stream: OutputStream) -> i64 {
     }
 }
 
+/// Like [`response_status`], but also returns the `Location` response header
+/// (`resp.header.Location` meta) for redirect assertions. A redirect is always
+/// a Response terminal, so the header only exists on the `Ok` path; Error
+/// terminals (the JSON 403 contract) carry no `Location`.
+async fn response_status_and_location(stream: OutputStream) -> (i64, Option<String>) {
+    match stream.collect_buffered().await {
+        Ok(buf) => {
+            let status = i64::from(http_codec::resolve_status(&buf.meta, 200));
+            let location = buf
+                .meta
+                .iter()
+                .find(|e| e.key == "resp.header.Location")
+                .map(|e| e.value.clone());
+            (status, location)
+        }
+        Err(TerminalNotResponse::Error(err)) => {
+            (i64::from(http_codec::resolve_error_status(&err)), None)
+        }
+        Err(other) => panic!("unexpected terminal: {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -263,6 +285,62 @@ async fn admin_extra_route_allows_admin() {
     assert_eq!(status, 200);
 
     assert_eq!(ctx.calls(), vec!["gizza-ai/admin".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// F3: unauthenticated HTML requests redirect to login instead of a bare 403.
+//
+// Stale-cookie and no-cookie requests both reach `check_access` with an empty
+// `user_id` (crypto.rs silently leaves identity unset on any invalid token), so
+// fixing the anonymous case fixes the stale-session dead-end at the single
+// enforcement point. Browser (HTML) requests get a 302 to the login page with a
+// `?redirect=` return path; API callers keep the JSON 403 contract. The
+// role-failure case (authenticated non-admin) must NOT redirect — that's a real
+// 403, not a "you need to log in".
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn anonymous_html_request_on_authenticated_route_redirects_to_login() {
+    let ctx = RecordingContext::new();
+    let extras = vec![ExtraRoute {
+        prefix: "/b/chat/".into(),
+        access: RouteAccess::Authenticated,
+        block_name: "gizza-ai/chat".into(),
+    }];
+    let mut msg = make_msg("/b/chat/hello");
+    msg.set_meta("http.header.accept", "text/html,application/xhtml+xml");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &[], &extras).await;
+    let (status, location) = response_status_and_location(stream).await;
+    assert_eq!(status, 302);
+    assert_eq!(
+        location.as_deref(),
+        Some("/b/auth/login?redirect=%2Fb%2Fchat%2Fhello")
+    );
+    assert!(ctx.calls().is_empty(), "dispatch must NOT happen");
+}
+
+#[tokio::test]
+async fn authenticated_non_admin_html_request_on_admin_route_still_403s() {
+    let ctx = RecordingContext::new();
+    let extras = vec![ExtraRoute {
+        prefix: "/b/gizza-admin/".into(),
+        access: RouteAccess::Admin,
+        block_name: "gizza-ai/admin".into(),
+    }];
+    // Authenticated (user_id set) but lacking the admin role, asking for HTML.
+    // The role-failure case is a genuine 403 — it must NOT redirect to login.
+    let mut msg = make_msg_with_user("/b/gizza-admin/dash", "user-123");
+    msg.set_meta("http.header.accept", "text/html,application/xhtml+xml");
+    let stream =
+        routing::route_to_block(&ctx, msg, InputStream::empty(), &AllEnabled, &[], &extras).await;
+    let (status, location) = response_status_and_location(stream).await;
+    assert_eq!(status, 403, "role failure must stay 403, not redirect");
+    assert_eq!(
+        location, None,
+        "role failure must not carry a login Location"
+    );
+    assert!(ctx.calls().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem (F3)

An unauthenticated browser request to a protected route — whether truly anonymous or carrying a **stale session cookie** — landed on a bare 403 dead-end. By the time the single auth enforcement point (`routing.rs::check_access`, post-S4-U) runs, the two cases are indistinguishable: `crypto.rs` silently leaves `user_id` empty on any invalid token. So fixing the empty-identity case at that one point fixes the stale-session dead-end too.

## Behavior matrix

| Route tier | Identity | Accept | Before | After |
|---|---|---|---|---|
| `Authenticated` or `Admin` | empty `user_id` (anonymous OR stale cookie) | HTML (`text/html`, no `application/json`) | bare 403 | **302 → `/b/auth/login?redirect=<urlencoded path>`** |
| `Authenticated` or `Admin` | empty `user_id` | non-HTML (API) | 403 JSON | 403 JSON `err_forbidden("authentication required")` (message clarified) |
| `Admin` | authenticated non-admin | any | 403 (`forbidden_response`) | unchanged — role failure is a real 403, must NOT redirect |
| `Public` | any | any | dispatch | unchanged |

The `?redirect=` param is form-encoded via `util::urlencode` (e.g. `/b/chat/hello` → `%2Fb%2Fchat%2Fhello`) — the exact param name and encoding the login page consumes via `is_safe_local_redirect`.

## Adjudication: API callers keep 403, not 401

The non-HTML branch intentionally keeps **status 403** (not the RFC-purist 401) so existing API clients and tests that assert the current JSON 403 contract don't break; only the error message is clarified to `"authentication required"`.

## Implementation

- `ui/mod.rs`: new `unauthenticated_response(msg)` next to `forbidden_response`, using the same Accept-header content negotiation pattern; HTML → `http::redirect(302, ...)`, else JSON 403.
- `routing.rs::check_access`: empty-identity denials on both protected tiers route through `unauthenticated_response`; the `Admin` role-failure arm keeps `forbidden_response`.

## Tests (TDD)

- RED: `anonymous_html_request_on_authenticated_route_redirects_to_login` failed with `left: 403, right: 302` before the implementation.
- `extra_routes_test.rs`: redirect test (asserts exact `Location` incl. encoding + no dispatch) and `authenticated_non_admin_html_request_on_admin_route_still_403s` (role failure must not redirect, no `Location`). Existing `authenticated_extra_route_forbids_empty_user_id` (no Accept header → 403 JSON) passes unchanged.
- `ui/mod.rs` unit tests: HTML → 302 + `Location`; JSON Accept → 403. Existing `forbidden_response_uses_status_template` unchanged.

## Verification

- `cargo +nightly fmt --all --check` clean.
- `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings`: error list byte-identical to base (zero new findings; remaining findings pre-exist on main and CI runs clippy without `-D warnings`).
- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare`: all green except 4 pre-existing `crates/solobase/tests/` wasm-bundling failures caused by the local 0-byte `solobase_web_bg.wasm` dev stub — each confirmed failing identically on base `bd28046`; CI downloads the real pkg artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)