### PR TITLE
fix(ui): a11y batch from the 2026-07-11 UI/UX review (contrast, focus-visible, aria-labels, h1 + skip link, table containment)

### DIFF
--- a/crates/solobase-bundle/src/assets.rs
+++ b/crates/solobase-bundle/src/assets.rs
@@ -11,7 +11,7 @@ pub struct Asset {
 }
 
 pub fn static_assets() -> &'static [Asset] {
-    &ASSETS
+    ASSETS
 }
 
 pub fn write_to(dir: &Path) -> std::io::Result<()> {

--- a/crates/solobase-bundle/src/bundle/mod.rs
+++ b/crates/solobase-bundle/src/bundle/mod.rs
@@ -230,9 +230,8 @@ pub fn run(pkg_dir: &Path, repo_dir: &Path, app: AppConfig) -> Result<()> {
 /// scan) and safe — the regex matches only the exact short-hash format we
 /// emit, so user files like `app-1.js` or `app_bg-final.wasm` are untouched.
 fn remove_previously_hashed(pkg_dir: &Path) -> Result<()> {
-    let entries = match std::fs::read_dir(pkg_dir) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
+    let Ok(entries) = std::fs::read_dir(pkg_dir) else {
+        return Ok(());
     };
     for entry in entries.flatten() {
         let name = entry.file_name();
@@ -309,7 +308,7 @@ fn build_template_vars(
             let escaped = path.replace('\\', "\\\\").replace('\'', "\\'");
             out.push_str(" || url.pathname === '");
             out.push_str(&escaped);
-            out.push_str("'");
+            out.push('\'');
         }
         out
     };

--- a/crates/solobase-bundle/src/bundle/template.rs
+++ b/crates/solobase-bundle/src/bundle/template.rs
@@ -14,7 +14,7 @@ pub fn render_to_file(
         .with_context(|| format!("reading template {}", template_src.display()))?;
     let mut rendered = body;
     for (key, value) in vars {
-        let token = format!("__{}__", key);
+        let token = format!("__{key}__");
         rendered = rendered.replace(&token, value);
     }
     if let Some(stray) = find_unresolved_placeholder(&rendered) {

--- a/crates/solobase-bundle/tests/bundle_integration.rs
+++ b/crates/solobase-bundle/tests/bundle_integration.rs
@@ -73,8 +73,7 @@ fn end_to_end_renames_rewrites_and_templates() {
         entries
             .iter()
             .any(|n| n.starts_with("app-") && n.ends_with(".js")),
-        "missing hashed JS in {:?}",
-        entries
+        "missing hashed JS in {entries:?}"
     );
     assert!(entries
         .iter()

--- a/crates/solobase-core/src/blocks/admin/pages/blocks.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/blocks.rs
@@ -302,7 +302,7 @@ pub async fn handle_block_detail(
                         span .toggle-slider {}
                     }
                 }
-                p style="font-size:0.875rem;color:#94a3b8;margin-top:1rem" {
+                p style="font-size:0.875rem;color:var(--text-muted);margin-top:1rem" {
                     @if is_enabled {
                         "Restart the server to see its full details."
                     } @else {

--- a/crates/solobase-core/src/blocks/admin/pages/email.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/email.rs
@@ -150,8 +150,9 @@ mod tests {
             "the API key field must render as a masked password input: {html}"
         );
         assert!(
-            html.contains("i.type=i.type==='password'?'text':'password'"),
-            "the reveal/edit eye toggle must be present: {html}"
+            html.contains(r#"aria-label="Reveal value""#)
+                && html.contains("i.type='text';this.title='Hide'"),
+            "the reveal/edit eye toggle must be present, with an accessible name: {html}"
         );
         assert!(
             html.contains("(set)"),

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -186,6 +186,7 @@ fn var_row(row: &VarRow) -> Markup {
                     hx-target="#edit-var-modal"
                     hx-swap="innerHTML"
                     title="Edit"
+                    aria-label=(format!("Edit {}", row.key))
                 { (icons::edit()) }
             }
         }
@@ -291,6 +292,7 @@ async fn config_all_tab(ctx: &dyn Context) -> Markup {
                                             hx-target="#edit-var-modal"
                                             hx-swap="innerHTML"
                                             title="Edit"
+                                            aria-label=(format!("Edit {key}"))
                                         { (icons::edit()) }
                                     }
                                 }
@@ -547,8 +549,9 @@ pub async fn handle_edit_variable_form(
                             button .btn .btn-ghost .btn-icon
                                 type="button"
                                 style="position:absolute;right:0.25rem;top:50%;transform:translateY(-50%)"
-                                onclick="var i=document.getElementById('edit-value');if(i.type==='password'){i.type='text';this.title='Hide'}else{i.type='password';this.title='Reveal'}"
+                                onclick="var i=document.getElementById('edit-value');if(i.type==='password'){i.type='text';this.title='Hide';this.setAttribute('aria-label','Hide value')}else{i.type='password';this.title='Reveal';this.setAttribute('aria-label','Reveal value')}"
                                 title="Reveal"
+                                aria-label="Reveal value"
                             { (icons::eye()) }
                         }
                     } @else {
@@ -598,4 +601,31 @@ pub async fn handle_update_variable(
     }
 
     variables_page(ctx, &msg).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The icon-only edit button must carry an accessible name derived from
+    /// the row key (2026-07-11 review: 49 unlabeled icon buttons on the
+    /// Variables page alone).
+    #[test]
+    fn var_row_edit_button_carries_accessible_name() {
+        let s = var_row(&VarRow {
+            key: "SOLOBASE_SHARED__APP_NAME",
+            name: None,
+            value: ValueState::Plain("Solobase".to_string()),
+            default: None,
+            auto_generate: false,
+            description: "App name",
+            warning: "",
+            show_default: false,
+        })
+        .into_string();
+        assert!(
+            s.contains(r#"aria-label="Edit SOLOBASE_SHARED__APP_NAME""#),
+            "edit button must expose an aria-label with the row key: {s}"
+        );
+    }
 }

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -224,17 +224,19 @@ fn var_table(header: Markup, show_default: bool, body: Markup) -> Markup {
         div .card .mt-4 {
             (header)
             div .card-body {
-                table .table {
-                    thead {
-                        tr {
-                            th { "Key" }
-                            th { "Value" }
-                            @if show_default { th { "Default" } }
-                            th { "Description" }
-                            th style="width:50px" {}
+                div .table-container {
+                    table .table {
+                        thead {
+                            tr {
+                                th { "Key" }
+                                th { "Value" }
+                                @if show_default { th { "Default" } }
+                                th { "Description" }
+                                th style="width:50px" {}
+                            }
                         }
+                        tbody { (body) }
                     }
-                    tbody { (body) }
                 }
             }
         }

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -362,7 +362,7 @@ fn email_shell(
     if let Some(note) = footnote {
         out.push('\n');
         out.push_str(&format!(
-            r#"<p style="color:#94a3b8;font-size:0.813rem">{note}</p>"#
+            r#"<p style="color:#64748b;font-size:0.813rem">{note}</p>"#
         ));
     }
     out.push_str("\n</div>");

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -41,7 +41,10 @@ pub fn entry_card(record: &db::Record) -> Markup {
                 "background:#eff6ff;border-left:3px solid #3b82f6",
                 "badge-info",
             ),
-            "agent" | "assistant" => ("background:#f8fafc;border-left:3px solid #94a3b8", "badge"),
+            "agent" | "assistant" => (
+                "background:#f8fafc;border-left:3px solid var(--text-muted)",
+                "badge",
+            ),
             "system" => (
                 "background:#fefce8;border-left:3px solid #eab308",
                 "badge-warning",

--- a/crates/solobase-core/src/blocks/messages/pages.rs
+++ b/crates/solobase-core/src/blocks/messages/pages.rs
@@ -317,7 +317,7 @@ fn render_default_view(context: &db::Record, entries: &[db::Record], context_id:
     html! {
         div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem" {
             a .btn .btn-ghost .btn-sm href="/b/messages/" { "\u{2190} Back" }
-            h1 .page-title style="margin:0" { (display_title) }
+            h2 .page-title style="margin:0" { (display_title) }
             span .badge style="text-transform:capitalize" { (context_type) }
             span .badge { (context_status) }
         }

--- a/crates/solobase-core/src/ui/assets/base.css
+++ b/crates/solobase-core/src/ui/assets/base.css
@@ -12,3 +12,10 @@ input, textarea, select, [contenteditable="true"] {
 	-webkit-user-select: text !important;
 	user-select: text !important;
 }
+
+/* ===== Keyboard focus ===== */
+/* Keyboard-focus ring — low specificity so component rules can refine it. */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+	outline: 2px solid var(--primary-color);
+	outline-offset: 2px;
+}

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -309,9 +309,10 @@ dialog.modal input[type="password"] {
 	color: var(--text-primary);
 	background: var(--bg-card, #fff);
 }
+/* Focus ring comes from the global :where(...):focus-visible rule in
+   base.css (the old `outline: var(--focus-ring)` here was an invalid
+   outline value — --focus-ring is box-shadow syntax — and got dropped). */
 dialog.modal input:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 1px;
 	border-color: var(--primary-color);
 }
 dialog.modal .form-hint {

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -2,6 +2,13 @@
 
 /* ===== Components ===== */
 
+/* Skip-to-content link — first focusable element in the shell; parked
+   off-screen until keyboard focus brings it into view. */
+.skip-link { position: absolute; left: -9999px; top: 0; z-index: 100;
+  background: var(--primary-color); color: #fff; padding: 8px 16px;
+  border-radius: 0 0 4px 0; }
+.skip-link:focus { left: 0; }
+
 /* Page Header */
 .page-header {
 	background: white;

--- a/crates/solobase-core/src/ui/assets/components.css
+++ b/crates/solobase-core/src/ui/assets/components.css
@@ -469,7 +469,6 @@ dialog.modal .modal-error[hidden] { display: none; }
 .form-input:focus,
 .form-select:focus,
 .form-textarea:focus {
-	outline: none;
 	border-color: rgba(24, 154, 180, 0.5);
 	background: white;
 	box-shadow: 0 0 0 3px rgba(24, 154, 180, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -628,7 +627,7 @@ dialog.modal .modal-error[hidden] { display: none; }
 .palette[data-open="true"] { display: block; }
 .palette__backdrop { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.4); }
 .palette__panel { position: relative; max-width: 560px; margin: 12vh auto 0; background: var(--surface-1); border: 1px solid var(--border-color); border-radius: var(--radius-lg); box-shadow: var(--shadow-lg); overflow: hidden; }
-.palette__input { width: 100%; padding: var(--spacing-md); border: none; border-bottom: 1px solid var(--border-light); font-family: inherit; font-size: var(--text-base); outline: none; background: var(--surface-1); color: var(--text-primary); }
+.palette__input { width: 100%; padding: var(--spacing-md); border: none; border-bottom: 1px solid var(--border-light); font-family: inherit; font-size: var(--text-base); background: var(--surface-1); color: var(--text-primary); }
 .palette__list { list-style: none; padding: 0; margin: 0; max-height: 50vh; overflow-y: auto; }
 .palette__item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem var(--spacing-md); cursor: pointer; font-size: var(--text-sm); color: var(--text-primary); }
 .palette__item:hover, .palette__item[aria-selected="true"] { background: var(--bg-hover); }

--- a/crates/solobase-core/src/ui/assets/layout.css
+++ b/crates/solobase-core/src/ui/assets/layout.css
@@ -268,7 +268,7 @@
 	position: absolute; right: 0.5rem; top: 50%;
 	transform: translateY(-50%);
 	background: none; border: none; cursor: pointer;
-	padding: 0.25rem; color: #94a3b8;
+	padding: 0.25rem; color: var(--text-muted);
 	display: flex; align-items: center;
 }
 

--- a/crates/solobase-core/src/ui/assets/layout.css
+++ b/crates/solobase-core/src/ui/assets/layout.css
@@ -589,7 +589,15 @@
 .topbar__crumbs li + li::before { content: "›"; padding: 0 0.3rem; color: var(--text-muted); }
 .topbar__crumbs a { color: var(--text-secondary); text-decoration: none; }
 .topbar__crumbs a:hover { color: var(--primary-color); text-decoration: underline; }
-.topbar__crumbs [aria-current="page"] { color: var(--text-primary); }
+/* Current page — an `h1` rendered AFTER the breadcrumb nav. Font copies what
+   the last crumb used to get (16px from the ol rule, normal weight,
+   text-primary from the old [aria-current="page"] rule) so the visual output
+   is unchanged. */
+.topbar__title { font-size: 16px; font-weight: 400; color: var(--text-primary); margin: 0; }
+/* Separator between the last ancestor crumb and the h1 (was li+li::before
+   when the current page still lived inside the nav; the extra 0.4rem on the
+   left stands in for the ol's flex gap the old li got). */
+.topbar__crumbs li:last-child::after { content: "›"; padding: 0 0.3rem 0 0.7rem; color: var(--text-muted); }
 .topbar__right { margin-left: auto; display: flex; align-items: center; gap: var(--spacing-sm); }
 .topbar__palette {
 	display: inline-flex; align-items: center; gap: 0.4rem;

--- a/crates/solobase-core/src/ui/assets/layout.css
+++ b/crates/solobase-core/src/ui/assets/layout.css
@@ -272,7 +272,7 @@
 	display: flex; align-items: center;
 }
 
-.pw-toggle:hover { color: #64748b; }
+.pw-toggle:hover { color: var(--text-primary); }
 .pw-toggle svg { width: 1.125rem; height: 1.125rem; }
 
 .login-button {

--- a/crates/solobase-core/src/ui/assets/llm-chat.js
+++ b/crates/solobase-core/src/ui/assets/llm-chat.js
@@ -44,7 +44,7 @@
       bg = 'background:#eff6ff;border-left:3px solid #3b82f6';
       badge = 'badge-info';
     } else if (role === 'assistant') {
-      bg = 'background:#f8fafc;border-left:3px solid #94a3b8';
+      bg = 'background:#f8fafc;border-left:3px solid var(--text-muted)';
       badge = 'badge';
     } else if (role === 'system') {
       bg = 'background:#fefce8;border-left:3px solid #eab308';

--- a/crates/solobase-core/src/ui/assets/tokens.css
+++ b/crates/solobase-core/src/ui/assets/tokens.css
@@ -24,7 +24,7 @@
 
 	--text-primary: #1e293b;
 	--text-secondary: #64748b;
-	--text-muted: #94a3b8;
+	--text-muted: #64748b;
 
 	--border-color: #e2e8f0;
 	--border-light: #f1f5f9;

--- a/crates/solobase-core/src/ui/components.rs
+++ b/crates/solobase-core/src/ui/components.rs
@@ -207,11 +207,14 @@ pub fn modal(id: &str, title: &str, body: Markup) -> Markup {
 // ---------------------------------------------------------------------------
 
 /// Render a page header with title, optional subtitle, and optional action slot.
+///
+/// The title is an `h2`: the shell's topbar owns the page's single `h1`
+/// (see `ui::shell::render_topbar`), so body headers are section headings.
 pub fn page_header(title: &str, subtitle: Option<&str>, action: Option<Markup>) -> Markup {
     html! {
         div .flex .items-center .justify-between .mb-4 {
             div {
-                h1 .page-title { (title) }
+                h2 .page-title { (title) }
                 @if let Some(sub) = subtitle {
                     p .page-subtitle { (sub) }
                 }

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -108,7 +108,7 @@ fn render_field(var: &ConfigVar, value: &str) -> Markup {
                             placeholder=(if has_value { "******** (set)" } else { "Not configured" })
                             style="flex:1";
                         button type="button" .btn .btn-ghost .btn-sm
-                            onclick={"var i=document.getElementById('" (var.key) "');i.type=i.type==='password'?'text':'password'"}
+                            onclick={"var i=document.getElementById('" (var.key) "');if(i.type==='password'){i.type='text';this.title='Hide';this.setAttribute('aria-label','Hide value')}else{i.type='password';this.title='Reveal';this.setAttribute('aria-label','Reveal value')}"}
                             title="Reveal"
                             aria-label="Reveal value"
                         { (super::icons::eye()) }
@@ -339,8 +339,15 @@ mod tests {
             "value must render empty: {set}"
         );
         assert!(set.contains("(set)"));
-        // eye toggle present
-        assert!(set.contains("i.type=i.type==='password'?'text':'password'"));
+        // Eye toggle present, with an accessible name that the handler keeps
+        // in sync with the shown/hidden state (2026-07-11 a11y review).
+        assert!(set.contains(r#"aria-label="Reveal value""#));
+        assert!(set.contains(
+            "i.type='text';this.title='Hide';this.setAttribute('aria-label','Hide value')"
+        ));
+        assert!(set.contains(
+            "i.type='password';this.title='Reveal';this.setAttribute('aria-label','Reveal value')"
+        ));
 
         let empty = render_field(&v, "").into_string();
         assert!(empty.contains("Not configured"));

--- a/crates/solobase-core/src/ui/settings_form.rs
+++ b/crates/solobase-core/src/ui/settings_form.rs
@@ -109,6 +109,8 @@ fn render_field(var: &ConfigVar, value: &str) -> Markup {
                             style="flex:1";
                         button type="button" .btn .btn-ghost .btn-sm
                             onclick={"var i=document.getElementById('" (var.key) "');i.type=i.type==='password'?'text':'password'"}
+                            title="Reveal"
+                            aria-label="Reveal value"
                         { (super::icons::eye()) }
                     }
                     @if !var.description.is_empty() {

--- a/crates/solobase-core/src/ui/shell.rs
+++ b/crates/solobase-core/src/ui/shell.rs
@@ -249,6 +249,35 @@ mod tests {
         assert!(!s.contains("topbar__crumbs"));
     }
 
+    /// Regression guard for the double-h1 review finding: pages that render
+    /// `components::page_header(...)` in their body (products, llm,
+    /// legalpages/auth_ui settings, userportal branding, ...) must not add a
+    /// second h1 next to the topbar's — the body header is an h2.
+    #[test]
+    fn shell_page_with_body_page_header_still_has_exactly_one_h1() {
+        let groups = one_group(vec![item("Products", "/b/products/")]);
+        let tb = Topbar {
+            crumbs: vec![Crumb {
+                label: "Products",
+                href: None,
+            }],
+            ..Topbar::default()
+        };
+        let body = crate::ui::components::page_header(
+            "Products Overview",
+            Some("Product catalog statistics"),
+            None,
+        );
+        let s = shell(&groups, None, "/b/products/", "", "", tb, body).into_string();
+        assert_eq!(
+            s.matches("<h1").count(),
+            1,
+            "the shell topbar owns the only h1; body page_header must be h2: {s}"
+        );
+        assert!(s.contains(r#"<h1 class="topbar__title">Products</h1>"#));
+        assert!(s.contains(r#"<h2 class="page-title">Products Overview</h2>"#));
+    }
+
     #[test]
     fn shell_can_omit_palette() {
         let groups = one_group(vec![item("X", "/x")]);

--- a/crates/solobase-core/src/ui/shell.rs
+++ b/crates/solobase-core/src/ui/shell.rs
@@ -42,20 +42,31 @@ fn render_topbar(t: &Topbar<'_>) -> Markup {
     {
         return html! {};
     }
+    // The current page (last crumb) renders as the page's single `h1` AFTER
+    // the breadcrumb nav — an h1 inside a breadcrumb nav is semantically
+    // wrong, and the ancestors stay ordinary breadcrumb `li`s.
+    let (current, ancestors) = match t.crumbs.split_last() {
+        Some((last, rest)) => (Some(last), rest),
+        None => (None, &[][..]),
+    };
     html! {
         header .topbar {
-            nav .topbar__crumbs aria-label="Breadcrumb" {
-                ol {
-                    @for (i, c) in t.crumbs.iter().enumerate() {
-                        @let last = i + 1 == t.crumbs.len();
-                        li {
-                            @match c.href {
-                                Some(h) if !last => a href=(h) { (c.label) },
-                                _ => span aria-current=[last.then_some("page")] { (c.label) },
+            @if !ancestors.is_empty() {
+                nav .topbar__crumbs aria-label="Breadcrumb" {
+                    ol {
+                        @for c in ancestors {
+                            li {
+                                @match c.href {
+                                    Some(h) => a href=(h) { (c.label) },
+                                    None => span { (c.label) },
+                                }
                             }
                         }
                     }
                 }
+            }
+            @if let Some(c) = current {
+                h1 .topbar__title { (c.label) }
             }
             @if let Some(s) = t.subtitle {
                 span .topbar__sep aria-hidden="true" { "|" }
@@ -97,6 +108,7 @@ pub fn shell(
 ) -> Markup {
     html! {
         div .shell {
+            a .skip-link href="#content" { "Skip to content" }
             header .shell__mobile-header {
                 button .shell__drawer-toggle type="button"
                     data-action="drawer-open"
@@ -170,9 +182,71 @@ mod tests {
         let s = shell(&groups, None, "/b/admin/users", "", "", topbar, body).into_string();
         assert!(s.contains("topbar__crumbs"));
         assert!(s.contains(">Workspace<"));
-        assert!(s.contains(r#"aria-current="page""#));
+        // The current page renders as the h1, after the breadcrumb nav.
+        assert!(s.contains(r#"<h1 class="topbar__title">Users</h1>"#));
         assert!(s.contains(r#"data-action="palette-open""#));
         assert!(s.contains("page body"));
+    }
+
+    #[test]
+    fn shell_renders_exactly_one_h1_and_skip_link() {
+        let groups = one_group(vec![item("Users", "/b/admin/users")]);
+        let topbar = Topbar {
+            crumbs: vec![
+                Crumb {
+                    label: "Workspace",
+                    href: Some("/b/admin"),
+                },
+                Crumb {
+                    label: "Users",
+                    href: None,
+                },
+            ],
+            primary_action: None,
+            subtitle: None,
+            show_palette: true,
+        };
+        let s = shell(
+            &groups,
+            None,
+            "/b/admin/users",
+            "",
+            "",
+            topbar,
+            html! { p { "body" } },
+        )
+        .into_string();
+        assert_eq!(s.matches("<h1").count(), 1, "expected exactly one h1");
+        assert!(s.contains(r#"<h1 class="topbar__title">Users</h1>"#));
+        // The ancestor crumb stays a breadcrumb link inside the nav…
+        assert!(s.contains(r#"<a href="/b/admin">Workspace</a>"#));
+        // …and the h1 sits AFTER the nav, not inside it.
+        let nav_end = s.find("</nav>").expect("breadcrumb nav present");
+        let h1_at = s.find("<h1").expect("h1 present");
+        assert!(h1_at > nav_end, "h1 must render after the breadcrumb nav");
+        // Skip link is the shell's first focusable element.
+        assert!(s.contains(r##"<a class="skip-link" href="#content">Skip to content</a>"##));
+        let skip_at = s.find("skip-link").unwrap();
+        assert!(
+            skip_at < s.find("shell__mobile-header").unwrap(),
+            "skip link must come before the rest of the chrome"
+        );
+    }
+
+    #[test]
+    fn shell_single_crumb_renders_h1_without_breadcrumb_nav() {
+        let groups = one_group(vec![item("X", "/x")]);
+        let tb = Topbar {
+            crumbs: vec![Crumb {
+                label: "Dashboard",
+                href: None,
+            }],
+            ..Topbar::default()
+        };
+        let s = shell(&groups, None, "/x", "", "", tb, html! {}).into_string();
+        assert!(s.contains(r#"<h1 class="topbar__title">Dashboard</h1>"#));
+        // No ancestors -> no empty breadcrumb nav.
+        assert!(!s.contains("topbar__crumbs"));
     }
 
     #[test]
@@ -187,7 +261,8 @@ mod tests {
         }];
         let s = shell(&groups, None, "/x", "", "", tb, html! {}).into_string();
         assert!(!s.contains("topbar__palette"));
-        assert!(s.contains("topbar__crumbs"));
+        // The single crumb renders as the page h1 (no ancestor nav needed).
+        assert!(s.contains(r#"<h1 class="topbar__title">X</h1>"#));
     }
 
     #[test]

--- a/crates/solobase-core/src/ui/templates.rs
+++ b/crates/solobase-core/src/ui/templates.rs
@@ -22,7 +22,8 @@ fn render_header(h: &PageHeader<'_>) -> Markup {
     html! {
         header .page-header {
             div .page-header__text {
-                @if !h.title.is_empty() { h1 .page-header__title { (h.title) } }
+                // h2, not h1: the shell topbar owns the page's single h1.
+                @if !h.title.is_empty() { h2 .page-header__title { (h.title) } }
                 @if let Some(s) = h.subtitle { p .page-header__subtitle { (s) } }
             }
             @if let Some(a) = &h.primary_action {
@@ -81,7 +82,10 @@ pub fn detail_page(
             header .detail-hero {
                 @if let Some(icon) = hero.icon { div .detail-hero__icon { (icon) } }
                 div .detail-hero__text {
-                    h1 .detail-hero__title { (hero.title) }
+                    // h2, not h1: the shell topbar owns the page's single h1
+                    // (the vector index detail page renders this hero inside
+                    // a shell whose last crumb is already the index name).
+                    h2 .detail-hero__title { (hero.title) }
                     @if let Some(s) = hero.subtitle { p .detail-hero__subtitle { (s) } }
                     @if !hero.badges.is_empty() {
                         div .detail-hero__badges { @for b in &hero.badges { (b.clone()) } }


### PR DESCRIPTION
Fixes the top accessibility items from the 2026-07-11 UI/UX review (`docs/checks/2026-07-11-solobase-ui-ux-review.md`), one commit per sub-item.

## 1. Muted text meets WCAG AA (`d5847bd`)
The review measured muted text at **2.25–2.56:1** on white (AA requires 4.5:1) — the single biggest contrast failure, appearing on every page (stat labels, table headers, empty states, descriptions). `--text-muted` goes `#94a3b8` → `#64748b` (**4.7:1**). The four stray `#94a3b8` literals that bypassed the token are fixed too: `layout.css` `.pw-toggle`, `blocks.rs` detail-modal hint, `messages/pages.rs` entry-card border (→ `var(--text-muted)`), and `email.rs` footnote (→ literal `#64748b`, since it renders into an email body with no stylesheet).

## 2. Designed `:focus-visible` ring (`f377e39`)
The review found **no designed focus state**: form inputs and the palette input killed the native outline with compensation only on mouse `:focus`, so keyboard users lose their position. A low-specificity global ring (`:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible` → 2px solid `--primary-color`, 2px offset) now covers everything, and the two compensation-free `outline: none` declarations are removed. `.btn:focus-visible` already carries `outline: none` + its own box-shadow ring, so every element type shows exactly one indicator.

## 3. One `h1` + skip-to-content link per shell page (`2281686`)
The review measured `document.querySelectorAll('h1').length === 0` on every admin page and found no skip link. The current page (last crumb) now renders as `h1.topbar__title` **after** the breadcrumb nav (an h1 inside the nav is semantically wrong); ancestors stay breadcrumb `li`s and a single-crumb topbar skips the empty nav. `.topbar__title` copies the crumb's exact font (16px / 400 / `--text-primary`) so visual output is unchanged. The shell's first focusable element is now `a.skip-link[href="#content"]`, parked off-screen until keyboard focus. Unit tests assert exactly one `<h1` positioned after the nav plus the skip-link anchor.

## 4. Accessible names for icon-only buttons (`ae8cf63`)
The review counted **49 icon-only buttons with no `aria-label` on the Variables page alone** (per-row pencil edits render only an SVG — screen readers announce nothing). Edit buttons in `var_row` and the All-Variables tab get `aria-label="Edit {key}"`; the sensitive-value eye toggle gets `aria-label="Reveal value"` (kept in sync when the handler flips it to Hide), and the settings-form Password-widget eye toggle gets `title="Reveal"` + `aria-label="Reveal value"`. Unit test asserts the rendered `var_row` carries the label.

## 5. Contain the Variables by-block tables (`2e62c8b`)
At 375px the Variables page scrolled the **whole document to 2425px** wide — the by-block config tables rendered a bare `table.table` with no overflow containment (the All-Variables tab already had `.table-container`). `var_table()` now wraps its table in the same `div.table-container` (`overflow-x: auto`) so the page body never scrolls horizontally.

## 6. Pre-existing solobase-bundle lints (`0d0ae9f`, not part of the a11y batch)
Five mechanical lint fixes (needless_borrow, uninlined_format_args ×2, manual_let_else, single_char_add_str) that landed on main with the recent `extra_bypass_exact` work. They fail `cargo clippy --workspace --all-targets -- -D warnings` for every branch — `solobase-bundle` opts into `[workspace.lints]` and the `solobase` CLI pulls it in as a path dependency, so `--exclude` can't dodge it. No behavior change.

## Verification
- `cargo fmt --all --check` clean (stable + nightly).
- `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare --all-targets` — **zero warnings attributable to this diff** (every remaining warning location was blame-checked against the branch commits; all 100+ are pre-existing workspace-lint debt, concentrated in `solobase-core`/`solobase-browser` — see note below).
- `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` (the CI invocation; the excluded crates are wasm32-only) green, incl. the new shell h1/skip-link tests and the `var_row` aria-label test.

> Note for follow-up: the strict form `cargo clippy --workspace --all-targets -- -D warnings` does **not** pass on main — ~115 pre-existing hits of the advisory `[workspace.lints]` (mostly `uninlined_format_args`/`manual_let_else`) across `solobase-core` and `solobase-browser`. Repo CI clippy runs without `-D warnings`, so CI is green regardless. Worth one dedicated cleanup PR.

## Baselines
The topbar h1 and muted-color change will drift the visual baselines — regen from CI via `regen-visual-baselines.yml` after review, then close/reopen the PR to re-trigger CI (the auto-commit's GITHUB_TOKEN suppresses it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H
