### PR TITLE
chore: clippy -D warnings sweep across solobase workspace

### DIFF
--- a/crates/solobase-browser/src/asset_loader.rs
+++ b/crates/solobase-browser/src/asset_loader.rs
@@ -59,13 +59,10 @@ struct LoadAssetReply {
 #[async_trait::async_trait(?Send)]
 impl LoadAssetCallback for SwAssetLoader {
     async fn load(&self, asset_id: &str) -> AssetLoadStatus {
-        let manifest = match lookup_manifest(asset_id) {
-            Some(m) => m,
-            None => {
-                return AssetLoadStatus::Failed(AssetLoadError::UnknownLoader(format!(
-                    "no external_asset with id='{asset_id}' in any registered block"
-                )));
-            }
+        let Some(manifest) = lookup_manifest(asset_id) else {
+            return AssetLoadStatus::Failed(AssetLoadError::UnknownLoader(format!(
+                "no external_asset with id='{asset_id}' in any registered block"
+            )));
         };
 
         let manifest_json = match serde_json::to_string(&ManifestForJs {

--- a/crates/solobase-browser/src/convert.rs
+++ b/crates/solobase-browser/src/convert.rs
@@ -45,8 +45,8 @@ pub async fn request_to_message(
     let path = url.pathname();
     // search() includes the leading '?' — strip it.
     let search = url.search();
-    let raw_query = if search.starts_with('?') {
-        search[1..].to_string()
+    let raw_query = if let Some(stripped) = search.strip_prefix('?') {
+        stripped.to_string()
     } else {
         search
     };

--- a/crates/solobase-browser/src/image/catalog.rs
+++ b/crates/solobase-browser/src/image/catalog.rs
@@ -30,18 +30,17 @@ pub fn default_catalog() -> ModelCatalog {
 }
 
 fn janus_pro_caps() -> ModelCapabilities {
-    // `ModelCapabilities` is `#[non_exhaustive]`; construct via Default + field assignment.
     // Janus-Pro is autoregressive (not diffusion). Output is 384×384; `steps`
     // / `guidance_scale` / `negative_prompt` are ignored by the engine. The
     // capability flags here describe what the UI should expose; we set
     // `supports_negative_prompt = false` and leave `max_steps = None` because
     // those knobs don't apply to the autoregressive token loop.
-    let mut c = ModelCapabilities::default();
-    c.max_width = Some(384);
-    c.max_height = Some(384);
-    c.supports_negative_prompt = false;
-    c.max_steps = None;
-    c
+    ModelCapabilities {
+        max_width: Some(384),
+        max_height: Some(384),
+        supports_negative_prompt: false,
+        max_steps: None,
+    }
 }
 
 fn default_models() -> Vec<ModelInfo> {

--- a/crates/solobase-browser/src/llm/catalog.rs
+++ b/crates/solobase-browser/src/llm/catalog.rs
@@ -31,11 +31,11 @@ pub fn default_catalog() -> ModelCatalog {
 }
 
 fn caps() -> ModelCapabilities {
-    // `ModelCapabilities` is `#[non_exhaustive]`; construct via Default.
-    let mut c = ModelCapabilities::default();
-    c.streaming = true;
-    c.tools = true;
-    c
+    ModelCapabilities {
+        streaming: true,
+        tools: true,
+        ..Default::default()
+    }
 }
 
 fn default_models() -> Vec<ModelInfo> {

--- a/crates/solobase-browser/src/llm/openai_codec.rs
+++ b/crates/solobase-browser/src/llm/openai_codec.rs
@@ -118,6 +118,12 @@ pub struct StreamingDecoder {
     open_tool_calls: HashMap<u64, OpenToolCall>, // index → { id }
 }
 
+impl Default for StreamingDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StreamingDecoder {
     pub fn new() -> Self {
         Self {
@@ -171,9 +177,10 @@ impl StreamingDecoder {
 
                     // ToolCallStart — first time we see this index with id + name
                     if let (Some(id), Some(name)) = (entry_id, func_name) {
-                        if !self.open_tool_calls.contains_key(&index) {
-                            self.open_tool_calls
-                                .insert(index, OpenToolCall { id: id.to_string() });
+                        if let std::collections::hash_map::Entry::Vacant(e) =
+                            self.open_tool_calls.entry(index)
+                        {
+                            e.insert(OpenToolCall { id: id.to_string() });
                             out.push(ChatChunk::delta(ChunkDelta::ToolCallStart {
                                 id: id.to_string(),
                                 name: name.to_string(),
@@ -250,10 +257,11 @@ pub fn parse_finish_reason(s: &str) -> Option<FinishReason> {
 pub fn parse_usage(v: &serde_json::Value) -> Option<TokenUsage> {
     let prompt = v.get("prompt_tokens").and_then(|t| t.as_u64())?;
     let completion = v.get("completion_tokens").and_then(|t| t.as_u64())?;
-    let mut u = TokenUsage::default();
-    u.input_tokens = prompt as u32;
-    u.output_tokens = completion as u32;
-    Some(u)
+    Some(TokenUsage {
+        input_tokens: prompt as u32,
+        output_tokens: completion as u32,
+        ..Default::default()
+    })
 }
 
 // ---------- Tests ----------

--- a/crates/solobase-browser/src/runtime.rs
+++ b/crates/solobase-browser/src/runtime.rs
@@ -72,14 +72,11 @@ pub async fn dispatch_request(request: web_sys::Request) -> Result<web_sys::Resp
         }
     });
 
-    let wafer_ptr = match wafer_ptr {
-        Ok(p) => p,
-        Err(()) => {
-            return Ok(build_error_response(
-                503,
-                "solobase-browser: runtime not initialized — call store_wafer() first",
-            )?);
-        }
+    let Ok(wafer_ptr) = wafer_ptr else {
+        return build_error_response(
+            503,
+            "solobase-browser: runtime not initialized — call store_wafer() first",
+        );
     };
 
     let (msg, input) = convert::request_to_message(&request).await?;

--- a/crates/solobase-browser/src/vector/service.rs
+++ b/crates/solobase-browser/src/vector/service.rs
@@ -447,11 +447,10 @@ impl VectorService for BrowserVectorService {
     }
 }
 
-fn load_all_vectors(
-    index: &str,
-    dims: u32,
-    f: &MetadataFilter,
-) -> VResult<Vec<(String, Vec<f32>, Option<serde_json::Value>)>> {
+/// A loaded vector row: `(id, vector, metadata)`.
+type VectorRow = (String, Vec<f32>, Option<serde_json::Value>);
+
+fn load_all_vectors(index: &str, dims: u32, f: &MetadataFilter) -> VResult<Vec<VectorRow>> {
     let s = format!(r#"SELECT id, vector, metadata FROM "{index}_vectors""#);
     let json = bridge::db_query_raw(&s, "[]").map_err(|e| VectorError::Internal(js_err(e)))?;
     let rows: Vec<serde_json::Value> = serde_json::from_str(&json)
@@ -541,7 +540,7 @@ fn attach_metadata(
     scored
         .into_iter()
         .map(|(id, score)| VectorMatch {
-            metadata: by_id.get(id.as_str()).cloned().cloned().unwrap_or(None),
+            metadata: by_id.get(id.as_str()).copied().cloned().unwrap_or(None),
             id,
             score,
         })

--- a/crates/solobase-browser/src/vector/sql.rs
+++ b/crates/solobase-browser/src/vector/sql.rs
@@ -480,7 +480,7 @@ mod tests {
             metadata_json: "{}".into(),
             text: Some("hello".into()),
         };
-        let stmts = build_upsert_sql_stmts("suppers_ai__vector__docs", true, &[entry.clone()]);
+        let stmts = build_upsert_sql_stmts("suppers_ai__vector__docs", true, &[entry]);
         assert_eq!(stmts.len(), 3, "expected vectors + fts + meta upserts");
         assert!(stmts[0]
             .sql

--- a/crates/solobase-cloudflare/src/lib.rs
+++ b/crates/solobase-cloudflare/src/lib.rs
@@ -80,20 +80,26 @@ pub fn make_kv_cached_database_service(
 /// a `KvStore` handle from `env` on every request. The `/_deploy/init`
 /// endpoint re-derives its own handle via `make_kv_backend` for its
 /// post-funnel config-version bump.
+/// Return type of [`make_kv_cached_database_service_with_backend`]: the
+/// wrapped `DatabaseService` alongside the raw `KvBackend` it was built from.
+type KvCachedDbServiceWithBackend = (
+    Arc<dyn DatabaseService>,
+    Arc<dyn solobase_core::kv::KvBackend>,
+);
+
 fn make_kv_cached_database_service_with_backend(
     env: &worker::Env,
     d1_binding: &str,
     kv_binding: &str,
     mode: kv_cached_db::CacheMode,
-) -> Result<
-    (
-        Arc<dyn DatabaseService>,
-        Arc<dyn solobase_core::kv::KvBackend>,
-    ),
-    worker::Error,
-> {
+) -> Result<KvCachedDbServiceWithBackend, worker::Error> {
     let inner = make_d1_database_service(env, d1_binding)?;
     let backend = make_kv_backend(env, kv_binding)?;
+    // `DatabaseService` only requires `MaybeSend + MaybeSync` (real
+    // `Send + Sync` on native, a no-op marker on wasm32 — see
+    // wafer_block::compat), so this `Arc` doesn't promise cross-thread
+    // safety; this crate only ever targets wasm32, which is single-threaded.
+    #[allow(clippy::arc_with_non_send_sync)]
     let db = Arc::new(kv_cached_db::KvCachedD1DatabaseService::with_mode(
         inner,
         backend.clone(),
@@ -528,6 +534,11 @@ where
     // 5. ConfigSource: D1-backed lazy per-block fetch. The overlay layers
     //    worker::Env secrets (PROTECTED_ENV_KEYS) on top of D1 rows so
     //    secrets never need to be mirrored into the variables table.
+    // `ConfigSource` only requires `MaybeSend + MaybeSync` (real
+    // `Send + Sync` on native, a no-op marker on wasm32 — see
+    // wafer_block::compat), so this `Arc` doesn't promise cross-thread
+    // safety; this crate only ever targets wasm32, which is single-threaded.
+    #[allow(clippy::arc_with_non_send_sync)]
     let cfg_source: Arc<dyn wafer_run::ConfigSource> = Arc::new(
         config_source::D1ConfigSource::with_overlay(db.clone(), overlay),
     );

--- a/crates/solobase-cloudflare/src/storage.rs
+++ b/crates/solobase-cloudflare/src/storage.rs
@@ -27,11 +27,11 @@ impl R2StorageService {
     }
 
     fn prefixed_key(&self, folder: &str, key: &str) -> String {
-        format!("{}/{}", folder, key)
+        format!("{folder}/{key}")
     }
 
     fn folder_prefix(&self, folder: &str) -> String {
-        format!("{}/", folder)
+        format!("{folder}/")
     }
 }
 
@@ -138,7 +138,7 @@ impl StorageService for R2StorageService {
                 let key = if full_key.len() > folder_prefix_len {
                     full_key[folder_prefix_len..].to_string()
                 } else {
-                    full_key.clone()
+                    full_key
                 };
 
                 ObjectInfo {

--- a/crates/solobase-core/src/blocks/admin/logs.rs
+++ b/crates/solobase-core/src/blocks/admin/logs.rs
@@ -53,7 +53,7 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
         filters.push(Filter {
             field: "resource".to_string(),
             operator: FilterOp::Like,
-            value: serde_json::Value::String(format!("%{}%", resource)),
+            value: serde_json::Value::String(format!("%{resource}%")),
         });
     }
 
@@ -94,7 +94,7 @@ async fn handle_system_logs(ctx: &dyn Context, msg: &Message) -> OutputStream {
         filters.push(Filter {
             field: "path".to_string(),
             operator: FilterOp::Like,
-            value: serde_json::Value::String(format!("%{}%", path_filter)),
+            value: serde_json::Value::String(format!("%{path_filter}%")),
         });
     }
 

--- a/crates/solobase-core/src/blocks/admin/mod.rs
+++ b/crates/solobase-core/src/blocks/admin/mod.rs
@@ -154,7 +154,7 @@ crate::solobase_feature_block! {
             AdminRoute::ExtensionsApi => {
                 let blocks: Vec<_> = ctx
                     .registered_blocks()
-                    .into_iter()
+                    .iter()
                     .map(|b| {
                         serde_json::json!({
                             "name": b.name,
@@ -173,11 +173,11 @@ crate::solobase_feature_block! {
                 // did this, but the original re-applied; we mirror by deriving
                 // from path_owned (NOT msg.path() which is now normalized).
                 let api_rest = path_owned.strip_prefix("/b/admin/api").unwrap_or("");
-                msg.set_meta("req.resource", &format!("/admin{}", api_rest));
+                msg.set_meta("req.resource", format!("/admin{api_rest}"));
                 ctx.call_block("suppers-ai/files", msg, input).await
             }
             AdminRoute::CloudStorageDelegate { rest } => {
-                msg.set_meta("req.resource", &format!("/admin/b/cloudstorage{}", rest));
+                msg.set_meta("req.resource", format!("/admin/b/cloudstorage{rest}"));
                 ctx.call_block("suppers-ai/files", msg, input).await
             }
             AdminRoute::ApiNotFound => err_not_found("not found"),
@@ -239,7 +239,7 @@ crate::solobase_feature_block! {
                 if old_tab.is_empty() {
                     redirect_308("/b/admin/settings/permissions")
                 } else {
-                    redirect_308(&format!("/b/admin/settings/permissions?subtab={}", old_tab))
+                    redirect_308(&format!("/b/admin/settings/permissions?subtab={old_tab}"))
                 }
             }
             AdminRoute::GrantsPage => pages::grants_page(ctx, &msg).await,

--- a/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/dashboard.rs
@@ -305,7 +305,7 @@ pub async fn dashboard(ctx: &dyn Context, msg: &Message) -> OutputStream {
     let new_users_str = new_users_today.to_string();
     let requests_str = requests_today.to_string();
     let errors_str = errors_today.to_string();
-    let avg_ms_str = format!("{:.0}ms", avg_ms);
+    let avg_ms_str = format!("{avg_ms:.0}ms");
 
     let stats = vec![
         StatTile {

--- a/crates/solobase-core/src/blocks/admin/pages/database.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/database.rs
@@ -241,8 +241,8 @@ async fn schema_panel(ctx: &dyn Context, table: Option<&str>) -> Markup {
                                 tr {
                                     td .font-medium { (c.name) }
                                     td .text-muted { (c.ty) }
-                                    td { @if c.notnull { "✓" } @else { "" } }
-                                    td { @if c.pk { "✓" } @else { "" } }
+                                    td { @if c.notnull { "✓" }  }
+                                    td { @if c.pk { "✓" }  }
                                     td .text-muted .text-sm { (c.default_value.as_deref().unwrap_or("")) }
                                 }
                             }
@@ -336,9 +336,8 @@ fn render_sql_results(rows: &[db::Record], duration_ms: u128) -> Markup {
                         tr {
                             @for c in &columns {
                                 td .text-sm {
-                                    @match r.data.get(c) {
-                                        Some(v) => (format_cell(v)),
-                                        None => "",
+                                    @if let Some(v) = r.data.get(c) {
+                                        (format_cell(v))
                                     }
                                 }
                             }
@@ -426,7 +425,7 @@ pub async fn handle_database_query(
 
     let fragment = match result {
         Ok(rows) => render_sql_results(&rows, elapsed),
-        Err(e) => render_sql_error(&format!("Query error: {}", e)),
+        Err(e) => render_sql_error(&format!("Query error: {e}")),
     };
     html_response(fragment)
 }

--- a/crates/solobase-core/src/blocks/admin/pages/permissions.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/permissions.rs
@@ -478,7 +478,7 @@ async fn permissions_all_tab(ctx: &dyn Context, _msg: &Message) -> Markup {
         } else {
             "can read"
         };
-        let sentence = format!("{} {} {}", grantee_display, verb, resource);
+        let sentence = format!("{grantee_display} {verb} {resource}");
         all_rows.push(PermRow {
             type_label: type_label.to_string(),
             sentence,

--- a/crates/solobase-core/src/blocks/admin/pages/users.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/users.rs
@@ -278,9 +278,8 @@ fn single_user_row(record: &db::Record, roles: &[String], current_uid: &str) -> 
 
 /// Render a single user table row (used by enable/disable mutations).
 async fn user_row_fragment(ctx: &dyn Context, user_id: &str) -> Markup {
-    let record = match db::get(ctx, USERS, user_id).await {
-        Ok(r) => r,
-        Err(_) => return html! {},
+    let Ok(record) = db::get(ctx, USERS, user_id).await else {
+        return html! {};
     };
 
     // Single-user lookup via the shared roles helper (the `[one]` case).

--- a/crates/solobase-core/src/blocks/admin/pages/variables.rs
+++ b/crates/solobase-core/src/blocks/admin/pages/variables.rs
@@ -499,7 +499,7 @@ pub async fn handle_create_variable(
     }
 
     // Re-render the variables page (htmx will swap #content)
-    variables_page(ctx, &msg).await
+    variables_page(ctx, msg).await
 }
 
 /// GET /b/admin/variables/{key}/edit -- return modal edit form content
@@ -508,16 +508,15 @@ pub async fn handle_edit_variable_form(
     _msg: &Message,
     var_key: &str,
 ) -> OutputStream {
-    let record = match db::get_by_field(
+    let Ok(record) = db::get_by_field(
         ctx,
         VARIABLES,
         "key",
         serde_json::Value::String(var_key.to_string()),
     )
     .await
-    {
-        Ok(r) => r,
-        Err(_) => return err_not_found("Variable not found"),
+    else {
+        return err_not_found("Variable not found");
     };
 
     let key = record.str_field("key").to_string();
@@ -602,7 +601,7 @@ pub async fn handle_update_variable(
         return out;
     }
 
-    variables_page(ctx, &msg).await
+    variables_page(ctx, msg).await
 }
 
 #[cfg(test)]

--- a/crates/solobase-core/src/blocks/admin/settings.rs
+++ b/crates/solobase-core/src/blocks/admin/settings.rs
@@ -310,7 +310,7 @@ async fn handle_delete(ctx: &dyn Context, path: &str) -> OutputStream {
     }
 
     if key.starts_with("SOLOBASE_SHARED__") {
-        return err_bad_request(&format!("Cannot delete shared system variable: {}", key));
+        return err_bad_request(&format!("Cannot delete shared system variable: {key}"));
     }
 
     match db::get_by_field(
@@ -529,7 +529,7 @@ mod tests {
         warning_changed[0].warning = "careful".into();
         assert_ne!(h_base, seed_payload_hash(&warning_changed));
 
-        let mut sensitive_changed = base.clone();
+        let mut sensitive_changed = base;
         sensitive_changed[0].input_type = InputType::Password;
         assert_ne!(h_base, seed_payload_hash(&sensitive_changed));
     }
@@ -608,8 +608,7 @@ mod tests {
         assert_eq!(
             var_count_after_second, 0,
             "seed_defaults should short-circuit when snapshot hash matches; \
-             expected 0 rows in fresh variables table, got {}",
-            var_count_after_second
+             expected 0 rows in fresh variables table, got {var_count_after_second}"
         );
     }
 

--- a/crates/solobase-core/src/blocks/admin/users.rs
+++ b/crates/solobase-core/src/blocks/admin/users.rs
@@ -59,7 +59,7 @@ async fn handle_list(ctx: &dyn Context, msg: &Message) -> OutputStream {
         filters.push(Filter {
             field: "email".to_string(),
             operator: FilterOp::Like,
-            value: serde_json::Value::String(format!("%{}%", search)),
+            value: serde_json::Value::String(format!("%{search}%")),
         });
     }
 

--- a/crates/solobase-core/src/blocks/auth/config.rs
+++ b/crates/solobase-core/src/blocks/auth/config.rs
@@ -298,8 +298,10 @@ mod tests {
     #[test]
     fn auth_config_vars_declares_password_min_length() {
         let vars = auth_config_vars();
-        let keys: Vec<&str> = vars.iter().map(|v| v.key.as_str()).collect();
-        assert!(keys.contains(&PASSWORD_MIN_LENGTH_KEY));
+        assert!(vars
+            .iter()
+            .map(|v| v.key.as_str())
+            .any(|k| k == PASSWORD_MIN_LENGTH_KEY));
     }
 
     #[test]

--- a/crates/solobase-core/src/blocks/auth/repo/sessions.rs
+++ b/crates/solobase-core/src/blocks/auth/repo/sessions.rs
@@ -308,17 +308,13 @@ mod tests_phase_4 {
         insert(&ctx, fake_session("user-b", 0x02)).await.unwrap();
 
         // user-a tries to revoke user-b's session — should affect 0 rows.
-        let affected = delete_for_user(&ctx, "user-a", &vec![0x02; 32])
-            .await
-            .unwrap();
+        let affected = delete_for_user(&ctx, "user-a", &[0x02; 32]).await.unwrap();
         assert_eq!(affected, 0);
         // user-b's session is still there.
         assert_eq!(list_for_user(&ctx, "user-b").await.unwrap().len(), 1);
 
         // user-a can revoke their own.
-        let affected = delete_for_user(&ctx, "user-a", &vec![0x01; 32])
-            .await
-            .unwrap();
+        let affected = delete_for_user(&ctx, "user-a", &[0x01; 32]).await.unwrap();
         assert_eq!(affected, 1);
         assert_eq!(list_for_user(&ctx, "user-a").await.unwrap().len(), 0);
     }
@@ -353,14 +349,8 @@ mod tests_phase_4 {
         let ctx = TestContext::with_auth().await;
         seed_user(&ctx, "user-a").await;
         insert(&ctx, fake_session("user-a", 0x01)).await.unwrap();
-        assert_eq!(
-            delete_by_token_hash(&ctx, &vec![0x99; 32]).await.unwrap(),
-            0
-        );
-        assert_eq!(
-            delete_by_token_hash(&ctx, &vec![0x01; 32]).await.unwrap(),
-            1
-        );
+        assert_eq!(delete_by_token_hash(&ctx, &[0x99; 32]).await.unwrap(), 0);
+        assert_eq!(delete_by_token_hash(&ctx, &[0x01; 32]).await.unwrap(), 1);
         assert_eq!(list_for_user(&ctx, "user-a").await.unwrap().len(), 0);
     }
 

--- a/crates/solobase-core/src/blocks/auth/service.rs
+++ b/crates/solobase-core/src/blocks/auth/service.rs
@@ -37,6 +37,11 @@ impl BlockState {
     /// Production constructor — context cell starts empty and is populated
     /// later by [`AuthServiceImpl::init`] when the framework AuthBlock fires
     /// its `Init` lifecycle event.
+    // `dyn Context` only requires `MaybeSend + MaybeSync` (real `Send + Sync`
+    // on native, a no-op marker on wasm32 — see wafer_block::compat), so this
+    // `Arc` doesn't promise cross-thread safety on wasm32; it's a shared
+    // handle, not a thread-safety claim, and wasm32 is single-threaded.
+    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new() -> Self {
         Self {
             ctx: Arc::new(OnceLock::new()),
@@ -45,6 +50,7 @@ impl BlockState {
 
     /// Test-only constructor. Pre-populates the context cell so service
     /// methods can run without going through the full `init` lifecycle.
+    #[allow(clippy::arc_with_non_send_sync)]
     pub fn for_test(ctx: Arc<dyn Context>) -> Self {
         let cell = OnceLock::new();
         let _ = cell.set(ctx);

--- a/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/api/refresh.rs
@@ -39,11 +39,8 @@ pub async fn handle(ctx: &dyn Context, input: InputStream) -> OutputStream {
     // Verify the JWT signature/expiry. A valid signature alone is not enough
     // — the row lookup below is the source of truth for "this token has not
     // been used or revoked yet".
-    let claims = match crypto::verify(ctx, &body.refresh_token).await {
-        Ok(c) => c,
-        Err(_) => {
-            return error_response(ErrorCode::InvalidToken, "Invalid or expired refresh token")
-        }
+    let Ok(claims) = crypto::verify(ctx, &body.refresh_token).await else {
+        return error_response(ErrorCode::InvalidToken, "Invalid or expired refresh token");
     };
 
     let Some(user_id) = claims

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/callback.rs
@@ -50,9 +50,8 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
     // match check passes even if the live config changed mid-flow.
     let redirect_uri = pkce_row.redirect_uri.clone();
 
-    let spec = match super::spec::lookup(&provider) {
-        Some(s) => s,
-        None => return err_bad_request("Unsupported OAuth provider"),
+    let Some(spec) = super::spec::lookup(&provider) else {
+        return err_bad_request("Unsupported OAuth provider");
     };
 
     let client_id = config::get_default(
@@ -135,7 +134,7 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         &user_id,
         &email,
         &roles,
-        &format!("oauth.{}", provider),
+        &format!("oauth.{provider}"),
         None,
         0,
     )
@@ -525,9 +524,8 @@ fn is_safe_frontend_url(s: &str) -> bool {
     if s.chars().any(|c| c.is_control()) {
         return false;
     }
-    let parsed = match url::Url::parse(s) {
-        Ok(u) => u,
-        Err(_) => return false,
+    let Ok(parsed) = url::Url::parse(s) else {
+        return false;
     };
     let host = match parsed.host_str() {
         Some(h) if !h.is_empty() => h,

--- a/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
+++ b/crates/solobase-core/src/blocks/auth_ui/oauth/start.rs
@@ -51,9 +51,8 @@ pub async fn handle(ctx: &dyn Context, msg: &Message) -> OutputStream {
         "SUPPERS_AI__AUTH_UI__OAUTH_{}_CLIENT_ID",
         provider.to_uppercase()
     );
-    let client_id = match config::get(ctx, &client_id_key).await {
-        Ok(id) => id,
-        Err(_) => return err_bad_request(&format!("OAuth provider '{}' not configured", provider)),
+    let Ok(client_id) = config::get(ctx, &client_id_key).await else {
+        return err_bad_request(&format!("OAuth provider '{provider}' not configured"));
     };
 
     let redirect_uri = config::get_default(

--- a/crates/solobase-core/src/blocks/email.rs
+++ b/crates/solobase-core/src/blocks/email.rs
@@ -307,7 +307,7 @@ async fn handle_send_template(
             let greeting = if name.is_empty() {
                 "Welcome!".to_string()
             } else {
-                format!("Welcome, {}!", name)
+                format!("Welcome, {name}!")
             };
             let pricing_url = format!("{site_url}/pricing/");
             let dashboard_url = format!("{base_url}/b/admin/");
@@ -420,7 +420,7 @@ async fn send_email(
 
     // Base64-encode "api:{api_key}" for HTTP Basic auth.
     use base64ct::Encoding;
-    let credentials = base64ct::Base64::encode_string(format!("api:{}", api_key).as_bytes());
+    let credentials = base64ct::Base64::encode_string(format!("api:{api_key}").as_bytes());
 
     // Call network block via the typed client. The buffered helper consumes
     // the two-frame response (header + body) and returns a typed
@@ -429,10 +429,7 @@ async fn send_email(
     let base = resolve_base_url(&configured);
     let url = format!("{base}/v3/{domain}/messages");
     let mut headers = HashMap::new();
-    headers.insert(
-        "Authorization".to_string(),
-        format!("Basic {}", credentials),
-    );
+    headers.insert("Authorization".to_string(), format!("Basic {credentials}"));
     headers.insert(
         "Content-Type".to_string(),
         "application/x-www-form-urlencoded".to_string(),

--- a/crates/solobase-core/src/blocks/errors.rs
+++ b/crates/solobase-core/src/blocks/errors.rs
@@ -117,6 +117,60 @@ impl std::fmt::Display for ErrorCode {
     }
 }
 
+/// Helper to create a JSON error response with a structured error code.
+///
+/// Maps the fine-grained solobase [`ErrorCode`] to the coarse wafer
+/// `ErrorCode` (which drives transport/status mapping) and attaches the
+/// precise solobase code as structured `error.code` meta via
+/// [`wafer_run::WaferError::with_detail_code`] — the
+/// `wafer_block::META_ERROR_CODE` convention. The message stays human-only;
+/// the old `"[{code}] {message}"` in-band prefix is gone, so HTTP adapters
+/// surface the machine-readable code as a JSON `code` field from the meta
+/// rather than callers parsing it back out of the message.
+pub fn error_response(code: ErrorCode, message: &str) -> wafer_run::OutputStream {
+    let wafer_code = solobase_error_code_to_wafer(code);
+    wafer_run::OutputStream::error(
+        wafer_run::WaferError::new(wafer_code, message.to_string()).with_detail_code(code.as_str()),
+    )
+}
+
+/// Map a solobase `ErrorCode` to a wafer `ErrorCode`.
+pub(crate) fn solobase_error_code_to_wafer(code: ErrorCode) -> wafer_run::ErrorCode {
+    match code {
+        ErrorCode::InvalidCredentials
+        | ErrorCode::NotAuthenticated
+        | ErrorCode::InvalidToken
+        | ErrorCode::TokenExpired => wafer_run::ErrorCode::Unauthenticated,
+
+        ErrorCode::Forbidden
+        | ErrorCode::AdminRequired
+        | ErrorCode::AccountDisabled
+        | ErrorCode::EmailNotVerified => wafer_run::ErrorCode::PermissionDenied,
+
+        ErrorCode::NotFound => wafer_run::ErrorCode::NotFound,
+
+        ErrorCode::EmailAlreadyExists | ErrorCode::Conflict => wafer_run::ErrorCode::AlreadyExists,
+
+        ErrorCode::PasswordTooShort
+        | ErrorCode::PasswordTooLong
+        | ErrorCode::InvalidEmail
+        | ErrorCode::InvalidInput
+        | ErrorCode::InvalidPurchaseStatus => wafer_run::ErrorCode::InvalidArgument,
+
+        ErrorCode::QuotaExceeded | ErrorCode::FileTooLarge => {
+            wafer_run::ErrorCode::ResourceExhausted
+        }
+
+        ErrorCode::RateLimitExceeded => wafer_run::ErrorCode::ResourceExhausted,
+
+        ErrorCode::PaymentNotConfigured
+        | ErrorCode::ConfigurationError
+        | ErrorCode::DatabaseError
+        | ErrorCode::InternalError
+        | ErrorCode::RefundFailed => wafer_run::ErrorCode::Internal,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,59 +252,5 @@ mod tests {
             }
             other => panic!("expected an error stream, got {other:?}"),
         }
-    }
-}
-
-/// Helper to create a JSON error response with a structured error code.
-///
-/// Maps the fine-grained solobase [`ErrorCode`] to the coarse wafer
-/// `ErrorCode` (which drives transport/status mapping) and attaches the
-/// precise solobase code as structured `error.code` meta via
-/// [`wafer_run::WaferError::with_detail_code`] — the
-/// `wafer_block::META_ERROR_CODE` convention. The message stays human-only;
-/// the old `"[{code}] {message}"` in-band prefix is gone, so HTTP adapters
-/// surface the machine-readable code as a JSON `code` field from the meta
-/// rather than callers parsing it back out of the message.
-pub fn error_response(code: ErrorCode, message: &str) -> wafer_run::OutputStream {
-    let wafer_code = solobase_error_code_to_wafer(code);
-    wafer_run::OutputStream::error(
-        wafer_run::WaferError::new(wafer_code, message.to_string()).with_detail_code(code.as_str()),
-    )
-}
-
-/// Map a solobase `ErrorCode` to a wafer `ErrorCode`.
-pub(crate) fn solobase_error_code_to_wafer(code: ErrorCode) -> wafer_run::ErrorCode {
-    match code {
-        ErrorCode::InvalidCredentials
-        | ErrorCode::NotAuthenticated
-        | ErrorCode::InvalidToken
-        | ErrorCode::TokenExpired => wafer_run::ErrorCode::Unauthenticated,
-
-        ErrorCode::Forbidden
-        | ErrorCode::AdminRequired
-        | ErrorCode::AccountDisabled
-        | ErrorCode::EmailNotVerified => wafer_run::ErrorCode::PermissionDenied,
-
-        ErrorCode::NotFound => wafer_run::ErrorCode::NotFound,
-
-        ErrorCode::EmailAlreadyExists | ErrorCode::Conflict => wafer_run::ErrorCode::AlreadyExists,
-
-        ErrorCode::PasswordTooShort
-        | ErrorCode::PasswordTooLong
-        | ErrorCode::InvalidEmail
-        | ErrorCode::InvalidInput
-        | ErrorCode::InvalidPurchaseStatus => wafer_run::ErrorCode::InvalidArgument,
-
-        ErrorCode::QuotaExceeded | ErrorCode::FileTooLarge => {
-            wafer_run::ErrorCode::ResourceExhausted
-        }
-
-        ErrorCode::RateLimitExceeded => wafer_run::ErrorCode::ResourceExhausted,
-
-        ErrorCode::PaymentNotConfigured
-        | ErrorCode::ConfigurationError
-        | ErrorCode::DatabaseError
-        | ErrorCode::InternalError
-        | ErrorCode::RefundFailed => wafer_run::ErrorCode::Internal,
     }
 }

--- a/crates/solobase-core/src/blocks/legalpages/pages.rs
+++ b/crates/solobase-core/src/blocks/legalpages/pages.rs
@@ -693,7 +693,7 @@ struct PreviewRequest {
 /// the Preview tab in the editor matches production typography exactly.
 pub(super) fn render_preview_fragment(markdown: &str) -> String {
     let rendered = super::markdown_to_html(markdown);
-    format!(r#"<div class="public-page__content">{}</div>"#, rendered)
+    format!(r#"<div class="public-page__content">{rendered}</div>"#)
 }
 
 /// `POST /b/legalpages/admin/render-preview` — body: `{"content": "<markdown>"}`.

--- a/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/anthropic.rs
@@ -517,9 +517,10 @@ mod tests {
 
     fn req_with_max_tokens(msgs: Vec<ChatMessage>) -> ChatRequest {
         let mut req = ChatRequest::new("anthropic-main", "claude-3-5-sonnet", msgs);
-        let mut params = ChatParams::default();
-        params.max_tokens = Some(1024);
-        req.params = params;
+        req.params = ChatParams {
+            max_tokens: Some(1024),
+            ..Default::default()
+        };
         req
     }
 

--- a/crates/solobase-core/src/blocks/llm/providers/openai.rs
+++ b/crates/solobase-core/src/blocks/llm/providers/openai.rs
@@ -566,14 +566,15 @@ mod tests {
 
     #[test]
     fn encodes_params() {
-        let mut params = ChatParams::default();
-        params.temperature = Some(0.3);
-        params.max_tokens = Some(512);
-        params.top_p = Some(0.9);
-        params.seed = Some(42);
-        params.stop_sequences = vec!["END".into()];
         let mut req = ChatRequest::new("openai-main", "gpt-4o", vec![ChatMessage::user("hi")]);
-        req.params = params;
+        req.params = ChatParams {
+            temperature: Some(0.3),
+            max_tokens: Some(512),
+            top_p: Some(0.9),
+            seed: Some(42),
+            stop_sequences: vec!["END".into()],
+            ..Default::default()
+        };
 
         let (_, _, body) = encode_chat_request(&req, &openai_provider(), Some("sk")).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();

--- a/crates/solobase-core/src/blocks/messages/service.rs
+++ b/crates/solobase-core/src/blocks/messages/service.rs
@@ -138,6 +138,9 @@ pub async fn delete_context(ctx: &dyn Context, id: &str) -> Result<(), WaferErro
 // Entry operations
 // ---------------------------------------------------------------------------
 
+// One argument per message field the caller must supply; a param-struct
+// refactor is out of scope for a lint sweep (behavior-preserving cleanup only).
+#[allow(clippy::too_many_arguments)]
 pub async fn add_entry(
     ctx: &dyn Context,
     context_id: &str,

--- a/crates/solobase-core/src/blocks/mod.rs
+++ b/crates/solobase-core/src/blocks/mod.rs
@@ -82,6 +82,12 @@ macro_rules! feature_block_manifest {
         /// Used by `collect_all_config_vars()` to discover declared config
         /// variables, by the inspector route table, and by the routing/auth
         /// policy, before block registration runs.
+        // Each push in the body below is individually gated by an optional
+        // `#[cfg]` from the macro's entry list, so the set of pushed elements
+        // varies by feature flags — a `vec![..]` literal can't express
+        // per-element `#[cfg]` gating, so this can't collapse to the
+        // suggested rewrite.
+        #[allow(clippy::vec_init_then_push)]
         pub fn all_block_infos() -> Vec<wafer_run::BlockInfo> {
             use wafer_run::Block as _;
             #[allow(unused_mut)]
@@ -159,7 +165,12 @@ feature_block_manifest! {
 /// `ProviderLlmService` on native (`feature = "llm"`) or a `NoopProviderAdmin`
 /// on wasm32 (where the browser configures providers inside its own
 /// `BrowserLlmService`).
+// `LlmBlock` holds `Arc<dyn ProviderAdmin>`, which only requires
+// `MaybeSend + MaybeSync` (real `Send + Sync` on native, a no-op marker on
+// wasm32 — see wafer_block::compat), so this `Arc` doesn't promise
+// cross-thread safety on wasm32; wasm32 is single-threaded.
 #[cfg(feature = "block-llm")]
+#[allow(clippy::arc_with_non_send_sync)]
 pub fn register_llm(
     w: &mut wafer_run::Wafer,
     provider_admin: std::sync::Arc<dyn llm::provider_admin::ProviderAdmin>,
@@ -182,6 +193,12 @@ pub fn register_llm(
 /// when the runtime fires the framework AuthBlock's `lifecycle(Init)` event,
 /// which calls into `AuthService::init` and stashes `ctx.clone_arc()` for
 /// later `require_*` dispatches.
+// `AuthServiceImpl` holds a `BlockState` whose `dyn Context` cell only
+// requires `MaybeSend + MaybeSync` (real `Send + Sync` on native, a no-op
+// marker on wasm32 — see wafer_block::compat), so this `Arc` doesn't promise
+// cross-thread safety on wasm32; it's a shared handle, not a thread-safety
+// claim, and wasm32 is single-threaded.
+#[allow(clippy::arc_with_non_send_sync)]
 pub fn register_auth(wafer: &mut wafer_run::Wafer) -> Result<(), wafer_run::RuntimeError> {
     use std::sync::Arc;
     let state = auth::service::BlockState::new();

--- a/crates/solobase-core/src/blocks/products/pricing.rs
+++ b/crates/solobase-core/src/blocks/products/pricing.rs
@@ -111,9 +111,8 @@ pub async fn handle_calculate(ctx: &dyn Context, input: InputStream) -> OutputSt
     };
 
     // Get product
-    let product = match db::get(ctx, PRODUCTS_TABLE, &body.product_id).await {
-        Ok(p) => p,
-        Err(_) => return err_not_found("Product not found"),
+    let Ok(product) = db::get(ctx, PRODUCTS_TABLE, &body.product_id).await else {
+        return err_not_found("Product not found");
     };
 
     let resolved =
@@ -358,7 +357,7 @@ fn parse_factor(
             let val = parse_factor(tokens, pos, vars)?;
             Ok(-val)
         }
-        _ => Err(format!("Unexpected token at position {}", pos)),
+        _ => Err(format!("Unexpected token at position {pos}")),
     }
 }
 

--- a/crates/solobase-core/src/blocks/products/purchase.rs
+++ b/crates/solobase-core/src/blocks/products/purchase.rs
@@ -51,9 +51,8 @@ pub async fn handle_create(ctx: &dyn Context, msg: &Message, input: InputStream)
         if item.quantity <= 0 {
             return err_bad_request("Quantity must be positive");
         }
-        let product = match db::get(ctx, PRODUCTS_TABLE, &item.product_id).await {
-            Ok(p) => p,
-            Err(_) => return err_not_found(&format!("Product {} not found", item.product_id)),
+        let Ok(product) = db::get(ctx, PRODUCTS_TABLE, &item.product_id).await else {
+            return err_not_found(&format!("Product {} not found", item.product_id));
         };
 
         // Reject draft/deleted/inactive products

--- a/crates/solobase-core/src/blocks/products/stripe.rs
+++ b/crates/solobase-core/src/blocks/products/stripe.rs
@@ -14,9 +14,8 @@ use crate::{
 };
 
 pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStream) -> OutputStream {
-    let stripe_key = match config::get(ctx, "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY").await {
-        Ok(k) => k,
-        Err(_) => return err_internal_no_cause("Stripe is not configured"),
+    let Ok(stripe_key) = config::get(ctx, "SUPPERS_AI__PRODUCTS__STRIPE_SECRET_KEY").await else {
+        return err_internal_no_cause("Stripe is not configured");
     };
 
     #[derive(serde::Deserialize)]
@@ -32,9 +31,8 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     };
 
     // Get purchase and verify ownership
-    let purchase = match repo::purchases::get(ctx, &body.purchase_id).await {
-        Ok(p) => p,
-        Err(_) => return err_not_found("Purchase not found"),
+    let Ok(purchase) = repo::purchases::get(ctx, &body.purchase_id).await else {
+        return err_not_found("Purchase not found");
     };
     let purchase_user = purchase
         .data
@@ -108,14 +106,11 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     )
     .await;
     let success_url = body.success_url.unwrap_or_else(|| {
-        format!(
-            "{}/checkout/success?session_id={{CHECKOUT_SESSION_ID}}",
-            base_url
-        )
+        format!("{base_url}/checkout/success?session_id={{CHECKOUT_SESSION_ID}}")
     });
     let cancel_url = body
         .cancel_url
-        .unwrap_or_else(|| format!("{}/checkout/cancel", base_url));
+        .unwrap_or_else(|| format!("{base_url}/checkout/cancel"));
 
     // Reject caller-supplied URLs not on the configured frontend origin.
     // Stops attackers from luring users into a Stripe-branded session that
@@ -142,10 +137,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
     );
 
     let mut headers = HashMap::new();
-    headers.insert(
-        "Authorization".to_string(),
-        format!("Bearer {}", stripe_key),
-    );
+    headers.insert("Authorization".to_string(), format!("Bearer {stripe_key}"));
     headers.insert(
         "Content-Type".to_string(),
         "application/x-www-form-urlencoded".to_string(),
@@ -157,7 +149,7 @@ pub async fn handle_checkout(ctx: &dyn Context, msg: &Message, input: InputStrea
         "https://api.stripe.com",
     )
     .await;
-    let checkout_url_endpoint = format!("{}/v1/checkout/sessions", stripe_api_url);
+    let checkout_url_endpoint = format!("{stripe_api_url}/v1/checkout/sessions");
 
     let resp = match network::do_request(
         ctx,
@@ -617,9 +609,8 @@ async fn sync_addon_totals_from_items(ctx: &dyn Context, user_id: &str, items: &
             let meta = item
                 .get("metadata")
                 .or_else(|| item.pointer("/price/metadata"));
-            let meta = match meta {
-                Some(m) => m,
-                None => continue,
+            let Some(meta) = meta else {
+                continue;
             };
 
             // Skip non-addon items (the base plan item won't have addon_id)
@@ -685,7 +676,7 @@ mod tests {
         let computed = primitives::hmac_sha256(secret.as_bytes(), &signed_payload);
         let computed_hex = hex_encode(&computed);
 
-        let sig_header = format!("t={},v1={}", timestamp, computed_hex);
+        let sig_header = format!("t={timestamp},v1={computed_hex}");
 
         assert!(verify_stripe_signature(payload, &sig_header, secret));
     }
@@ -702,7 +693,7 @@ mod tests {
         let computed = primitives::hmac_sha256(secret.as_bytes(), &signed_payload);
         let computed_hex = hex_encode(&computed);
 
-        let sig_header = format!("t={},v1={}", timestamp, computed_hex);
+        let sig_header = format!("t={timestamp},v1={computed_hex}");
         assert!(verify_stripe_signature(payload, &sig_header, secret));
     }
 
@@ -711,8 +702,7 @@ mod tests {
         let timestamp = chrono::Utc::now().timestamp() as u64;
 
         let sig_header = format!(
-            "t={},v1=0000000000000000000000000000000000000000000000000000000000000000",
-            timestamp
+            "t={timestamp},v1=0000000000000000000000000000000000000000000000000000000000000000"
         );
 
         assert!(!verify_stripe_signature(b"payload", &sig_header, "secret"));
@@ -728,7 +718,7 @@ mod tests {
         let computed = primitives::hmac_sha256(secret.as_bytes(), &signed_payload);
         let computed_hex = hex_encode(&computed);
 
-        let sig_header = format!("t={},v1={}", old_timestamp, computed_hex);
+        let sig_header = format!("t={old_timestamp},v1={computed_hex}");
 
         assert!(!verify_stripe_signature(payload, &sig_header, secret));
     }

--- a/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/handler_tests.rs
@@ -71,7 +71,7 @@ async fn admin_get_product() {
         .unwrap()
         .to_string();
 
-    let (get_msg_data, get_input) = admin_get_msg(&format!("/admin/b/products/products/{}", id));
+    let (get_msg_data, get_input) = admin_get_msg(&format!("/admin/b/products/products/{id}"));
     let out = dispatch_admin(&ctx, get_msg_data, get_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["data"]["name"], "Widget");
@@ -95,7 +95,7 @@ async fn admin_update_product() {
 
     let (mut update, update_input) = request_msg(
         "update",
-        &format!("/admin/b/products/products/{}", id),
+        &format!("/admin/b/products/products/{id}"),
         "admin_1",
         serde_json::json!({
             "name": "New Name", "base_price": 20
@@ -123,14 +123,14 @@ async fn admin_delete_product() {
         .unwrap()
         .to_string();
 
-    let (mut del, del_input) = delete_msg(&format!("/admin/b/products/products/{}", id), "admin_1");
+    let (mut del, del_input) = delete_msg(&format!("/admin/b/products/products/{id}"), "admin_1");
     del.set_meta("auth.user_roles", "admin");
     let out = dispatch_admin(&ctx, del, del_input).await;
     let body = output_to_json(out).await;
     assert_eq!(body["deleted"], true);
 
     // Verify it's gone
-    let (get, get_input) = admin_get_msg(&format!("/admin/b/products/products/{}", id));
+    let (get, get_input) = admin_get_msg(&format!("/admin/b/products/products/{id}"));
     let out = dispatch_admin(&ctx, get, get_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
@@ -207,7 +207,7 @@ async fn admin_pricing_template_crud() {
     // Update
     let (mut update, update_input) = request_msg(
         "update",
-        &format!("/admin/b/products/pricing/{}", id),
+        &format!("/admin/b/products/pricing/{id}"),
         "admin_1",
         serde_json::json!({
             "price_formula": "base * quantity * 0.85"
@@ -222,7 +222,7 @@ async fn admin_pricing_template_crud() {
     );
 
     // Delete
-    let (mut del, del_input) = delete_msg(&format!("/admin/b/products/pricing/{}", id), "admin_1");
+    let (mut del, del_input) = delete_msg(&format!("/admin/b/products/pricing/{id}"), "admin_1");
     del.set_meta("auth.user_roles", "admin");
     let del_out = dispatch_admin(&ctx, del, del_input).await;
     assert_eq!(output_to_json(del_out).await["deleted"], true);
@@ -361,7 +361,7 @@ async fn user_cannot_see_other_users_products() {
         .to_string();
 
     // user_2 tries to get it
-    let (get, get_input) = get_msg(&format!("/b/products/products/{}", prod_id), "user_2");
+    let (get, get_input) = get_msg(&format!("/b/products/products/{prod_id}"), "user_2");
     let out = dispatch_user(&ctx, get, get_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
@@ -384,7 +384,7 @@ async fn user_cannot_update_other_users_products() {
         .to_string();
 
     let (update, update_input) = update_msg(
-        &format!("/b/products/products/{}", prod_id),
+        &format!("/b/products/products/{prod_id}"),
         "user_2",
         serde_json::json!({
             "name": "Hijacked!"
@@ -411,7 +411,7 @@ async fn user_cannot_delete_other_users_products() {
         .unwrap()
         .to_string();
 
-    let (del, del_input) = delete_msg(&format!("/b/products/products/{}", prod_id), "user_2");
+    let (del, del_input) = delete_msg(&format!("/b/products/products/{prod_id}"), "user_2");
     let out = dispatch_user(&ctx, del, del_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }
@@ -462,7 +462,7 @@ async fn user_update_prevents_ownership_change() {
 
     // Try to change created_by — should be stripped
     let (update, update_input) = update_msg(
-        &format!("/b/products/products/{}", prod_id),
+        &format!("/b/products/products/{prod_id}"),
         "user_1",
         serde_json::json!({
             "name": "Updated",
@@ -520,7 +520,7 @@ async fn user_cannot_update_other_users_group() {
         .to_string();
 
     let (update, update_input) = update_msg(
-        &format!("/b/products/groups/{}", group_id),
+        &format!("/b/products/groups/{group_id}"),
         "user_2",
         serde_json::json!({
             "name": "Stolen"
@@ -546,7 +546,7 @@ async fn user_group_update_prevents_ownership_change() {
         .to_string();
 
     let (update, update_input) = update_msg(
-        &format!("/b/products/groups/{}", group_id),
+        &format!("/b/products/groups/{group_id}"),
         "user_1",
         serde_json::json!({
             "name": "Renamed",
@@ -627,10 +627,10 @@ async fn user_group_products_list() {
     dispatch_user(&ctx, cp, cp_input).await;
 
     // List products in group
-    let (list, list_input) = get_msg(&format!("/b/products/groups/{}/products", gid), "user_1");
+    let (list, list_input) = get_msg(&format!("/b/products/groups/{gid}/products"), "user_1");
     let out = dispatch_user(&ctx, list, list_input).await;
     let body = output_to_json(out).await;
-    assert!(body["records"].as_array().unwrap().len() >= 1);
+    assert!(!body["records"].as_array().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -646,7 +646,7 @@ async fn user_cannot_list_other_users_group_products() {
     let gid = output_to_json(gr).await["id"].as_str().unwrap().to_string();
 
     // user_2 tries to list user_1's group products
-    let (list, list_input) = get_msg(&format!("/b/products/groups/{}/products", gid), "user_2");
+    let (list, list_input) = get_msg(&format!("/b/products/groups/{gid}/products"), "user_2");
     let out = dispatch_user(&ctx, list, list_input).await;
     assert!(output_is_error(out, ErrorCode::NotFound).await);
 }

--- a/crates/solobase-core/src/blocks/products/tests/stripe_tests.rs
+++ b/crates/solobase-core/src/blocks/products/tests/stripe_tests.rs
@@ -28,7 +28,7 @@ fn webhook_msg(payload: &serde_json::Value, secret: &str) -> (Message, InputStre
     let sig_bytes = primitives::hmac_sha256(secret.as_bytes(), signed.as_bytes());
     let sig_hex = hex_encode(&sig_bytes);
 
-    let sig_header = format!("t={},v1={}", timestamp, sig_hex);
+    let sig_header = format!("t={timestamp},v1={sig_hex}");
 
     let mut msg = Message::new("http.request");
     msg.set_meta("req.action", "create");
@@ -252,7 +252,7 @@ async fn webhook_rejects_tampered_payload() {
     let signed = format!("{}.{}", timestamp, String::from_utf8_lossy(&original_bytes));
     let sig_bytes = primitives::hmac_sha256(WEBHOOK_SECRET.as_bytes(), signed.as_bytes());
     let sig_hex = hex_encode(&sig_bytes);
-    let sig_header = format!("t={},v1={}", timestamp, sig_hex);
+    let sig_header = format!("t={timestamp},v1={sig_hex}");
 
     // But send a different payload
     let tampered_event = checkout_completed_event("pur_HACKED", "pi_evil");

--- a/crates/solobase-core/src/blocks/rate_limit.rs
+++ b/crates/solobase-core/src/blocks/rate_limit.rs
@@ -249,7 +249,7 @@ impl UserRateLimiter {
     /// Build a composite key from user identity and category.
     /// For unauthenticated endpoints (login/signup), use IP as the identity.
     pub fn key(identity: &str, category: &str) -> String {
-        format!("{}:{}", identity, category)
+        format!("{identity}:{category}")
     }
 }
 
@@ -378,9 +378,8 @@ pub async fn check_rate_limit(
     category: &str,
     default: RateLimit,
 ) -> RateLimitOutcome {
-    let limit = match default.resolve(ctx, category).await {
-        Some(l) => l,
-        None => return RateLimitOutcome::Disabled,
+    let Some(limit) = default.resolve(ctx, category).await else {
+        return RateLimitOutcome::Disabled;
     };
     let key = UserRateLimiter::key(identity, category);
     match limiter.check(ctx, &key, limit).await {

--- a/crates/solobase-core/src/blocks/router.rs
+++ b/crates/solobase-core/src/blocks/router.rs
@@ -85,7 +85,7 @@ impl Block for SolobaseRouterBlock {
         } else {
             let cookie_token = msg.cookie("auth_token");
             if !cookie_token.is_empty() {
-                Some(format!("Bearer {}", cookie_token))
+                Some(format!("Bearer {cookie_token}"))
             } else {
                 None
             }

--- a/crates/solobase-core/src/blocks/storage.rs
+++ b/crates/solobase-core/src/blocks/storage.rs
@@ -261,7 +261,7 @@ impl Block for SolobaseStorageBlock {
         if caller != "unknown" && !is_safe_block_name(&caller) {
             return OutputStream::error(WaferError::new(
                 ErrorCode::PermissionDenied,
-                format!("block name '{}' is not safe for storage paths", caller),
+                format!("block name '{caller}' is not safe for storage paths"),
             ));
         }
 
@@ -445,6 +445,11 @@ async fn log_storage_access(
 ///
 /// After the runtime starts, call `update_wrap_grants()` to inject the
 /// collected grants for cross-block access checks.
+// `StorageService` only requires `MaybeSend + MaybeSync` (real `Send + Sync`
+// on native, a no-op marker on wasm32 — see wafer_block::compat), so this
+// `Arc` doesn't promise cross-thread safety on wasm32; it's a shared handle,
+// not a thread-safety claim, and wasm32 is single-threaded.
+#[allow(clippy::arc_with_non_send_sync)]
 pub fn create(
     service: Arc<dyn StorageService>,
     admin_block: Arc<str>,

--- a/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
+++ b/crates/solobase-core/src/blocks/userportal/pages/admin_buttons.rs
@@ -250,9 +250,8 @@ pub async fn handle_edit_button_form(ctx: &dyn Context, id: &str) -> OutputStrea
     if !is_safe_dom_id(id) {
         return err_not_found("Button not found");
     }
-    let record = match db::get(ctx, TABLE, id).await {
-        Ok(r) => r,
-        Err(_) => return err_not_found("Button not found"),
+    let Ok(record) = db::get(ctx, TABLE, id).await else {
+        return err_not_found("Button not found");
     };
 
     let current_icon = record.str_field("icon");

--- a/crates/solobase-core/src/blocks/vector/pages.rs
+++ b/crates/solobase-core/src/blocks/vector/pages.rs
@@ -157,9 +157,8 @@ pub(super) async fn create_index(
     // Borrow the caller's `model` when present; only fall back to the static
     // `DEFAULT_MODEL` literal when absent. Avoids a String allocation per call.
     let model_id: &str = body.model.as_deref().unwrap_or(DEFAULT_MODEL);
-    let model = match get_model(model_id) {
-        Some(m) => m,
-        None => return err_bad_request(&format!("unknown embedding model: {model_id}")),
+    let Some(model) = get_model(model_id) else {
+        return err_bad_request(&format!("unknown embedding model: {model_id}"));
     };
 
     if let Some(requested) = body.dimensions {

--- a/crates/solobase-core/src/blocks/vector/pages_ui.rs
+++ b/crates/solobase-core/src/blocks/vector/pages_ui.rs
@@ -283,7 +283,7 @@ pub async fn index_detail_page(ctx: &dyn Context, msg: &Message, name: &str) -> 
     let body = detail_page(
         DetailHero {
             icon: None,
-            title: &display,
+            title: display,
             subtitle: Some(&subtitle),
             badges: Vec::new(),
             action_menu: None,

--- a/crates/solobase-core/src/builder.rs
+++ b/crates/solobase-core/src/builder.rs
@@ -377,6 +377,12 @@ impl SolobaseBuilder {
             llm_router.register(label, svc);
         }
 
+        // `MultiBackendLlmService` holds `dyn LlmService` backends, which only
+        // require `MaybeSend + MaybeSync` (real `Send + Sync` on native, a
+        // no-op marker on wasm32 — see wafer_block::compat), so this `Arc`
+        // doesn't promise cross-thread safety on wasm32; wasm32 is
+        // single-threaded.
+        #[allow(clippy::arc_with_non_send_sync)]
         wafer_core::service_blocks::llm::register_with(&mut wafer, Arc::new(llm_router))?;
 
         // 4a-bis. Build the image router and register the service block
@@ -389,6 +395,12 @@ impl SolobaseBuilder {
         for (label, svc) in self.extra_image_services {
             image_router.register(label, svc);
         }
+        // `MultiBackendImageService` holds `dyn ImageService` backends, which
+        // only require `MaybeSend + MaybeSync` (real `Send + Sync` on native,
+        // a no-op marker on wasm32 — see wafer_block::compat), so this `Arc`
+        // doesn't promise cross-thread safety on wasm32; wasm32 is
+        // single-threaded.
+        #[allow(clippy::arc_with_non_send_sync)]
         wafer_core::service_blocks::image::register_with(&mut wafer, Arc::new(image_router))?;
 
         // 4b. Register the `wafer-run/vector` runtime block when the
@@ -412,6 +424,11 @@ impl SolobaseBuilder {
             )?;
             #[cfg(target_arch = "wasm32")]
             {
+                // `TransformersEmbedBlock` only requires `MaybeSend + MaybeSync`
+                // (a no-op marker on wasm32 — see wafer_block::compat), so this
+                // `Arc` doesn't promise cross-thread safety; wasm32 is
+                // single-threaded and this whole block is wasm32-only.
+                #[allow(clippy::arc_with_non_send_sync)]
                 wafer.register_block(
                     "suppers-ai/transformers-embed".to_string(),
                     Arc::new(
@@ -536,6 +553,12 @@ impl SolobaseBuilder {
             block_infos,
             self.extra_routes,
         );
+        // `SolobaseRouterBlock` holds `Arc<dyn FeatureConfig>`, which only
+        // requires `MaybeSend + MaybeSync` (real `Send + Sync` on native, a
+        // no-op marker on wasm32 — see wafer_block::compat), so this `Arc`
+        // doesn't promise cross-thread safety on wasm32; wasm32 is
+        // single-threaded.
+        #[allow(clippy::arc_with_non_send_sync)]
         wafer.register_block("suppers-ai/router", Arc::new(router))?;
         wafer.add_block_config("suppers-ai/router", routes_cfg);
 

--- a/crates/solobase-core/src/crypto.rs
+++ b/crates/solobase-core/src/crypto.rs
@@ -57,9 +57,8 @@ pub async fn extract_auth_meta(
 ) {
     use wafer_run::*;
 
-    let token = match auth_header.strip_prefix("Bearer ") {
-        Some(t) => t,
-        None => return,
+    let Some(token) = auth_header.strip_prefix("Bearer ") else {
+        return;
     };
 
     // Session tokens (access + refresh) are minted by the `suppers-ai/auth-ui`
@@ -79,11 +78,11 @@ pub async fn extract_auth_meta(
         jwt_secret.as_bytes(),
         crate::blocks::auth_ui::AUTH_UI_BLOCK_ID,
     );
-    let claims =
-        match primitives::jwt_verify(token, derived_secret.as_bytes(), JwtExpPolicy::Required) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
+    let Ok(claims) =
+        primitives::jwt_verify(token, derived_secret.as_bytes(), JwtExpPolicy::Required)
+    else {
+        return;
+    };
 
     // Allow-list: only an explicit "access" token authenticates. A refresh
     // token — or any token whose `type` is missing or not "access" — is
@@ -142,7 +141,7 @@ pub async fn extract_auth_meta(
         msg.set_meta(META_AUTH_JTI, jti);
     }
     if let Some(exp) = claims.get("exp").and_then(|v| v.as_i64()) {
-        msg.set_meta(META_AUTH_EXP, &exp.to_string());
+        msg.set_meta(META_AUTH_EXP, exp.to_string());
     }
 }
 

--- a/crates/solobase-core/src/features.rs
+++ b/crates/solobase-core/src/features.rs
@@ -634,9 +634,8 @@ mod seed_plan_tests {
         // Pick five blocks from ENABLED_DEFAULTS to stage in different states.
         // ENABLED_DEFAULTS has 7 entries; assign one to each lane and let the
         // remaining 2 fall into the "absent → Insert" lane.
-        let names: Vec<&&'static str> = ENABLED_DEFAULTS.iter().map(|(n, _)| n).collect();
         assert!(
-            names.len() >= 5,
+            ENABLED_DEFAULTS.len() >= 5,
             "test assumes at least 5 entries in ENABLED_DEFAULTS"
         );
 

--- a/crates/solobase-core/src/pipeline.rs
+++ b/crates/solobase-core/src/pipeline.rs
@@ -90,6 +90,10 @@ pub fn drain_queued_request_logs() -> Vec<QueuedRequestLog> {
 /// returned `OutputStream` as `StreamEvent::Error`. Request-log
 /// persistence failures are intentionally swallowed (best-effort) so a
 /// failing audit-log table never breaks the response.
+// This is the single request-pipeline entry point; each argument is a distinct
+// piece of request/runtime context and a param-struct refactor is out of scope
+// for a lint sweep (behavior-preserving cleanup only).
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_request(
     ctx: &dyn Context,
     mut msg: Message,
@@ -105,7 +109,7 @@ pub async fn handle_request(
     if path == "/openapi.json" || path == "/.well-known/agent.json" {
         let is_openapi = path == "/openapi.json";
         let host = msg.header("host").to_string();
-        let server_url = format!("https://{}", host);
+        let server_url = format!("https://{host}");
         // The project/display name for the discovery documents (OpenAPI
         // `info.title` and the agent-card `name`). Previously this was
         // derived from the `Host` header (`host.split('.').next()`), which
@@ -160,8 +164,7 @@ pub async fn handle_request(
             let expected_iss = crate::blocks::auth::helpers::expected_issuer(ctx).await;
             crate::crypto::extract_auth_meta(ctx, header, jwt_secret, &expected_iss, &mut msg)
                 .await;
-        } else if header.starts_with("ApiKey ") {
-            let api_key = &header["ApiKey ".len()..];
+        } else if let Some(api_key) = header.strip_prefix("ApiKey ") {
             crate::blocks::auth::authenticate_api_key(ctx, api_key, &mut msg).await;
         }
     }

--- a/crates/solobase-core/src/routing.rs
+++ b/crates/solobase-core/src/routing.rs
@@ -462,7 +462,7 @@ mod tests {
         // sub-routes (`/b/legalpages/admin`, `/b/legalpages/api`) that DO
         // require admin. Those sub-routes are verified by
         // `legalpages_admin_routes_require_admin`.
-        let non_admin_prefixes = vec![
+        let non_admin_prefixes = [
             "/health",
             "/static/",
             "/b/auth/",

--- a/crates/solobase-core/src/ui/assets.rs
+++ b/crates/solobase-core/src/ui/assets.rs
@@ -119,10 +119,7 @@ pub fn css_bundle() -> &'static str {
         let tokens = TOKENS_CSS
             .replace("__ITIM_LATIN_URL__", itim_latin_woff2_url())
             .replace("__ITIM_LATIN_EXT_URL__", itim_latin_ext_woff2_url());
-        format!(
-            "{}\n{}\n{}\n{}\n{}\n",
-            tokens, BASE_CSS, COMPONENTS_CSS, LAYOUT_CSS, CHARTS_CSS
-        )
+        format!("{tokens}\n{BASE_CSS}\n{COMPONENTS_CSS}\n{LAYOUT_CSS}\n{CHARTS_CSS}\n")
     })
 }
 

--- a/crates/solobase-core/src/ui/shell.rs
+++ b/crates/solobase-core/src/ui/shell.rs
@@ -281,13 +281,15 @@ mod tests {
     #[test]
     fn shell_can_omit_palette() {
         let groups = one_group(vec![item("X", "/x")]);
-        let mut tb = Topbar::default();
-        tb.show_palette = false;
         // Need at least one declared input to render the topbar at all.
-        tb.crumbs = vec![Crumb {
-            label: "X",
-            href: None,
-        }];
+        let tb = Topbar {
+            show_palette: false,
+            crumbs: vec![Crumb {
+                label: "X",
+                href: None,
+            }],
+            ..Default::default()
+        };
         let s = shell(&groups, None, "/x", "", "", tb, html! {}).into_string();
         assert!(!s.contains("topbar__palette"));
         // The single crumb renders as the page h1 (no ancestor nav needed).
@@ -322,8 +324,10 @@ mod tests {
     #[test]
     fn shell_mobile_header_omits_palette_icon_when_disabled() {
         let groups = one_group(vec![item("X", "/x")]);
-        let mut tb = Topbar::default();
-        tb.show_palette = false;
+        let tb = Topbar {
+            show_palette: false,
+            ..Default::default()
+        };
         let s = shell(&groups, None, "/x", "", "", tb, html! {}).into_string();
         // Mobile header itself is always rendered…
         assert!(s.contains("shell__mobile-header"));
@@ -334,8 +338,10 @@ mod tests {
     #[test]
     fn shell_renders_no_topbar_when_all_inputs_empty() {
         let groups = one_group(vec![item("X", "/x")]);
-        let mut tb = Topbar::default();
-        tb.show_palette = false;
+        let tb = Topbar {
+            show_palette: false,
+            ..Default::default()
+        };
         let s = shell(&groups, None, "/x", "", "", tb, html! { "body" }).into_string();
         // No topbar element at all when there's nothing to render in it.
         assert!(!s.contains(r#"class="topbar""#));

--- a/crates/solobase-core/src/ui/templates.rs
+++ b/crates/solobase-core/src/ui/templates.rs
@@ -394,10 +394,10 @@ pub fn public_page(opts: PublicPage<'_>, body: Markup) -> Markup {
         (bg, accent) => {
             let mut s = String::from(":root{");
             if let Some(c) = bg {
-                s.push_str(&format!("--public-page-bg:{};", c));
+                s.push_str(&format!("--public-page-bg:{c};"));
             }
             if let Some(c) = accent {
-                s.push_str(&format!("--public-page-accent:{};", c));
+                s.push_str(&format!("--public-page-accent:{c};"));
             }
             s.push('}');
             s

--- a/crates/solobase/src/cli/cmd.rs
+++ b/crates/solobase/src/cli/cmd.rs
@@ -73,6 +73,10 @@ pub async fn run(step: &str, mut cmd: Command) -> anyhow::Result<()> {
     )))
 }
 
+/// Re-export to keep call-site imports terse; the rest of the CLI builds
+/// `tokio::process::Command` and passes it to [`run`].
+pub use tokio::process::Command as TokioCommand;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,7 +100,3 @@ mod tests {
         assert!(msg.contains("exit code: <signal>"));
     }
 }
-
-/// Re-export to keep call-site imports terse; the rest of the CLI builds
-/// `tokio::process::Command` and passes it to [`run`].
-pub use tokio::process::Command as TokioCommand;

--- a/crates/solobase/src/cli/helpers/cloudflare/profile_check.rs
+++ b/crates/solobase/src/cli/helpers/cloudflare/profile_check.rs
@@ -58,17 +58,16 @@ pub fn check_release_profile(repo_root: &Path) -> Result<()> {
 /// Measure the produced WASM and warn if it's likely to exceed the
 /// startup-CPU cap. Called after `worker-build` finishes.
 pub fn check_wasm_size(wasm_path: &Path) -> Result<()> {
-    let meta = match std::fs::metadata(wasm_path) {
-        Ok(m) => m,
-        // No file = nothing to check; the build step itself will surface
-        // the actual error. Don't double-report.
-        Err(_) => return Ok(()),
+    // No file = nothing to check; the build step itself will surface
+    // the actual error. Don't double-report.
+    let Ok(meta) = std::fs::metadata(wasm_path) else {
+        return Ok(());
     };
     let size = meta.len();
     let mb = size as f64 / (1024.0 * 1024.0);
 
     if size <= WASM_SIZE_WARN_BYTES {
-        eprintln!("-> WASM: {mb:.2} MB ({} bytes)", size);
+        eprintln!("-> WASM: {mb:.2} MB ({size} bytes)");
         return Ok(());
     }
 

--- a/crates/solobase/src/cli/helpers/http_server.rs
+++ b/crates/solobase/src/cli/helpers/http_server.rs
@@ -59,14 +59,11 @@ pub async fn serve_static(dir: &Path, port: u16) -> Result<()> {
                 .and_then(|l| l.split_whitespace().nth(1))
                 .unwrap_or("/");
 
-            let file_path = match resolve_request_path(&dir, raw_path) {
-                Some(p) => p,
-                None => {
-                    let _ = socket
-                        .write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
-                        .await;
-                    return;
-                }
+            let Some(file_path) = resolve_request_path(&dir, raw_path) else {
+                let _ = socket
+                    .write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+                    .await;
+                return;
             };
 
             let body = tokio::fs::read(&file_path).await;

--- a/crates/solobase/src/cli/server_config.rs
+++ b/crates/solobase/src/cli/server_config.rs
@@ -32,44 +32,39 @@ pub fn filter_to_declared_keys(env_vars: HashMap<String, String>) -> Vec<(String
 /// Reads the `suppers_ai__admin__wrap_grants` table and returns a list of
 /// `ResourceGrant` values that should be injected into the WAFER runtime.
 pub fn load_wrap_grants(db_path: &str) -> Vec<wafer_run::ResourceGrant> {
-    let conn = match rusqlite::Connection::open(db_path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+    let Ok(conn) = rusqlite::Connection::open(db_path) else {
+        return Vec::new();
     };
 
     let mut grants = Vec::new();
-    let mut stmt = match conn.prepare(
+    let Ok(mut stmt) = conn.prepare(
         "SELECT grantee, resource, write, resource_type FROM suppers_ai__admin__wrap_grants",
-    ) {
-        Ok(s) => s,
-        Err(_) => {
-            // Fall back to query without resource_type (column may not exist yet)
-            let mut stmt = match conn
-                .prepare("SELECT grantee, resource, write FROM suppers_ai__admin__wrap_grants")
-            {
-                Ok(s) => s,
-                Err(_) => return Vec::new(),
-            };
-            let rows = stmt.query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, i32>(2)?,
-                ))
-            });
-            if let Ok(rows) = rows {
-                for row in rows.flatten() {
-                    let (grantee, resource, write) = row;
-                    grants.push(wafer_run::ResourceGrant {
-                        grantee,
-                        resource,
-                        write: write != 0,
-                        resource_type: None,
-                    });
-                }
+    ) else {
+        // Fall back to query without resource_type (column may not exist yet)
+        let Ok(mut stmt) =
+            conn.prepare("SELECT grantee, resource, write FROM suppers_ai__admin__wrap_grants")
+        else {
+            return Vec::new();
+        };
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i32>(2)?,
+            ))
+        });
+        if let Ok(rows) = rows {
+            for row in rows.flatten() {
+                let (grantee, resource, write) = row;
+                grants.push(wafer_run::ResourceGrant {
+                    grantee,
+                    resource,
+                    write: write != 0,
+                    resource_type: None,
+                });
             }
-            return grants;
         }
+        return grants;
     };
 
     let rows = stmt.query_map([], |row| {


### PR DESCRIPTION
## Summary

Preventive quality sweep (Task LINT). CI runs `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare` **without** `-D warnings`, so these findings never gated a build. This PR makes both clippy surfaces fully clean under `-D warnings` — no behavior changes, lint cleanups only.

**Baseline:** 115 warnings on the host-clippy'd surface (`cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare --all-targets`): 50 `uninlined_format_args`, 21 `manual_let_else`, 8 `field_reassign_with_default`, 5 `useless_vec`, 3 `needless_borrows_for_generic_args`/`needless_borrow`, 2 `too_many_arguments`, 2 `needless_else`, 2 `redundant_clone`, 2 `items_after_test_module`, and one each of `map_entry`, `manual_strip`, `len_zero`, `into_iter_on_ref`, `cloned_ref_to_slice_refs`, `single_match`, `new_without_default`, `vec_init_then_push`.

Also verified the two wasm32-only crates (`solobase-cloudflare`, `solobase-web`) under `--target wasm32-unknown-unknown -- -D warnings`. These pull in `solobase-core`/`solobase-browser` under the wasm32 target, which surfaced a *separate* set of target-specific findings not visible on host (`arc_with_non_send_sync`, `type_complexity`, `manual_strip`, `redundant_clone`, plus a couple more `manual_let_else`) — also fixed to 0.

### `--fix` vs manual

- `cargo clippy --fix --allow-dirty --allow-staged` (run per-target, since cargo declines to batch-apply fixes across lib+tests when they'd conflict) handled the bulk: all `uninlined_format_args`, `useless_vec`, `needless_borrow*`, `redundant_clone`, `needless_question_mark`, `manual_strip` (browser), and reordered the 2 `items_after_test_module` occurrences (moved the non-test items above `#[cfg(test)] mod tests`).
- Manual fixes: all 21+ `manual_let_else` rewrites (clippy's own applicability didn't auto-apply these — verified each preserves the diverging-arm semantics exactly), `field_reassign_with_default` → struct-literal init (7 total: 2 LLM provider tests, 3 `Topbar` test fixtures, 2 in solobase-browser catalogs), `needless_collect` (2, inlined into the consuming `assert!`), 2 `type_complexity` (local type aliases, non-breaking), and one `clippy::single_match` inside a `maud::html!` macro — cargo's mechanical fix corrupted the maud DSL syntax (`@match` → malformed `@if`), so this one was hand-rewritten as proper `@if let Some(v) = ... { }`.

### `#[allow]`s added, each with a one-line reason

- **`too_many_arguments`** (2): `solobase_core::blocks::messages::service::add_entry` (8 args) and `solobase_core::pipeline::handle_request` (8 args). Per the brief, a param-struct refactor is out of scope for a lint sweep — allowed, not refactored.
- **`vec_init_then_push`** (1): `solobase_core::blocks::mod::all_block_infos` — each `push` is individually gated by an optional `#[cfg]` from the `feature_block_manifest!` macro's entry list, so the set of pushed elements varies by feature flags; a `vec![..]` literal can't express per-element `#[cfg]` gating.
- **`arc_with_non_send_sync`** (11 sites across `solobase-core`, `solobase-cloudflare`): every flagged `Arc::new(...)` wraps a type whose trait bound is `MaybeSend + MaybeSync` (`wafer_block::compat`) — a real `Send + Sync` requirement on native, but a no-op marker on `wasm32` (single-threaded execution model, no real thread-safety concern). This is a known false-positive pattern for cross-platform wasm code using this compat alias; confirmed each concrete type (`AuthServiceImpl`, `SolobaseStorageBlock`, `MultiBackendLlmService`, `MultiBackendImageService`, `TransformersEmbedBlock`, `SolobaseRouterBlock`, `LlmBlock`, `KvCachedD1DatabaseService`, `D1ConfigSource`) is only non-`Send`/`Sync` via this wasm32 marker path, not a real soundness gap.

### Corrected stale comments

Two `field_reassign_with_default` sites in `solobase-browser` had comments claiming `ModelCapabilities` is `#[non_exhaustive]` (which would have blocked the struct-literal rewrite). Checked the actual `wafer_block::wire::{llm,image}::ModelCapabilities` definitions at the pinned commit (`b5c82fd8`) — neither is `#[non_exhaustive]`; the comments were stale. Rewrote to struct-literal init and removed the incorrect comments.

### Warnings left unfixed

None — both surfaces are 0 warnings under `-D warnings`.

## Verify

```
cargo fmt --all --check
# clean

cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare --all-targets -- -D warnings
# Finished, 0 warnings

cargo clippy -p solobase-cloudflare --target wasm32-unknown-unknown -- -D warnings
cargo clippy -p solobase-web --target wasm32-unknown-unknown -- -D warnings
# Finished, 0 warnings (both, incl. --tests)

cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare
# all green, 0 failures
```

Full report: `.superpowers/sdd/rs2026/task-lint-report.md` (workspace-level scratch, not part of this diff).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --exclude solobase-web --exclude solobase-cloudflare --all-targets -- -D warnings` → 0 warnings
- [x] `cargo clippy -p solobase-cloudflare --target wasm32-unknown-unknown -- -D warnings` → 0 warnings
- [x] `cargo clippy -p solobase-web --target wasm32-unknown-unknown -- -D warnings` → 0 warnings
- [x] `cargo test --workspace --exclude solobase-web --exclude solobase-cloudflare` → all green
- [x] Self-reviewed full diff — every hunk is either `--fix`-applied or a manual mechanical rewrite; no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM5M8t8U4TR2CpYZtaRy8H