### PR TITLE
refactor(files): repo/ data layer — M10 (T4)

### DIFF
--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -437,7 +437,7 @@ mod tests {
             "created_by": owner,
             "created_at": crate::util::now_rfc3339(),
         }));
-        db::create(&ctx, crate::blocks::files::storage::BUCKETS_TABLE, data)
+        db::create(&ctx, crate::blocks::files::BUCKETS_TABLE, data)
             .await
             .expect("seed bucket");
 

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 
-use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
-use wafer_core::clients::database as db;
 use wafer_run::{context::Context, ErrorCode, InputStream, Message, OutputStream};
 
-use super::{ACCESS_LOGS_TABLE, QUOTAS_TABLE, SHARES_TABLE};
+use super::repo;
 use crate::http::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json};
 
 pub async fn handle(ctx: &dyn Context, msg: Message, input: InputStream) -> OutputStream {
@@ -31,23 +29,7 @@ pub async fn handle(ctx: &dyn Context, msg: Message, input: InputStream) -> Outp
 }
 
 async fn handle_list_shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let user_id = msg.user_id().to_string();
-
-    let opts = ListOptions {
-        filters: vec![Filter {
-            field: "created_by".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id),
-        }],
-        sort: vec![SortField {
-            field: "created_at".to_string(),
-            desc: true,
-        }],
-        limit: 100,
-        ..Default::default()
-    };
-
-    match db::list(ctx, SHARES_TABLE, &opts).await {
+    match repo::shares::list_for_user(ctx, msg.user_id(), 100).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -136,25 +118,17 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
         }
     };
 
-    let mut data = crate::util::json_map(serde_json::json!({
-        "token": token,
-        "bucket": body.bucket,
-        "key": body.key,
-        "created_by": msg.user_id(),
-        "created_at": now.to_rfc3339(),
-        "access_count": 0,
-    }));
-    if let Some(exp) = &expires_at {
-        data.insert(
-            "expires_at".to_string(),
-            serde_json::Value::String(exp.clone()),
-        );
-    }
-    if let Some(max) = body.max_access_count {
-        data.insert("max_access_count".to_string(), serde_json::json!(max));
-    }
-
-    match db::create(ctx, SHARES_TABLE, data).await {
+    let created_at = now.to_rfc3339();
+    let new_share = repo::shares::NewShare {
+        token: &token,
+        bucket: &body.bucket,
+        key: &body.key,
+        created_by: msg.user_id(),
+        created_at: &created_at,
+        expires_at: expires_at.as_deref(),
+        max_access_count: body.max_access_count,
+    };
+    match repo::shares::insert(ctx, new_share).await {
         Ok(record) => ok_json(&serde_json::json!({
             "id": record.id,
             "token": token,
@@ -172,7 +146,7 @@ async fn handle_delete_share(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Verify ownership
-    if let Ok(share) = db::get(ctx, SHARES_TABLE, id).await {
+    if let Ok(share) = repo::shares::find_by_id(ctx, id).await {
         let owner = share
             .data
             .get("created_by")
@@ -183,7 +157,7 @@ async fn handle_delete_share(ctx: &dyn Context, msg: &Message) -> OutputStream {
         }
     }
 
-    match db::delete(ctx, SHARES_TABLE, id).await {
+    match repo::shares::delete(ctx, id).await {
         Ok(()) => ok_json(&serde_json::json!({"deleted": true})),
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Share not found"),
         Err(e) => err_internal("Database error", e),
@@ -201,16 +175,8 @@ async fn handle_get_quota(ctx: &dyn Context, msg: &Message) -> OutputStream {
 
 async fn handle_admin_list_shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let (page, page_size, _) = msg.pagination_params(20);
-    let opts = ListOptions {
-        sort: vec![SortField {
-            field: "created_at".to_string(),
-            desc: true,
-        }],
-        limit: page_size as i64,
-        offset: ((page - 1) * page_size) as i64,
-        ..Default::default()
-    };
-    match db::list(ctx, SHARES_TABLE, &opts).await {
+    let offset = ((page - 1) * page_size) as i64;
+    match repo::shares::list_recent(ctx, page_size as i64, offset).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -218,41 +184,18 @@ async fn handle_admin_list_shares(ctx: &dyn Context, msg: &Message) -> OutputStr
 
 async fn handle_access_logs(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let (page, page_size, _) = msg.pagination_params(50);
-
-    let mut filters = Vec::new();
     let share_id = msg.query("share_id").to_string();
-    if !share_id.is_empty() {
-        filters.push(Filter {
-            field: "share_id".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(share_id),
-        });
-    }
+    let share_id = (!share_id.is_empty()).then_some(share_id.as_str());
+    let offset = ((page - 1) * page_size) as i64;
 
-    let opts = ListOptions {
-        filters,
-        sort: vec![SortField {
-            field: "accessed_at".to_string(),
-            desc: true,
-        }],
-        limit: page_size as i64,
-        offset: ((page - 1) * page_size) as i64,
-        skip_count: false,
-        ..Default::default()
-    };
-
-    match db::list(ctx, ACCESS_LOGS_TABLE, &opts).await {
+    match repo::shares::list_access_logs(ctx, share_id, page_size as i64, offset).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
 }
 
 async fn handle_admin_quotas(ctx: &dyn Context, _msg: &Message) -> OutputStream {
-    let opts = ListOptions {
-        limit: 1000,
-        ..Default::default()
-    };
-    match db::list(ctx, QUOTAS_TABLE, &opts).await {
+    match repo::quota::list(ctx, 1000).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -274,8 +217,9 @@ async fn handle_update_quota(ctx: &dyn Context, msg: &Message, input: InputStrea
     };
 
     // SEC-059: whitelist accepted quota fields — never forward arbitrary
-    // caller-controlled keys to `db::upsert`. Reject anything outside the
-    // known quota schema.
+    // caller-controlled keys to the upsert. Reject anything outside the
+    // known quota schema. (`user_id` + `updated_at` are stamped by
+    // `repo::quota::upsert_for_user`.)
     const ALLOWED_QUOTA_FIELDS: &[&str] = &[
         "max_storage_bytes",
         "max_file_size_bytes",
@@ -288,25 +232,7 @@ async fn handle_update_quota(ctx: &dyn Context, msg: &Message, input: InputStrea
         }
     }
 
-    let mut data = body;
-    data.insert(
-        "user_id".to_string(),
-        serde_json::Value::String(user_id.to_string()),
-    );
-    data.insert(
-        "updated_at".to_string(),
-        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-    );
-
-    match db::upsert_by_field(
-        ctx,
-        QUOTAS_TABLE,
-        "user_id",
-        serde_json::Value::String(user_id.to_string()),
-        data,
-    )
-    .await
-    {
+    match repo::quota::upsert_for_user(ctx, user_id, body).await {
         Ok(record) => ok_json(&record),
         Err(e) => err_internal("Database error", e),
     }
@@ -437,9 +363,7 @@ mod tests {
             "created_by": owner,
             "created_at": crate::util::now_rfc3339(),
         }));
-        db::create(&ctx, crate::blocks::files::BUCKETS_TABLE, data)
-            .await
-            .expect("seed bucket");
+        repo::buckets::seed(&ctx, data).await.expect("seed bucket");
 
         ctx
     }
@@ -576,7 +500,7 @@ mod tests {
             .expect("successful create_share returns an id")
             .to_string();
 
-        let record = db::get(&ctx, SHARES_TABLE, &id).await.expect("share row");
+        let record = repo::shares::find_by_id(&ctx, &id).await.expect("share row");
         let expires_at = record
             .data
             .get("expires_at")

--- a/crates/solobase-core/src/blocks/files/cloud.rs
+++ b/crates/solobase-core/src/blocks/files/cloud.rs
@@ -74,7 +74,7 @@ async fn handle_create_share(ctx: &dyn Context, msg: &Message, input: InputStrea
     // Verify the user owns this bucket (or is admin) — shared helper from
     // storage.rs so the two modules stay in lockstep on what "access
     // denied" means.
-    if super::storage::is_bucket_access_denied(ctx, &msg, &body.bucket).await {
+    if super::storage::is_bucket_access_denied(ctx, msg, &body.bucket).await {
         return err_forbidden("Access denied to this bucket");
     }
 
@@ -152,7 +152,7 @@ async fn handle_delete_share(ctx: &dyn Context, msg: &Message) -> OutputStream {
             .get("created_by")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        if owner != msg.user_id() && !crate::util::is_admin(&msg) {
+        if owner != msg.user_id() && !crate::util::is_admin(msg) {
             return err_forbidden("Cannot delete another user's share");
         }
     }
@@ -500,7 +500,9 @@ mod tests {
             .expect("successful create_share returns an id")
             .to_string();
 
-        let record = repo::shares::find_by_id(&ctx, &id).await.expect("share row");
+        let record = repo::shares::find_by_id(&ctx, &id)
+            .await
+            .expect("share row");
         let expires_at = record
             .data
             .get("expires_at")

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -4,17 +4,14 @@ pub(crate) mod models;
 mod pages_admin;
 pub(crate) mod pages_user;
 mod quota;
+pub(crate) mod repo;
 mod share;
 pub(crate) mod storage;
 
-pub(crate) use quota::TABLE as QUOTAS_TABLE;
-pub(crate) use share::{ACCESS_LOGS_TABLE, SHARES_TABLE};
-pub(crate) use storage::{BUCKETS_TABLE, OBJECTS_TABLE};
-
-/// Object-view audit table. Has no dedicated owner module — only the
-/// schema declaration here and a single insert site in `storage.rs`
-/// (`record_view`) — so the constant lives in mod.rs.
-pub(crate) const VIEWS_TABLE: &str = "suppers_ai__files__views";
+pub(crate) use repo::{
+    buckets::TABLE as BUCKETS_TABLE, objects::TABLE as OBJECTS_TABLE, quota::TABLE as QUOTAS_TABLE,
+    shares::ACCESS_LOGS_TABLE, shares::TABLE as SHARES_TABLE, views::TABLE as VIEWS_TABLE,
+};
 
 use wafer_run::{BlockEndpoint, BlockInfo, InstanceMode};
 

--- a/crates/solobase-core/src/blocks/files/mod.rs
+++ b/crates/solobase-core/src/blocks/files/mod.rs
@@ -8,11 +8,6 @@ pub(crate) mod repo;
 mod share;
 pub(crate) mod storage;
 
-pub(crate) use repo::{
-    buckets::TABLE as BUCKETS_TABLE, objects::TABLE as OBJECTS_TABLE, quota::TABLE as QUOTAS_TABLE,
-    shares::ACCESS_LOGS_TABLE, shares::TABLE as SHARES_TABLE, views::TABLE as VIEWS_TABLE,
-};
-
 use wafer_run::{BlockEndpoint, BlockInfo, InstanceMode};
 
 use super::rate_limit::{check_user_rate_limit_with, RateLimit, RateLimitOutcome, UserRateLimiter};
@@ -39,12 +34,12 @@ crate::solobase_feature_block! {
             // single source for both runtime `migrations::apply()` and the
             // Cloudflare D1 build).
             .collections(vec![
-                CollectionSchema::new(BUCKETS_TABLE),
-                CollectionSchema::new(OBJECTS_TABLE),
-                CollectionSchema::new(VIEWS_TABLE),
-                CollectionSchema::new(SHARES_TABLE),
-                CollectionSchema::new(ACCESS_LOGS_TABLE),
-                CollectionSchema::new(QUOTAS_TABLE),
+                CollectionSchema::new(repo::buckets::TABLE),
+                CollectionSchema::new(repo::objects::TABLE),
+                CollectionSchema::new(repo::views::TABLE),
+                CollectionSchema::new(repo::shares::TABLE),
+                CollectionSchema::new(repo::shares::ACCESS_LOGS_TABLE),
+                CollectionSchema::new(repo::quota::TABLE),
             ])
             .category(wafer_run::BlockCategory::Feature)
             .description("File storage and management with bucket-based organization. Supports file upload, download, deletion, search, and sharing via public links with expiration and access counting. Includes per-user storage quotas.")

--- a/crates/solobase-core/src/blocks/files/pages_admin.rs
+++ b/crates/solobase-core/src/blocks/files/pages_admin.rs
@@ -1,11 +1,9 @@
 //! SSR admin pages for the files block.
 
 use maud::{html, Markup};
-use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
-use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
 
-use super::{BUCKETS_TABLE, OBJECTS_TABLE, QUOTAS_TABLE, SHARES_TABLE};
+use super::repo;
 use crate::{
     ui::{self, components, icons, shell::Crumb},
     util::{format_bytes, RecordExt},
@@ -172,37 +170,29 @@ pub async fn overview(ctx: &dyn Context, msg: &Message) -> OutputStream {
 }
 
 async fn load_admin_stats(ctx: &dyn Context) -> AdminStats {
-    let buckets = db::count(ctx, BUCKETS_TABLE, &[])
-        .await
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e.message, "admin overview: bucket count failed");
-            0
-        });
+    let buckets = repo::buckets::count_all(ctx).await.unwrap_or_else(|e| {
+        tracing::warn!(error = %e.message, "admin overview: bucket count failed");
+        0
+    });
 
-    let complete_filter = [Filter {
-        field: "status".into(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String("complete".into()),
-    }];
-
-    let files = db::count(ctx, OBJECTS_TABLE, &complete_filter)
+    let files = repo::objects::count_completed(ctx)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(error = %e.message, "admin overview: files count failed");
             0
         });
 
-    let shares = db::count(ctx, SHARES_TABLE, &[]).await.unwrap_or_else(|e| {
+    let shares = repo::shares::count_all(ctx).await.unwrap_or_else(|e| {
         tracing::warn!(error = %e.message, "admin overview: shares count failed");
         0
     });
 
-    let quotas_count = db::count(ctx, QUOTAS_TABLE, &[]).await.unwrap_or_else(|e| {
+    let quotas_count = repo::quota::count_all(ctx).await.unwrap_or_else(|e| {
         tracing::warn!(error = %e.message, "admin overview: quotas count failed");
         0
     });
 
-    let total_size_bytes = db::sum(ctx, OBJECTS_TABLE, "size", &complete_filter)
+    let total_size_bytes = repo::objects::sum_size_completed(ctx)
         .await
         .map(|s| s as i64)
         .unwrap_or_else(|e| {
@@ -265,16 +255,7 @@ pub fn render_admin_buckets_table(rows: &[AdminBucketRow]) -> Markup {
 pub async fn buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let opts = ListOptions {
-        sort: vec![SortField {
-            field: "created_at".into(),
-            desc: true,
-        }],
-        limit: 100,
-        ..Default::default()
-    };
-
-    let rows: Vec<AdminBucketRow> = match db::list(ctx, BUCKETS_TABLE, &opts).await {
+    let rows: Vec<AdminBucketRow> = match repo::buckets::list_recent(ctx, 100).await {
         Ok(list) => list
             .records
             .into_iter()
@@ -399,16 +380,7 @@ pub fn render_admin_shares_table(rows: &[AdminShareRow]) -> Markup {
 pub async fn shares(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let opts = ListOptions {
-        sort: vec![SortField {
-            field: "created_at".into(),
-            desc: true,
-        }],
-        limit: 100,
-        ..Default::default()
-    };
-
-    let rows: Vec<AdminShareRow> = match db::list(ctx, SHARES_TABLE, &opts).await {
+    let rows: Vec<AdminShareRow> = match repo::shares::list_recent(ctx, 100, 0).await {
         Ok(list) => list
             .records
             .into_iter()
@@ -516,16 +488,7 @@ pub fn render_admin_quotas_table(rows: &[AdminQuotaRow]) -> Markup {
 pub async fn quotas(ctx: &dyn Context, msg: &Message) -> OutputStream {
     use crate::ui::templates::{list_page, PageHeader};
 
-    let opts = ListOptions {
-        sort: vec![SortField {
-            field: "created_at".into(),
-            desc: true,
-        }],
-        limit: 100,
-        ..Default::default()
-    };
-
-    let rows: Vec<AdminQuotaRow> = match db::list(ctx, QUOTAS_TABLE, &opts).await {
+    let rows: Vec<AdminQuotaRow> = match repo::quota::list_recent(ctx, 100).await {
         Ok(list) => list
             .records
             .into_iter()
@@ -635,9 +598,7 @@ mod tests {
             std::collections::HashMap::new();
         row.insert("name".into(), serde_json::json!("photos"));
         row.insert("created_by".into(), serde_json::json!("admin_1"));
-        db::create(&ctx, BUCKETS_TABLE, row)
-            .await
-            .expect("seed bucket");
+        repo::buckets::seed(&ctx, row).await.expect("seed bucket");
 
         let msg = admin_msg("retrieve", "/b/storage/admin/");
         let html = output_html(overview(&ctx, &msg).await).await;

--- a/crates/solobase-core/src/blocks/files/pages_user.rs
+++ b/crates/solobase-core/src/blocks/files/pages_user.rs
@@ -98,9 +98,9 @@ pub fn render_new_bucket_modal() -> Markup {
     }
 }
 
-use wafer_core::clients::database as db;
 use wafer_run::{context::Context, Message, OutputStream};
 
+use super::repo;
 use crate::ui::{
     self,
     components::{button, BtnVariant, CtrlSize},
@@ -110,35 +110,15 @@ use crate::ui::{
 
 /// Load the calling user's buckets, decorated with live object counts.
 ///
-/// `created_by` filtering keeps users from seeing each other's buckets.
-/// Object counts come from a single GROUP BY query on the objects table
-/// (one row per bucket) so we avoid the previous N+1 `db::count` per
-/// bucket.
+/// `created_by` filtering (inside [`repo::buckets::list_owned_sorted`])
+/// keeps users from seeing each other's buckets. Object counts come from
+/// a single GROUP BY query on the objects table
+/// ([`repo::objects::count_by_bucket`], one row per bucket) so we avoid
+/// the previous N+1 count query per bucket.
 pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<BucketRow> {
     use std::collections::HashMap;
 
-    use wafer_block::{
-        db::{Filter, FilterOp, SortField},
-        wire::database as wire,
-    };
-
-    use super::{BUCKETS_TABLE, OBJECTS_TABLE};
-
-    let recs = match db::list_sorted(
-        ctx,
-        BUCKETS_TABLE,
-        vec![Filter {
-            field: "created_by".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.into()),
-        }],
-        vec![SortField {
-            field: "name".into(),
-            desc: false,
-        }],
-    )
-    .await
-    {
+    let recs = match repo::buckets::list_owned_sorted(ctx, user_id).await {
         Ok(records) => records,
         Err(e) => {
             tracing::warn!(error = %e, "files bucket list failed");
@@ -146,44 +126,22 @@ pub async fn list_buckets_for_user(ctx: &dyn Context, user_id: &str) -> Vec<Buck
         }
     };
 
-    // Build a list of bucket names this user owns; restrict the GROUP BY
-    // to those buckets so the count matches the previous per-bucket
-    // db::count semantics exactly (which counted all objects in the
-    // bucket regardless of `uploaded_by`).
-    let bucket_names: Vec<serde_json::Value> = recs
+    // Restrict the GROUP BY to the buckets this user owns so the count
+    // matches the previous per-bucket count semantics exactly (which
+    // counted all objects in the bucket regardless of `uploaded_by`).
+    let bucket_names: Vec<String> = recs
         .iter()
         .filter_map(|r| r.data.get("name").and_then(|v| v.as_str()))
-        .map(|s| serde_json::Value::String(s.to_string()))
+        .map(str::to_string)
         .collect();
-    let req = wire::AggregateRequest {
-        collection: OBJECTS_TABLE.to_string(),
-        select_columns: vec!["bucket".into()],
-        aggregates: vec![wire::AggregateColumnDef::Count {
-            alias: "cnt".into(),
-        }],
-        filters: vec![wire::FilterNode::Leaf(wire::FilterDef {
-            field: "bucket".into(),
-            operator: "in".into(),
-            value: serde_json::Value::Array(bucket_names),
-        })],
-        group_by: vec![wire::GroupByDef::Column("bucket".into())],
-        sort: vec![],
-        limit: 0,
-    };
-    let counts_by_bucket: HashMap<String, i64> = match db::aggregate(ctx, req).await {
-        Ok(rows) => rows
-            .into_iter()
-            .filter_map(|r| {
-                let bucket = r.data.get("bucket").and_then(|v| v.as_str())?.to_string();
-                let cnt = r.i64_field("cnt");
-                Some((bucket, cnt))
-            })
-            .collect(),
-        Err(e) => {
-            tracing::warn!(error = %e, "files bucket object counts failed");
-            HashMap::new()
-        }
-    };
+    let counts_by_bucket: HashMap<String, i64> =
+        match repo::objects::count_by_bucket(ctx, &bucket_names).await {
+            Ok(counts) => counts,
+            Err(e) => {
+                tracing::warn!(error = %e, "files bucket object counts failed");
+                HashMap::new()
+            }
+        };
 
     let mut rows: Vec<BucketRow> = Vec::with_capacity(recs.len());
     for r in recs {
@@ -451,25 +409,7 @@ pub fn render_breadcrumbs(bucket: &str, current_prefix: &str) -> Markup {
 }
 
 async fn list_objects_in_bucket(ctx: &dyn Context, bucket: &str) -> Vec<ObjectRow> {
-    use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
-
-    use super::OBJECTS_TABLE;
-
-    let opts = ListOptions {
-        filters: vec![Filter {
-            field: "bucket".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(bucket.into()),
-        }],
-        sort: vec![SortField {
-            field: "key".into(),
-            desc: false,
-        }],
-        limit: 1000,
-        ..Default::default()
-    };
-
-    match db::list(ctx, OBJECTS_TABLE, &opts).await {
+    match repo::objects::list_for_bucket(ctx, bucket, 1000).await {
         Ok(rl) => rl
             .records
             .into_iter()
@@ -676,24 +616,7 @@ pub fn render_shares_table(rows: &[ShareRow]) -> Markup {
 }
 
 async fn list_shares_for_user(ctx: &dyn Context, user_id: &str) -> Vec<ShareRow> {
-    use wafer_block::db::{Filter, FilterOp, SortField};
-
-    use super::SHARES_TABLE;
-    match db::list_sorted(
-        ctx,
-        SHARES_TABLE,
-        vec![Filter {
-            field: "created_by".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.into()),
-        }],
-        vec![SortField {
-            field: "created_at".into(),
-            desc: true,
-        }],
-    )
-    .await
-    {
+    match repo::shares::list_all_for_user(ctx, user_id).await {
         Ok(records) => records
             .into_iter()
             .map(|r| ShareRow {
@@ -1173,13 +1096,9 @@ mod integration_tests {
     use std::collections::HashMap;
 
     use serde_json::json;
-    use wafer_core::clients::database as db;
 
     use super::*;
-    use crate::{
-        blocks::files::{BUCKETS_TABLE, OBJECTS_TABLE, QUOTAS_TABLE, SHARES_TABLE},
-        test_support::{admin_msg, output_html, TestContext},
-    };
+    use crate::test_support::{admin_msg, output_html, TestContext};
 
     /// Seed two buckets + two objects in `photos`, none in `docs`.
     async fn seed_two_buckets(ctx: &TestContext, owner: &str) {
@@ -1188,9 +1107,7 @@ mod integration_tests {
             row.insert("name".into(), json!(name));
             row.insert("public".into(), json!(public));
             row.insert("created_by".into(), json!(owner));
-            db::create(ctx, BUCKETS_TABLE, row)
-                .await
-                .expect("seed bucket");
+            repo::buckets::seed(ctx, row).await.expect("seed bucket");
         }
         for key in ["a.png", "nested/b.png"] {
             let mut row: HashMap<String, serde_json::Value> = HashMap::new();
@@ -1198,9 +1115,7 @@ mod integration_tests {
             row.insert("key".into(), json!(key));
             row.insert("size".into(), json!(1024));
             row.insert("uploaded_by".into(), json!(owner));
-            db::create(ctx, OBJECTS_TABLE, row)
-                .await
-                .expect("seed object");
+            repo::objects::seed(ctx, row).await.expect("seed object");
         }
     }
 
@@ -1248,7 +1163,7 @@ mod integration_tests {
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("name".into(), json!("secrets"));
         row.insert("created_by".into(), json!("other_user"));
-        db::create(&ctx, BUCKETS_TABLE, row)
+        repo::buckets::seed(&ctx, row)
             .await
             .expect("seed cross-user bucket");
 
@@ -1388,7 +1303,7 @@ mod integration_tests {
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("name".into(), json!("secrets"));
         row.insert("created_by".into(), json!("other_user"));
-        db::create(&ctx, BUCKETS_TABLE, row).await.expect("seed");
+        repo::buckets::seed(&ctx, row).await.expect("seed");
 
         let mut msg = admin_msg("retrieve", "/b/storage/secrets/");
         msg.set_meta("http.header.accept", "text/html");
@@ -1427,16 +1342,12 @@ mod integration_tests {
         share.insert("key".into(), json!("a.png"));
         share.insert("created_by".into(), json!("admin_1"));
         share.insert("access_count".into(), json!(2));
-        db::create(&ctx, SHARES_TABLE, share)
-            .await
-            .expect("seed share");
+        repo::shares::seed(&ctx, share).await.expect("seed share");
 
         let mut quota: HashMap<String, serde_json::Value> = HashMap::new();
         quota.insert("user_id".into(), json!("admin_1"));
         quota.insert("max_storage_bytes".into(), json!(1_073_741_824i64));
-        db::create(&ctx, QUOTAS_TABLE, quota)
-            .await
-            .expect("seed quota");
+        repo::quota::seed(&ctx, quota).await.expect("seed quota");
 
         let msg = admin_msg("retrieve", "/b/cloudstorage/");
         let resp = cloudstorage_page(&ctx, &msg).await;
@@ -1460,18 +1371,14 @@ mod integration_tests {
         let mut quota: HashMap<String, serde_json::Value> = HashMap::new();
         quota.insert("user_id".into(), json!("admin_1"));
         quota.insert("max_storage_bytes".into(), json!(2048));
-        db::create(&ctx, QUOTAS_TABLE, quota)
-            .await
-            .expect("seed quota");
+        repo::quota::seed(&ctx, quota).await.expect("seed quota");
 
         let mut obj: HashMap<String, serde_json::Value> = HashMap::new();
         obj.insert("bucket".into(), json!("photos"));
         obj.insert("key".into(), json!("a.png"));
         obj.insert("size".into(), json!(1024));
         obj.insert("uploaded_by".into(), json!("admin_1"));
-        db::create(&ctx, OBJECTS_TABLE, obj)
-            .await
-            .expect("seed obj");
+        repo::objects::seed(&ctx, obj).await.expect("seed obj");
 
         let msg = admin_msg("retrieve", "/b/cloudstorage/");
         let body = output_html(cloudstorage_page(&ctx, &msg).await).await;
@@ -1490,18 +1397,14 @@ mod integration_tests {
         mine.insert("bucket".into(), json!("photos"));
         mine.insert("key".into(), json!("a.png"));
         mine.insert("created_by".into(), json!("admin_1"));
-        db::create(&ctx, SHARES_TABLE, mine)
-            .await
-            .expect("seed mine");
+        repo::shares::seed(&ctx, mine).await.expect("seed mine");
         // Seed another user's share.
         let mut theirs: HashMap<String, serde_json::Value> = HashMap::new();
         theirs.insert("token".into(), json!("theirs"));
         theirs.insert("bucket".into(), json!("secrets"));
         theirs.insert("key".into(), json!("k"));
         theirs.insert("created_by".into(), json!("other_user"));
-        db::create(&ctx, SHARES_TABLE, theirs)
-            .await
-            .expect("seed theirs");
+        repo::shares::seed(&ctx, theirs).await.expect("seed theirs");
 
         let msg = admin_msg("retrieve", "/b/cloudstorage/");
         let body = output_html(cloudstorage_page(&ctx, &msg).await).await;
@@ -1562,7 +1465,7 @@ mod integration_tests {
         let mut bucket: HashMap<String, serde_json::Value> = HashMap::new();
         bucket.insert("name".into(), json!("photos"));
         bucket.insert("created_by".into(), json!("admin_1"));
-        db::create(&ctx, BUCKETS_TABLE, bucket)
+        repo::buckets::seed(&ctx, bucket)
             .await
             .expect("seed bucket");
 
@@ -1574,9 +1477,7 @@ mod integration_tests {
         // must accept both shapes.
         obj.insert("size".into(), json!(2048));
         obj.insert("uploaded_by".into(), json!("admin_1"));
-        db::create(&ctx, OBJECTS_TABLE, obj)
-            .await
-            .expect("seed obj");
+        repo::objects::seed(&ctx, obj).await.expect("seed obj");
 
         let msg = admin_msg("retrieve", "/b/storage/photos/");
         let body = output_html(object_list_page(&ctx, &msg, "photos", "").await).await;
@@ -1597,7 +1498,7 @@ mod integration_tests {
         let mut bucket: HashMap<String, serde_json::Value> = HashMap::new();
         bucket.insert("name".into(), json!("foo</script>bar"));
         bucket.insert("created_by".into(), json!("admin_1"));
-        db::create(&ctx, BUCKETS_TABLE, bucket).await.expect("seed");
+        repo::buckets::seed(&ctx, bucket).await.expect("seed");
 
         let msg = admin_msg("retrieve", "/b/storage/foo</script>bar/");
         let body = output_html(object_list_page(&ctx, &msg, "foo</script>bar", "").await).await;

--- a/crates/solobase-core/src/blocks/files/quota.rs
+++ b/crates/solobase-core/src/blocks/files/quota.rs
@@ -2,12 +2,8 @@ use wafer_block::db::{Filter, FilterOp};
 use wafer_core::clients::database::{self as db, Record};
 use wafer_run::{context::Context, OutputStream};
 
-use super::{models::QuotaConfig, OBJECTS_TABLE};
+use super::{models::QuotaConfig, QUOTAS_TABLE as TABLE, OBJECTS_TABLE};
 use crate::{http::err_bad_request, util::RecordExt};
-
-/// Per-user quota override table. Stores explicit byte/file caps that
-/// override the block defaults for individual users.
-pub(crate) const TABLE: &str = "suppers_ai__files__cloud_quotas";
 
 /// Map a quota-override row onto a `QuotaConfig`, falling back to the
 /// block defaults field-by-field. Numeric fields accept both JSON numbers

--- a/crates/solobase-core/src/blocks/files/quota.rs
+++ b/crates/solobase-core/src/blocks/files/quota.rs
@@ -1,8 +1,7 @@
-use wafer_block::db::{Filter, FilterOp};
-use wafer_core::clients::database::{self as db, Record};
+use wafer_core::clients::database::Record;
 use wafer_run::{context::Context, OutputStream};
 
-use super::{models::QuotaConfig, QUOTAS_TABLE as TABLE, OBJECTS_TABLE};
+use super::{models::QuotaConfig, repo};
 use crate::{http::err_bad_request, util::RecordExt};
 
 /// Map a quota-override row onto a `QuotaConfig`, falling back to the
@@ -30,40 +29,24 @@ fn quota_from_record(record: &Record) -> QuotaConfig {
 
 pub async fn get_user_quota(ctx: &dyn Context, user_id: &str) -> QuotaConfig {
     // Check for user-specific override
-    match db::get_by_field(
-        ctx,
-        TABLE,
-        "user_id",
-        serde_json::Value::String(user_id.to_string()),
-    )
-    .await
-    {
+    match repo::quota::find_for_user(ctx, user_id).await {
         Ok(record) => quota_from_record(&record),
         Err(_) => QuotaConfig::default(),
     }
 }
 
-/// Filter matching all objects uploaded by `user_id` (the rows that count
-/// toward that user's quota, including in-flight `pending` reservations).
-fn owned_objects_filter(user_id: &str) -> Vec<Filter> {
-    vec![Filter {
-        field: "uploaded_by".to_string(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String(user_id.to_string()),
-    }]
-}
-
 /// Total bytes used by `user_id`, computed as `SUM(size)` over the user's
-/// object rows via the `db::sum` aggregate (no row materialization).
+/// object rows ([`repo::objects::sum_size_for_uploader`], no row
+/// materialization).
 pub async fn get_used_bytes(ctx: &dyn Context, user_id: &str) -> i64 {
-    db::sum(ctx, OBJECTS_TABLE, "size", &owned_objects_filter(user_id))
+    repo::objects::sum_size_for_uploader(ctx, user_id)
         .await
         .unwrap_or(0.0) as i64
 }
 
 /// Number of object rows owned by `user_id`.
 pub async fn get_file_count(ctx: &dyn Context, user_id: &str) -> i64 {
-    db::count(ctx, OBJECTS_TABLE, &owned_objects_filter(user_id))
+    repo::objects::count_for_uploader(ctx, user_id)
         .await
         .unwrap_or(0)
 }
@@ -119,24 +102,7 @@ pub async fn check_quota(
 /// certainly an orphan.
 pub async fn sweep_stale_pending(ctx: &dyn Context, user_id: &str, older_than_seconds: i64) {
     let cutoff = (chrono::Utc::now() - chrono::Duration::seconds(older_than_seconds)).to_rfc3339();
-    let filters = vec![
-        Filter {
-            field: "uploaded_by".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.to_string()),
-        },
-        Filter {
-            field: "status".into(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String("pending".into()),
-        },
-        Filter {
-            field: "uploaded_at".into(),
-            operator: FilterOp::LessThan,
-            value: serde_json::Value::String(cutoff),
-        },
-    ];
-    if let Err(e) = db::delete_by_filters(ctx, OBJECTS_TABLE, filters).await {
+    if let Err(e) = repo::objects::delete_stale_pending(ctx, user_id, &cutoff).await {
         tracing::warn!(error = %e, user_id = %user_id, "failed to sweep stale pending uploads");
     }
 }
@@ -232,7 +198,7 @@ mod tests {
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("user_id".into(), json!("u1"));
         row.insert("max_storage_bytes".into(), json!(2048));
-        db::create(&ctx, TABLE, row).await.expect("seed quota");
+        repo::quota::seed(&ctx, row).await.expect("seed quota");
 
         let quota = get_user_quota(&ctx, "u1").await;
         assert_eq!(quota.max_storage_bytes, 2048);
@@ -254,7 +220,7 @@ mod tests {
             row.insert("key".into(), json!(key));
             row.insert("size".into(), json!(size));
             row.insert("uploaded_by".into(), json!(owner));
-            db::create(&ctx, OBJECTS_TABLE, row).await.expect("seed");
+            repo::objects::seed(&ctx, row).await.expect("seed");
         }
 
         assert_eq!(get_used_bytes(&ctx, "u1").await, 2048);
@@ -271,7 +237,7 @@ mod tests {
         let mut row: HashMap<String, serde_json::Value> = HashMap::new();
         row.insert("user_id".into(), json!("u1"));
         row.insert("max_storage_bytes".into(), json!(2048));
-        db::create(&ctx, TABLE, row).await.expect("seed quota");
+        repo::quota::seed(&ctx, row).await.expect("seed quota");
 
         assert!(check_quota(&ctx, "u1", 1024).await.is_ok());
         assert!(

--- a/crates/solobase-core/src/blocks/files/repo/buckets.rs
+++ b/crates/solobase-core/src/blocks/files/repo/buckets.rs
@@ -1,0 +1,176 @@
+//! Row-level access over `suppers_ai__files__buckets`.
+//!
+//! Buckets are user-created storage containers (one row per bucket). The
+//! table is the single source of truth for bucket existence / ownership /
+//! visibility — both the admin and user listing paths read it, and
+//! [`find_owned`] is *the* ownership lookup every access-control caller
+//! derives from (`storage::bucket_owned_by` → `is_bucket_access_denied`,
+//! the SSR portal's owner check, and the share-creation path).
+
+use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+
+/// Buckets table — user-created storage containers (one row per bucket).
+pub const TABLE: &str = "suppers_ai__files__buckets";
+
+fn created_by_filter(user_id: &str) -> Filter {
+    Filter {
+        field: "created_by".to_string(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String(user_id.to_string()),
+    }
+}
+
+/// Look up the bucket named `name` owned by `user_id`. Returns `Ok(None)`
+/// when no such row exists (unknown bucket OR a bucket owned by someone
+/// else — callers cannot distinguish the two, by design).
+///
+/// This is the single bucket-ownership predicate for the files block;
+/// `storage::bucket_owned_by` layers the fail-closed bool + logging on top,
+/// and the admin-bypass policy split lives in
+/// `storage::is_bucket_access_denied` (see its docs).
+pub async fn find_owned(
+    ctx: &dyn Context,
+    name: &str,
+    user_id: &str,
+) -> Result<Option<Record>, WaferError> {
+    let filters = vec![
+        Filter {
+            field: "name".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(name.to_string()),
+        },
+        created_by_filter(user_id),
+    ];
+    let records = db::list_all(ctx, TABLE, filters).await?;
+    Ok(records.into_iter().next())
+}
+
+/// List bucket rows visible to `owner`: `Some(user_id)` restricts to that
+/// user's buckets (`created_by` filter), `None` returns every bucket (the
+/// admin view). Unsorted, unpaginated — mirrors the JSON API listing.
+pub async fn list_visible(
+    ctx: &dyn Context,
+    owner: Option<&str>,
+) -> Result<Vec<Record>, WaferError> {
+    let filters = match owner {
+        Some(user_id) => vec![created_by_filter(user_id)],
+        None => Vec::new(),
+    };
+    db::list_all(ctx, TABLE, filters).await
+}
+
+/// List `user_id`'s buckets sorted by `name` ascending (the SSR bucket-list
+/// page order).
+pub async fn list_owned_sorted(
+    ctx: &dyn Context,
+    user_id: &str,
+) -> Result<Vec<Record>, WaferError> {
+    db::list_sorted(
+        ctx,
+        TABLE,
+        vec![created_by_filter(user_id)],
+        vec![SortField {
+            field: "name".to_string(),
+            desc: false,
+        }],
+    )
+    .await
+}
+
+/// Most recently created buckets, newest first (admin listing).
+pub async fn list_recent(ctx: &dyn Context, limit: i64) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        sort: vec![SortField {
+            field: "created_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// Insert a bucket row (`created_at` stamped with
+/// [`crate::util::now_rfc3339`]) and return it.
+pub async fn insert(
+    ctx: &dyn Context,
+    name: &str,
+    public: bool,
+    created_by: &str,
+) -> Result<Record, WaferError> {
+    let data = crate::util::json_map(serde_json::json!({
+        "name": name,
+        "public": public,
+        "created_by": created_by,
+        "created_at": crate::util::now_rfc3339(),
+    }));
+    db::create(ctx, TABLE, data).await
+}
+
+/// Delete the bucket row named `name` (bucket names are unique).
+pub async fn delete_by_name(ctx: &dyn Context, name: &str) -> Result<(), WaferError> {
+    db::delete_by_field(
+        ctx,
+        TABLE,
+        "name",
+        serde_json::Value::String(name.to_string()),
+    )
+    .await
+}
+
+/// Total number of bucket rows (admin stats).
+pub async fn count_all(ctx: &dyn Context) -> Result<i64, WaferError> {
+    db::count(ctx, TABLE, &[]).await
+}
+
+/// Test-fixture seeding: insert a raw row map exactly as given (no stamped
+/// columns), so tests control the precise row shape.
+#[cfg(test)]
+pub async fn seed(
+    ctx: &dyn Context,
+    data: std::collections::HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, TABLE, data).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestContext;
+
+    /// The ownership predicate matches on BOTH `name` and `created_by`:
+    /// a hit requires the exact (bucket, owner) pair, cross-user lookups
+    /// and unknown buckets both come back `None`.
+    #[tokio::test]
+    async fn find_owned_matches_only_the_name_owner_pair() {
+        let ctx = TestContext::with_files().await;
+        insert(&ctx, "photos", false, "alice").await.expect("seed");
+        insert(&ctx, "docs", true, "bob").await.expect("seed");
+
+        let hit = find_owned(&ctx, "photos", "alice")
+            .await
+            .expect("find_owned")
+            .expect("alice owns photos");
+        assert_eq!(
+            hit.data.get("name").and_then(|v| v.as_str()),
+            Some("photos")
+        );
+        assert_eq!(
+            hit.data.get("created_by").and_then(|v| v.as_str()),
+            Some("alice")
+        );
+
+        // Someone else's bucket → None (cross-user isolation).
+        assert!(find_owned(&ctx, "photos", "bob")
+            .await
+            .expect("find_owned")
+            .is_none());
+        // Unknown bucket → None.
+        assert!(find_owned(&ctx, "missing", "alice")
+            .await
+            .expect("find_owned")
+            .is_none());
+    }
+}

--- a/crates/solobase-core/src/blocks/files/repo/mod.rs
+++ b/crates/solobase-core/src/blocks/files/repo/mod.rs
@@ -1,0 +1,24 @@
+//! Row-level data access for the `suppers-ai/files` block.
+//!
+//! Mirrors `blocks/auth/repo/`: each submodule owns its table — the
+//! `TABLE` const and every `db::*` statement that touches it live here, so
+//! the handler/page modules above never issue database calls directly.
+//! Functions are thin typed wrappers around the pre-existing queries (same
+//! filters, same values) and surface the db client's `WaferError`
+//! unchanged, so call-site error handling (NotFound matching, warn-and-
+//! default, `err_internal`) keeps its exact previous behavior.
+//!
+//! Submodule → table map:
+//! - [`buckets`] — `suppers_ai__files__buckets`
+//! - [`objects`] — `suppers_ai__files__objects`
+//! - [`views`] — `suppers_ai__files__views`
+//! - [`shares`] — `suppers_ai__files__cloud_shares` +
+//!   `suppers_ai__files__cloud_access_logs` (the access log is a child
+//!   audit table of shares; one submodule owns both)
+//! - [`quota`] — `suppers_ai__files__cloud_quotas`
+
+pub mod buckets;
+pub mod objects;
+pub mod quota;
+pub mod shares;
+pub mod views;

--- a/crates/solobase-core/src/blocks/files/repo/objects.rs
+++ b/crates/solobase-core/src/blocks/files/repo/objects.rs
@@ -1,0 +1,316 @@
+//! Row-level access over `suppers_ai__files__objects`.
+//!
+//! Object metadata rows — one row per uploaded file (sibling of the raw
+//! storage blob in `wafer-run/storage`). Tracks size, content type,
+//! status, uploader and timestamps. Rows are inserted `pending` *before*
+//! the storage upload (to close the quota TOCTOU window) and flipped to
+//! `complete` afterward; quota accounting sums/counts by `uploaded_by`
+//! (including in-flight `pending` reservations), while user-facing search
+//! and admin stats only see `complete` rows.
+
+use std::collections::HashMap;
+
+use wafer_block::{
+    db::{Filter, FilterOp, ListOptions, SortField},
+    wire::database as wire,
+};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+
+use crate::util::RecordExt;
+
+/// Object metadata table — one row per uploaded file (sibling of the raw
+/// storage blob in `wafer-run/storage`). Tracks size, content type, status,
+/// uploader and timestamps.
+pub const TABLE: &str = "suppers_ai__files__objects";
+
+/// Filter matching only fully uploaded rows (`status = 'complete'`),
+/// excluding in-flight `pending` reservations.
+fn complete_filter() -> [Filter; 1] {
+    [Filter {
+        field: "status".to_string(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String("complete".to_string()),
+    }]
+}
+
+/// Filter matching all objects uploaded by `user_id` (the rows that count
+/// toward that user's quota, including in-flight `pending` reservations).
+fn owned_objects_filter(user_id: &str) -> Vec<Filter> {
+    vec![Filter {
+        field: "uploaded_by".to_string(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String(user_id.to_string()),
+    }]
+}
+
+/// Escape SQL LIKE wildcards (`%`, `_`) and the escape char itself (`\`) in
+/// user-supplied search terms so a user searching for `100% off` doesn't
+/// also match arbitrary characters.
+///
+/// SQLite's `LIKE` has *no* default escape character — a bare backslash is
+/// just a literal byte, so escaping here would be silently inert on its own.
+/// What makes it effective is the `wafer-sql-utils` `FilterOp::Like` builder
+/// (used by [`search_completed`]'s query below), which renders an explicit
+/// `ESCAPE '\'` clause on every backend (SQLite/D1 and Postgres) — see
+/// `wafer-sql-utils::query::leaf_expr`. Without that clause, a query
+/// containing `_` or `%` would match as a wildcard instead of a literal
+/// character.
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(c);
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Insert the `pending` reservation row written BEFORE the storage upload,
+/// so concurrent quota checks see the in-flight size (closes the
+/// check-quota → upload TOCTOU race). `uploaded_at` is stamped with
+/// [`crate::util::now_rfc3339`].
+pub async fn insert_pending(
+    ctx: &dyn Context,
+    bucket: &str,
+    key: &str,
+    size: usize,
+    content_type: &str,
+    uploaded_by: &str,
+) -> Result<Record, WaferError> {
+    let data = crate::util::json_map(serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "size": size,
+        "content_type": content_type,
+        "status": "pending",
+        "uploaded_by": uploaded_by,
+        "uploaded_at": crate::util::now_rfc3339(),
+    }));
+    db::create(ctx, TABLE, data).await
+}
+
+/// Flip a `pending` row to `status = 'complete'` after its storage upload
+/// succeeded.
+pub async fn mark_complete(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
+    let data = crate::util::json_map(serde_json::json!({ "status": "complete" }));
+    db::update(ctx, TABLE, id, data).await.map(|_| ())
+}
+
+/// Hard-delete one object row by id (the compensating delete when a
+/// storage upload fails after its `pending` row was inserted).
+pub async fn delete(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
+    db::delete(ctx, TABLE, id).await
+}
+
+/// Delete every object row in `bucket` (bucket-deletion metadata cleanup).
+pub async fn delete_for_bucket(ctx: &dyn Context, bucket: &str) -> Result<(), WaferError> {
+    db::delete_by_field(
+        ctx,
+        TABLE,
+        "bucket",
+        serde_json::Value::String(bucket.to_string()),
+    )
+    .await
+}
+
+/// Delete the object row for `(bucket, key)` (object-deletion metadata
+/// cleanup).
+pub async fn delete_by_bucket_key(
+    ctx: &dyn Context,
+    bucket: &str,
+    key: &str,
+) -> Result<(), WaferError> {
+    db::delete_by_filters(
+        ctx,
+        TABLE,
+        vec![
+            Filter {
+                field: "bucket".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(bucket.to_string()),
+            },
+            Filter {
+                field: "key".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(key.to_string()),
+            },
+        ],
+    )
+    .await
+}
+
+/// Delete `user_id`'s `pending`-status rows with `uploaded_at` strictly
+/// before `cutoff` (an RFC 3339 timestamp, string-compared the same way the
+/// column is written). See `quota::sweep_stale_pending` for the policy and
+/// why this is safe to run best-effort on every upload.
+pub async fn delete_stale_pending(
+    ctx: &dyn Context,
+    user_id: &str,
+    cutoff: &str,
+) -> Result<(), WaferError> {
+    let filters = vec![
+        Filter {
+            field: "uploaded_by".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        },
+        Filter {
+            field: "status".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String("pending".to_string()),
+        },
+        Filter {
+            field: "uploaded_at".to_string(),
+            operator: FilterOp::LessThan,
+            value: serde_json::Value::String(cutoff.to_string()),
+        },
+    ];
+    db::delete_by_filters(ctx, TABLE, filters).await
+}
+
+/// Search `user_id`'s `complete` objects whose key contains `query`
+/// (case rules per backend `LIKE`), newest upload first. `query` is
+/// LIKE-escaped here ([`escape_like`]) so `%`/`_` match literally.
+pub async fn search_completed(
+    ctx: &dyn Context,
+    user_id: &str,
+    query: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        filters: vec![
+            Filter {
+                field: "key".to_string(),
+                operator: FilterOp::Like,
+                value: serde_json::Value::String(format!("%{}%", escape_like(query))),
+            },
+            // Only show the current user's files
+            Filter {
+                field: "uploaded_by".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String(user_id.to_string()),
+            },
+            // Exclude pending uploads
+            Filter {
+                field: "status".to_string(),
+                operator: FilterOp::Equal,
+                value: serde_json::Value::String("complete".to_string()),
+            },
+        ],
+        sort: vec![SortField {
+            field: "uploaded_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        offset,
+        skip_count: false,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// List up to `limit` object rows in `bucket`, sorted by `key` ascending
+/// (the SSR object-browser order).
+pub async fn list_for_bucket(
+    ctx: &dyn Context,
+    bucket: &str,
+    limit: i64,
+) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "bucket".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(bucket.to_string()),
+        }],
+        sort: vec![SortField {
+            field: "key".to_string(),
+            desc: false,
+        }],
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// Object counts per bucket for the given bucket names, via a single
+/// GROUP BY aggregate (one row per bucket) — avoids an N+1 `db::count` per
+/// bucket. Counts ALL rows in each bucket regardless of `uploaded_by` or
+/// status, matching the previous per-bucket `db::count` semantics. Buckets
+/// with zero objects are simply absent from the returned map.
+pub async fn count_by_bucket(
+    ctx: &dyn Context,
+    bucket_names: &[String],
+) -> Result<HashMap<String, i64>, WaferError> {
+    let names: Vec<serde_json::Value> = bucket_names
+        .iter()
+        .map(|s| serde_json::Value::String(s.clone()))
+        .collect();
+    let req = wire::AggregateRequest {
+        collection: TABLE.to_string(),
+        select_columns: vec!["bucket".into()],
+        aggregates: vec![wire::AggregateColumnDef::Count {
+            alias: "cnt".into(),
+        }],
+        filters: vec![wire::FilterNode::Leaf(wire::FilterDef {
+            field: "bucket".into(),
+            operator: "in".into(),
+            value: serde_json::Value::Array(names),
+        })],
+        group_by: vec![wire::GroupByDef::Column("bucket".into())],
+        sort: vec![],
+        limit: 0,
+    };
+    let rows = db::aggregate(ctx, req).await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|r| {
+            let bucket = r.data.get("bucket").and_then(|v| v.as_str())?.to_string();
+            let cnt = r.i64_field("cnt");
+            Some((bucket, cnt))
+        })
+        .collect())
+}
+
+/// Number of `complete` object rows (admin stats).
+pub async fn count_completed(ctx: &dyn Context) -> Result<i64, WaferError> {
+    db::count(ctx, TABLE, &complete_filter()).await
+}
+
+/// `SUM(size)` over `complete` object rows (admin stats).
+pub async fn sum_size_completed(ctx: &dyn Context) -> Result<f64, WaferError> {
+    db::sum(ctx, TABLE, "size", &complete_filter()).await
+}
+
+/// Number of object rows uploaded by `user_id` (quota accounting —
+/// includes `pending` reservations).
+pub async fn count_for_uploader(ctx: &dyn Context, user_id: &str) -> Result<i64, WaferError> {
+    db::count(ctx, TABLE, &owned_objects_filter(user_id)).await
+}
+
+/// `SUM(size)` over the rows uploaded by `user_id` (quota accounting —
+/// includes `pending` reservations; no row materialization).
+pub async fn sum_size_for_uploader(ctx: &dyn Context, user_id: &str) -> Result<f64, WaferError> {
+    db::sum(ctx, TABLE, "size", &owned_objects_filter(user_id)).await
+}
+
+/// Test-fixture seeding: insert a raw row map exactly as given (no stamped
+/// columns), so tests control the precise row shape.
+#[cfg(test)]
+pub async fn seed(
+    ctx: &dyn Context,
+    data: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, TABLE, data).await
+}
+
+/// Test helper: every object row, unfiltered.
+#[cfg(test)]
+pub async fn list_all(ctx: &dyn Context) -> Result<Vec<Record>, WaferError> {
+    db::list_all(ctx, TABLE, vec![]).await
+}

--- a/crates/solobase-core/src/blocks/files/repo/quota.rs
+++ b/crates/solobase-core/src/blocks/files/repo/quota.rs
@@ -1,0 +1,94 @@
+//! Row-level access over `suppers_ai__files__cloud_quotas`.
+//!
+//! Per-user quota override table. Stores explicit byte/file caps that
+//! override the block defaults for individual users (one row per user,
+//! keyed by `user_id`). The interpretation of a row — field-by-field
+//! fallback to `QuotaConfig` defaults — lives in `files::quota`; usage
+//! accounting (sums/counts over object rows) lives in
+//! [`super::objects`].
+
+use std::collections::HashMap;
+
+use wafer_block::db::{ListOptions, SortField};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+
+/// Per-user quota override table.
+pub const TABLE: &str = "suppers_ai__files__cloud_quotas";
+
+/// Look up `user_id`'s quota-override row. Errors (including NotFound —
+/// most users have no override) are surfaced for the caller to map to the
+/// block defaults.
+pub async fn find_for_user(ctx: &dyn Context, user_id: &str) -> Result<Record, WaferError> {
+    db::get_by_field(
+        ctx,
+        TABLE,
+        "user_id",
+        serde_json::Value::String(user_id.to_string()),
+    )
+    .await
+}
+
+/// Up to `limit` override rows, unsorted (admin JSON listing).
+pub async fn list(ctx: &dyn Context, limit: i64) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// Newest override rows first (admin SSR listing).
+pub async fn list_recent(ctx: &dyn Context, limit: i64) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        sort: vec![SortField {
+            field: "created_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// Total number of override rows (admin stats).
+pub async fn count_all(ctx: &dyn Context) -> Result<i64, WaferError> {
+    db::count(ctx, TABLE, &[]).await
+}
+
+/// Create-or-replace `user_id`'s override row with the given (already
+/// whitelisted — see SEC-059 in `cloud::handle_update_quota`) quota
+/// `fields`. `user_id` and an `updated_at` stamp are written here so every
+/// upsert path stays consistent.
+pub async fn upsert_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+    mut fields: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    fields.insert(
+        "user_id".to_string(),
+        serde_json::Value::String(user_id.to_string()),
+    );
+    fields.insert(
+        "updated_at".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    db::upsert_by_field(
+        ctx,
+        TABLE,
+        "user_id",
+        serde_json::Value::String(user_id.to_string()),
+        fields,
+    )
+    .await
+}
+
+/// Test-fixture seeding: insert a raw row map exactly as given (no stamped
+/// columns), so tests control the precise row shape.
+#[cfg(test)]
+pub async fn seed(
+    ctx: &dyn Context,
+    data: HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, TABLE, data).await
+}

--- a/crates/solobase-core/src/blocks/files/repo/shares.rs
+++ b/crates/solobase-core/src/blocks/files/repo/shares.rs
@@ -1,0 +1,235 @@
+//! Row-level access over `suppers_ai__files__cloud_shares` and its child
+//! audit table `suppers_ai__files__cloud_access_logs`.
+//!
+//! A share row is one generated public link (token, source object,
+//! optional expiry / access cap, running `access_count`). Every recorded
+//! access appends an access-log row ([`log_access`]). Both tables are
+//! owned here because the log rows are meaningless without their share.
+
+use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+
+/// Public share-link table — one row per generated token.
+pub const TABLE: &str = "suppers_ai__files__cloud_shares";
+
+/// Access log table — one row per recorded share access (audit trail).
+pub const ACCESS_LOGS_TABLE: &str = "suppers_ai__files__cloud_access_logs";
+
+/// Insert payload for [`insert`]. Borrowed fields — the caller keeps
+/// ownership. `created_at` is caller-supplied (not stamped here) because
+/// the share's `expires_at` is derived from the same instant.
+#[derive(Debug, Clone, Copy)]
+pub struct NewShare<'a> {
+    pub token: &'a str,
+    pub bucket: &'a str,
+    pub key: &'a str,
+    pub created_by: &'a str,
+    /// RFC 3339 creation instant (also the base of `expires_at`).
+    pub created_at: &'a str,
+    /// Optional absolute expiry (RFC 3339).
+    pub expires_at: Option<&'a str>,
+    /// Optional access cap; `None` (or a non-positive stored value) means
+    /// unlimited.
+    pub max_access_count: Option<i64>,
+}
+
+/// Insert a share row (`access_count` starts at 0) and return it.
+pub async fn insert(ctx: &dyn Context, new: NewShare<'_>) -> Result<Record, WaferError> {
+    let mut data = crate::util::json_map(serde_json::json!({
+        "token": new.token,
+        "bucket": new.bucket,
+        "key": new.key,
+        "created_by": new.created_by,
+        "created_at": new.created_at,
+        "access_count": 0,
+    }));
+    if let Some(exp) = new.expires_at {
+        data.insert(
+            "expires_at".to_string(),
+            serde_json::Value::String(exp.to_string()),
+        );
+    }
+    if let Some(max) = new.max_access_count {
+        data.insert("max_access_count".to_string(), serde_json::json!(max));
+    }
+    db::create(ctx, TABLE, data).await
+}
+
+/// Look up a share by its raw token (the value embedded in the public
+/// `/b/storage/direct/{token}` URL).
+pub async fn find_by_token(ctx: &dyn Context, token: &str) -> Result<Record, WaferError> {
+    db::get_by_field(
+        ctx,
+        TABLE,
+        "token",
+        serde_json::Value::String(token.to_string()),
+    )
+    .await
+}
+
+/// Look up a share by its primary `id`.
+pub async fn find_by_id(ctx: &dyn Context, id: &str) -> Result<Record, WaferError> {
+    db::get(ctx, TABLE, id).await
+}
+
+/// Hard-delete a share row by id.
+pub async fn delete(ctx: &dyn Context, id: &str) -> Result<(), WaferError> {
+    db::delete(ctx, TABLE, id).await
+}
+
+/// Up to `limit` of `user_id`'s shares, newest first (JSON API listing).
+pub async fn list_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+    limit: i64,
+) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "created_by".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        }],
+        sort: vec![SortField {
+            field: "created_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// ALL of `user_id`'s shares, newest first, unpaginated (the SSR shares
+/// page).
+pub async fn list_all_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+) -> Result<Vec<Record>, WaferError> {
+    db::list_sorted(
+        ctx,
+        TABLE,
+        vec![Filter {
+            field: "created_by".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        }],
+        vec![SortField {
+            field: "created_at".to_string(),
+            desc: true,
+        }],
+    )
+    .await
+}
+
+/// Newest shares across ALL users (admin listing).
+pub async fn list_recent(
+    ctx: &dyn Context,
+    limit: i64,
+    offset: i64,
+) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        sort: vec![SortField {
+            field: "created_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        offset,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}
+
+/// Total number of share rows (admin stats).
+pub async fn count_all(ctx: &dyn Context) -> Result<i64, WaferError> {
+    db::count(ctx, TABLE, &[]).await
+}
+
+/// CAS-style increment of `access_count` for a share row. Returns `Ok(true)`
+/// if a row was updated (and the cap, if any, still allowed the access),
+/// `Ok(false)` if the row was already at its cap, or `Err` on DB failure.
+///
+/// `max <= 0` means unlimited — we only filter on id. Otherwise we add
+/// `access_count < max` to the WHERE so two concurrent accesses can't both
+/// pass a 1-access cap:
+///   UPDATE shares SET access_count = access_count + 1
+///   WHERE id = ? AND access_count < max
+/// With the cap inside the WHERE clause, at most one updater wins per row
+/// and rowcount 0 ⇒ cap reached.
+pub async fn increment_access_count_capped(
+    ctx: &dyn Context,
+    share_id: &str,
+    max: i64,
+) -> Result<bool, WaferError> {
+    let mut filters: Vec<Filter> = vec![Filter {
+        field: "id".to_string(),
+        operator: FilterOp::Equal,
+        value: serde_json::Value::String(share_id.to_string()),
+    }];
+    if max > 0 {
+        filters.push(Filter {
+            field: "access_count".to_string(),
+            operator: FilterOp::LessThan,
+            value: serde_json::json!(max),
+        });
+    }
+    let rows = db::increment_field_where(ctx, TABLE, "access_count", 1, &filters).await?;
+    Ok(rows > 0)
+}
+
+/// Append an access-log row for `share_id` (`accessed_at` stamped with
+/// [`crate::util::now_rfc3339`]).
+pub async fn log_access(
+    ctx: &dyn Context,
+    share_id: &str,
+    ip_address: &str,
+    user_agent: &str,
+) -> Result<Record, WaferError> {
+    let data = crate::util::json_map(serde_json::json!({
+        "share_id": share_id,
+        "accessed_at": crate::util::now_rfc3339(),
+        "ip_address": ip_address,
+        "user_agent": user_agent,
+    }));
+    db::create(ctx, ACCESS_LOGS_TABLE, data).await
+}
+
+/// Access-log rows, newest first, optionally restricted to one share
+/// (admin audit listing).
+pub async fn list_access_logs(
+    ctx: &dyn Context,
+    share_id: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> Result<RecordList, WaferError> {
+    let mut filters = Vec::new();
+    if let Some(share_id) = share_id {
+        filters.push(Filter {
+            field: "share_id".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(share_id.to_string()),
+        });
+    }
+    let opts = ListOptions {
+        filters,
+        sort: vec![SortField {
+            field: "accessed_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        offset,
+        skip_count: false,
+        ..Default::default()
+    };
+    db::list(ctx, ACCESS_LOGS_TABLE, &opts).await
+}
+
+/// Test-fixture seeding: insert a raw share row map exactly as given (no
+/// stamped columns), so tests control the precise row shape.
+#[cfg(test)]
+pub async fn seed(
+    ctx: &dyn Context,
+    data: std::collections::HashMap<String, serde_json::Value>,
+) -> Result<Record, WaferError> {
+    db::create(ctx, TABLE, data).await
+}

--- a/crates/solobase-core/src/blocks/files/repo/views.rs
+++ b/crates/solobase-core/src/blocks/files/repo/views.rs
@@ -1,0 +1,52 @@
+//! Row-level access over `suppers_ai__files__views`.
+//!
+//! Object-view audit table — one row per tracked object download
+//! ([`insert`], written best-effort by `storage::handle_get_object`), read
+//! back newest-first by the `/b/storage/api/recent` endpoint
+//! ([`list_recent_for_user`]).
+
+use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
+use wafer_core::clients::database::{self as db, Record, RecordList};
+use wafer_run::{context::Context, WaferError};
+
+/// Object-view audit table.
+pub const TABLE: &str = "suppers_ai__files__views";
+
+/// Record that `user_id` viewed `(bucket, key)` (`viewed_at` stamped with
+/// [`crate::util::now_rfc3339`]).
+pub async fn insert(
+    ctx: &dyn Context,
+    bucket: &str,
+    key: &str,
+    user_id: &str,
+) -> Result<Record, WaferError> {
+    let data = crate::util::json_map(serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "user_id": user_id,
+        "viewed_at": crate::util::now_rfc3339(),
+    }));
+    db::create(ctx, TABLE, data).await
+}
+
+/// `user_id`'s most recent views, newest first.
+pub async fn list_recent_for_user(
+    ctx: &dyn Context,
+    user_id: &str,
+    limit: i64,
+) -> Result<RecordList, WaferError> {
+    let opts = ListOptions {
+        filters: vec![Filter {
+            field: "user_id".to_string(),
+            operator: FilterOp::Equal,
+            value: serde_json::Value::String(user_id.to_string()),
+        }],
+        sort: vec![SortField {
+            field: "viewed_at".to_string(),
+            desc: true,
+        }],
+        limit,
+        ..Default::default()
+    };
+    db::list(ctx, TABLE, &opts).await
+}

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 
-use wafer_core::clients::{crypto, database as db, storage as store};
+use wafer_core::clients::{crypto, storage as store};
 use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 
-use super::{ACCESS_LOGS_TABLE, SHARES_TABLE};
+use super::repo;
 use crate::{
     blocks::rate_limit::{check_rate_limit, RateLimit, RateLimitOutcome, UserRateLimiter},
     http::{
         err_bad_request, err_forbidden, err_internal, err_internal_no_cause, err_not_found,
         ResponseBuilder,
     },
-    util::{json_map, now_rfc3339, RecordExt},
+    util::{json_map, RecordExt},
 };
 
 pub async fn generate_share_token(
@@ -70,20 +70,13 @@ pub async fn handle_direct_access(
     // Verify the token's HMAC before touching the DB. Tokens are JWT-signed
     // at issue time (`generate_share_token`), so an invalid signature means
     // the token wasn't minted by us — short-circuit before the DB lookup so
-    // attackers can't enumerate the SHARES_TABLE via random tokens.
+    // attackers can't enumerate the shares table via random tokens.
     if crypto::verify(ctx, token).await.is_err() {
         return err_not_found("Share not found or expired");
     }
 
     // Look up share by token
-    let share = match db::get_by_field(
-        ctx,
-        SHARES_TABLE,
-        "token",
-        serde_json::Value::String(token.to_string()),
-    )
-    .await
-    {
+    let share = match repo::shares::find_by_token(ctx, token).await {
         Ok(s) => s,
         Err(_) => return err_not_found("Share not found or expired"),
     };
@@ -107,7 +100,7 @@ pub async fn handle_direct_access(
     // serve the file. With the cap inside the WHERE clause, at most one
     // updater wins per row and rowcount 0 ⇒ cap reached.
     let max = share.i64_field("max_access_count");
-    match increment_access_count_atomic(ctx, &share.id, max).await {
+    match repo::shares::increment_access_count_capped(ctx, &share.id, max).await {
         Ok(true) => {}
         Ok(false) => return err_forbidden("Share link access limit reached"),
         Err(e) => {
@@ -131,13 +124,9 @@ pub async fn handle_direct_access(
     }
 
     // Log access
-    let log_data = json_map(serde_json::json!({
-        "share_id": share.id,
-        "accessed_at": now_rfc3339(),
-        "ip_address": msg.remote_addr(),
-        "user_agent": msg.header("User-Agent"),
-    }));
-    if let Err(e) = db::create(ctx, ACCESS_LOGS_TABLE, log_data).await {
+    if let Err(e) =
+        repo::shares::log_access(ctx, &share.id, msg.remote_addr(), msg.header("User-Agent")).await
+    {
         tracing::warn!("Failed to log share access: {e}");
     }
 
@@ -156,34 +145,4 @@ pub async fn handle_direct_access(
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("File not found"),
         Err(e) => err_internal("Storage error", e),
     }
-}
-
-/// CAS-style increment of `access_count` for a share row. Returns `Ok(true)`
-/// if a row was updated (and the cap, if any, still allowed the access),
-/// `Ok(false)` if the row was already at its cap, or `Err` on DB failure.
-///
-/// `max <= 0` means unlimited — we only filter on id. Otherwise we add
-/// `access_count < max` to the WHERE so two concurrent accesses can't both
-/// pass a 1-access cap.
-async fn increment_access_count_atomic(
-    ctx: &dyn Context,
-    share_id: &str,
-    max: i64,
-) -> Result<bool, wafer_run::WaferError> {
-    use wafer_block::db::{Filter, FilterOp};
-
-    let mut filters: Vec<Filter> = vec![Filter {
-        field: "id".into(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String(share_id.to_string()),
-    }];
-    if max > 0 {
-        filters.push(Filter {
-            field: "access_count".into(),
-            operator: FilterOp::LessThan,
-            value: serde_json::json!(max),
-        });
-    }
-    let rows = db::increment_field_where(ctx, SHARES_TABLE, "access_count", 1, &filters).await?;
-    Ok(rows > 0)
 }

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -76,9 +76,8 @@ pub async fn handle_direct_access(
     }
 
     // Look up share by token
-    let share = match repo::shares::find_by_token(ctx, token).await {
-        Ok(s) => s,
-        Err(_) => return err_not_found("Share not found or expired"),
+    let Ok(share) = repo::shares::find_by_token(ctx, token).await else {
+        return err_not_found("Share not found or expired");
     };
 
     // Check expiry

--- a/crates/solobase-core/src/blocks/files/share.rs
+++ b/crates/solobase-core/src/blocks/files/share.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use wafer_core::clients::{crypto, database as db, storage as store};
 use wafer_run::{context::Context, ErrorCode, Message, OutputStream};
 
+use super::{ACCESS_LOGS_TABLE, SHARES_TABLE};
 use crate::{
     blocks::rate_limit::{check_rate_limit, RateLimit, RateLimitOutcome, UserRateLimiter},
     http::{
@@ -11,12 +12,6 @@ use crate::{
     },
     util::{json_map, now_rfc3339, RecordExt},
 };
-
-/// Public share-link table — one row per generated token.
-pub(crate) const SHARES_TABLE: &str = "suppers_ai__files__cloud_shares";
-
-/// Access log table — one row per recorded share access (audit trail).
-pub(crate) const ACCESS_LOGS_TABLE: &str = "suppers_ai__files__cloud_access_logs";
 
 pub async fn generate_share_token(
     ctx: &dyn Context,

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -540,7 +540,9 @@ async fn handle_delete_object(ctx: &dyn Context, msg: &Message) -> OutputStream 
     match store::delete(ctx, bucket, key).await {
         Ok(()) => {
             // Clean up metadata
-            repo::objects::delete_by_bucket_key(ctx, bucket, key).await.ok();
+            repo::objects::delete_by_bucket_key(ctx, bucket, key)
+                .await
+                .ok();
             ok_json(&serde_json::json!({"deleted": true}))
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Object not found"),
@@ -863,7 +865,9 @@ mod integration_tests {
     /// Fetch the single object-metadata row (asserting there is exactly
     /// one) and return its `(size, content_type, status)`.
     async fn sole_object_row(ctx: &TestContext) -> (i64, String, String) {
-        let rows = repo::objects::list_all(ctx).await.expect("list object rows");
+        let rows = repo::objects::list_all(ctx)
+            .await
+            .expect("list object rows");
         assert_eq!(rows.len(), 1, "expected exactly one object metadata row");
         let data = &rows[0].data;
         (

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -1,8 +1,7 @@
-use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
-use wafer_core::clients::{database as db, storage as store};
+use wafer_core::clients::storage as store;
 use wafer_run::{context::Context, ErrorCode, HttpMethod, InputStream, Message, OutputStream};
 
-use super::{BUCKETS_TABLE, OBJECTS_TABLE};
+use super::repo;
 use crate::{
     endpoint_match::{self, EndpointRoute},
     http::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json, ResponseBuilder},
@@ -130,9 +129,9 @@ fn extract_object_key(msg: &Message) -> String {
     }
 }
 
-/// True when `user_id` owns a bucket named `bucket` (i.e. a matching row
-/// exists in [`BUCKETS_TABLE`]). DB errors are logged and treated as "not
-/// owned" (fail closed).
+/// True when `user_id` owns a bucket named `bucket` (i.e.
+/// [`repo::buckets::find_owned`] finds a matching row). DB errors are
+/// logged and treated as "not owned" (fail closed).
 ///
 /// This is the single ownership predicate for the files block. Callers
 /// decide the admin policy on top of it:
@@ -143,20 +142,8 @@ fn extract_object_key(msg: &Message) -> String {
 ///   admin browsing `/b/storage/` sees only their own buckets; cross-user
 ///   inspection happens via the admin pages instead.
 pub(super) async fn bucket_owned_by(ctx: &dyn Context, user_id: &str, bucket: &str) -> bool {
-    let filters = vec![
-        Filter {
-            field: "name".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(bucket.to_string()),
-        },
-        Filter {
-            field: "created_by".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.to_string()),
-        },
-    ];
-    match db::list_all(ctx, BUCKETS_TABLE, filters).await {
-        Ok(records) => !records.is_empty(),
+    match repo::buckets::find_owned(ctx, bucket, user_id).await {
+        Ok(record) => record.is_some(),
         Err(e) => {
             tracing::warn!(error = %e, bucket = %bucket, "bucket-ownership check failed");
             false
@@ -255,49 +242,18 @@ async fn collect_with_cap(
     Ok(out)
 }
 
-/// Escape SQL LIKE wildcards (`%`, `_`) and the escape char itself (`\`) in
-/// user-supplied search terms so a user searching for `100% off` doesn't
-/// also match arbitrary characters.
-///
-/// SQLite's `LIKE` has *no* default escape character — a bare backslash is
-/// just a literal byte, so escaping here would be silently inert on its own.
-/// What makes it effective is the `wafer-sql-utils` `FilterOp::Like` builder
-/// (used by [`handle_search`]'s query below), which renders an explicit
-/// `ESCAPE '\'` clause on every backend (SQLite/D1 and Postgres) — see
-/// `wafer-sql-utils::query::leaf_expr`. Without that clause, a query
-/// containing `_` or `%` would match as a wildcard instead of a literal
-/// character.
-fn escape_like(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for c in input.chars() {
-        match c {
-            '\\' | '%' | '_' => {
-                out.push('\\');
-                out.push(c);
-            }
-            other => out.push(other),
-        }
-    }
-    out
-}
-
 async fn handle_list_buckets(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    // [`BUCKETS_TABLE`] is the single source of truth for bucket existence /
-    // ownership / visibility. Both the admin and user branches read it (the
-    // admin sees every bucket, the user only their own) — storage folders are
-    // a blob namespace, not a directory we enumerate here, so the admin list
-    // no longer diverges from `store::list_folders`.
-    let user_id = msg.user_id();
-    let filters = if crate::util::is_admin(msg) {
-        Vec::new()
+    // [`repo::buckets::TABLE`] is the single source of truth for bucket
+    // existence / ownership / visibility. Both the admin and user branches
+    // read it (the admin sees every bucket, the user only their own) —
+    // storage folders are a blob namespace, not a directory we enumerate
+    // here, so the admin list no longer diverges from `store::list_folders`.
+    let owner = if crate::util::is_admin(msg) {
+        None
     } else {
-        vec![Filter {
-            field: "created_by".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id.to_string()),
-        }]
+        Some(msg.user_id())
     };
-    match db::list_all(ctx, BUCKETS_TABLE, filters).await {
+    match repo::buckets::list_visible(ctx, owner).await {
         Ok(records) => {
             let names: Vec<&str> = records
                 .iter()
@@ -338,18 +294,12 @@ async fn handle_create_bucket(
         return err_internal("Failed to create bucket", e);
     }
 
-    // [`BUCKETS_TABLE`] is the source of truth for bucket existence, so the
-    // metadata insert must succeed for the bucket to count as created. If it
-    // fails, compensate by deleting the just-created folder rather than
+    // [`repo::buckets::TABLE`] is the source of truth for bucket existence,
+    // so the metadata insert must succeed for the bucket to count as created.
+    // If it fails, compensate by deleting the just-created folder rather than
     // warn-and-continue (which would leave an orphan folder invisible to every
     // listing path, which now all read the table).
-    let data = crate::util::json_map(serde_json::json!({
-        "name": body.name,
-        "public": body.public,
-        "created_by": msg.user_id(),
-        "created_at": crate::util::now_rfc3339(),
-    }));
-    if let Err(e) = db::create(ctx, BUCKETS_TABLE, data).await {
+    if let Err(e) = repo::buckets::insert(ctx, &body.name, body.public, msg.user_id()).await {
         if let Err(cleanup) = store::delete_folder(ctx, &body.name).await {
             tracing::error!(
                 bucket = %body.name,
@@ -378,22 +328,8 @@ async fn handle_delete_bucket(ctx: &dyn Context, msg: &Message) -> OutputStream 
     match store::delete_folder(ctx, bucket).await {
         Ok(()) => {
             // Clean up DB metadata for the bucket and its objects
-            db::delete_by_field(
-                ctx,
-                BUCKETS_TABLE,
-                "name",
-                serde_json::Value::String(bucket.to_string()),
-            )
-            .await
-            .ok();
-            db::delete_by_field(
-                ctx,
-                OBJECTS_TABLE,
-                "bucket",
-                serde_json::Value::String(bucket.to_string()),
-            )
-            .await
-            .ok();
+            repo::buckets::delete_by_name(ctx, bucket).await.ok();
+            repo::objects::delete_for_bucket(ctx, bucket).await.ok();
             ok_json(&serde_json::json!({"deleted": true}))
         }
         Err(e) => err_internal("Failed to delete bucket", e),
@@ -444,13 +380,7 @@ async fn handle_get_object(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     // Track view in DB
-    let data = crate::util::json_map(serde_json::json!({
-        "bucket": bucket,
-        "key": key,
-        "user_id": msg.user_id(),
-        "viewed_at": crate::util::now_rfc3339(),
-    }));
-    if let Err(e) = db::create(ctx, super::VIEWS_TABLE, data).await {
+    if let Err(e) = repo::views::insert(ctx, bucket, key, msg.user_id()).await {
         tracing::warn!("Failed to track storage object view: {e}");
     }
 
@@ -560,17 +490,16 @@ async fn handle_upload_object(
 
     // Insert a pending record BEFORE uploading so concurrent quota checks see it.
     // This closes the TOCTOU race between check_quota and the actual upload.
-    let pending_data = crate::util::json_map(serde_json::json!({
-        "bucket": bucket,
-        "key": key,
-        "size": content.len(),
-        "content_type": content_type,
-        "status": "pending",
-        "uploaded_by": msg.user_id(),
-        "uploaded_at": crate::util::now_rfc3339(),
-    }));
-
-    let pending_record = match db::create(ctx, OBJECTS_TABLE, pending_data).await {
+    let pending_record = match repo::objects::insert_pending(
+        ctx,
+        bucket,
+        &key,
+        content.len(),
+        &content_type,
+        msg.user_id(),
+    )
+    .await
+    {
         Ok(record) => record,
         Err(e) => return err_internal("Failed to reserve upload slot", e),
     };
@@ -578,15 +507,14 @@ async fn handle_upload_object(
     match store::put(ctx, bucket, &key, &content, &content_type).await {
         Ok(()) => {
             // Upload succeeded — mark the pending record as complete.
-            let update_data = crate::util::json_map(serde_json::json!({ "status": "complete" }));
-            if let Err(e) = db::update(ctx, OBJECTS_TABLE, &pending_record.id, update_data).await {
+            if let Err(e) = repo::objects::mark_complete(ctx, &pending_record.id).await {
                 tracing::warn!("Failed to mark upload as complete: {e}");
             }
             ok_json(&serde_json::json!({"bucket": bucket, "key": key, "uploaded": true}))
         }
         Err(e) => {
             // Upload failed — delete the pending record so it doesn't block quota.
-            if let Err(del_err) = db::delete(ctx, OBJECTS_TABLE, &pending_record.id).await {
+            if let Err(del_err) = repo::objects::delete(ctx, &pending_record.id).await {
                 tracing::warn!("Failed to clean up pending record: {del_err}");
             }
             err_internal("Upload failed", e)
@@ -612,24 +540,7 @@ async fn handle_delete_object(ctx: &dyn Context, msg: &Message) -> OutputStream 
     match store::delete(ctx, bucket, key).await {
         Ok(()) => {
             // Clean up metadata
-            db::delete_by_filters(
-                ctx,
-                OBJECTS_TABLE,
-                vec![
-                    Filter {
-                        field: "bucket".to_string(),
-                        operator: FilterOp::Equal,
-                        value: serde_json::Value::String(bucket.to_string()),
-                    },
-                    Filter {
-                        field: "key".to_string(),
-                        operator: FilterOp::Equal,
-                        value: serde_json::Value::String(key.to_string()),
-                    },
-                ],
-            )
-            .await
-            .ok();
+            repo::objects::delete_by_bucket_key(ctx, bucket, key).await.ok();
             ok_json(&serde_json::json!({"deleted": true}))
         }
         Err(e) if e.code == ErrorCode::NotFound => err_not_found("Object not found"),
@@ -644,60 +555,22 @@ async fn handle_search(ctx: &dyn Context, msg: &Message) -> OutputStream {
     }
 
     let (_, page_size, offset) = msg.pagination_params(20);
-    let opts = ListOptions {
-        filters: vec![
-            Filter {
-                field: "key".to_string(),
-                operator: FilterOp::Like,
-                value: serde_json::Value::String(format!("%{}%", escape_like(&query))),
-            },
-            // Only show the current user's files
-            Filter {
-                field: "uploaded_by".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String(msg.user_id().to_string()),
-            },
-            // Exclude pending uploads
-            Filter {
-                field: "status".to_string(),
-                operator: FilterOp::Equal,
-                value: serde_json::Value::String("complete".to_string()),
-            },
-        ],
-        sort: vec![SortField {
-            field: "uploaded_at".to_string(),
-            desc: true,
-        }],
-        limit: page_size as i64,
-        offset: offset as i64,
-        skip_count: false,
-        ..Default::default()
-    };
-
-    match db::list(ctx, OBJECTS_TABLE, &opts).await {
+    match repo::objects::search_completed(
+        ctx,
+        msg.user_id(),
+        &query,
+        page_size as i64,
+        offset as i64,
+    )
+    .await
+    {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Search failed", e),
     }
 }
 
 async fn handle_recent(ctx: &dyn Context, msg: &Message) -> OutputStream {
-    let user_id = msg.user_id().to_string();
-
-    let opts = ListOptions {
-        filters: vec![Filter {
-            field: "user_id".to_string(),
-            operator: FilterOp::Equal,
-            value: serde_json::Value::String(user_id),
-        }],
-        sort: vec![SortField {
-            field: "viewed_at".to_string(),
-            desc: true,
-        }],
-        limit: 20,
-        ..Default::default()
-    };
-
-    match db::list(ctx, super::VIEWS_TABLE, &opts).await {
+    match repo::views::list_recent_for_user(ctx, msg.user_id(), 20).await {
         Ok(result) => ok_json(&result),
         Err(e) => err_internal("Database error", e),
     }
@@ -987,12 +860,10 @@ mod integration_tests {
         msg
     }
 
-    /// Fetch the single OBJECTS_TABLE metadata row (asserting there is
-    /// exactly one) and return its `(size, content_type, status)`.
+    /// Fetch the single object-metadata row (asserting there is exactly
+    /// one) and return its `(size, content_type, status)`.
     async fn sole_object_row(ctx: &TestContext) -> (i64, String, String) {
-        let rows = db::list_all(ctx, OBJECTS_TABLE, vec![])
-            .await
-            .expect("list object rows");
+        let rows = repo::objects::list_all(ctx).await.expect("list object rows");
         assert_eq!(rows.len(), 1, "expected exactly one object metadata row");
         let data = &rows[0].data;
         (
@@ -1136,9 +1007,7 @@ mod integration_tests {
             "created_by": owner,
             "created_at": crate::util::now_rfc3339(),
         }));
-        db::create(ctx, BUCKETS_TABLE, data)
-            .await
-            .expect("seed bucket");
+        repo::buckets::seed(ctx, data).await.expect("seed bucket");
     }
 
     fn bucket_names(v: &serde_json::Value) -> Vec<String> {
@@ -1152,7 +1021,7 @@ mod integration_tests {
             .unwrap_or_default()
     }
 
-    /// Seed an [`OBJECTS_TABLE`] row directly (bypassing `handle_upload_object`
+    /// Seed an object-metadata row directly (bypassing `handle_upload_object`
     /// / the real storage backend, same as [`seed_bucket`] does for buckets) —
     /// enough to exercise `handle_search`'s DB query.
     async fn seed_object(ctx: &TestContext, bucket: &str, key: &str, owner: &str) {
@@ -1165,9 +1034,7 @@ mod integration_tests {
             "uploaded_by": owner,
             "uploaded_at": crate::util::now_rfc3339(),
         }));
-        db::create(ctx, OBJECTS_TABLE, data)
-            .await
-            .expect("seed object");
+        repo::objects::seed(ctx, data).await.expect("seed object");
     }
 
     fn search_result_keys(v: &serde_json::Value) -> Vec<String> {
@@ -1187,7 +1054,7 @@ mod integration_tests {
     }
 
     /// Single source of truth: the admin bucket listing now reads
-    /// [`BUCKETS_TABLE`] (every bucket) instead of `store::list_folders`, so it
+    /// [`repo::buckets::TABLE`] (every bucket) instead of `store::list_folders`,
     /// can no longer diverge from the per-user listing that already read the
     /// table. An admin sees all buckets regardless of owner.
     #[tokio::test]
@@ -1215,7 +1082,7 @@ mod integration_tests {
         assert_eq!(names, vec!["alice-bucket"]);
     }
 
-    /// `handle_stats` counts buckets from [`BUCKETS_TABLE`] (the same source the
+    /// `handle_stats` counts buckets from [`repo::buckets::TABLE`] (the same source
     /// admin SSR overview uses), not by enumerating storage folders.
     #[tokio::test]
     async fn stats_counts_buckets_from_metadata_table() {
@@ -1267,20 +1134,11 @@ mod integration_tests {
 }
 
 async fn handle_stats(ctx: &dyn Context, _msg: &Message) -> OutputStream {
-    let complete_filter = &[Filter {
-        field: "status".to_string(),
-        operator: FilterOp::Equal,
-        value: serde_json::Value::String("complete".to_string()),
-    }];
-    let total_objects = db::count(ctx, OBJECTS_TABLE, complete_filter)
-        .await
-        .unwrap_or(0);
-    let total_size = db::sum(ctx, OBJECTS_TABLE, "size", complete_filter)
-        .await
-        .unwrap_or(0.0);
+    let total_objects = repo::objects::count_completed(ctx).await.unwrap_or(0);
+    let total_size = repo::objects::sum_size_completed(ctx).await.unwrap_or(0.0);
     // Count buckets from the metadata table (single source of truth), the same
     // way the admin SSR overview does, rather than enumerating storage folders.
-    let bucket_count = db::count(ctx, BUCKETS_TABLE, &[]).await.unwrap_or(0);
+    let bucket_count = repo::buckets::count_all(ctx).await.unwrap_or(0);
 
     ok_json(&serde_json::json!({
         "total_objects": total_objects,

--- a/crates/solobase-core/src/blocks/files/storage.rs
+++ b/crates/solobase-core/src/blocks/files/storage.rs
@@ -2,18 +2,11 @@ use wafer_block::db::{Filter, FilterOp, ListOptions, SortField};
 use wafer_core::clients::{database as db, storage as store};
 use wafer_run::{context::Context, ErrorCode, HttpMethod, InputStream, Message, OutputStream};
 
+use super::{BUCKETS_TABLE, OBJECTS_TABLE};
 use crate::{
     endpoint_match::{self, EndpointRoute},
     http::{err_bad_request, err_forbidden, err_internal, err_not_found, ok_json, ResponseBuilder},
 };
-
-/// Buckets table — user-created storage containers (one row per bucket).
-pub(crate) const BUCKETS_TABLE: &str = "suppers_ai__files__buckets";
-
-/// Object metadata table — one row per uploaded file (sibling of the raw
-/// storage blob in `wafer-run/storage`). Tracks size, content type, status,
-/// uploader and timestamps.
-pub(crate) const OBJECTS_TABLE: &str = "suppers_ai__files__objects";
 
 /// In-block dispatch targets for the user storage API.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## What

Move-only refactor giving `blocks/files/` the same `repo/` data-layer structure as `blocks/auth/repo/`: repo modules are the sole place issuing `db::*` calls and own their TABLE consts. Behavior identical — existing tests are the safety net (zero test assertions changed).

**Structure before:**
```
blocks/files/
  storage.rs      (19 db sites, BUCKETS_TABLE + OBJECTS_TABLE)
  pages_user.rs   (22 db sites)
  cloud.rs        (12 db sites)
  pages_admin.rs  (10 db sites)
  quota.rs        ( 9 db sites, quotas TABLE)
  share.rs        ( 4 db sites, SHARES_TABLE + ACCESS_LOGS_TABLE)
  mod.rs          (VIEWS_TABLE)
```

**Structure after:**
```
blocks/files/
  repo/
    mod.rs      (layer docs)
    buckets.rs  (suppers_ai__files__buckets)
    objects.rs  (suppers_ai__files__objects)
    views.rs    (suppers_ai__files__views)
    shares.rs   (suppers_ai__files__cloud_shares + cloud_access_logs)
    quota.rs    (suppers_ai__files__cloud_quotas)
  storage.rs / pages_user.rs / cloud.rs / pages_admin.rs / quota.rs / share.rs
    — handlers/pages only, zero db:: statements
```

Repo fns are thin typed wrappers around the pre-existing queries (same filters, same values, `WaferError` surfaced unchanged), so call-site error handling — NotFound matching, warn-and-default, `err_internal` — kept its exact previous behavior. Test fixtures seed through `#[cfg(test)] repo::*::seed(raw map)` so seeded row shapes are byte-identical to before.

**The one real dedup:** the bucket-ownership predicate (name + created_by lookup) is now `repo::buckets::find_owned(ctx, name, user_id) -> Result<Option<Record>>`; `storage::bucket_owned_by` / `is_bucket_access_denied`, the SSR portal owner check, and the share-creation path all derive from it. New unit test pins the (name, owner)-pair semantics. `escape_like` also moved next to the LIKE query it protects (`repo::objects::search_completed`) so call sites can't forget the escaping.

## Acceptance gate

`grep -rn "db::" crates/solobase-core/src/blocks/files/ | grep -v "/repo/"` → only one non-call comment in the migration SQL file. No TABLE consts outside `repo/`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` (CI command) — **all green**, 889 solobase-core lib tests + every integration suite
- clippy: the files block is `-D warnings` clean; the workspace has ~59 pre-existing strict-clippy findings in *other* blocks (admin, auth_ui, email, products, …) and 4 in solobase-bundle — CI runs clippy **without** `-D warnings`, so these never gated, and this diff touches only `blocks/files/**` (left for a dedicated lint-sweep, not this move-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H
