### PR TITLE
test(core): host-testable KV version-stamp retry + fail-closed grant-loading Err branch

### DIFF
--- a/crates/solobase-cloudflare/src/kv_cached_db.rs
+++ b/crates/solobase-cloudflare/src/kv_cached_db.rs
@@ -3,36 +3,15 @@
 //!
 //! See `docs/superpowers/specs/2026-05-22-kv-cached-d1-config-source-design.md`.
 //!
-//! Pure cache-key derivation lives in `solobase_core::cache_key` so it can
-//! be unit-tested on host (this crate is excluded from `cargo test --workspace`).
+//! Host-testable logic lives in `solobase-core` so it can be unit-tested
+//! (this crate is wasm32-only and excluded from `cargo test --workspace`):
+//! pure cache-key derivation in `solobase_core::cache_key`, and the
+//! [`KvBackend`] trait + [`put_version_stamp_with_retry`] in
+//! `solobase_core::kv`.
 
-use wafer_block::{MaybeSend, MaybeSync};
+use solobase_core::kv::{put_version_stamp_with_retry, KvBackend};
 
-/// Pluggable KV backend. Production uses `worker::kv::KvStore` via
-/// `WorkerKvBackend`; tests use `MockKvBackend` (see `tests/support`).
-///
-/// All errors are returned as `String` and never propagate as a hard
-/// failure to callers — `KvCachedD1DatabaseService` treats every KV
-/// error as a cache miss and falls through to the underlying database.
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait KvBackend: MaybeSend + MaybeSync {
-    /// Returns `Ok(Some(value))` on cache hit, `Ok(None)` on miss,
-    /// `Err(msg)` on KV transport error.
-    async fn get(&self, key: &str) -> Result<Option<String>, String>;
-
-    /// Writes `value` under `key` with the given TTL (seconds).
-    async fn put_with_ttl(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), String>;
-
-    /// Writes `value` under `key` with no expiration. Reserved for the
-    /// config-version stamp — row-cache entries always carry a TTL.
-    async fn put(&self, key: &str, value: &str) -> Result<(), String>;
-
-    /// Deletes `key`. Deleting a non-existent key is not an error.
-    async fn delete(&self, key: &str) -> Result<(), String>;
-}
-
-/// Production `KvBackend` backed by `worker::kv::KvStore`.
+/// Production [`KvBackend`] backed by `worker::kv::KvStore`.
 pub struct WorkerKvBackend(pub worker::kv::KvStore);
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -173,22 +152,6 @@ impl KvCachedD1DatabaseService {
         } else {
             tracing::debug!(table = %collection, version = %stamp, op, "config_version_bump");
         }
-    }
-}
-
-/// PUT `stamp` under [`cache_key::CONFIG_VERSION_KEY`] persistently (no
-/// TTL — a quiet day must not expire the stamp and trigger a fleet-wide
-/// restamp), retrying once on KV transport error.
-pub(crate) async fn put_version_stamp_with_retry(
-    kv: &dyn KvBackend,
-    stamp: &str,
-) -> Result<(), String> {
-    match kv.put(cache_key::CONFIG_VERSION_KEY, stamp).await {
-        Ok(()) => Ok(()),
-        Err(first) => kv
-            .put(cache_key::CONFIG_VERSION_KEY, stamp)
-            .await
-            .map_err(|second| format!("first attempt: {first}; retry: {second}")),
     }
 }
 

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -85,7 +85,13 @@ fn make_kv_cached_database_service_with_backend(
     d1_binding: &str,
     kv_binding: &str,
     mode: kv_cached_db::CacheMode,
-) -> Result<(Arc<dyn DatabaseService>, Arc<dyn kv_cached_db::KvBackend>), worker::Error> {
+) -> Result<
+    (
+        Arc<dyn DatabaseService>,
+        Arc<dyn solobase_core::kv::KvBackend>,
+    ),
+    worker::Error,
+> {
     let inner = make_d1_database_service(env, d1_binding)?;
     let backend = make_kv_backend(env, kv_binding)?;
     let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::with_mode(
@@ -96,15 +102,15 @@ fn make_kv_cached_database_service_with_backend(
     Ok((db, backend))
 }
 
-/// Construct a raw [`KvBackend`](kv_cached_db::KvBackend) from a worker `Env`
-/// and a KV binding name. Single construction path shared by the KV-cached DB
-/// factory above and the per-isolate runtime cache's config-version probe
-/// (`runtime_cache::get_or_build`), so both derive the `KvStore` handle the
-/// same way.
+/// Construct a raw [`KvBackend`](solobase_core::kv::KvBackend) from a worker
+/// `Env` and a KV binding name. Single construction path shared by the
+/// KV-cached DB factory above and the per-isolate runtime cache's
+/// config-version probe (`runtime_cache::get_or_build`), so both derive the
+/// `KvStore` handle the same way.
 pub(crate) fn make_kv_backend(
     env: &worker::Env,
     binding: &str,
-) -> Result<Arc<dyn kv_cached_db::KvBackend>, worker::Error> {
+) -> Result<Arc<dyn solobase_core::kv::KvBackend>, worker::Error> {
     let kv_store = env.kv(binding)?;
     Ok(Arc::new(kv_cached_db::WorkerKvBackend(kv_store)))
 }
@@ -364,7 +370,7 @@ struct BuiltRuntime {
     /// KV backend the DB service is cached through — reused by the per-isolate
     /// runtime cache (`runtime_cache`) to probe the config-version stamp
     /// without re-deriving a second `KvStore` handle from `env`.
-    kv: Arc<dyn kv_cached_db::KvBackend>,
+    kv: Arc<dyn solobase_core::kv::KvBackend>,
 }
 
 /// Register any admin-created WRAP grants loaded from D1 onto the built

--- a/crates/solobase-cloudflare/src/runtime_cache.rs
+++ b/crates/solobase-cloudflare/src/runtime_cache.rs
@@ -24,7 +24,7 @@ pub(crate) struct ReadyRuntime {
     /// KV backend this runtime was built with. Held so the config-version
     /// probe on the request hot path reuses it instead of constructing a fresh
     /// `KvStore` handle from `env` on every request.
-    pub kv: Arc<dyn crate::kv_cached_db::KvBackend>,
+    pub kv: Arc<dyn solobase_core::kv::KvBackend>,
     pub version: String,
 }
 
@@ -49,13 +49,12 @@ pub(crate) fn peek() -> Option<Rc<ReadyRuntime>> {
 
 /// Current KV config-version stamp. Missing key ⇒ stamp a fresh one so all
 /// isolates converge on the same generation.
-async fn current_version(kv: &Arc<dyn crate::kv_cached_db::KvBackend>) -> String {
+async fn current_version(kv: &Arc<dyn solobase_core::kv::KvBackend>) -> String {
     match kv.get(CONFIG_VERSION_KEY).await {
         Ok(Some(v)) => v,
         _ => {
             let v = crate::kv_cached_db::new_version_stamp();
-            if let Err(e) = crate::kv_cached_db::put_version_stamp_with_retry(kv.as_ref(), &v).await
-            {
+            if let Err(e) = solobase_core::kv::put_version_stamp_with_retry(kv.as_ref(), &v).await {
                 tracing::warn!(error = %e, "config-version stamp persist failed; runtime tagged with local stamp only (KV unstamped; re-mints until a put lands)");
             }
             v

--- a/crates/solobase-core/src/boot.rs
+++ b/crates/solobase-core/src/boot.rs
@@ -493,4 +493,124 @@ mod wrap_grants_tests {
             .expect("empty resource_type row kept");
         assert_eq!(g4.resource_type, None);
     }
+
+    use wafer_block::db::Filter;
+    use wafer_core::interfaces::database::service::{
+        Column, DatabaseError, Record, RecordList, Table,
+    };
+
+    /// A [`DatabaseService`] whose existence check fails hard and whose every
+    /// other method is [`unreachable!`]. Isolates the fail-closed `Err` arm of
+    /// [`load_wrap_grants_from_db`]: the only method it should reach is
+    /// `schema_table_exists`, so a real read error there must short-circuit to
+    /// an empty grant set without ever touching `list`.
+    struct ErroringDb;
+
+    #[async_trait::async_trait]
+    impl DatabaseService for ErroringDb {
+        async fn schema_table_exists(&self, _name: &str) -> Result<bool, DatabaseError> {
+            Err(DatabaseError::Internal(
+                "simulated wrap_grants existence-check failure".into(),
+            ))
+        }
+
+        async fn get(&self, _collection: &str, _id: &str) -> Result<Record, DatabaseError> {
+            unreachable!(
+                "load_wrap_grants_from_db must not read rows after an existence-check error"
+            )
+        }
+
+        async fn list(
+            &self,
+            _collection: &str,
+            _opts: &ListOptions,
+        ) -> Result<RecordList, DatabaseError> {
+            unreachable!(
+                "load_wrap_grants_from_db must not list rows after an existence-check error"
+            )
+        }
+
+        async fn create(
+            &self,
+            _collection: &str,
+            _data: HashMap<String, serde_json::Value>,
+        ) -> Result<Record, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn update(
+            &self,
+            _collection: &str,
+            _id: &str,
+            _data: HashMap<String, serde_json::Value>,
+        ) -> Result<Record, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn delete(&self, _collection: &str, _id: &str) -> Result<(), DatabaseError> {
+            unreachable!()
+        }
+
+        async fn count(
+            &self,
+            _collection: &str,
+            _filters: &[Filter],
+        ) -> Result<i64, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn sum(
+            &self,
+            _collection: &str,
+            _field: &str,
+            _filters: &[Filter],
+        ) -> Result<f64, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn query_raw(
+            &self,
+            _query: &str,
+            _args: &[serde_json::Value],
+        ) -> Result<Vec<Record>, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn exec_raw(
+            &self,
+            _query: &str,
+            _args: &[serde_json::Value],
+        ) -> Result<i64, DatabaseError> {
+            unreachable!()
+        }
+
+        async fn ensure_schema_table(&self, _table: &Table) -> Result<(), DatabaseError> {
+            unreachable!()
+        }
+
+        async fn schema_drop_table(&self, _name: &str) -> Result<(), DatabaseError> {
+            unreachable!()
+        }
+
+        async fn schema_add_column(
+            &self,
+            _table: &str,
+            _column: &Column,
+        ) -> Result<(), DatabaseError> {
+            unreachable!()
+        }
+    }
+
+    /// A hard read error from the existence check is fail-closed: dynamic
+    /// grants are additive, so a runtime that cannot confirm the table exists
+    /// must build WRAP-denying (empty grants) rather than risk widening access
+    /// on a bad read.
+    #[tokio::test]
+    async fn load_wrap_grants_existence_check_error_fails_closed() {
+        let db: Arc<dyn DatabaseService> = Arc::new(ErroringDb);
+        assert!(
+            load_wrap_grants_from_db(&db).await.is_empty(),
+            "a schema_table_exists error must degrade to an empty grant set"
+        );
+    }
 }

--- a/crates/solobase-core/src/kv.rs
+++ b/crates/solobase-core/src/kv.rs
@@ -1,0 +1,58 @@
+//! Pluggable KV backend trait + config-version-stamp retry helper for the
+//! Cloudflare config-var hot path.
+//!
+//! Lives in `solobase-core` (not `solobase-cloudflare`) so the retry logic is
+//! host-testable: `solobase-cloudflare` is wasm32-only and excluded from
+//! `cargo test --workspace`. Follows the `cache_key` extraction precedent —
+//! pure logic that a wasm-only crate would otherwise leave untested moves
+//! here.
+//!
+//! The production [`KvBackend`] impl (`WorkerKvBackend`, over
+//! `worker::kv::KvStore`) and the `KvCachedD1DatabaseService` that consume this
+//! trait stay in `solobase-cloudflare`, which owns the `worker` dependency.
+
+use wafer_block::{MaybeSend, MaybeSync};
+
+/// Pluggable KV backend. Production (`solobase-cloudflare`) uses
+/// `worker::kv::KvStore` via `WorkerKvBackend`; host tests use the in-module
+/// `MockKvBackend` (see the `#[cfg(test)] mod tests` below).
+///
+/// All errors are returned as `String` and never propagate as a hard
+/// failure to callers — `KvCachedD1DatabaseService` treats every KV
+/// error as a cache miss and falls through to the underlying database.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait KvBackend: MaybeSend + MaybeSync {
+    /// Returns `Ok(Some(value))` on cache hit, `Ok(None)` on miss,
+    /// `Err(msg)` on KV transport error.
+    async fn get(&self, key: &str) -> Result<Option<String>, String>;
+
+    /// Writes `value` under `key` with the given TTL (seconds).
+    async fn put_with_ttl(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), String>;
+
+    /// Writes `value` under `key` with no expiration. Reserved for the
+    /// config-version stamp — row-cache entries always carry a TTL.
+    async fn put(&self, key: &str, value: &str) -> Result<(), String>;
+
+    /// Deletes `key`. Deleting a non-existent key is not an error.
+    async fn delete(&self, key: &str) -> Result<(), String>;
+}
+
+/// PUT `stamp` under [`crate::cache_key::CONFIG_VERSION_KEY`] persistently (no
+/// TTL — a quiet day must not expire the stamp and trigger a fleet-wide
+/// restamp), retrying once on KV transport error.
+///
+/// On a double failure the returned error names both attempts
+/// (`"first attempt: …; retry: …"`) so log correlation can distinguish a
+/// one-off transient blip (which the retry papers over silently) from a
+/// sustained KV outage.
+pub async fn put_version_stamp_with_retry(kv: &dyn KvBackend, stamp: &str) -> Result<(), String> {
+    match kv.put(crate::cache_key::CONFIG_VERSION_KEY, stamp).await {
+        Ok(()) => Ok(()),
+        Err(first) => kv
+            .put(crate::cache_key::CONFIG_VERSION_KEY, stamp)
+            .await
+            .map_err(|second| format!("first attempt: {first}; retry: {second}")),
+    }
+}
+

--- a/crates/solobase-core/src/kv.rs
+++ b/crates/solobase-core/src/kv.rs
@@ -56,3 +56,124 @@ pub async fn put_version_stamp_with_retry(kv: &dyn KvBackend, stamp: &str) -> Re
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// Which `put()` calls a [`MockKvBackend`] fails, to drive both retry
+    /// arms of [`put_version_stamp_with_retry`].
+    enum PutFail {
+        /// Every `put()` succeeds.
+        None,
+        /// Only the first `put()` fails; the retry succeeds.
+        FirstOnly,
+        /// Every `put()` fails.
+        All,
+    }
+
+    /// In-memory [`KvBackend`] that counts `put()` calls and fails them per
+    /// [`PutFail`]. Only `put()` is exercised by the retry helper; the other
+    /// trait methods are unreachable on this path.
+    struct MockKvBackend {
+        puts: AtomicUsize,
+        fail: PutFail,
+    }
+
+    impl MockKvBackend {
+        fn new(fail: PutFail) -> Self {
+            Self {
+                puts: AtomicUsize::new(0),
+                fail,
+            }
+        }
+
+        fn put_count(&self) -> usize {
+            self.puts.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl KvBackend for MockKvBackend {
+        async fn get(&self, _key: &str) -> Result<Option<String>, String> {
+            unreachable!("put_version_stamp_with_retry never reads")
+        }
+
+        async fn put_with_ttl(
+            &self,
+            _key: &str,
+            _value: &str,
+            _ttl_secs: u64,
+        ) -> Result<(), String> {
+            unreachable!("put_version_stamp_with_retry uses put(), not put_with_ttl()")
+        }
+
+        async fn put(&self, _key: &str, _value: &str) -> Result<(), String> {
+            // 0-based index of this call (value before the increment).
+            let n = self.puts.fetch_add(1, Ordering::SeqCst);
+            let fail = match self.fail {
+                PutFail::None => false,
+                PutFail::FirstOnly => n == 0,
+                PutFail::All => true,
+            };
+            if fail {
+                Err(format!("kv transport error on put #{}", n + 1))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn delete(&self, _key: &str) -> Result<(), String> {
+            unreachable!("put_version_stamp_with_retry never deletes")
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_recovers_when_first_put_fails() {
+        let kv = MockKvBackend::new(PutFail::FirstOnly);
+        let result = put_version_stamp_with_retry(&kv, "v-abc123").await;
+        assert!(
+            result.is_ok(),
+            "a single transient failure must be recovered by the retry: {result:?}"
+        );
+        assert_eq!(
+            kv.put_count(),
+            2,
+            "must attempt exactly twice (initial put + one retry)"
+        );
+    }
+
+    #[tokio::test]
+    async fn both_puts_failing_returns_combined_error() {
+        let kv = MockKvBackend::new(PutFail::All);
+        let err = put_version_stamp_with_retry(&kv, "v-abc123")
+            .await
+            .expect_err("both attempts fail → Err");
+        assert!(
+            err.contains("first attempt"),
+            "error must name the first attempt for log correlation: {err}"
+        );
+        assert!(
+            err.contains("retry"),
+            "error must name the retry for log correlation: {err}"
+        );
+        assert_eq!(
+            kv.put_count(),
+            2,
+            "must stop after exactly one retry, not loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_put_succeeding_does_not_retry() {
+        let kv = MockKvBackend::new(PutFail::None);
+        let result = put_version_stamp_with_retry(&kv, "v-abc123").await;
+        assert!(result.is_ok());
+        assert_eq!(
+            kv.put_count(),
+            1,
+            "a successful first put must not trigger the retry"
+        );
+    }
+}

--- a/crates/solobase-core/src/lib.rs
+++ b/crates/solobase-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod endpoint_match;
 pub mod features;
 pub mod flows;
 pub mod http;
+pub mod kv;
 pub mod messages_schema;
 pub mod migration_helper;
 pub mod multipart;


### PR DESCRIPTION
## Summary

Task T8 of the deferred-work sweep: closes two test-coverage gaps.

**1. `put_version_stamp_with_retry` was untestable (and its doc lied).**
`solobase-cloudflare` is wasm32-only and excluded from `cargo test --workspace`, so the KV version-stamp retry helper had no runnable tests — and the `KvBackend` trait doc claimed a `MockKvBackend` existed in `tests/support` that was never written. Following the `solobase_core::cache_key` extraction precedent, the `KvBackend` trait (wasm32/native `async_trait` cfg_attrs kept) and the retry helper move to a new `solobase_core::kv` module; `WorkerKvBackend` + `KvCachedD1DatabaseService` stay in `solobase-cloudflare`, whose callers (`kv_cached_db.rs`, `runtime_cache.rs`, `lib.rs`) now import from core — no back-compat shim. The stale doc is gone; the trait doc now points at the real in-module mock.

New host tests (`solobase_core::kv::tests`, `MockKvBackend` with an `AtomicUsize` put counter):
- first put fails, retry succeeds → `Ok`, exactly 2 puts
- both puts fail → `Err` containing both `"first attempt"` and `"retry"`, exactly 2 puts (no loop)
- first put succeeds → exactly 1 put (no spurious retry)

**2. `load_wrap_grants_from_db`'s fail-closed `Err` arm was uncovered.**
`boot::wrap_grants_tests` gains an in-module `ErroringDb` (`DatabaseService` whose `schema_table_exists` returns `Err`, every other method `unreachable!()`): an existence-check failure must degrade to an empty grant set without ever reaching `list()`.

Note: these pin existing production behavior (the retry helper moved verbatim; the boot `Err` arm predates this PR), so they are coverage tests, not red-first TDD.

## Verification

- `cargo +nightly fmt --all -- --check` clean
- CI-exact `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` clean; no warnings in any touched file (pre-existing `-D warnings` violations in `solobase-bundle`/`blocks/admin` are untouched)
- CI-exact `cargo check -p solobase-cloudflare --target wasm32-unknown-unknown` green (trait cfg_attrs resolve across the crate move)
- CI-exact `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` green (incl. 3 new kv tests + 2 wrap_grants tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H