### PR TITLE
fix: review-mediums residuals — M12 vclient count, M21 legalpages create dedup, M28 icon fallback, M03 sensitive-empty guard

### DIFF
--- a/crates/solobase-core/src/blocks/admin/ops.rs
+++ b/crates/solobase-core/src/blocks/admin/ops.rs
@@ -354,9 +354,11 @@ pub(super) struct VariableUpdate<'a> {
 }
 
 /// Update a config variable identified by `key` (upsert on the `key` column),
-/// writing an audit-log row. Enforces the sensitive-empty guard (a `_SECRET` /
-/// `_KEY` value can't be cleared) and the `_URL` SSRF validation on both
-/// surfaces.
+/// writing an audit-log row. Enforces the sensitive-empty guard (a sensitive
+/// value can't be cleared — see [`is_sensitive_key`]: the `_SECRET`/`_KEY`
+/// suffix rule unioned with the row's stored `sensitive` flag, which covers
+/// Password-typed declared vars like `BOOTSTRAP_ADMIN_PASSWORD`) and the
+/// `_URL` SSRF validation on both surfaces.
 ///
 /// Returns the upserted record.
 pub(super) async fn update_variable(
@@ -371,11 +373,32 @@ pub(super) async fn update_variable(
     let admin_id = msg.user_id().to_string();
 
     if let Some(value) = update.value {
-        // Prevent clearing a secret/key (would break auth).
-        if (key.ends_with("_SECRET") || key.ends_with("_KEY")) && value.is_empty() {
-            return Err(err_bad_request(&format!(
-                "Cannot set {key} to an empty value"
-            )));
+        // Prevent clearing a sensitive value (would break auth). Sensitivity
+        // is the same union the read/masking paths use ([`is_sensitive_key`]):
+        // the SEC-060 `_SECRET`/`_KEY` suffix rule OR the row's stored
+        // `sensitive` flag — the flag is what marks Password-typed declared
+        // vars without the suffix (e.g. `BOOTSTRAP_ADMIN_PASSWORD`, `*_TOKEN`)
+        // and ad hoc rows flagged in the UI. The row lookup only happens on
+        // the empty-value path; a missing row (upsert-create branch) has no
+        // stored secret to wipe, so only the suffix rule applies there.
+        if value.is_empty() {
+            let stored_flag = match db::get_by_field(
+                ctx,
+                VARIABLES_TABLE,
+                "key",
+                serde_json::Value::String(key.to_string()),
+            )
+            .await
+            {
+                Ok(record) => record.i64_field("sensitive"),
+                Err(e) if e.code == ErrorCode::NotFound => 0,
+                Err(e) => return Err(err_internal("Database error", e)),
+            };
+            if is_sensitive_key(key, stored_flag) {
+                return Err(err_bad_request(&format!(
+                    "Cannot set {key} to an empty value"
+                )));
+            }
         }
         // Validate URL-type keys (SSRF) on both surfaces.
         if key.ends_with("_URL") {
@@ -630,6 +653,76 @@ mod tests {
         )
         .await
         .is_err());
+    }
+
+    /// The sensitive-empty guard must honor the row's stored `sensitive`
+    /// flag, not only the `_SECRET`/`_KEY` suffix — Password-typed declared
+    /// vars (e.g. `BOOTSTRAP_ADMIN_PASSWORD`, `*_TOKEN`) are stored with
+    /// `sensitive = 1` but carry neither suffix, and clearing one would
+    /// break auth just the same.
+    #[tokio::test]
+    async fn password_typed_var_without_suffix_cannot_be_cleared() {
+        let ctx = admin_ctx().await;
+        let msg = admin_msg("update", "/admin/settings");
+
+        // Seed the row the way the declared-ConfigVar sync does for
+        // `InputType::Password` vars: `sensitive = 1`, suffix-less key.
+        expect_ok(
+            create_variable(
+                &ctx,
+                &msg,
+                "BOOTSTRAP_ADMIN_PASSWORD",
+                "hunter2",
+                None,
+                None,
+                true,
+            )
+            .await,
+        );
+
+        // Clearing it must be rejected...
+        assert!(update_variable(
+            &ctx,
+            &msg,
+            "BOOTSTRAP_ADMIN_PASSWORD",
+            VariableUpdate {
+                value: Some(""),
+                description: None,
+            },
+        )
+        .await
+        .is_err());
+
+        // ...leaving the stored value untouched.
+        let row = db::get_by_field(
+            &ctx,
+            VARIABLES_TABLE,
+            "key",
+            serde_json::Value::String("BOOTSTRAP_ADMIN_PASSWORD".to_string()),
+        )
+        .await
+        .expect("seeded row still present");
+        assert_eq!(
+            row.data.get("value").and_then(|v| v.as_str()),
+            Some("hunter2"),
+            "rejected clear must not overwrite the stored secret"
+        );
+
+        // A var that is neither suffix-sensitive nor flagged can still be
+        // cleared (the guard is a union, not a blanket empty-value ban).
+        expect_ok(create_variable(&ctx, &msg, "SITE_TAGLINE", "x", None, None, false).await);
+        expect_ok(
+            update_variable(
+                &ctx,
+                &msg,
+                "SITE_TAGLINE",
+                VariableUpdate {
+                    value: Some(""),
+                    description: None,
+                },
+            )
+            .await,
+        );
     }
 
     /// Self-disable and self-delete guards hold; a successful user mutation

--- a/crates/solobase-core/src/blocks/legalpages/mod.rs
+++ b/crates/solobase-core/src/blocks/legalpages/mod.rs
@@ -15,7 +15,6 @@ use crate::{
     endpoint_match::{self, EndpointRoute},
     http::{err_bad_request, err_internal, err_not_found, ok_json, ResponseBuilder},
     ui::{self, templates, SiteConfig},
-    util::json_map,
 };
 
 /// In-block dispatch targets, one per declared HTTP endpoint.
@@ -311,17 +310,17 @@ impl LegalPagesBlock {
             Err(e) => return err_bad_request(&format!("Invalid body: {e}")),
         };
 
-        let mut data = json_map(serde_json::json!({
-            "doc_type": body.doc_type,
-            "title": body.title,
-            "content": body.content,
-            "status": "draft",
-            "version": 1,
-            "created_by": msg.user_id()
-        }));
-        crate::util::stamp_created(&mut data);
-
-        match db::create(ctx, COLLECTION, data).await {
+        // Draft shape lives in `service::create_draft` (shared with the
+        // admin editor's save handler in `pages.rs`).
+        match service::create_draft(
+            ctx,
+            &body.doc_type,
+            &body.title,
+            &body.content,
+            msg.user_id(),
+        )
+        .await
+        {
             Ok(record) => ok_json(&record),
             Err(e) => err_internal("Database error", e),
         }
@@ -370,7 +369,6 @@ impl LegalPagesBlock {
             return;
         }
 
-        let now = crate::util::now_rfc3339();
         for (doc_type, title, content) in &[
             (
                 "terms",
@@ -383,18 +381,23 @@ impl LegalPagesBlock {
                 "This is the default privacy policy. Please update it in the admin panel.\n",
             ),
         ] {
-            let data = json_map(serde_json::json!({
-                "doc_type": doc_type,
-                "title": title,
-                "content": content,
-                "status": "published",
-                "version": 1,
-                "created_at": now,
-                "updated_at": now,
-                "published_at": now,
-                "created_by": "system"
-            }));
-            if let Err(e) = db::create(ctx, COLLECTION, data).await {
+            // Seed through the same service fn both publish surfaces use —
+            // the published-document shape (status/version/published_at/…)
+            // exists exactly once, in `service.rs`. The table is empty here
+            // (count == 0 above), so the archive pass is a no-op.
+            if let Err(e) = service::publish_document(
+                ctx,
+                service::PublishRequest {
+                    doc_type,
+                    doc_id: "",
+                    title: Some(title),
+                    content: Some(content),
+                    version: 1,
+                    created_by: "system",
+                },
+            )
+            .await
+            {
                 tracing::warn!("Failed to seed default legal page '{doc_type}': {e}");
             }
         }

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -530,8 +530,6 @@ pub async fn handle_save(ctx: &dyn Context, msg: &Message, input: InputStream) -
         Err(e) => return err_bad_request(&format!("Invalid request: {e}")),
     };
 
-    let now = crate::util::now_rfc3339();
-
     // If editing a published document, create a new draft instead of modifying the live version
     let should_create_new = if body.doc_id.is_empty() {
         true
@@ -549,17 +547,17 @@ pub async fn handle_save(ctx: &dyn Context, msg: &Message, input: InputStream) -
     };
 
     if should_create_new {
-        let data = json_map(serde_json::json!({
-            "doc_type": body.doc_type,
-            "title": body.title,
-            "content": body.content,
-            "status": "draft",
-            "version": 1,
-            "created_at": now,
-            "updated_at": now,
-            "created_by": msg.user_id()
-        }));
-        match db::create(ctx, COLLECTION, data).await {
+        // Draft shape lives in `service::create_draft` (shared with the JSON
+        // API's document-create handler in `mod.rs`).
+        match service::create_draft(
+            ctx,
+            &body.doc_type,
+            &body.title,
+            &body.content,
+            msg.user_id(),
+        )
+        .await
+        {
             Ok(record) => ok_json(&serde_json::json!({
                 "doc_id": record.id,
                 "status": "draft",
@@ -571,7 +569,7 @@ pub async fn handle_save(ctx: &dyn Context, msg: &Message, input: InputStream) -
         let data = json_map(serde_json::json!({
             "title": body.title,
             "content": body.content,
-            "updated_at": now
+            "updated_at": crate::util::now_rfc3339()
         }));
         match db::update(ctx, COLLECTION, &body.doc_id, data).await {
             Ok(_) => ok_json(&serde_json::json!({

--- a/crates/solobase-core/src/blocks/legalpages/service.rs
+++ b/crates/solobase-core/src/blocks/legalpages/service.rs
@@ -94,6 +94,33 @@ pub(super) async fn publish_document(
     Ok(Published { record, version })
 }
 
+/// Create a new version-1 draft document.
+///
+/// Single owner of the draft-creation shape (`status: "draft"`,
+/// `version: 1`, creation timestamps, `created_by`) — both create surfaces
+/// delegate here so the shape can't drift:
+///
+/// - the JSON API handler (`POST /b/legalpages/api/documents`)
+/// - the admin-UI editor save (`POST /b/legalpages/admin/save`, create branch)
+pub(super) async fn create_draft(
+    ctx: &dyn Context,
+    doc_type: &str,
+    title: &str,
+    content: &str,
+    created_by: &str,
+) -> Result<db::Record, WaferError> {
+    let mut data = json_map(serde_json::json!({
+        "doc_type": doc_type,
+        "title": title,
+        "content": content,
+        "status": "draft",
+        "version": 1,
+        "created_by": created_by,
+    }));
+    crate::util::stamp_created(&mut data);
+    db::create(ctx, COLLECTION, data).await
+}
+
 /// Read a document's `version` field, tolerating integer or string storage.
 pub(super) fn doc_version(record: &db::Record) -> Option<i64> {
     let v = record.data.get("version")?;
@@ -293,6 +320,72 @@ mod tests {
         assert_eq!(
             archived.data.get("status").and_then(|v| v.as_str()),
             Some("archived")
+        );
+    }
+
+    /// Both create surfaces — the JSON API (`POST /b/legalpages/api/documents`)
+    /// and the admin editor save (`POST /b/legalpages/admin/save`, create
+    /// branch) — must produce version-1 drafts of the identical stored shape,
+    /// because both delegate to the one [`create_draft`] fn.
+    #[tokio::test]
+    async fn both_create_surfaces_produce_version_1_drafts_via_create_draft() {
+        use wafer_run::InputStream;
+
+        use crate::test_support::{admin_msg, output_json};
+
+        let ctx = ctx_with_schema().await;
+        let body = serde_json::to_vec(&serde_json::json!({
+            "doc_type": "terms",
+            "title": "Terms",
+            "content": "the terms",
+        }))
+        .expect("serialize create body");
+
+        // JSON API surface.
+        let block = super::super::LegalPagesBlock::new();
+        let msg = admin_msg("create", "/b/legalpages/api/documents");
+        let out = block
+            .handle_admin_create(&ctx, &msg, InputStream::from_bytes(body.clone()))
+            .await;
+        let api_resp = output_json(out).await;
+        let api_id = api_resp["id"]
+            .as_str()
+            .expect("api create returns the record")
+            .to_string();
+
+        // Admin editor save surface (create branch: no doc_id).
+        let msg = admin_msg("create", "/b/legalpages/admin/save");
+        let out = super::super::pages::handle_save(&ctx, &msg, InputStream::from_bytes(body)).await;
+        let save_resp = output_json(out).await;
+        let save_id = save_resp["doc_id"]
+            .as_str()
+            .expect("save returns doc_id")
+            .to_string();
+
+        let api_doc = db::get(&ctx, COLLECTION, &api_id).await.expect("api doc");
+        let save_doc = db::get(&ctx, COLLECTION, &save_id).await.expect("save doc");
+        for doc in [&api_doc, &save_doc] {
+            assert_eq!(
+                doc.data.get("status").and_then(|v| v.as_str()),
+                Some("draft")
+            );
+            assert_eq!(doc_version(doc), Some(1));
+            assert_eq!(
+                doc.data.get("created_by").and_then(|v| v.as_str()),
+                Some("admin_1")
+            );
+        }
+
+        // Identical stored field set — the draft shape exists exactly once.
+        let keys = |r: &db::Record| {
+            let mut k: Vec<&str> = r.data.keys().map(String::as_str).collect();
+            k.sort_unstable();
+            k.into_iter().map(str::to_owned).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            keys(&api_doc),
+            keys(&save_doc),
+            "both surfaces must store the same draft shape"
         );
     }
 

--- a/crates/solobase-core/src/blocks/userportal/mod.rs
+++ b/crates/solobase-core/src/blocks/userportal/mod.rs
@@ -13,7 +13,10 @@ use crate::{
 };
 
 pub(crate) mod migrations;
-mod pages;
+// `pub(crate)`: `ui::sidebar`'s ICON_OPTIONS-coverage test reads
+// `pages::admin_buttons::ICON_OPTIONS` to keep the icon dropdown and the
+// `nav_icon` resolver in lockstep.
+pub(crate) mod pages;
 
 const TABLE: &str = "suppers_ai__userportal__buttons";
 

--- a/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
@@ -20,7 +20,12 @@ use crate::{
 };
 
 /// Known icon names available for button configuration.
-const ICON_OPTIONS: &[(&str, &str)] = &[
+///
+/// `pub(crate)`: `ui::sidebar`'s coverage test asserts every entry here
+/// resolves to a real `nav_icon` arm (not the unknown-icon fallback), so
+/// adding an option without a matching arm fails the build's tests instead
+/// of rendering a `?` glyph at runtime.
+pub(crate) const ICON_OPTIONS: &[(&str, &str)] = &[
     ("package", "Package"),
     ("shopping-cart", "Shopping Cart"),
     ("folder", "Folder"),

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -415,12 +415,13 @@ mod integration_tests {
     use crate::test_support::{admin_msg, output_html, TestContext};
 
     /// Minimal `wafer-run/vector` stand-in answering `vector.describe_index`
-    /// with the columns of the `_meta` fixture table. The TestContext's
-    /// database service owns a private in-memory connection, so a real
-    /// `SqliteVecService` can't see fixture tables; the real describe
-    /// behavior is covered upstream by wafer-run's sqlite behavior tests and
-    /// handler authorization suites. This fake keeps the page-rendering
-    /// assertions meaningful.
+    /// with the columns of the `_meta` fixture table and `vector.count` by
+    /// counting that same fixture table. The TestContext's database service
+    /// owns a private in-memory connection, so a real `SqliteVecService`
+    /// can't see fixture tables; the real describe/count behavior is covered
+    /// upstream by wafer-run's sqlite behavior tests and handler
+    /// authorization suites. This fake keeps the page-rendering assertions
+    /// meaningful: the rendered count still traces back to the seeded row.
     struct FakeVectorBlock;
 
     #[wafer_block::wafer_async_trait]
@@ -431,11 +432,23 @@ mod integration_tests {
 
         async fn handle(
             &self,
-            _ctx: &dyn Context,
+            ctx: &dyn Context,
             msg: Message,
-            _input: InputStream,
+            input: InputStream,
         ) -> OutputStream {
             match msg.kind.as_str() {
+                "vector.count" => {
+                    let body = input.collect_to_bytes().await;
+                    let req: wafer_block::wire::vector::CountRequest =
+                        wafer_block::codec::decode(&body).expect("decode count request");
+                    let count = db::count(ctx, &format!("{}_meta", req.index), &[])
+                        .await
+                        .expect("count fixture _meta table") as u64;
+                    let resp = wafer_block::wire::vector::CountResponse { count };
+                    OutputStream::respond(
+                        wafer_block::codec::encode(&resp).expect("encode count response"),
+                    )
+                }
                 "vector.describe_index" => {
                     let resp = wafer_block::wire::vector::DescribeIndexResponse {
                         exists: true,
@@ -490,7 +503,8 @@ mod integration_tests {
         // upstream `wafer-run/vector` runtime block via `vclient::create_index`
         // (see vector/migrations/mod.rs header). The runtime no longer
         // auto-creates tables on first insert, so the test materialises it
-        // explicitly with the columns the count loader expects.
+        // explicitly with the columns `FakeVectorBlock`'s count/describe
+        // arms expect.
         db::exec_raw(
             ctx,
             "CREATE TABLE IF NOT EXISTS suppers_ai__vector__docs_meta (id TEXT PRIMARY KEY, vector_id TEXT, created_at TEXT, updated_at TEXT)",
@@ -507,7 +521,11 @@ mod integration_tests {
 
     #[tokio::test]
     async fn index_list_page_renders_admin_view() {
-        let ctx = TestContext::with_vector().await;
+        let mut ctx = TestContext::with_vector().await;
+        // Counts now flow through the vector service (`vclient::count`),
+        // so the list page needs the backend block registered to see a
+        // non-zero count.
+        ctx.register_block("wafer-run/vector", Arc::new(FakeVectorBlock));
         seed_docs_index(&ctx).await;
 
         let msg = admin_msg("retrieve", "/b/vector/");
@@ -521,12 +539,32 @@ mod integration_tests {
         assert!(body.contains(">docs<"), "seeded row missing: {body}");
         assert!(body.contains("fastembed"), "missing model column: {body}");
         // The count cell is rendered as `<td data-label="Vectors">1</td>`.
-        // Asserting the exact substring guards against the previously-masked
-        // bug where `db::count` was issued against the registry's
-        // `prefixed_name` (no `_meta` suffix) and silently returned 0.
+        // Asserting the exact substring proves the count traces through
+        // `vclient::count` back to the seeded row (a broken index name or
+        // an unregistered backend would silently render 0).
         assert!(
             body.contains(r#"data-label="Vectors">1<"#),
             "vector count cell should show 1, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_list_page_count_degrades_to_zero_without_backend() {
+        // No `wafer-run/vector` block registered: `vclient::count` fails
+        // with NotFound and `map_index_row` must degrade the count to 0
+        // (same fallback the API stats route uses) instead of erroring
+        // the whole listing.
+        let ctx = TestContext::with_vector().await;
+        seed_docs_index(&ctx).await;
+
+        let msg = admin_msg("retrieve", "/b/vector/");
+        let resp = index_list_page(&ctx, &msg).await;
+        let body = output_html(resp).await;
+
+        assert!(body.contains(">docs<"), "seeded row missing: {body}");
+        assert!(
+            body.contains(r#"data-label="Vectors">0<"#),
+            "vector count cell should degrade to 0, got: {body}"
         );
     }
 

--- a/crates/solobase-core/src/blocks/vector/service.rs
+++ b/crates/solobase-core/src/blocks/vector/service.rs
@@ -6,7 +6,7 @@
 //! boundary — no magic mapping elsewhere in the stack.
 
 use wafer_block::db::SortField;
-use wafer_core::clients::database as db;
+use wafer_core::clients::{database as db, vector as vclient};
 use wafer_run::{context::Context, ErrorCode, WaferError};
 
 use crate::util::RecordExt;
@@ -109,11 +109,11 @@ pub fn validate_index_name(name: &str) -> Result<&str, WaferError> {
     Ok(name)
 }
 
-/// Map one registry record into an `IndexRow`, querying the matching
-/// `_meta` table for the live vector count. Returns `None` if the row
-/// has no `prefixed_name`. Shared between the list and detail loaders
-/// so the column-extraction quirks (TEXT-as-string round-trip from the
-/// SQLite service) live in exactly one place.
+/// Map one registry record into an `IndexRow`, asking the vector service
+/// for the live vector count. Returns `None` if the row has no
+/// `prefixed_name`. Shared between the list and detail loaders so the
+/// column-extraction quirks (TEXT-as-string round-trip from the SQLite
+/// service) live in exactly one place.
 async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> {
     let storage_name = rec
         .data
@@ -136,32 +136,33 @@ async fn map_index_row(ctx: &dyn Context, rec: &db::Record) -> Option<IndexRow> 
     let dimensions = rec.u64_field("dimensions") as u32;
     let keyword_search = rec.bool_field("keyword_search");
 
-    // Vectors live in `{prefixed}_meta` (see `pages.rs::ingest`/`reindex`),
-    // not in the registry's `prefixed_name` table. Counting that meta
-    // table is what gives a correct per-index vector count.
-    let meta_table = format!("{storage_name}_meta");
-    // audit-allow: own-block per-index meta table — `storage_name` was just read out of the vector registry (line above), so the owner is always `suppers-ai/vector`. The runtime table name is dynamic; static analysis can't see it.
-    let count = db::count(ctx, &meta_table, &[]).await.unwrap_or(0);
+    // Count through the vector service boundary — the same `vclient::count`
+    // the API `stats()` route uses — instead of reaching around it with a
+    // `db::count` on the backend-private `{storage}_meta` table. An absent
+    // backend or a just-dropped index degrades to a count of 0, matching
+    // the stats route's own fallback.
+    let count = vclient::count(ctx, &storage_name).await.unwrap_or(0);
 
     Some(IndexRow {
         name: storage_name,
         model,
         dimensions,
-        vector_count: count.max(0) as u64,
+        vector_count: count,
         keyword_search,
     })
 }
 
-/// Read every registered vector index plus its current row count from
-/// the meta table. Caller decides what to do with errors — returning
-/// `Result` (rather than swallowing) keeps the helper testable in
-/// isolation, while the page handler maps any failure to the empty
+/// Read every registered vector index plus its current vector count
+/// (via the vector service). Caller decides what to do with errors —
+/// returning `Result` (rather than swallowing) keeps the helper testable
+/// in isolation, while the page handler maps any failure to the empty
 /// state.
 ///
 /// On a fresh database the registry table doesn't exist yet; the
 /// SQLite service returns an empty `RecordList` for unknown
 /// collections, so `db::list` gives us `Ok(empty)` rather than an
-/// error. Same for `db::count` against the per-index meta table.
+/// error. Per-index counts come from `vclient::count`, which degrades
+/// to 0 in `map_index_row` when the backend is absent.
 pub async fn list_index_rows(ctx: &dyn Context) -> Result<Vec<IndexRow>, WaferError> {
     let records = db::list_sorted(
         ctx,

--- a/crates/solobase-core/src/ui/icons.rs
+++ b/crates/solobase-core/src/ui/icons.rs
@@ -209,6 +209,15 @@ pub fn info() -> Markup {
     icon(r#"<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>"#)
 }
 
+/// `?`-in-circle glyph. Used by `ui::sidebar::nav_icon` as the visibly
+/// distinct "unknown icon name" marker — don't reuse it for a nav entry's
+/// own icon or the drift signal disappears.
+pub fn help_circle() -> Markup {
+    icon(
+        r#"<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>"#,
+    )
+}
+
 pub fn database() -> Markup {
     icon(
         r#"<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>"#,

--- a/crates/solobase-core/src/ui/sidebar.rs
+++ b/crates/solobase-core/src/ui/sidebar.rs
@@ -11,6 +11,12 @@ use super::icons;
 /// misspelled icon in `nav_groups.rs` is a build error rather than a silent
 /// fallback. This resolver survives only for the genuinely-dynamic case
 /// where the name comes from user input at runtime.
+///
+/// Unknown names render the visibly distinct [`icons::help_circle`] glyph
+/// (plus a warn log) rather than silently masquerading as the package icon —
+/// a stored name that no arm matches is a data/`ICON_OPTIONS` drift that
+/// should be seen, not hidden. The `ICON_OPTIONS`-coverage test below keeps
+/// every dropdown-selectable name resolving to a real arm.
 pub fn nav_icon(name: &str) -> Markup {
     match name {
         "layout-dashboard" | "dashboard" => icons::layout_dashboard(),
@@ -31,7 +37,10 @@ pub fn nav_icon(name: &str) -> Markup {
         "bar-chart" | "stats" => icons::bar_chart(),
         "dollar-sign" => icons::dollar_sign(),
         "link" => icons::link(),
-        _ => icons::package(), // fallback
+        _ => {
+            tracing::warn!("unknown nav icon name: {name}");
+            icons::help_circle()
+        }
     }
 }
 
@@ -210,6 +219,39 @@ mod tests {
         }];
         let s = sidebar_grouped(&groups, None, "/b/storage/files/foo.png", "", "").into_string();
         assert!(s.contains("is-active"));
+    }
+
+    /// Every user-selectable icon name (the userportal admin-button editor's
+    /// `ICON_OPTIONS` dropdown) must resolve to a real `nav_icon` arm.
+    /// Rendering the visibly-distinct unknown-icon glyph for a listed option
+    /// means the dropdown and the resolver drifted.
+    #[cfg(feature = "block-userportal")]
+    #[test]
+    fn every_icon_option_resolves_to_a_non_fallback_icon() {
+        let fallback = icons::help_circle().into_string();
+        for (name, display) in crate::blocks::userportal::pages::admin_buttons::ICON_OPTIONS {
+            assert_ne!(
+                nav_icon(name).into_string(),
+                fallback,
+                "ICON_OPTIONS entry '{name}' ({display}) hit the unknown-icon \
+                 fallback — add a matching arm to nav_icon"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_icon_name_renders_the_distinct_help_glyph() {
+        let rendered = nav_icon("definitely-not-an-icon").into_string();
+        assert_eq!(
+            rendered,
+            icons::help_circle().into_string(),
+            "unknown names must render the visibly-distinct help glyph"
+        );
+        assert_ne!(
+            rendered,
+            icons::package().into_string(),
+            "unknown names must NOT silently render the package glyph"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the residuals of four 2026-06-05 review mediums, one commit per finding, each with its test.

## M12 — vector count via the service boundary (`blocks/vector/service.rs`)
`map_index_row` reached around the service boundary with `db::count` on the backend-private `{storage}_meta` table plus an `audit-allow` pragma, while the API `stats()` route already counted through `vclient::count`. **Closed by:** both counting paths now go through `vclient::count` (host-side WRAP authorizes on the index's own `suppers_ai__vector__*` namespace); the pragma is gone and `scripts/audit-wrap-grants.sh` stays green. Absent backend degrades to count 0 (new test); the test `FakeVectorBlock` answers `vector.count` by counting the seeded fixture table, so the existing count=1 render assertions still trace to real rows.

## M21 — legalpages create dedup (`blocks/legalpages/`)
The version-1 draft-create logic was duplicated between `mod.rs::handle_admin_create` (JSON API) and `pages.rs::handle_save`'s create branch, and `seed_defaults` hand-rolled a third document-create shape. **Closed by:** new `service::create_draft` owns the draft shape (mirroring how publish already lives in `service::publish_document`); both surfaces delegate, and `seed_defaults` seeds through `publish_document`. No direct `db::create` for documents exists outside `service.rs`. New both-surfaces test drives both real handlers and asserts version-1 drafts with identical stored field sets (green before and after — behavior pinned, then deduplicated).

## M28 — visible unknown-icon fallback (`ui/sidebar.rs`, `ui/icons.rs`)
`nav_icon` silently fell back to `icons::package()` for unknown names, so a stored icon name with no arm masqueraded as the package glyph (the same class of drift as the old Security "lock" mis-render). **Closed by:** unknowns now render a new `icons::help_circle()` (?-in-circle) and warn-log the name. `ICON_OPTIONS` widened to `pub(crate)` so a new sidebar test asserts every dropdown-selectable entry resolves to a non-fallback arm (RED→GREEN).

## M03 — sensitive-empty guard union (`blocks/admin/ops.rs`)
`update_variable`'s clear-guard was suffix-only (`_SECRET`/`_KEY`), so Password-typed vars stored with `sensitive = 1` but no suffix (e.g. `BOOTSTRAP_ADMIN_PASSWORD`, `*_TOKEN`) could be emptied — while the read paths already masked them via `util::is_sensitive_key`. **Closed by:** the guard now uses the same `is_sensitive_key(key, stored_flag)` union, fetching the row's flag only on the empty-value path (no extra query on normal updates; missing row falls back to the suffix rule). RED→GREEN test: clearing a seeded suffix-less `sensitive=1` var is rejected and leaves the value untouched; unflagged vars stay clearable.

## Verification
- `cargo fmt --all --check` + `cargo +nightly fmt --all -- --check` (CI invocation) clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean on 1.94 and 1.96.0
- `cargo test --workspace` green
- `scripts/audit-wrap-grants.sh` — OK, no missing WRAP grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H
