### PR TITLE
chore: bump wafer-run lockfile to b5c82fd (#275, #276)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5850,7 +5850,6 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5874,7 +5873,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5886,7 +5884,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5907,7 +5904,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5918,7 +5914,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5933,7 +5928,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5946,7 +5940,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5958,7 +5951,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5969,7 +5961,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "futures",
@@ -5986,7 +5977,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6007,7 +5997,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6017,7 +6006,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6029,7 +6017,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6045,7 +6032,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6055,7 +6041,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6076,7 +6061,6 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6088,7 +6072,6 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6110,7 +6093,6 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "serde",
  "serde_json",
@@ -6120,7 +6102,6 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6150,7 +6131,6 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "serde",
  "serde_json",
@@ -6160,7 +6140,6 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
-source = "git+https://github.com/wafer-run/wafer-run?branch=main#166cdd880d81f387c77ba2cb638d17a75f62097f"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
Bumps the committed `Cargo.lock` from wafer-run `166cdd8` → `b5c82fd` (current main). Range = #275 (build-script fix) + #276 (CORS warn narrowing); no consumer API change. Local `cargo check --workspace` clean against sibling `b5c82fd`; this PR's CI does the authoritative git-source build. Needed so gizza-ai can bump its `wafer-run-pin.txt` to `b5c82fd` with a matching `solobase-pin.txt` (its guard greps solobase/Cargo.lock's wafer sha).