### PR TITLE
fix: restore wafer-run git sources in Cargo.lock (repair #344)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5850,6 +5850,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "wafer-block"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5873,6 +5874,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-cors"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -5884,6 +5886,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-crypto"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5904,6 +5907,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-fastembed"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "fastembed",
@@ -5914,6 +5918,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-http-listener"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -5928,6 +5933,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-inspector"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -5940,6 +5946,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-local-storage"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5951,6 +5958,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-macro"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5961,6 +5969,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-network"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "futures",
@@ -5977,6 +5986,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-postgres"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -5997,6 +6007,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-readonly-guard"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6006,6 +6017,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-router"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "serde_json",
@@ -6017,6 +6029,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-s3"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6032,6 +6045,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-security-headers"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "wafer-block",
@@ -6041,6 +6055,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-sqlite"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6061,6 +6076,7 @@ dependencies = [
 [[package]]
 name = "wafer-block-web"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "tracing",
@@ -6072,6 +6088,7 @@ dependencies = [
 [[package]]
 name = "wafer-core"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6093,6 +6110,7 @@ dependencies = [
 [[package]]
 name = "wafer-flow"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6102,6 +6120,7 @@ dependencies = [
 [[package]]
 name = "wafer-run"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -6131,6 +6150,7 @@ dependencies = [
 [[package]]
 name = "wafer-schema"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6140,6 +6160,7 @@ dependencies = [
 [[package]]
 name = "wafer-sql-utils"
 version = "0.1.0"
+source = "git+https://github.com/wafer-run/wafer-run?branch=main#b5c82fd862a7bcb8850163506cfdddae8ab3fc0a"
 dependencies = [
  "sea-query",
  "serde_json",


### PR DESCRIPTION
#344's lock was committed after a patched `cargo check` stripped all 21 `wafer-*` `source = "git+…"` lines (the documented `.cargo/config.toml` lock-strip gotcha). solobase CI stays green (it re-resolves git deps live), but gizza-ai's pin-consistency guard greps `solobase/Cargo.lock` for `wafer-run?branch=main#<sha>` and now finds none — blocking the gizza pin bump.

This regenerates the lock from `dee0332` (pre-#344, git sources at 166cdd8) and `cargo update`s the wafer crates to `b5c82fd`, with no patched command touching the file after. 21 git sources restored; sibling `cargo check --workspace` clean (run against a throwaway lock copy).