### PR TITLE
fix(llm): persist streamed assistant turns to conversation history

### DIFF
--- a/crates/solobase-core/src/blocks/llm/routes.rs
+++ b/crates/solobase-core/src/blocks/llm/routes.rs
@@ -7,6 +7,8 @@
 //! `ChatChunk` stream returned by the service into either a buffered JSON
 //! response or a Server-Sent Events stream.
 
+use std::sync::Arc;
+
 use futures::StreamExt;
 use wafer_core::clients::{
     config, database as db,
@@ -17,7 +19,8 @@ use wafer_core::clients::{
     NativeTypedFrameStream,
 };
 use wafer_run::{
-    context::Context, InputStream, Message, MetaEntry, OutputStream, META_RESP_CONTENT_TYPE,
+    context::Context, InputStream, Message, MetaEntry, OutputSink, OutputStream,
+    META_RESP_CONTENT_TYPE,
 };
 
 use super::{
@@ -269,8 +272,9 @@ pub(super) async fn handle_chat(
 }
 
 /// SSE streaming chat handler: forwards each `ChatChunk` (as its JSON
-/// encoding) to the HTTP response as a `data:` frame. After the stream
-/// ends, writes the accumulated assistant text back to the messages block.
+/// encoding) to the HTTP response as a `data:` frame, then persists the
+/// accumulated assistant text to the messages block at natural
+/// end-of-stream — see [`sse_chat_response`].
 pub(super) async fn handle_chat_stream(
     block: &LlmBlock,
     ctx: &dyn Context,
@@ -289,24 +293,126 @@ pub(super) async fn handle_chat_stream(
         Err(err) => return err,
     };
 
-    // Capture everything we need inside the producer. `ctx` and `msg` can't
-    // cross the spawn boundary, so we snapshot the bits needed to persist
-    // the assistant reply.
-    //
-    // Persistence of the assistant message requires calling `ctx.call_block`
-    // after the stream ends. `ctx` is `&dyn Context` and not `'static`, so we
-    // can't move it into the producer. Instead, we split: emit SSE frames
-    // here, then let the outer caller fire-and-forget `messages_create` once
-    // the consumer drains the stream. Since the producer runs in a spawned
-    // task, we keep it simple: forward chunks, and skip assistant-persistence
-    // in the SSE path. Clients can fetch the assistant message via the normal
-    // messages endpoint after the stream ends if needed.
-    //
-    // TODO(llm-phase-b-task-14): wire assistant persistence through a
-    // dedicated "finalize" call that doesn't require capturing `ctx`.
-    let _ = thread_id;
+    // The SSE producer runs in a spawned task, so it can't borrow `ctx` or
+    // `msg`. `Context::clone_arc()` yields an owned handle that crosses the
+    // spawn boundary, and `Message` is `Clone` — `messages_create` only
+    // reads the forwarded auth identity off it.
+    sse_chat_response(stream, ctx.clone_arc(), msg.clone(), thread_id)
+}
 
-    sse_json_response(stream)
+/// Terminal SSE frame for natural end-of-stream, letting clients distinguish
+/// it from a transport-level disconnect.
+const SSE_DONE_FRAME: &[u8] = b"data: [DONE]\n\n";
+
+/// Terminal SSE frame emitted when the service stream yields an error or an
+/// item fails to JSON-encode, so the consumer sees a clean SSE event instead
+/// of an abrupt disconnect.
+const SSE_ERROR_FRAME: &[u8] = b"event: error\ndata: {}\n\n";
+
+/// Encode one typed item as an SSE `data: <json>\n\n` frame.
+///
+/// Returns `None` when JSON encoding fails; callers emit [`SSE_ERROR_FRAME`]
+/// and terminate. Shared by [`sse_json_response`] and [`sse_chat_response`]
+/// so the SSE wire format cannot drift between the generic and the
+/// chat-finalizing paths.
+fn sse_json_frame<T: serde::Serialize>(item: &T) -> Option<Vec<u8>> {
+    let json = serde_json::to_vec(item).ok()?;
+    let mut frame = Vec::with_capacity(json.len() + 8);
+    frame.extend_from_slice(b"data: ");
+    frame.extend_from_slice(&json);
+    frame.extend_from_slice(b"\n\n");
+    Some(frame)
+}
+
+/// Send the `text/event-stream` content-type as a mid-stream meta event so
+/// the HTTP listener writes the SSE header before the first `data:` frame.
+/// A send failure only means the consumer already dropped the stream; the
+/// producer's next `send_chunk` surfaces that, so it is ignored here.
+async fn send_sse_content_type(sink: &OutputSink) {
+    let _ = sink
+        .send_meta(MetaEntry {
+            key: META_RESP_CONTENT_TYPE.to_string(),
+            value: "text/event-stream".to_string(),
+        })
+        .await;
+}
+
+/// SSE wrapper for the chat endpoint: frames each [`ChatChunk`] exactly like
+/// [`sse_json_response`] while accumulating `ChunkDelta::Text` deltas, then
+/// persists the assistant turn via [`messages_create`] at natural
+/// end-of-stream (immediately before the terminal `data: [DONE]` frame, so a
+/// client that refetches history on `[DONE]` sees the new message).
+///
+/// Accumulation mirrors [`handle_chat`]: text deltas are concatenated up to
+/// [`MAX_BUFFERED_RESPONSE_BYTES`] (an overflowing delta stops accumulation
+/// with a warning at end-of-stream, while frames keep flowing to the
+/// client), and tool-call/empty deltas are forwarded but not accumulated. A
+/// service error or encode failure terminates the stream with an error frame
+/// and skips persistence — the same outcome as `handle_chat`, which returns
+/// a 500 without persisting when the stream errors.
+///
+/// Generic over the chunk stream (rather than taking
+/// [`NativeTypedFrameStream`]`<ChatChunk>` directly, whose constructor is
+/// private to wafer-core) so tests can drive it with a scripted stream. The
+/// `MaybeSend` bound keeps it compilable on wasm32, where
+/// [`OutputStream::from_producer`] does not require `Send`.
+fn sse_chat_response<S>(
+    stream: S,
+    ctx: Arc<dyn Context>,
+    msg: Message,
+    thread_id: String,
+) -> OutputStream
+where
+    S: futures::Stream<Item = Result<ChatChunk, wafer_run::WaferError>>
+        + wafer_run::MaybeSend
+        + Unpin
+        + 'static,
+{
+    OutputStream::from_producer(move |sink, _cancel| async move {
+        send_sse_content_type(&sink).await;
+
+        let mut stream = stream;
+        let mut content = String::new();
+        let mut truncated = false;
+        while let Some(item) = stream.next().await {
+            let Ok(chunk) = item else {
+                let _ = sink.send_chunk(SSE_ERROR_FRAME.to_vec()).await;
+                return;
+            };
+            if let ChunkDelta::Text(s) = &chunk.delta {
+                if content.len() + s.len() > MAX_BUFFERED_RESPONSE_BYTES {
+                    // Stop accumulating (same skip-the-delta semantics as
+                    // `handle_chat`) but keep forwarding frames — the client
+                    // still receives the full stream.
+                    truncated = true;
+                } else {
+                    content.push_str(s);
+                }
+            }
+            let Some(frame) = sse_json_frame(&chunk) else {
+                let _ = sink.send_chunk(SSE_ERROR_FRAME.to_vec()).await;
+                return;
+            };
+            if sink.send_chunk(frame).await.is_err() {
+                return;
+            }
+        }
+        if truncated {
+            tracing::warn!(
+                cap = MAX_BUFFERED_RESPONSE_BYTES,
+                "llm streamed response exceeded persistence cap — stored assistant message truncated"
+            );
+        }
+
+        // Natural end-of-stream: persist the assistant turn before
+        // signalling `[DONE]`, so a client that refetches history on
+        // `[DONE]` already sees the new message. Persistence failure is
+        // non-fatal here, exactly as in `handle_chat` (`messages_create`
+        // logs and returns `None`).
+        let _ = messages_create(ctx.as_ref(), &msg, &thread_id, "assistant", &content).await;
+
+        let _ = sink.send_chunk(SSE_DONE_FRAME.to_vec()).await;
+    })
 }
 
 /// Stream a typed frame stream to the client as JSON Server-Sent Events.
@@ -318,44 +424,31 @@ pub(super) async fn handle_chat_stream(
 /// natural end-of-stream becomes a terminal `data: [DONE]\n\n` frame so
 /// clients can distinguish it from a transport-level disconnect.
 ///
-/// Shared by every LLM SSE endpoint (chat-stream, model-load) so the wire
-/// format can't drift between them.
+/// Used by the model-load endpoint; the chat-stream endpoint uses
+/// [`sse_chat_response`], which shares the same frame encoding via
+/// [`sse_json_frame`] and the same terminal frames so the wire format can't
+/// drift between them.
 fn sse_json_response<T>(stream: NativeTypedFrameStream<T>) -> OutputStream
 where
     T: serde::Serialize + serde::de::DeserializeOwned + Unpin + Send + 'static,
 {
     OutputStream::from_producer(move |sink, _cancel| async move {
-        // Send the content-type as a mid-stream meta event so the HTTP
-        // listener writes the SSE header before the first `data:` frame.
-        let _ = sink
-            .send_meta(MetaEntry {
-                key: META_RESP_CONTENT_TYPE.to_string(),
-                value: "text/event-stream".to_string(),
-            })
-            .await;
+        send_sse_content_type(&sink).await;
 
         let mut stream = stream;
         while let Some(item) = stream.next().await {
             // A mid-stream service error or a JSON-encode failure both
             // terminate the stream with a final `event: error` frame, so the
             // consumer sees a clean SSE event instead of an abrupt disconnect.
-            let Some(json) = item.ok().and_then(|v| serde_json::to_vec(&v).ok()) else {
-                let _ = sink
-                    .send_chunk(b"event: error\ndata: {}\n\n".to_vec())
-                    .await;
+            let Some(frame) = item.ok().and_then(|v| sse_json_frame(&v)) else {
+                let _ = sink.send_chunk(SSE_ERROR_FRAME.to_vec()).await;
                 return;
             };
-            let mut frame = Vec::with_capacity(json.len() + 8);
-            frame.extend_from_slice(b"data: ");
-            frame.extend_from_slice(&json);
-            frame.extend_from_slice(b"\n\n");
             if sink.send_chunk(frame).await.is_err() {
                 return;
             }
         }
-        // Emit a terminal `data: [DONE]` frame so clients can distinguish
-        // natural end-of-stream from a transport-level disconnect.
-        let _ = sink.send_chunk(b"data: [DONE]\n\n".to_vec()).await;
+        let _ = sink.send_chunk(SSE_DONE_FRAME.to_vec()).await;
     })
 }
 
@@ -857,6 +950,185 @@ mod tests {
         // The parse-error tests reject before reaching the provider-admin
         // surface, so the no-op handle suffices.
         LlmBlock::new(Arc::new(NoopProviderAdmin))
+    }
+
+    /// One recorded `call_block` invocation on a [`RecordingCtx`].
+    struct RecordedCall {
+        block_name: String,
+        msg: Message,
+        body: Vec<u8>,
+    }
+
+    /// Context that records every `call_block` invocation (block name,
+    /// message, drained input body) and answers with a canned OK JSON body.
+    /// `clone_arc` hands out a handle sharing the same call log, so a test
+    /// can inspect calls made through the cloned Arc.
+    #[derive(Clone, Default)]
+    struct RecordingCtx {
+        calls: Arc<std::sync::Mutex<Vec<RecordedCall>>>,
+    }
+
+    impl RecordingCtx {
+        fn calls(&self) -> std::sync::MutexGuard<'_, Vec<RecordedCall>> {
+            self.calls.lock().expect("call log lock")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Context for RecordingCtx {
+        async fn call_block(
+            &self,
+            block_name: &str,
+            msg: Message,
+            input: InputStream,
+        ) -> OutputStream {
+            let body = input.collect_to_bytes().await;
+            self.calls().push(RecordedCall {
+                block_name: block_name.to_string(),
+                msg,
+                body,
+            });
+            OutputStream::respond(br#"{"id":"entry-1"}"#.to_vec())
+        }
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+        fn config_get(&self, _key: &str) -> Option<&str> {
+            None
+        }
+        fn clone_arc(&self) -> Arc<dyn Context> {
+            Arc::new(self.clone())
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // sse_chat_response — streamed assistant-turn persistence
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn sse_chat_response_persists_assistant_turn_at_done() {
+        let ctx = RecordingCtx::default();
+        let msg = Message::new("create:/b/llm/api/chat/stream");
+        let chunks: Vec<Result<ChatChunk, wafer_run::WaferError>> =
+            vec![Ok(ChatChunk::text("Hel")), Ok(ChatChunk::text("lo"))];
+
+        let out = sse_chat_response(
+            futures::stream::iter(chunks),
+            ctx.clone_arc(),
+            msg,
+            "thread-1".to_string(),
+        );
+        let buf = out.collect_buffered().await.expect("stream completes");
+        let body = String::from_utf8(buf.body).expect("SSE body is utf8");
+
+        assert!(
+            body.ends_with("data: [DONE]\n\n"),
+            "expected terminal [DONE] frame, got: {body}"
+        );
+        assert!(
+            body.contains("Hel") && body.contains("lo"),
+            "both text deltas must be forwarded as frames, got: {body}"
+        );
+        assert!(
+            buf.meta
+                .iter()
+                .any(|m| m.key == META_RESP_CONTENT_TYPE && m.value == "text/event-stream"),
+            "content-type meta must announce text/event-stream"
+        );
+
+        let calls = ctx.calls();
+        assert_eq!(
+            calls.len(),
+            1,
+            "expected exactly one persistence call, got {}",
+            calls.len()
+        );
+        let call = &calls[0];
+        assert_eq!(call.block_name, "suppers-ai/messages");
+        assert_eq!(
+            call.msg.get_meta("req.resource"),
+            "/b/messages/api/contexts/thread-1/entries"
+        );
+        let body_json: serde_json::Value =
+            serde_json::from_slice(&call.body).expect("persistence body is JSON");
+        assert_eq!(body_json["role"], "assistant");
+        assert_eq!(body_json["content"], "Hello");
+    }
+
+    #[tokio::test]
+    async fn sse_chat_response_skips_persistence_when_stream_errors() {
+        let ctx = RecordingCtx::default();
+        let msg = Message::new("create:/b/llm/api/chat/stream");
+        let chunks: Vec<Result<ChatChunk, wafer_run::WaferError>> = vec![
+            Ok(ChatChunk::text("partial")),
+            Err(wafer_run::WaferError::new(
+                ErrorCode::Internal,
+                "backend died",
+            )),
+        ];
+
+        let out = sse_chat_response(
+            futures::stream::iter(chunks),
+            ctx.clone_arc(),
+            msg,
+            "thread-1".to_string(),
+        );
+        let buf = out
+            .collect_buffered()
+            .await
+            .expect("producer auto-completes");
+        let body = String::from_utf8(buf.body).expect("SSE body is utf8");
+
+        assert!(
+            body.ends_with("event: error\ndata: {}\n\n"),
+            "expected terminal error frame, got: {body}"
+        );
+        assert!(!body.contains("[DONE]"), "no [DONE] after an error frame");
+        assert!(
+            ctx.calls().is_empty(),
+            "an errored stream must not persist an assistant turn (mirrors handle_chat)"
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_chat_response_caps_persisted_content() {
+        let ctx = RecordingCtx::default();
+        let msg = Message::new("create:/b/llm/api/chat/stream");
+        let head = "a".repeat(MAX_BUFFERED_RESPONSE_BYTES);
+        let chunks: Vec<Result<ChatChunk, wafer_run::WaferError>> =
+            vec![Ok(ChatChunk::text(head)), Ok(ChatChunk::text("overflow"))];
+
+        let out = sse_chat_response(
+            futures::stream::iter(chunks),
+            ctx.clone_arc(),
+            msg,
+            "thread-1".to_string(),
+        );
+        let buf = out.collect_buffered().await.expect("stream completes");
+        let body = String::from_utf8(buf.body).expect("SSE body is utf8");
+
+        // The overflowing delta is still forwarded to the client...
+        assert!(
+            body.contains("overflow"),
+            "frames keep flowing past the cap"
+        );
+        assert!(body.ends_with("data: [DONE]\n\n"), "still ends with [DONE]");
+
+        // ...but the persisted assistant message stops at the cap.
+        let calls = ctx.calls();
+        assert_eq!(calls.len(), 1, "exactly one persistence call");
+        let body_json: serde_json::Value =
+            serde_json::from_slice(&calls[0].body).expect("persistence body is JSON");
+        let content = body_json["content"].as_str().expect("content is a string");
+        assert_eq!(
+            content.len(),
+            MAX_BUFFERED_RESPONSE_BYTES,
+            "persisted content stops at the cap (overflowing delta skipped)"
+        );
+        assert!(
+            !content.contains("overflow"),
+            "the overflowing delta must not be persisted"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes the `TODO(llm-phase-b-task-14)` gap: the SSE chat path (`POST /b/llm/api/chat/stream`) forwarded chunks to the client but never persisted the assistant turn, so streamed conversations lost the assistant side of the history that the buffered path (`/b/llm/api/chat`) records.

The historical blocker — `&dyn Context` not being `'static`, so it couldn't cross the producer's spawn boundary — is gone: `Context::clone_arc()` yields an owned `Arc<dyn Context>`. `handle_chat_stream` now clones `ctx` + `msg` + `thread_id` into a chat-specific SSE wrapper, `sse_chat_response`, which:

- frames each `ChatChunk` exactly like the generic `sse_json_response` (shared `sse_json_frame` encoder + shared `SSE_DONE_FRAME`/`SSE_ERROR_FRAME` terminals + shared content-type meta helper, so the wire format cannot drift),
- accumulates `ChunkDelta::Text` deltas up to `MAX_BUFFERED_RESPONSE_BYTES` with the same skip-the-overflowing-delta semantics as `handle_chat` (frames keep flowing to the client past the cap; only persistence is capped),
- persists the accumulated assistant text via `messages_create` at natural end-of-stream, immediately before the terminal `data: [DONE]` frame — so a client that refetches history on `[DONE]` already sees the message,
- skips persistence when the stream errors (terminal `event: error` frame), mirroring `handle_chat`'s no-persistence-on-error behavior.

`sse_json_response` stays for the model-load endpoint, now built on the shared frame helpers.

## Wasm32 note

`sse_chat_response` is generic over the chunk stream (`NativeTypedFrameStream::new` is private to wafer-core, and tests drive a scripted stream) with a `wafer_run::MaybeSend` bound: `Send` on native (required by `OutputStream::from_producer`), unconstrained on wasm32 where `from_producer` doesn't require `Send` and `Arc<dyn Context>` isn't. Verified via `cargo check -p solobase-browser -p minimal-browser -p solobase-cloudflare --target wasm32-unknown-unknown`.

## Tests (TDD)

RED → GREEN: the wrapper was first landed framing-only; `sse_chat_response_persists_assistant_turn_at_done` and `sse_chat_response_caps_persisted_content` failed with "expected exactly one persistence call, got 0", then passed after wiring persistence.

- `sse_chat_response_persists_assistant_turn_at_done` — scripted two-delta stream ("Hel"/"lo"); asserts SSE body ends `data: [DONE]`, both frames forwarded, content-type meta, and exactly one recorded `call_block("suppers-ai/messages", …)` with `role: assistant`, `content: "Hello"`, posted to `/b/messages/api/contexts/thread-1/entries`.
- `sse_chat_response_skips_persistence_when_stream_errors` — mid-stream error → terminal error frame, no `[DONE]`, zero persistence calls.
- `sse_chat_response_caps_persisted_content` — cap-sized delta + overflow delta → overflow still streamed to the client, persisted content stops at the cap.

## Verification

- `cargo +nightly fmt --all -- --check` clean
- clippy (CI form): zero warnings in the touched file
- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare`: 34 suites, all green (891 tests in solobase-core)
- wasm32 checks: solobase-browser, minimal-browser, solobase-cloudflare all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H